### PR TITLE
Add testonly package for code only for use by tests

### DIFF
--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -2,21 +2,13 @@ package merkle
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
 )
-
-func mustHexDecode(b string) trillian.Hash {
-	r, err := hex.DecodeString(b)
-	if err != nil {
-		panic(err)
-	}
-	return r
-}
 
 func getInputs() []trillian.Hash {
 	return []trillian.Hash{
@@ -28,19 +20,19 @@ func getInputs() []trillian.Hash {
 func getTestRoots() []trillian.Hash {
 	return []trillian.Hash{
 		// constants from C++ test: https://github.com/google/certificate-transparency/blob/master/cpp/merkletree/merkle_tree_test.cc#L277
-		mustHexDecode("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
-		mustHexDecode("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"),
-		mustHexDecode("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"),
-		mustHexDecode("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
-		mustHexDecode("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"),
-		mustHexDecode("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"),
-		mustHexDecode("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"),
-		mustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
+		testonly.MustHexDecode("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
+		testonly.MustHexDecode("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"),
+		testonly.MustHexDecode("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"),
+		testonly.MustHexDecode("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
+		testonly.MustHexDecode("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"),
+		testonly.MustHexDecode("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"),
+		testonly.MustHexDecode("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"),
+		testonly.MustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
 }
 
 func emptyTreeHash() trillian.Hash {
 	const sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	return mustHexDecode(sha256EmptyTreeHash)
+	return testonly.MustHexDecode(sha256EmptyTreeHash)
 }
 
 func getTree() *CompactMerkleTree {

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -9,20 +9,12 @@ import (
 	"testing"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
 )
 
 // This root was calculated with the C++/Python sparse merkle tree code in the
 // github.com/google/certificate-transparency repo.
 const sparseEmptyRootHashB64 = "xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo="
-
-// TODO(al): collect these test helpers together somewhere.
-func mustDecode(b64 string) trillian.Hash {
-	r, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil {
-		panic(r)
-	}
-	return r
-}
 
 // createHStar2Leaves builds a list of HStar2LeafHash structs suitable for
 // passing into a the HStar2 sparse merkle tree implementation.
@@ -48,7 +40,7 @@ func TestHStar2EmptyRootKAT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to calculate root: %v", err)
 	}
-	if expected, got := mustDecode(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
+	if expected, got := testonly.MustDecodeBase64(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
 		t.Fatalf("Expected empty root:\n%v\nGot:\n%v", expected, got)
 	}
 }
@@ -74,7 +66,7 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 		}
-		if expected, got := mustDecode(x.rootB64), root; !bytes.Equal(expected, got) {
+		if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -109,7 +101,7 @@ func TestHStar2GetSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 		}
-		if expected, got := mustDecode(x.rootB64), root; !bytes.Equal(expected, got) {
+		if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -128,7 +120,7 @@ func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to calculate root %v", err)
 		}
-		if expected, got := mustDecode(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
+		if expected, got := testonly.MustDecodeBase64(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -181,7 +173,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 			}
-			if expected, got := mustDecode(x.rootB64), root; !bytes.Equal(expected, got) {
+			if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
 				t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 			}
 		}

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/testonly"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -45,15 +46,6 @@ func maybeProfileMemory(t *testing.T) {
 	}
 }
 
-// TODO(al): collect these test helpers together somewhere.
-func mustDecodeB64(b64 string) trillian.Hash {
-	r, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil {
-		panic(r)
-	}
-	return r
-}
-
 func getSparseMerkleTreeReaderWithMockTX(rev int64) (*SparseMerkleTreeReader, *storage.MockMapTX) {
 	tx := &storage.MockMapTX{}
 	return NewSparseMerkleTreeReader(rev, NewMapHasher(NewRFC6962TreeHasher(trillian.NewSHA256())), tx), tx
@@ -72,7 +64,7 @@ func isRootNodeOnly(nodes []storage.NodeID) bool {
 func getEmptyRootNode() storage.Node {
 	return storage.Node{
 		NodeID:       storage.NewEmptyNodeID(0),
-		Hash:         mustDecode(sparseEmptyRootHashB64),
+		Hash:         testonly.MustDecodeBase64(sparseEmptyRootHashB64),
 		NodeRevision: 0,
 	}
 }
@@ -186,7 +178,7 @@ func TestInclusionProofForNullEntryInEmptyTree(t *testing.T) {
 		}
 	}
 	// And hashing the zeroth proof element with itself should give us the empty root hash
-	if expected, got := mustDecode(sparseEmptyRootHashB64), treeHasher.HashChildren(proof[0], proof[0]); !bytes.Equal(expected, got) {
+	if expected, got := testonly.MustDecodeBase64(sparseEmptyRootHashB64), treeHasher.HashChildren(proof[0], proof[0]); !bytes.Equal(expected, got) {
 		t.Fatalf("Expected to generate sparseEmptyRootHash using proof[0], but got %v", got)
 	}
 }
@@ -280,13 +272,13 @@ func testSparseTreeCalculatedRootWithWriter(t *testing.T, rev int64, vec sparseT
 }
 
 func TestSparseMerkleTreeWriterEmptyTree(t *testing.T) {
-	testSparseTreeCalculatedRoot(t, sparseTestVector{[]sparseKeyValue{}, mustDecodeB64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")})
+	testSparseTreeCalculatedRoot(t, sparseTestVector{[]sparseKeyValue{}, testonly.MustDecodeBase64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")})
 }
 
 func TestSparseMerkleTreeWriter(t *testing.T) {
 	vec := sparseTestVector{
 		[]sparseKeyValue{{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}},
-		mustDecodeB64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ="),
+		testonly.MustDecodeBase64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ="),
 	}
 	testSparseTreeCalculatedRoot(t, vec)
 }
@@ -416,7 +408,7 @@ func DISABLEDTestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 
 	// calculated using python code.
 	const expectedRootB64 = "Av30xkERsepT6F/AgbZX3sp91TUmV1TKaXE6QPFfUZA="
-	if expected, got := mustDecodeB64(expectedRootB64), root; !bytes.Equal(expected, root) {
+	if expected, got := testonly.MustDecodeBase64(expectedRootB64), root; !bytes.Equal(expected, root) {
 		// Error, not Fatal so that we get our benchmark results regardless of the
 		// result - useful if you want to up the amount of data without having to
 		// figure out the expected root!

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -366,7 +366,7 @@ func testSparseTreeFetches(t *testing.T, vec sparseTestVector) {
 func TestSparseMerkleTreeWriterFetchesSingleLeaf(t *testing.T) {
 	vec := sparseTestVector{
 		[]sparseKeyValue{{"key1", "value1"}},
-		mustDecodeB64("PPI818D5CiUQQMZulH58LikjxeOFWw2FbnGM0AdVHWA="),
+		testonly.MustDecodeBase64("PPI818D5CiUQQMZulH58LikjxeOFWw2FbnGM0AdVHWA="),
 	}
 
 	testSparseTreeFetches(t, vec)
@@ -375,7 +375,7 @@ func TestSparseMerkleTreeWriterFetchesSingleLeaf(t *testing.T) {
 func TestSparseMerkleTreeWriterFetchesMultipleLeaves(t *testing.T) {
 	vec := sparseTestVector{
 		[]sparseKeyValue{{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}},
-		mustDecodeB64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ="),
+		testonly.MustDecodeBase64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ="),
 	}
 
 	testSparseTreeFetches(t, vec)

--- a/merkle/tree_hasher_test.go
+++ b/merkle/tree_hasher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
 )
 
 const (
@@ -25,7 +26,7 @@ func ensureHashMatches(expected, actual []byte, testCase string, t *testing.T) {
 func TestRfc6962Hasher(t *testing.T) {
 	hasher := NewRFC6962TreeHasher(trillian.NewSHA256())
 
-	ensureHashMatches(mustHexDecode(rfc6962EmptyHashHex), hasher.HashEmpty(), "RFC962 Empty", t)
-	ensureHashMatches(mustHexDecode(rfc6962LeafL123456HashHex), hasher.HashLeaf([]byte("L123456")), "RFC6962 Leaf", t)
-	ensureHashMatches(mustHexDecode(rfc6962NodeN123N456HashHex), hasher.HashChildren([]byte("N123"), []byte("N456")), "RFC6962 Node", t)
+	ensureHashMatches(testonly.MustHexDecode(rfc6962EmptyHashHex), hasher.HashEmpty(), "RFC962 Empty", t)
+	ensureHashMatches(testonly.MustHexDecode(rfc6962LeafL123456HashHex), hasher.HashLeaf([]byte("L123456")), "RFC6962 Leaf", t)
+	ensureHashMatches(testonly.MustHexDecode(rfc6962NodeN123N456HashHex), hasher.HashChildren([]byte("N123"), []byte("N456")), "RFC6962 Node", t)
 }

--- a/testonly/base64.go
+++ b/testonly/base64.go
@@ -1,0 +1,16 @@
+package testonly
+
+import (
+	"encoding/base64"
+
+	"github.com/google/trillian"
+)
+
+// MustDecodeBase64 expects a base 64 encoded string input and panics if it cannot be decoded
+func MustDecodeBase64(b64 string) trillian.Hash {
+	r, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		panic(r)
+	}
+	return r
+}

--- a/testonly/doc.go
+++ b/testonly/doc.go
@@ -1,0 +1,9 @@
+/*
+Package testonly contains code and data that should only be used by tests.
+Production code MUST NOT depend on anything in this package. This will be enforced
+by tools where possible.
+
+As an example PEM encoded test certificates and helper functions to decode them are
+suitable candidates for being placed in testonly.
+*/
+package testonly

--- a/testonly/doc.go
+++ b/testonly/doc.go
@@ -7,3 +7,6 @@ As an example PEM encoded test certificates and helper functions to decode them 
 suitable candidates for being placed in testonly.
 */
 package testonly
+
+// TODO(Martin2112): When all current work has landed split this up so that all the CT
+// specific test data is moved to an appropriate testonly directory under the CT frontend.

--- a/testonly/encoding.go
+++ b/testonly/encoding.go
@@ -2,6 +2,7 @@ package testonly
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 
 	"github.com/google/trillian"
 )
@@ -11,6 +12,15 @@ func MustDecodeBase64(b64 string) trillian.Hash {
 	r, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
 		panic(r)
+	}
+	return r
+}
+
+// MustHexDecode decodes its input string from hex and panics if this fails
+func MustHexDecode(b string) trillian.Hash {
+	r, err := hex.DecodeString(b)
+	if err != nil {
+		panic(err)
 	}
 	return r
 }


### PR DESCRIPTION
Refactor to move a couple of decoding helpers into testonly getting rid of dups.