### PR TITLE
Add a doc comment to CT package

### DIFF
--- a/examples/ct/doc.go
+++ b/examples/ct/doc.go
@@ -5,5 +5,7 @@ log server using a Trillian log server as backend storage via its GRPC API.
 IMPORTANT: Only code rooted within this part of the tree should refer to the CT
 Github repository. Other parts of the system must not assume that the data they're
 processing is X.509 or CT related.
+
+The CT repository can be found at: https://github.com/google/certificate-transparency
 */
 package ct

--- a/examples/ct/doc.go
+++ b/examples/ct/doc.go
@@ -1,0 +1,9 @@
+/*
+Package ct contains a usage example by providing an implementation of an RFC6962 compatible CT
+log server using a Trillian log server as backend storage via its GRPC API.
+
+IMPORTANT: Only code rooted within this part of the tree should refer to the CT
+Github repository. Other parts of the system must not assume that the data they're
+processing is X.509 or CT related.
+*/
+package ct


### PR DESCRIPTION
Make it clear that only code in examples/ct should reference the CT repository.