### PR TITLE
Add a test that checks compact merkle tree state loading 

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -37,7 +37,7 @@ func (s Sequencer) buildMerkleTreeFromStorageAtRoot(root trillian.SignedLogRoot,
 	if root.TreeRevision == nil {
 		return nil, errors.New("invalid root; TreeRevision unset")
 	}
-	mt := merkle.NewCompactMerkleTreeWithState(hasher, *root.TreeSize, func(depth int, index int64) (trillian.Hash, error) {
+	mt, err := merkle.NewCompactMerkleTreeWithState(hasher, *root.TreeSize, func(depth int, index int64) (trillian.Hash, error) {
 		nodeId := storage.NewNodeIDForTreeCoords(int64(depth), index, int(hasher.Size()))
 		nodes, err := tx.GetMerkleNodes([]storage.NodeID{nodeId}, *root.TreeRevision)
 
@@ -54,7 +54,7 @@ func (s Sequencer) buildMerkleTreeFromStorageAtRoot(root trillian.SignedLogRoot,
 		return nodes[0].Hash, nil
 	}, root.RootHash)
 
-	return mt, nil
+	return mt, err
 }
 
 func (s Sequencer) buildNodesFromNodeMap(nodeMap map[string]storage.Node, newVersion int64) ([]storage.Node, error) {

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -12,7 +12,7 @@ import (
 
 type RootHashMismatchError struct {
 	ExpectedHash []byte
-	ActualHash []byte
+	ActualHash   []byte
 }
 
 func (r RootHashMismatchError) Error() string {

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/trillian"
 )
 
-// This data came from the C++ CT tests
+// This data came from the C++ CT tests.
 // referenceMerkleInputs are the leaf data inputs to the tree for the first 7 leaves
 var referenceMerkleInputs = [][]byte{{}, {0x00}, {0x10}, {0x20, 0x21}, {0x30, 0x31}, {0x40, 0x41, 0x42, 0x43}, {0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57}}
 

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -3,11 +3,11 @@ package merkle
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/google/trillian"
 	"github.com/vektra/errors"
-	"strings"
 )
 
 func mustHexDecode(b string) trillian.Hash {

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/google/trillian"
+	"github.com/vektra/errors"
+	"strings"
 )
 
 func mustHexDecode(b string) trillian.Hash {
@@ -108,5 +110,34 @@ func TestAddingLeaves(t *testing.T) {
 		if got, want := tree.CurrentRoot(), roots[7]; !bytes.Equal(got, want) {
 			t.Fatalf("Expected root of %v, got %v", got, want)
 		}
+	}
+}
+
+func failingGetNodeFunc(depth int, index int64) (trillian.Hash, error) {
+	return trillian.Hash{}, errors.New("Bang!")
+}
+
+// This returns something that won't result in a valid root hash match, doesn't really
+// matter what it is but it must be correct length for an SHA256 hash as if it was real
+func fixedHashGetNodeFunc(depth int, index int64) (trillian.Hash, error) {
+	return []byte("12345678901234567890123456789012"), nil
+}
+
+func TestLoadingTreeFailsNodeFetch(t *testing.T) {
+	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, failingGetNodeFunc, []byte("notimportant"))
+
+	if err == nil || !strings.Contains(err.Error(), "Bang!"){
+		t.Fatalf("Did not return correctly on failed node fetch")
+	}
+}
+
+func TestLoadingTreeFailsBadRootHash(t *testing.T) {
+	// Supply a root hash that can't possibly match the result of the SHA 256 hashing on our dummy
+	// data
+	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
+	_, ok := err.(RootHashMismatchError);
+
+	if err == nil || !ok {
+		t.Fatalf("Did not return correct error type on root mismatch")
 	}
 }

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -126,7 +126,7 @@ func fixedHashGetNodeFunc(depth int, index int64) (trillian.Hash, error) {
 func TestLoadingTreeFailsNodeFetch(t *testing.T) {
 	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, failingGetNodeFunc, []byte("notimportant"))
 
-	if err == nil || !strings.Contains(err.Error(), "Bang!"){
+	if err == nil || !strings.Contains(err.Error(), "Bang!") {
 		t.Fatalf("Did not return correctly on failed node fetch")
 	}
 }
@@ -135,7 +135,7 @@ func TestLoadingTreeFailsBadRootHash(t *testing.T) {
 	// Supply a root hash that can't possibly match the result of the SHA 256 hashing on our dummy
 	// data
 	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
-	_, ok := err.(RootHashMismatchError);
+	_, ok := err.(RootHashMismatchError)
 
 	if err == nil || !ok {
 		t.Fatalf("Did not return correct error type on root mismatch")

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -3,6 +3,7 @@ package merkle
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,7 +13,8 @@ import (
 
 // This data came from the C++ CT tests
 // referenceMerkleInputs are the leaf data inputs to the tree for the first 7 leaves
-var referenceMerkleInputs = [][]byte{{}, { 0x00 }, { 0x10} , { 0x20, 0x21 }, { 0x30, 0x31 }, { 0x40, 0x41, 0x42, 0x43 }, { 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57}}
+var referenceMerkleInputs = [][]byte{{}, {0x00}, {0x10}, {0x20, 0x21}, {0x30, 0x31}, {0x40, 0x41, 0x42, 0x43}, {0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57}}
+
 // referenceRootHash7 is the expected root hash if the 7 elements above are added to the tree in order
 var referenceRootHash7 = []byte{0xdd, 0xb8, 0x9b, 0xe4, 0x03, 0x80, 0x9e, 0x32, 0x57, 0x50, 0xd3, 0xd2, 0x63, 0xcd, 0x78, 0x92, 0x9c, 0x29, 0x42, 0xb7, 0x94, 0x2a, 0x34, 0xb7, 0x7e, 0x12, 0x2c, 0x95, 0x94, 0xa7, 0x4c, 0x8c}
 
@@ -143,10 +145,10 @@ func cannedHashGetNodeFunc(depth int, index int64) (trillian.Hash, error) {
 	if depth == 1 && index == 2 {
 		// We want leaves 4&5 hashed as children of that node
 		return hasher.HashChildren(hasher.HashLeaf(referenceMerkleInputs[4]),
-				hasher.HashLeaf(referenceMerkleInputs[5])), nil
+			hasher.HashLeaf(referenceMerkleInputs[5])), nil
 	}
 
-	if (depth == 2 && index == 0) {
+	if depth == 2 && index == 0 {
 		// We want the level two hash of the left side of the tree
 		nodeHash1 := hasher.HashChildren(hasher.HashLeaf(referenceMerkleInputs[0]),
 			hasher.HashLeaf(referenceMerkleInputs[1]))


### PR DESCRIPTION
Using data from the reference tree tests that correct nodes are accessed and resulting root hash is correct.

Not ready for review until branch it's based on is merged.