### PR TITLE
Implement the CT add-pre-chain-handler

### DIFF
--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -246,7 +246,9 @@ func wrappedAddPreChainHandler(c CTRequestHandlers) http.HandlerFunc {
 		response, err := c.rpcClient.QueueLeaves(ctx, &request)
 
 		if err != nil || !rpcStatusOK(response.GetStatus()) {
-			// Request failed on backend, doesn't account for bad request etc. yet
+			// TODO(Martin2112): Possibly cases where the request we sent to the backend is invalid
+			// which isn't really an internal server error.
+			// Request failed on backend
 			sendHttpError(w, http.StatusInternalServerError, err)
 			return
 		}

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -3,6 +3,7 @@ package ct
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"crypto/sha256"
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/fixchain"
@@ -505,7 +505,7 @@ func TestAddPrecertChain(t *testing.T) {
 
 	recorder := makeAddPrechainRequest(t, reqHandlers, chain)
 
-	assert.Equal(t, http.StatusOK, recorder.Code, "expected HTTP OK for valid add-chain: %v", recorder.Body)
+	assert.Equal(t, http.StatusOK, recorder.Code, "expected HTTP OK for valid add-pre-chain: %v", recorder.Body)
 	km.AssertExpectations(t)
 	client.AssertExpectations(t)
 

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -416,9 +416,8 @@ func TestAddPrecertChainCert(t *testing.T) {
 	reqHandlers := CTRequestHandlers{0x42, roots, client, km, time.Millisecond * 500, fakeTimeSource}
 
 	cert, err := fixchain.CertificateFromPEM(testonly.TestCertPEM)
-	_, ok := err.(x509.NonFatalErrors)
 
-	if err != nil && !ok {
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -284,6 +284,9 @@ func TestAddChainPrecert(t *testing.T) {
 	roots := loadCertsIntoPoolOrDie(t, []string{testonly.CACertPEM})
 	reqHandlers := CTRequestHandlers{0x42, roots, client, km, time.Millisecond * 500, fakeTimeSource}
 
+	// TODO(Martin2112): I don't think CT should return NonFatalError for something we expect
+	// to happen - seeing a precert extension. If this is fixed upstream remove all references from
+	// our tests.
 	precert, err := fixchain.CertificateFromPEM(testonly.PrecertPEMValid)
 	if err != nil {
 		assert.IsType(t, x509.NonFatalErrors{}, err, "Unexpected error loading certificate: %v", err)

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -99,7 +99,7 @@ func allPostHandlersForTest(client trillian.TrillianLogClient) []handlerAndPath 
 
 	return []handlerAndPath{
 		{"add-chain", wrappedAddChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})},
-		{"add-pre-chain", wrappedAddPreChainHandler(client)}}
+		{"add-pre-chain", wrappedAddPreChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})}}
 }
 
 func TestPostHandlersOnlyAcceptPost(t *testing.T) {

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"crypto/sha256"
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/fixchain"
@@ -24,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/net/context"
-	"crypto/sha256"
 )
 
 // Arbitrary time for use in tests


### PR DESCRIPTION
This is mostly a refactoring and moving code around to break out helpers to make the add chain logic clearer and then a dedup of the code so that add-pre-chain shares everything. Most of the actual new code is tests.