### PR TITLE
Fix that SCTs were not being correctly signed

### DIFF
--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -99,10 +99,7 @@ func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t 
 	// For precerts we need to extract the relevant data from the Certificate container.
 	// This is only possible using the CT specific modified version of X.509.
 	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
-	tbsBytes := make([]byte, 0, len(cert.RawTBSCertificate)+sha256.Size)
-	tbsBytes = append(tbsBytes, keyHash[:]...)
-	tbsBytes = append(tbsBytes, cert.RawTBSCertificate...)
-	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: tbsBytes}
+	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: cert.RawTBSCertificate}
 
 	timestampedEntry := ct.TimestampedEntry{Timestamp:sctInput.Timestamp, EntryType:ct.PrecertLogEntryType, PrecertEntry:precert}
 	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType:ct.TimestampedEntryLeafType, TimestampedEntry:timestampedEntry}

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -60,21 +60,63 @@ func signSCT(km crypto.KeyManager, t time.Time, sctData []byte) (ct.SignedCertif
 		Signature:  digitallySigned}, nil
 }
 
-// CreateV1SCTForCertificate builds and signs a V1 CT SCT for a certificate using the key held
-// by a key manager.
-func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.SignedCertificateTimestamp, error) {
-	return signSCT(km, t, cert.Raw)
+// CreateV1SCTForCertificate creates a MerkleTreeLeaf and builds and signs a V1 CT SCT for a certificate
+// using the key held by a key manager.
+func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+	// Temp SCT for input to the serializer
+	sctInput := ct.SignedCertificateTimestamp{
+		SCTVersion: ct.V1,
+		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
+		Extensions: ct.CTExtensions{}}
+
+	// Build up a MerkleTreeLeaf for the cert
+	timestampedEntry := ct.TimestampedEntry{Timestamp:sctInput.Timestamp, EntryType:ct.X509LogEntryType, X509Entry:cert.Raw}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType:ct.TimestampedEntryLeafType, TimestampedEntry:timestampedEntry}
+
+	// Serialize SCT signature input to get the bytes that need to be signed
+	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf:leaf})
+
+	if err != nil {
+		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
+	}
+
+	// Create a complete SCT including signature
+	sct, err := signSCT(km, t, res)
+
+	return leaf, sct, err
 }
 
 // CreateV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
 // held by a key manager.
-func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.SignedCertificateTimestamp, error) {
+func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+	// Temp SCT for input to the serializer
+	sctInput := ct.SignedCertificateTimestamp{
+		SCTVersion:ct.V1,
+		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
+		Extensions: ct.CTExtensions{}}
+
+	// Build up a LogEntry for the precert
 	// For precerts we need to extract the relevant data from the Certificate container.
-	// This is only possible using our modified version of X.509.
+	// This is only possible using the CT specific modified version of X.509.
 	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	tbsBytes := make([]byte, 0, len(cert.RawTBSCertificate)+sha256.Size)
 	tbsBytes = append(tbsBytes, keyHash[:]...)
 	tbsBytes = append(tbsBytes, cert.RawTBSCertificate...)
+	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: tbsBytes}
 
-	return signSCT(km, t, tbsBytes)
+	timestampedEntry := ct.TimestampedEntry{Timestamp:sctInput.Timestamp, EntryType:ct.PrecertLogEntryType, PrecertEntry:precert}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType:ct.TimestampedEntryLeafType, TimestampedEntry:timestampedEntry}
+	logEntry := ct.LogEntry{Leaf:leaf}
+
+	// Serialize SCT signature input to get the bytes that need to be signed
+	res, err := ct.SerializeSCTSignatureInput(sctInput, logEntry)
+
+	if err != nil {
+		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
+	}
+
+	// Create a complete SCT including signature
+	sct, err := signSCT(km, t, res)
+
+	return leaf, sct, err
 }

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -32,6 +32,29 @@ const ctTesttubeLogID string = "sMyD5aX5fWuvfAnMKEkEhyrH6IsTLGNQt8b9JuFsbHc="
 // Log ID for a dummy log public key of "key" supplied by mock
 const ctMockLogID string = "LHDhK3oGRvkiefQnx7OOczTY5Tic/xZ6HcMOc/gmtoM="
 
+// Test data taken from CT repository cpp/log/test_signer.cc
+
+// Some time in September 2012.
+const defaultSCTTimestamp uint64 = 1348589665525
+
+const defaultCertSCTSignatureB64 string = "3046022100d3f7690e7ee80d9988a54a3821056393e9eb0c686ad67fbae3686c888fb1a3ce022100f9a51c6065bbba7ad7116a31bea1c31dbed6a921e1df02e4b403757fae3254ae"
+const defaultPrecertSCTSignatureB64 string = "304502206f247c7d1abe2b8f6c4530f99474f9ebe90629d21f76616389336f177ed7a7d00221009d3a60c2b407ab5a725a692fc79d0d301d6da61baec43175ed07514c535f1120"
+
+const ecP256PrivateKeyPEM string = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIG8QAquNnarN6Ik2cMIZtPBugh9wNRe0e309MCmDfBGuoAoGCCqGSM49
+AwEHoUQDQgAES0AfBkjr7b8b19p5Gk8plSAN16wWXZyhYsH6FMCEUK60t7pem/ck
+oPX8hupuaiJzJS0ZQ0SEoJGlFxkUFwft5g==
+-----END EC PRIVATE KEY-----`
+
+const ecP256PublicKeyPEM string = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES0AfBkjr7b8b19p5Gk8plSAN16wW
+XZyhYsH6FMCEUK60t7pem/ckoPX8hupuaiJzJS0ZQ0SEoJGlFxkUFwft5g==
+-----END PUBLIC KEY-----`
+
+const keyIDB64 string = "b69d879e3f2c4402556dcda2f6b2e02ff6b6df4789c53000e14f4b125ae847aa"
+
+// end of CT test data
+
 // This test uses the testtube key rather than our test key so we can verify the
 // result easily
 func TestGetCTLogID(t *testing.T) {
@@ -65,9 +88,9 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 		t.Fatalf("failed to set up test cert: %v", err)
 	}
 
-	km := setupMockKeyManager([]byte{0xd1, 0x66, 0x49, 0xc7, 0xbb, 0x48, 0xe7, 0x32, 0xa9, 0x71, 0xc3, 0x1b, 0x26, 0xf6, 0x5c, 0x26, 0x85, 0xd3, 0xc, 0xed, 0x22, 0x48, 0xc4, 0xd4, 0xdb, 0xaa, 0xee, 0x9d, 0x44, 0xf4, 0xc1, 0x6f})
+	km := setupMockKeyManager([]byte{0x5, 0x62, 0x4f, 0xb4, 0x9e, 0x32, 0x14, 0xb6, 0xc, 0xb8, 0x51, 0x28, 0x23, 0x93, 0x2c, 0x7a, 0x3d, 0x80, 0x93, 0x5f, 0xcd, 0x76, 0xef, 0x91, 0x6a, 0xaf, 0x1b, 0x8c, 0xe8, 0xb5, 0x2, 0xb5})
 
-	got, err := SignV1SCTForCertificate(km, cert, fixedTime)
+	_, got, err := SignV1SCTForCertificate(km, cert, fixedTime)
 
 	if err != nil {
 		t.Fatalf("create sct for cert failed", err)
@@ -102,9 +125,9 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 		t.Fatalf("failed to set up test precert: %v", err)
 	}
 
-	km := setupMockKeyManager([]byte{0xfd, 0x5c, 0x80, 0xd6, 0x5c, 0xdc, 0xee, 0xc, 0x6e, 0xc8, 0xc3, 0xfb, 0xb3, 0xe6, 0x4b, 0xc9, 0x1e, 0x1e, 0x9a, 0xf5, 0x18, 0x99, 0xeb, 0x86, 0x68, 0x0, 0xb5, 0xc, 0x36, 0x30, 0xc9, 0xf})
+	km := setupMockKeyManager([]byte{0x76, 0x2b, 0xa0, 0x63, 0x44, 0x5f, 0x52, 0x32, 0xb0, 0xd5, 0x9f, 0xd4, 0xab, 0x62, 0x55, 0x1e, 0xe8, 0xc0, 0xce, 0xe5, 0x20, 0x74, 0xba, 0x14, 0xd6, 0x88, 0xee, 0x7a, 0x79, 0x96, 0xee, 0xb9})
 
-	got, err := SignV1SCTForPrecertificate(km, cert, fixedTime)
+	_, got, err := SignV1SCTForPrecertificate(km, cert, fixedTime)
 
 	if err != nil {
 		t.Fatalf("create sct for precert failed", err)
@@ -130,6 +153,7 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 	assert.Equal(t, expected, got, "mismatched SCT (precert")
 }
 
+// Creates a mock key manager for use in interaction tests
 func setupMockKeyManager(toSign []byte) crypto.KeyManager {
 	hasher := trillian.NewSHA256()
 	mockKeyManager := new(crypto.MockKeyManager)
@@ -142,4 +166,19 @@ func setupMockKeyManager(toSign []byte) crypto.KeyManager {
 	mockKeyManager.On("GetRawPublicKey").Return([]byte("key"), nil)
 
 	return mockKeyManager
+}
+
+// This creates a real key manager with test keys loaded. Use for known answer tests
+func setupTestKeyManager(t *testing.T) crypto.KeyManager {
+	km := crypto.NewPEMKeyManager()
+
+	if err := km.LoadPrivateKey(ecP256PrivateKeyPEM, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := km.LoadPublicKey(ecP256PublicKeyPEM); err != nil {
+		t.Fatal(err)
+	}
+
+	return km
 }

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -32,29 +32,6 @@ const ctTesttubeLogID string = "sMyD5aX5fWuvfAnMKEkEhyrH6IsTLGNQt8b9JuFsbHc="
 // Log ID for a dummy log public key of "key" supplied by mock
 const ctMockLogID string = "LHDhK3oGRvkiefQnx7OOczTY5Tic/xZ6HcMOc/gmtoM="
 
-// Test data taken from CT repository cpp/log/test_signer.cc
-
-// Some time in September 2012.
-const defaultSCTTimestamp uint64 = 1348589665525
-
-const defaultCertSCTSignatureB64 string = "3046022100d3f7690e7ee80d9988a54a3821056393e9eb0c686ad67fbae3686c888fb1a3ce022100f9a51c6065bbba7ad7116a31bea1c31dbed6a921e1df02e4b403757fae3254ae"
-const defaultPrecertSCTSignatureB64 string = "304502206f247c7d1abe2b8f6c4530f99474f9ebe90629d21f76616389336f177ed7a7d00221009d3a60c2b407ab5a725a692fc79d0d301d6da61baec43175ed07514c535f1120"
-
-const ecP256PrivateKeyPEM string = `-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIG8QAquNnarN6Ik2cMIZtPBugh9wNRe0e309MCmDfBGuoAoGCCqGSM49
-AwEHoUQDQgAES0AfBkjr7b8b19p5Gk8plSAN16wWXZyhYsH6FMCEUK60t7pem/ck
-oPX8hupuaiJzJS0ZQ0SEoJGlFxkUFwft5g==
------END EC PRIVATE KEY-----`
-
-const ecP256PublicKeyPEM string = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES0AfBkjr7b8b19p5Gk8plSAN16wW
-XZyhYsH6FMCEUK60t7pem/ckoPX8hupuaiJzJS0ZQ0SEoJGlFxkUFwft5g==
------END PUBLIC KEY-----`
-
-const keyIDB64 string = "b69d879e3f2c4402556dcda2f6b2e02ff6b6df4789c53000e14f4b125ae847aa"
-
-// end of CT test data
-
 // This test uses the testtube key rather than our test key so we can verify the
 // result easily
 func TestGetCTLogID(t *testing.T) {

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -167,18 +167,3 @@ func setupMockKeyManager(toSign []byte) crypto.KeyManager {
 
 	return mockKeyManager
 }
-
-// This creates a real key manager with test keys loaded. Use for known answer tests
-func setupTestKeyManager(t *testing.T) crypto.KeyManager {
-	km := crypto.NewPEMKeyManager()
-
-	if err := km.LoadPrivateKey(ecP256PrivateKeyPEM, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := km.LoadPublicKey(ecP256PublicKeyPEM); err != nil {
-		t.Fatal(err)
-	}
-
-	return km
-}


### PR DESCRIPTION
Also builds MerkleTreeLeaf structure for them, which will shortly be used in the add chain handlers.