### PR TITLE
Improve database tests, try to make them clean up locks

### DIFF
--- a/server/trillian_log_server.go
+++ b/server/trillian_log_server.go
@@ -68,8 +68,6 @@ func (t *TrillianLogServer) QueueLeaves(ctx context.Context, req *trillian.Queue
 		return nil, err
 	}
 
-	defer rollbackTxIfOpen(tx)
-
 	err = tx.QueueLeaves(leaves)
 
 	if err != nil {
@@ -122,8 +120,6 @@ func (t *TrillianLogServer) GetLeavesByIndex(ctx context.Context, req *trillian.
 		return nil, err
 	}
 
-	defer rollbackTxIfOpen(tx)
-
 	leaves, err := tx.GetLeavesByIndex(req.LeafIndex)
 
 	if err != nil {
@@ -159,13 +155,6 @@ func (t *TrillianLogServer) prepareStorageTx(treeID int64) (storage.LogTX, error
 	}
 
 	return tx, err
-}
-
-// Rolls back if an error has occurred.
-func rollbackTxIfOpen(tx storage.LogTX) {
-	if tx != nil && tx.Open() {
-		tx.Rollback()
-	}
 }
 
 func buildStatus(code trillian.TrillianApiStatusCode) *trillian.TrillianApiStatus {

--- a/server/trillian_log_server.go
+++ b/server/trillian_log_server.go
@@ -68,10 +68,11 @@ func (t *TrillianLogServer) QueueLeaves(ctx context.Context, req *trillian.Queue
 		return nil, err
 	}
 
+	defer rollbackTxIfOpen(tx)
+
 	err = tx.QueueLeaves(leaves)
 
 	if err != nil {
-		tx.Rollback()
 		return nil, err
 	}
 
@@ -121,10 +122,11 @@ func (t *TrillianLogServer) GetLeavesByIndex(ctx context.Context, req *trillian.
 		return nil, err
 	}
 
+	defer rollbackTxIfOpen(tx)
+
 	leaves, err := tx.GetLeavesByIndex(req.LeafIndex)
 
 	if err != nil {
-		tx.Rollback()
 		return nil, err
 	}
 
@@ -157,6 +159,13 @@ func (t *TrillianLogServer) prepareStorageTx(treeID int64) (storage.LogTX, error
 	}
 
 	return tx, err
+}
+
+// Rolls back if an error has occurred.
+func rollbackTxIfOpen(tx storage.LogTX) {
+	if tx != nil && tx.Open() {
+		tx.Rollback()
+	}
 }
 
 func buildStatus(code trillian.TrillianApiStatusCode) *trillian.TrillianApiStatus {

--- a/server/trillian_log_server.go
+++ b/server/trillian_log_server.go
@@ -71,6 +71,7 @@ func (t *TrillianLogServer) QueueLeaves(ctx context.Context, req *trillian.Queue
 	err = tx.QueueLeaves(leaves)
 
 	if err != nil {
+		tx.Rollback()
 		return nil, err
 	}
 
@@ -123,6 +124,7 @@ func (t *TrillianLogServer) GetLeavesByIndex(ctx context.Context, req *trillian.
 	leaves, err := tx.GetLeavesByIndex(req.LeafIndex)
 
 	if err != nil {
+		tx.Rollback()
 		return nil, err
 	}
 

--- a/server/trillian_log_server_test.go
+++ b/server/trillian_log_server_test.go
@@ -76,6 +76,7 @@ func TestGetLeavesByIndexStorageError(t *testing.T) {
 
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("GetLeavesByIndex", []int64{0}).Return([]trillian.LogLeaf{}, errors.New("STORAGE"))
+	mockTx.On("Open").Return(true)
 	mockTx.On("Rollback").Return(nil)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
@@ -110,6 +111,7 @@ func TestGetLeavesByIndexCommitFails(t *testing.T) {
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("GetLeavesByIndex", []int64{0}).Return([]trillian.LogLeaf{leaf1}, nil)
 	mockTx.On("Commit").Return(errors.New("Bang!"))
+	mockTx.On("Open").Return(false)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
 
@@ -129,6 +131,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("GetLeavesByIndex", []int64{0}).Return([]trillian.LogLeaf{leaf1}, nil)
 	mockTx.On("Commit").Return(nil)
+	mockTx.On("Open").Return(false)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
 
@@ -156,6 +159,7 @@ func TestGetLeavesByIndexMultiple(t *testing.T) {
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("GetLeavesByIndex", []int64{0, 3}).Return([]trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.On("Commit").Return(nil)
+	mockTx.On("Open").Return(false)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
 
@@ -190,6 +194,7 @@ func TestQueueLeavesStorageError(t *testing.T) {
 
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("QueueLeaves", []trillian.LogLeaf{leaf0}).Return(errors.New("STORAGE"))
+	mockTx.On("Open").Return(true)
 	mockTx.On("Rollback").Return(nil)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
@@ -224,6 +229,7 @@ func TestQueueLeavesCommitFails(t *testing.T) {
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("QueueLeaves", []trillian.LogLeaf{leaf0}).Return(nil)
 	mockTx.On("Commit").Return(errors.New("Bang!"))
+	mockTx.On("Open").Return(false)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
 
@@ -243,6 +249,7 @@ func TestQueueLeaves(t *testing.T) {
 	mockStorage.On("Begin").Return(mockTx, nil)
 	mockTx.On("QueueLeaves", []trillian.LogLeaf{leaf0}).Return(nil)
 	mockTx.On("Commit").Return(nil)
+	mockTx.On("Open").Return(false)
 
 	server := NewTrillianLogServer(mockStorageProviderfunc(mockStorage))
 

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -72,7 +72,7 @@ func (t *MockTreeTX) Rollback() error {
 }
 
 // Open is a mock
-func (t *MockTreeTX) Open() bool {
+func (t *MockTreeTX) IsOpen() bool {
 	args := t.Called()
 
 	return args.Get(0).(bool)

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -71,6 +71,13 @@ func (t *MockTreeTX) Rollback() error {
 	return args.Error(0)
 }
 
+// Open is a mock
+func (t *MockTreeTX) Open() bool {
+	args := t.Called()
+
+	return args.Get(0).(bool)
+}
+
 // GetTreeRevisionAtSize is a mock
 func (t *MockTreeTX) GetTreeRevisionAtSize(treeSize int64) (int64, error) {
 	args := t.Called(treeSize)

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -374,8 +374,9 @@ func (m *mySQLMapStorage) Snapshot() (storage.ReadOnlyMapTX, error) {
 }
 
 type treeTX struct {
-	tx *sql.Tx
-	ts *mySQLTreeStorage
+	closed bool
+	tx     *sql.Tx
+	ts     *mySQLTreeStorage
 }
 
 type logTX struct {
@@ -856,6 +857,7 @@ func (t *treeTX) SetMerkleNodes(treeRevision int64, nodes []storage.Node) error 
 }
 
 func (t *treeTX) Commit() error {
+	t.closed = true
 	err := t.tx.Commit()
 
 	if err != nil {
@@ -866,6 +868,7 @@ func (t *treeTX) Commit() error {
 }
 
 func (t *treeTX) Rollback() error {
+	t.closed = true
 	err := t.tx.Rollback()
 
 	if err != nil {
@@ -889,4 +892,8 @@ func (m *mapTX) LatestSignedMapRoot() (trillian.SignedMapRoot, error) {
 
 func (m *mapTX) StoreSignedMapRoot(root trillian.SignedMapRoot) error {
 	return errors.New("unimplemented")
+}
+
+func (t *treeTX) Open() bool {
+	return !t.closed
 }

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -894,6 +894,6 @@ func (m *mapTX) StoreSignedMapRoot(root trillian.SignedMapRoot) error {
 	return errors.New("unimplemented")
 }
 
-func (t *treeTX) Open() bool {
+func (t *treeTX) IsOpen() bool {
 	return !t.closed
 }

--- a/storage/mysql/tree_storage_test.go
+++ b/storage/mysql/tree_storage_test.go
@@ -111,10 +111,10 @@ func TestOpenStateCommit(t *testing.T) {
 		t.Fatalf("Failed to set up db transaction")
 	}
 
-	assert.True(t, tx.Open(), "Transaction should be open on creation")
+	assert.True(t, tx.IsOpen(), "Transaction should be open on creation")
 	err = tx.Commit()
 	assert.Nil(t, err, "Failed to commit: %v", err)
-	assert.False(t, tx.Open(), "Transaction should be closed after commit")
+	assert.False(t, tx.IsOpen(), "Transaction should be closed after commit")
 }
 
 func TestOpenStateRollback(t *testing.T) {
@@ -128,10 +128,10 @@ func TestOpenStateRollback(t *testing.T) {
 		t.Fatalf("Failed to set up db transaction")
 	}
 
-	assert.True(t, tx.Open(), "Transaction should be open on creation")
+	assert.True(t, tx.IsOpen(), "Transaction should be open on creation")
 	err = tx.Rollback()
 	assert.Nil(t, err, "Failed to commit: %v", err)
-	assert.False(t, tx.Open(), "Transaction should be closed after rollback")
+	assert.False(t, tx.IsOpen(), "Transaction should be closed after rollback")
 }
 
 func TestNodeRoundTrip(t *testing.T) {
@@ -853,7 +853,7 @@ func beginTx(s storage.LogStorage, t *testing.T) storage.LogTX {
 }
 
 func failIfTXStillOpen(t *testing.T, op string, tx storage.LogTX) {
-	if tx != nil && tx.Open() {
+	if tx != nil && tx.IsOpen() {
 		t.Fatalf("Unclosed transaction in : %s", op)
 	}
 }

--- a/storage/mysql/tree_storage_test.go
+++ b/storage/mysql/tree_storage_test.go
@@ -160,7 +160,7 @@ func TestNodeRoundTrip(t *testing.T) {
 	{
 		tx, err := s.Begin()
 		defer tx.Commit()
-		
+
 		if err != nil {
 			t.Fatalf("Failed to Begin: %s", err)
 		}

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -19,6 +19,11 @@ type TreeTX interface {
 
 	// Rollback aborts any performed operations. No updates must be applied to the underlying storage.
 	Rollback() error
+
+	// Open indicates if this transaction is open. An open transaction is one for which
+	// Commit() or Rollback() has never been called. Implementations must do all clean up
+	// in these methods so transactions are assumed closed regardless of the reported success.
+	Open() bool
 }
 
 // NodeReader provides a read-only interface into the stored tree nodes.

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -23,7 +23,7 @@ type TreeTX interface {
 	// Open indicates if this transaction is open. An open transaction is one for which
 	// Commit() or Rollback() has never been called. Implementations must do all clean up
 	// in these methods so transactions are assumed closed regardless of the reported success.
-	Open() bool
+	IsOpen() bool
 }
 
 // NodeReader provides a read-only interface into the stored tree nodes.


### PR DESCRIPTION
Try to clean up transactions in database tests. And in some of the more complex cases make the test fail if the tx is left open. Add a bit more structure to some of the bigger tests.