### PR TITLE
Make the paper link a relative one to our copy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ## General Transparency
 
 Trillian is an implementation of the concepts described in the
-[Verifiable Data Structures](https://docs.google.com/viewer?a=v&pid=forums&srcid=MTIzNDY4MDQ0MTI2MDkzMjEyODgBMDg4MDU4MzE0NzQ4MzIzNTI0NjgBUlBsTmtFQ3FDUUFKATAuMQEBdjI&authuser=0)
+[Verifiable Data Structures](docs/VerifiableDataStructures.pdf)
 white paper, which in turn could be thought of as an extension and
 generalisation of the ideas which underpin
-[Certificate Transparency](https://certifiate-transparency.org).
+[Certificate Transparency](https://certificate-transparency.org).
 
 


### PR DESCRIPTION
Also fix embarrasing typo for CT site URL.