### PR TITLE
Inject a TreeHasher rather than just a Hasher

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -17,12 +17,12 @@ import (
 // There is no strong ordering guarantee but in general entries will be processed
 // in order of submission to the log.
 type Sequencer struct {
-	hasher     trillian.Hasher
+	hasher     merkle.TreeHasher
 	timeSource util.TimeSource
 	logStorage storage.LogStorage
 }
 
-func NewSequencer(hasher trillian.Hasher, timeSource util.TimeSource, logStorage storage.LogStorage) *Sequencer {
+func NewSequencer(hasher merkle.TreeHasher, timeSource util.TimeSource, logStorage storage.LogStorage) *Sequencer {
 	return &Sequencer{hasher, timeSource, logStorage}
 }
 

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/trillian/util"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/google/trillian/merkle"
 )
 
 // These can be shared between tests as they're never modified
@@ -145,7 +146,7 @@ func createTestContext(params testParameters) testContext {
 			})).Return(params.storeSignedRootError)
 	}
 
-	sequencer := NewSequencer(trillian.NewSHA256(), util.FakeTimeSource{fakeTimeForTest}, mockStorage)
+	sequencer := NewSequencer(merkle.NewRFC6962TreeHasher(trillian.NewSHA256()), util.FakeTimeSource{fakeTimeForTest}, mockStorage)
 
 	return testContext{mockTx, mockStorage, sequencer}
 }

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/assert"
-	"github.com/google/trillian/merkle"
+	"github.com/stretchr/testify/mock"
 )
 
 // These can be shared between tests as they're never modified

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -52,11 +52,9 @@ type GetNodeFunc func(depth int, index int64) (trillian.Hash, error)
 // |f| will be called a number of times with the co-ordinates of internal MerkleTree nodes whose hash values are
 // required to initialise the internal state of the CompactMerkleTree.  |expectedRoot| is the known-good tree root
 // of the tree at |size|, and is used to verify the correct initial state of the CompactMerkleTree after initialisation.
-// TODO: Should get a TreeHasher injected, not just a Hasher. Do this after current changes submitted
-// to avoid extra conflicts.
-func NewCompactMerkleTreeWithState(hasher trillian.Hasher, size int64, f GetNodeFunc, expectedRoot trillian.Hash) (*CompactMerkleTree, error) {
+func NewCompactMerkleTreeWithState(hasher TreeHasher, size int64, f GetNodeFunc, expectedRoot trillian.Hash) (*CompactMerkleTree, error) {
 	r := CompactMerkleTree{
-		hasher: NewRFC6962TreeHasher(hasher),
+		hasher: hasher,
 		nodes:  make([]trillian.Hash, bitLen(size)),
 		size:   size,
 	}
@@ -92,10 +90,10 @@ func NewCompactMerkleTreeWithState(hasher trillian.Hasher, size int64, f GetNode
 }
 
 // NewCompactMerkleTree creates a new CompactMerkleTree with size zero. This always succeeds.
-func NewCompactMerkleTree(hasher trillian.Hasher) *CompactMerkleTree {
+func NewCompactMerkleTree(hasher TreeHasher) *CompactMerkleTree {
 	emptyHash := hasher.Digest([]byte{})
 	r := CompactMerkleTree{
-		hasher: NewRFC6962TreeHasher(hasher),
+		hasher: hasher,
 		root:   trillian.Hash(emptyHash[:]),
 		nodes:  make([]trillian.Hash, 0),
 		size:   0,

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -44,7 +44,7 @@ func emptyTreeHash() trillian.Hash {
 }
 
 func getTree() *CompactMerkleTree {
-	return NewCompactMerkleTree(trillian.NewSHA256())
+	return NewCompactMerkleTree(NewRFC6962TreeHasher(trillian.NewSHA256()))
 }
 
 func TestAddingLeaves(t *testing.T) {
@@ -124,7 +124,7 @@ func fixedHashGetNodeFunc(depth int, index int64) (trillian.Hash, error) {
 }
 
 func TestLoadingTreeFailsNodeFetch(t *testing.T) {
-	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, failingGetNodeFunc, []byte("notimportant"))
+	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(trillian.NewSHA256()), 237, failingGetNodeFunc, []byte("notimportant"))
 
 	if err == nil || !strings.Contains(err.Error(), "Bang!") {
 		t.Fatalf("Did not return correctly on failed node fetch: %v", err)
@@ -134,7 +134,7 @@ func TestLoadingTreeFailsNodeFetch(t *testing.T) {
 func TestLoadingTreeFailsBadRootHash(t *testing.T) {
 	// Supply a root hash that can't possibly match the result of the SHA 256 hashing on our dummy
 	// data
-	_, err := NewCompactMerkleTreeWithState(trillian.NewSHA256(), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
+	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(trillian.NewSHA256()), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
 	_, ok := err.(RootHashMismatchError)
 
 	if err == nil || !ok {

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -6,8 +6,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/log"
-	"github.com/google/trillian/util"
 	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/util"
 )
 
 // SequencerManager controls sequencing activities for logs. At the moment it's very simple

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/util"
+	"github.com/google/trillian/merkle"
 )
 
 // SequencerManager controls sequencing activities for logs. At the moment it's very simple
@@ -67,7 +68,8 @@ func (s SequencerManager) sequenceActiveLogs(logIDs []trillian.LogID) bool {
 			continue
 		}
 
-		sequencer := log.NewSequencer(trillian.NewSHA256(), s.timeSource, storage)
+		// TODO(Martin2112): Allow for different tree hashers to be used by different logs
+		sequencer := log.NewSequencer(merkle.NewRFC6962TreeHasher(trillian.NewSHA256()), s.timeSource, storage)
 
 		leaves, err := sequencer.SequenceBatch(s.batchSize)
 


### PR DESCRIPTION
Addresses TODO. Moves dependency on RFC6962 hasher further up in the
system.