### PR TITLE
Set up MySQL for travis tests and fix sql typos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: go
 
 go:
@@ -9,3 +10,12 @@ install:
 script:
   - go build -v ./...
   - go test -v ./...
+
+services: mysql
+
+before_script:
+  - mysql -u root -e 'DROP DATABASE IF EXISTS test;'
+  - mysql -u root -e 'CREATE DATABASE test;'
+  - mysql -u root -e "GRANT ALL ON test.* TO 'test'@'localhost' IDENTIFIED BY 'zaphod';" 
+  - mysql -u root -D test < storage/mysql/storage.sql
+

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -64,8 +64,8 @@ CREATE TABLE IF NOT EXISTS Node(
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
 );
 
-// The TreeRevisionIdx is used to enforce that there is only one STH at any
-// tree revision
+-- The TreeRevisionIdx is used to enforce that there is only one STH at any
+-- tree revision
 CREATE TABLE IF NOT EXISTS TreeHead(
   TreeId               INTEGER NOT NULL,
   TreeHeadTimestamp    BIGINT,
@@ -86,7 +86,7 @@ CREATE TABLE IF NOT EXISTS Unsequenced(
   -- we can try to stomp dupe submissions.
   MessageId            BINARY(32) NOT NULL,
   Payload              BLOB NOT NULL,
-  QueueTimestamp       TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  QueueTimestamp       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   SignedEntryTimestamp BLOB,
   PRIMARY KEY (TreeId, LeafHash, MessageId)
-)
+);


### PR DESCRIPTION
Add blank password to sql commands

Fix up sql commands.

Use the proper way of specifying no password.

Specify database.

Try different way of dropping the db.

Fix typo.

Fix typo on comment.

Add missing trailing ; to create table.

Investigating potential MariaDB / MySQL difference.