### PR TITLE
Implement Serialization for MerkleTreeLeaf and CTLogEntry

### DIFF
--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -4,6 +4,10 @@ package ct
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/google/certificate-transparency/go"
@@ -13,6 +17,15 @@ import (
 )
 
 const millisPerNano int64 = 1000
+
+// CTLogEntry holds the data we send to the backend with the leaf. There is a LogEntry type in
+// the CT code but it is a superset of what we need.
+type CTLogEntry struct {
+	// The leaf structure that was built from the client submission
+	leaf ct.MerkleTreeLeaf
+	// The complete chain for the certificate or precertificate as raw bytes
+	chain []ct.ASN1Cert
+}
 
 // GetCTKeyID takes the key manager for a log and returns the LogID. (see RFC 6962 S3.2)
 // In CT V1 the log id is a hash of the public key.
@@ -28,7 +41,7 @@ func GetCTLogID(km crypto.KeyManager) ([sha256.Size]byte, error) {
 
 func serializeAndSignSCT(km crypto.KeyManager, leaf ct.MerkleTreeLeaf, sctInput ct.SignedCertificateTimestamp, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
 	// Serialize SCT signature input to get the bytes that need to be signed
-	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf:leaf})
+	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf: leaf})
 
 	if err != nil {
 		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
@@ -81,8 +94,8 @@ func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t tim
 	sctInput := getSCTForSignatureInput(t)
 
 	// Build up a MerkleTreeLeaf for the cert
-	timestampedEntry := ct.TimestampedEntry{Timestamp:sctInput.Timestamp, EntryType:ct.X509LogEntryType, X509Entry:cert.Raw}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType:ct.TimestampedEntryLeafType, TimestampedEntry:timestampedEntry}
+	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.X509LogEntryType, X509Entry: cert.Raw}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
 
 	return serializeAndSignSCT(km, leaf, sctInput, t)
 }
@@ -99,15 +112,208 @@ func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t 
 	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: cert.RawTBSCertificate}
 
-	timestampedEntry := ct.TimestampedEntry{Timestamp:sctInput.Timestamp, EntryType:ct.PrecertLogEntryType, PrecertEntry:precert}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType:ct.TimestampedEntryLeafType, TimestampedEntry:timestampedEntry}
+	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.PrecertLogEntryType, PrecertEntry: precert}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
 
 	return serializeAndSignSCT(km, leaf, sctInput, t)
 }
 
-func getSCTForSignatureInput(t time.Time) (ct.SignedCertificateTimestamp) {
+func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
 	return ct.SignedCertificateTimestamp{
-		SCTVersion:ct.V1,
+		SCTVersion: ct.V1,
 		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
 		Extensions: ct.CTExtensions{}}
+}
+
+func NewLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLogEntry {
+	chain := []ct.ASN1Cert{}
+
+	for _, cert := range certChain {
+		chain = append(chain, cert.Raw)
+	}
+
+	logEntry := new(CTLogEntry)
+
+	logEntry.leaf = leaf
+	logEntry.chain = chain
+
+	return logEntry
+}
+
+// WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
+// by RFC 6962. The CT go code includes a deserializer but not a serializer so we might as
+// well make this available.
+func WriteTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
+	if err := binary.Write(w, binary.BigEndian, &t.Timestamp); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, &t.EntryType); err != nil {
+		return err
+	}
+	switch t.EntryType {
+	case ct.X509LogEntryType:
+		if err := writeVarBytes(w, t.X509Entry, ct.CertificateLengthBytes); err != nil {
+			return err
+		}
+	case ct.PrecertLogEntryType:
+		if err := binary.Write(w, binary.BigEndian, t.PrecertEntry.IssuerKeyHash); err != nil {
+			return err
+		}
+		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, ct.PreCertificateLengthBytes); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
+	}
+
+	return writeVarBytes(w, t.Extensions, ct.ExtensionsLengthBytes)
+}
+
+// WriteMerkleTreeLeaf writes a MerkleTreeLeaf in the binary format specified by RFC 6962.
+// The CT go code includes a deserializer but not a serializer and we might as well make this
+// available to other users.
+func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
+	if l.Version != ct.V1 {
+		return fmt.Errorf("unknown Version: %d", l.Version)
+	}
+
+	if l.LeafType != ct.TimestampedEntryLeafType {
+		return fmt.Errorf("unknown LeafType: %d", l.LeafType)
+	}
+
+	if err := binary.Write(w, binary.BigEndian, l.Version); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, l.LeafType); err != nil {
+		return err
+	}
+	if err := WriteTimestampedEntry(w, l.TimestampedEntry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Serialize writes out a CTLogEntry in binary form. This is not an RFC 6962 data structure
+// and is only used internally by the log.
+func (c CTLogEntry) Serialize(w io.Writer) error {
+	if err := WriteMerkleTreeLeaf(w, c.leaf); err != nil {
+		return err
+	}
+
+	if err := writeUint(w, uint64(len(c.chain)), 2); err != nil {
+		return err
+	}
+
+	for _, certBytes := range c.chain {
+		if err := writeVarBytes(w, certBytes, 4); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Deserialize reads a binary format CTLogEntry and stores the result into an existing
+// CTLogEntry struct. This is an internal data structure and is not defined in RFC 6962 or
+// exposed to clients.
+func (c *CTLogEntry) Deserialize(r io.Reader) error {
+	leaf, err := ct.ReadMerkleTreeLeaf(r)
+
+	if err != nil {
+		return err
+	}
+
+	c.leaf = *leaf
+
+	numCerts, err := readUint(r, 2)
+
+	if err != nil {
+		return err
+	}
+
+	chain := make([]ct.ASN1Cert, 0, numCerts)
+	var cert uint64
+
+	for cert = 0; cert < numCerts; cert++ {
+		certBytes, err := readVarBytes(r, 4)
+
+		if err != nil {
+			return err
+		}
+
+		chain = append(chain, certBytes)
+	}
+
+	c.chain = chain
+
+	return nil
+}
+
+// These came from the CT go code. Currently don't want to push changes upstream to make
+// them visible but this is an option for the future.
+
+func writeVarBytes(w io.Writer, value []byte, numLenBytes int) error {
+	if err := writeUint(w, uint64(len(value)), numLenBytes); err != nil {
+		return err
+	}
+	if _, err := w.Write(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeUint(w io.Writer, value uint64, numBytes int) error {
+	buf := make([]uint8, numBytes)
+	for i := 0; i < numBytes; i++ {
+		buf[numBytes-i-1] = uint8(value & 0xff)
+		value >>= 8
+	}
+	if value != 0 {
+		return errors.New("numBytes was insufficiently large to represent value")
+	}
+	if _, err := w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readUint(r io.Reader, numBytes int) (uint64, error) {
+	var l uint64
+	for i := 0; i < numBytes; i++ {
+		l <<= 8
+		var t uint8
+		if err := binary.Read(r, binary.BigEndian, &t); err != nil {
+			return 0, err
+		}
+		l |= uint64(t)
+	}
+	return l, nil
+}
+
+// Reads a variable length array of bytes from |r|. |numLenBytes| specifies the
+// number of (BigEndian) prefix-bytes which contain the length of the actual
+// array data bytes that follow.
+// Allocates an array to hold the contents and returns a slice view into it if
+// the read was successful, or an error otherwise.
+func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
+	switch {
+	case numLenBytes > 8:
+		return nil, fmt.Errorf("numLenBytes too large (%d)", numLenBytes)
+	case numLenBytes == 0:
+		return nil, errors.New("numLenBytes should be > 0")
+	}
+	l, err := readUint(r, numLenBytes)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, l)
+	n, err := r.Read(data)
+	if err != nil {
+		return nil, err
+	}
+	if n != int(l) {
+		return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
+	}
+	return data, nil
 }

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -22,9 +22,9 @@ const millisPerNano int64 = 1000
 // the CT code but it is a superset of what we need.
 type CTLogEntry struct {
 	// The leaf structure that was built from the client submission
-	leaf ct.MerkleTreeLeaf
+	Leaf  ct.MerkleTreeLeaf
 	// The complete chain for the certificate or precertificate as raw bytes
-	chain []ct.ASN1Cert
+	Chain []ct.ASN1Cert
 }
 
 // GetCTKeyID takes the key manager for a log and returns the LogID. (see RFC 6962 S3.2)
@@ -134,8 +134,8 @@ func NewLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLogEn
 
 	logEntry := new(CTLogEntry)
 
-	logEntry.leaf = leaf
-	logEntry.chain = chain
+	logEntry.Leaf = leaf
+	logEntry.Chain = chain
 
 	return logEntry
 }
@@ -197,15 +197,15 @@ func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
 // Serialize writes out a CTLogEntry in binary form. This is not an RFC 6962 data structure
 // and is only used internally by the log.
 func (c CTLogEntry) Serialize(w io.Writer) error {
-	if err := WriteMerkleTreeLeaf(w, c.leaf); err != nil {
+	if err := WriteMerkleTreeLeaf(w, c.Leaf); err != nil {
 		return err
 	}
 
-	if err := writeUint(w, uint64(len(c.chain)), 2); err != nil {
+	if err := writeUint(w, uint64(len(c.Chain)), 2); err != nil {
 		return err
 	}
 
-	for _, certBytes := range c.chain {
+	for _, certBytes := range c.Chain {
 		if err := writeVarBytes(w, certBytes, 4); err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ func (c *CTLogEntry) Deserialize(r io.Reader) error {
 		return err
 	}
 
-	c.leaf = *leaf
+	c.Leaf = *leaf
 
 	numCerts, err := readUint(r, 2)
 
@@ -245,7 +245,7 @@ func (c *CTLogEntry) Deserialize(r io.Reader) error {
 		chain = append(chain, certBytes)
 	}
 
-	c.chain = chain
+	c.Chain = chain
 
 	return nil
 }

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -19,10 +19,12 @@ import (
 const millisPerNano int64 = 1000
 
 // CTLogEntry holds the data we send to the backend with the leaf. There is a LogEntry type in
-// the CT code but it is a superset of what we need.
+// the CT code but it is a superset of what we need. These structs are purely containers
+// for data passed between the frontend and backend. They are not responsible for request
+// validation or chain checking.
 type CTLogEntry struct {
 	// The leaf structure that was built from the client submission
-	Leaf  ct.MerkleTreeLeaf
+	Leaf ct.MerkleTreeLeaf
 	// The complete chain for the certificate or precertificate as raw bytes
 	Chain []ct.ASN1Cert
 }
@@ -125,19 +127,14 @@ func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
 		Extensions: ct.CTExtensions{}}
 }
 
-func NewLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLogEntry {
+func NewCTLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLogEntry {
 	chain := []ct.ASN1Cert{}
 
 	for _, cert := range certChain {
 		chain = append(chain, cert.Raw)
 	}
 
-	logEntry := new(CTLogEntry)
-
-	logEntry.Leaf = leaf
-	logEntry.Chain = chain
-
-	return logEntry
+	return &CTLogEntry{Leaf: leaf, Chain: chain}
 }
 
 // WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
@@ -317,3 +314,5 @@ func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
 	}
 	return data, nil
 }
+
+// End of code from CT repository

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -21,7 +21,8 @@ const millisPerNano int64 = 1000
 // CTLogEntry holds the data we send to the backend with the leaf. There is a LogEntry type in
 // the CT code but it is a superset of what we need. These structs are purely containers
 // for data passed between the frontend and backend. They are not responsible for request
-// validation or chain checking.
+// validation or chain checking. Validation of submitted chains is the responsibility of
+// the frontend. The backend handles generic blobs and does not know their format.
 type CTLogEntry struct {
 	// The leaf structure that was built from the client submission
 	Leaf ct.MerkleTreeLeaf

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -226,7 +226,7 @@ func TestSerializeCTLogEntry(t *testing.T) {
 		var buff bytes.Buffer
 		w := bufio.NewWriter(&buff)
 
-		logEntry := CTLogEntry{leaf: leaf, chain: chain}
+		logEntry := CTLogEntry{Leaf: leaf, Chain: chain}
 		err := logEntry.Serialize(w)
 
 		if err != nil {

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -1,14 +1,14 @@
 package ct
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"io"
 	"testing"
 	"time"
 
-	"bufio"
-	"bytes"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/fixchain"
 	"github.com/google/certificate-transparency/go/x509"

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -154,9 +154,10 @@ func TestSerializeMerkleTreeLeafBadVersion(t *testing.T) {
 
 	leaf.Version = 199 // Out of any expected valid range
 
-	var w io.Writer
-	err := WriteMerkleTreeLeaf(w, leaf)
+	var b bytes.Buffer
+	err := WriteMerkleTreeLeaf(&b, leaf)
 	assert.Error(t, err, "incorrectly serialized leaf with bad version")
+	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
 }
 
 func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
@@ -165,13 +166,18 @@ func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
 	leaf.Version = ct.V1
 	leaf.LeafType = 212
 
-	var w io.Writer
-	err := WriteMerkleTreeLeaf(w, leaf)
+	var b bytes.Buffer
+	err := WriteMerkleTreeLeaf(&b, leaf)
 	assert.Error(t, err, "incorrectly serialized leaf with bad leaf type")
+	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
 }
 
 func TestSerializeMerkleTreeLeafCert(t *testing.T) {
-	ts := ct.TimestampedEntry{Timestamp: 12345, EntryType: ct.X509LogEntryType, X509Entry: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}), Extensions: ct.CTExtensions{}}
+	ts := ct.TimestampedEntry{
+		Timestamp:  12345,
+		EntryType:  ct.X509LogEntryType,
+		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
+		Extensions: ct.CTExtensions{}}
 	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
 
 	var buff bytes.Buffer
@@ -194,7 +200,12 @@ func TestSerializeMerkleTreeLeafCert(t *testing.T) {
 }
 
 func TestSerializeMerkleTreePrecert(t *testing.T) {
-	ts := ct.TimestampedEntry{Timestamp: 12345, EntryType: ct.PrecertLogEntryType, PrecertEntry: ct.PreCert{IssuerKeyHash: [sha256.Size]byte{0x55, 0x56, 0x57, 0x58, 0x59}, TBSCertificate: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23})}, Extensions: ct.CTExtensions{}}
+	ts := ct.TimestampedEntry{Timestamp: 12345,
+		EntryType: ct.PrecertLogEntryType,
+		PrecertEntry: ct.PreCert{
+			IssuerKeyHash:  [sha256.Size]byte{0x55, 0x56, 0x57, 0x58, 0x59},
+			TBSCertificate: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23})},
+		Extensions: ct.CTExtensions{}}
 	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
 
 	var buff bytes.Buffer
@@ -217,7 +228,11 @@ func TestSerializeMerkleTreePrecert(t *testing.T) {
 }
 
 func TestSerializeCTLogEntry(t *testing.T) {
-	ts := ct.TimestampedEntry{Timestamp: 12345, EntryType: ct.X509LogEntryType, X509Entry: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}), Extensions: ct.CTExtensions{}}
+	ts := ct.TimestampedEntry{
+		Timestamp:  12345,
+		EntryType:  ct.X509LogEntryType,
+		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
+		Extensions: ct.CTExtensions{}}
 	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
 
 	for chainLength := 1; chainLength < 10; chainLength++ {
@@ -267,9 +282,9 @@ func createCertChain(numCerts int) []ct.ASN1Cert {
 	chain := make([]ct.ASN1Cert, 0, numCerts)
 
 	for c := 0; c < numCerts; c++ {
-		certBytes := make([]byte, c + 2)
+		certBytes := make([]byte, c+2)
 
-		for i := 0; i < c + 2; i++ {
+		for i := 0; i < c+2; i++ {
 			certBytes[i] = byte(c)
 		}
 


### PR DESCRIPTION
Missing piece to be able to finish the add-chain handler. CTLogEntry is internal to server and will be used as in the C++ code to store the CT specific data when the leaf is passed to the backend.