### PR TITLE
Add the ct-get-entries handler

### DIFF
--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -37,6 +38,12 @@ const (
 	jsonMapKeyCertificates string = "certificates"
 	// Logging level for debug verbose logs
 	logVerboseLevel glog.Level = 2
+	// Max number of entries we allow in a get-entries request
+	maxGetEntriesAllowed int64 = 50
+	// The name of the get-entries start parameter
+	getEntriesParamStart = "start"
+	// The name of the get-entries end parameter
+	getEntriesParamEnd = "end"
 )
 
 // CTRequestHandlers provides HTTP handler functions for CT V1 as defined in RFC 6962
@@ -79,6 +86,17 @@ type addChainResponse struct {
 	Timestamp  uint64 `json:timestamp`
 	Extensions string `json:extensions`
 	Signature  string `json:signature`
+}
+
+// getEntriesEntry is a struct that represents one element in a get-entries response
+type getEntriesEntry struct {
+	LeafInput []byte `json:leaf_input`
+	ExtraData []byte `json:extra_data`
+}
+
+// getEntriesResponse is a struct for marshalling get-entries respsonses. See RFC6962 Section 4.6
+type getEntriesResponse struct {
+	Entries []getEntriesEntry `json:entries`
 }
 
 func parseBodyAsJSONChain(w http.ResponseWriter, r *http.Request) (addChainRequest, error) {
@@ -246,13 +264,80 @@ func wrappedGetProofByHashHandler(rpcClient trillian.TrillianLogClient) http.Han
 	}
 }
 
-func wrappedGetEntriesHandler(rpcClient trillian.TrillianLogClient) http.HandlerFunc {
+func wrappedGetEntriesHandler(c CTRequestHandlers) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !enforceMethod(w, r, httpMethodGet) {
 			return
 		}
 
-		http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
+		// The first job is to parse the params and make sure they're sensible. We just make
+		// sure the range is valid. We don't do an extra roundtrip to get the current tree
+		// size and prefer to let the backend handle this case
+		startIndex, endIndex, err := parseAndValidateGetEntriesRange(r, maxGetEntriesAllowed)
+
+		if err != nil {
+			glog.Warningf("Bad range on get-entries request: %v", err)
+			sendHttpError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		// Now make a request to the backend to get the relevant leaves
+		requestIndices := buildIndicesForRange(startIndex, endIndex)
+		request := trillian.GetLeavesByIndexRequest{LogId: c.logID, LeafIndex: requestIndices}
+
+		ctx, _ := context.WithDeadline(context.Background(), getRPCDeadlineTime(c))
+
+		response, err := c.rpcClient.GetLeavesByIndex(ctx, &request)
+
+		if err != nil || !rpcStatusOK(response.GetStatus()) {
+			sendHttpError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		// Apply additional checks on the response to make sure we got a contiguous leaf range.
+		// It's allowed by the RFC for the backend to truncate the range in cases where the
+		// range exceeds the tree size etc. so we could get fewer leaves than we requested but
+		// never more.
+		if expected, got := len(requestIndices), len(response.Leaves); got > expected {
+			glog.Warningf("Backend returned more leaves (%d) than requested: (%d)", got, expected)
+			sendHttpError(w, http.StatusInternalServerError, fmt.Errorf("Backend returned too many leaves: %d", got))
+			return
+		}
+
+		if err := isResponseContiguousRange(response, startIndex, endIndex); err != nil {
+			glog.Warningf("Invalid get-entries range received from backend: %v", err)
+			sendHttpError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		// Now we've checked the response and it seems to be valid we need to serialize the
+		// leaves in JSON format. Doing a round trip via the leaf deserializer gives us another
+		// chance to prevent bad / corrupt data from reaching the client.
+		jsonResponse, err := marshalGetEntriesResponse(response)
+
+		if err != nil {
+			glog.Warningf("Failed to process leaves returned from backend: %v", err)
+			sendHttpError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		w.Header().Set(contentTypeHeader, contentTypeJSON)
+		jsonData, err := json.Marshal(&jsonResponse)
+
+		if err != nil {
+			glog.Warningf("Failed to marshal get-entries resp: %v", jsonResponse)
+			sendHttpError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		_, err = w.Write(jsonData)
+
+		if err != nil {
+			glog.Warningf("Failed to write get-entries resp: %v", jsonResponse)
+			// Probably too late for this as headers might have been written but we don't know for sure
+			sendHttpError(w, http.StatusInternalServerError, err)
+			return
+		}
 	}
 }
 
@@ -301,7 +386,7 @@ func (c CTRequestHandlers) RegisterCTHandlers() {
 	http.HandleFunc(pathFor("get-sth"), wrappedGetSTHHandler(c.rpcClient))
 	http.HandleFunc(pathFor("get-sth-consistency"), wrappedGetSTHConsistencyHandler(c.rpcClient))
 	http.HandleFunc(pathFor("get-proof-by-hash"), wrappedGetProofByHashHandler(c.rpcClient))
-	http.HandleFunc(pathFor("get-entries"), wrappedGetEntriesHandler(c.rpcClient))
+	http.HandleFunc(pathFor("get-entries"), wrappedGetEntriesHandler(c))
 	http.HandleFunc(pathFor("get-roots"), wrappedGetRootsHandler(c.trustedRoots, c.rpcClient))
 	http.HandleFunc(pathFor("get-entry-and-proof"), wrappedGetEntryAndProofHandler(c.rpcClient))
 }
@@ -435,4 +520,87 @@ func marshalAndWriteAddChainResponse(sct ct.SignedCertificateTimestamp, km crypt
 	}
 
 	return nil
+}
+
+func parseAndValidateGetEntriesRange(r *http.Request, maxAllowedRange int64) (int64, int64, error) {
+	startIndex, err := strconv.ParseInt(r.FormValue(getEntriesParamStart), 10, 64)
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	endIndex, err := strconv.ParseInt(r.FormValue(getEntriesParamEnd), 10, 64)
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return validateStartAndEnd(startIndex, endIndex, maxAllowedRange)
+}
+
+// validateStartAndEnd applies validation to the range params for get-entries. Returns nil if
+// we accept them or an error giving the reason why not
+func validateStartAndEnd(start, end, maxRange int64) (int64, int64, error) {
+	if start < 0 || end < 0 {
+		return 0, 0, fmt.Errorf("start (%d) and end (%d) parameters must be >= 0", start, end)
+	}
+
+	if start > end {
+		return 0, 0, fmt.Errorf("start (%d) and end (%d) is not a valid range", start, end)
+	}
+
+	numEntries := end - start + 1
+
+	if numEntries > maxRange {
+		return 0, 0, fmt.Errorf("requesting %d entries but we only allow up to %d", numEntries, maxRange)
+	}
+
+	return start, end, nil
+}
+
+// buildIndicesForRange expands the range out, the backend allows for non contiguous leaf fetches
+// but the CT spec doesn't. The input values should have been checked for consistency before calling
+// this.
+func buildIndicesForRange(start, end int64) []int64 {
+	indices := make([]int64, 0, end - start + 1)
+	for i := start; i <= end; i++ {
+		indices = append(indices, i)
+	}
+
+	return indices
+}
+
+// isResponseContiguousRange checks that the response has a contiguous range of leaves and
+// that it is a subset or equal to the requested range. This is additional protection against
+// backend bugs. Returns nil if the response looks valid.
+func isResponseContiguousRange(response *trillian.GetLeavesByIndexResponse, start, end int64) error {
+	for li, l := range response.Leaves {
+		if l.LeafIndex < start || l.LeafIndex > end {
+			return fmt.Errorf("backend returned leaf:%d outside requested range:%d, %d", l.LeafIndex, start, end)
+		}
+
+		if li > 0 && response.Leaves[li].LeafIndex - response.Leaves[li - 1].LeafIndex != 1 {
+			return fmt.Errorf("backend returned non contiguous leaves: %v %v", response.Leaves[li - 1], response.Leaves[li])
+		}
+	}
+
+	return nil
+}
+
+// marshalGetEntriesResponse does the conversion from the backend response to the one we need for
+// an RFC compliant JSON response to the client.
+func marshalGetEntriesResponse(rpcResponse *trillian.GetLeavesByIndexResponse) (getEntriesResponse, error) {
+	jsonResponse := getEntriesResponse{}
+
+	for _, leaf := range rpcResponse.Leaves {
+		// We're only deserializing it to ensure it's valid, don't need the result
+		if _, err := ct.ReadMerkleTreeLeaf(bytes.NewBuffer(leaf.LeafData)); err != nil {
+			return getEntriesResponse{}, errors.New("Failed to deserialize merkle leaf from backend")
+		}
+
+		entry := getEntriesEntry{LeafInput: leaf.LeafData, ExtraData: leaf.ExtraData}
+		jsonResponse.Entries = append(jsonResponse.Entries, entry)
+	}
+
+	return jsonResponse, nil
 }

--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -51,17 +51,17 @@ const (
 // log backend RPC service.
 type CTRequestHandlers struct {
 	// logID is the tree ID that identifies this log in node storage
-	logID         int64
+	logID int64
 	// trustedRoots is a pool of certificates that defines the roots the CT log will accept
-	trustedRoots  *PEMCertPool
+	trustedRoots *PEMCertPool
 	// rpcClient is the client used to communicate with the trillian backend
-	rpcClient     trillian.TrillianLogClient
+	rpcClient trillian.TrillianLogClient
 	// logKeyManager holds the keys this log needs to sign objects
 	logKeyManager crypto.KeyManager
 	// rpcDeadline is the deadline that will be set on all backend RPC requests
-	rpcDeadline   time.Duration
+	rpcDeadline time.Duration
 	// timeSource is a util.TimeSource that can be injected for testing
-	timeSource    util.TimeSource
+	timeSource util.TimeSource
 }
 
 // NewCTRequestHandlers creates a new instance of CTRequestHandlers. They must still
@@ -563,7 +563,7 @@ func validateStartAndEnd(start, end, maxRange int64) (int64, int64, error) {
 // but the CT spec doesn't. The input values should have been checked for consistency before calling
 // this.
 func buildIndicesForRange(start, end int64) []int64 {
-	indices := make([]int64, 0, end - start + 1)
+	indices := make([]int64, 0, end-start+1)
 	for i := start; i <= end; i++ {
 		indices = append(indices, i)
 	}
@@ -576,8 +576,8 @@ func buildIndicesForRange(start, end int64) []int64 {
 // backend bugs. Returns nil if the response looks valid.
 func isResponseContiguousRange(response *trillian.GetLeavesByIndexResponse, start, end int64) error {
 	for li, l := range response.Leaves {
-		if li > 0 && response.Leaves[li].LeafIndex - response.Leaves[li - 1].LeafIndex != 1 {
-			return fmt.Errorf("backend returned non contiguous leaves: %v %v", response.Leaves[li - 1], response.Leaves[li])
+		if li > 0 && response.Leaves[li].LeafIndex-response.Leaves[li-1].LeafIndex != 1 {
+			return fmt.Errorf("backend returned non contiguous leaves: %v %v", response.Leaves[li-1], response.Leaves[li])
 		}
 
 		if l.LeafIndex < start || l.LeafIndex > end {

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -34,7 +34,7 @@ var fakeTime = time.Date(2016, 7, 22, 11, 01, 13, 0, time.UTC)
 // The deadline should be the above bumped by 500ms
 var fakeDeadlineTime = time.Date(2016, 7, 22, 11, 01, 13, 500*1000*1000, time.UTC)
 var fakeTimeSource = util.FakeTimeSource{fakeTime}
-var okStatus = &trillian.TrillianApiStatus{StatusCode:trillian.TrillianApiStatusCode_OK}
+var okStatus = &trillian.TrillianApiStatus{StatusCode: trillian.TrillianApiStatusCode_OK}
 
 type jsonChain struct {
 	Chain []string `json:chain`
@@ -50,7 +50,7 @@ type getEntriesRangeTestCase struct {
 
 var getEntriesRangeTestCases = []getEntriesRangeTestCase{
 	{-1, 0, http.StatusBadRequest, "-ve start value not allowed", false},
-	{0, -1, http.StatusBadRequest, "-ve end value not allowed", false },
+	{0, -1, http.StatusBadRequest, "-ve end value not allowed", false},
 	{20, 10, http.StatusBadRequest, "invalid range end>start", false},
 	{3000, -50, http.StatusBadRequest, "invalid range, -ve end", false},
 	{10, 20, http.StatusInternalServerError, "valid range", true},
@@ -598,10 +598,10 @@ func TestGetEntriesRanges(t *testing.T) {
 		client := new(trillian.MockTrillianLogClient)
 
 		if testCase.rpcExpected {
-			client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:buildIndicesForRange(testCase.start, testCase.end)}, mock.Anything /* []grpc.CallOption */).Return(nil, errors.New("RPCMADE"))
+			client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: buildIndicesForRange(testCase.start, testCase.end)}, mock.Anything /* []grpc.CallOption */).Return(nil, errors.New("RPCMADE"))
 		}
 
-		c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+		c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 		handler := wrappedGetEntriesHandler(c)
 
 		path := fmt.Sprintf("/ct/v1/get-entries?start=%d&end=%d", testCase.start, testCase.end)
@@ -635,9 +635,9 @@ func TestGetEntriesRanges(t *testing.T) {
 func TestGetEntriesErrorFromBackend(t *testing.T) {
 	client := new(trillian.MockTrillianLogClient)
 
-	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:[]int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(nil, errors.New("Bang!"))
+	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: []int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(nil, errors.New("Bang!"))
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	req, err := http.NewRequest("GET", "/ct/v1/get-entries?start=1&end=2", nil)
@@ -660,10 +660,10 @@ func TestGetEntriesErrorFromBackend(t *testing.T) {
 func TestGetEntriesBackendReturnedExtraLeaves(t *testing.T) {
 	client := new(trillian.MockTrillianLogClient)
 
-	rpcLeaves := []*trillian.LeafProto{{LeafIndex:1}, {LeafIndex:2}, {LeafIndex:3}}
-	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:[]int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status:okStatus, Leaves:rpcLeaves}, nil)
+	rpcLeaves := []*trillian.LeafProto{{LeafIndex: 1}, {LeafIndex: 2}, {LeafIndex: 3}}
+	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: []int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status: okStatus, Leaves: rpcLeaves}, nil)
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	req, err := http.NewRequest("GET", "/ct/v1/get-entries?start=1&end=2", nil)
@@ -686,10 +686,10 @@ func TestGetEntriesBackendReturnedExtraLeaves(t *testing.T) {
 func TestGetEntriesBackendReturnedNonContiguousRange(t *testing.T) {
 	client := new(trillian.MockTrillianLogClient)
 
-	rpcLeaves := []*trillian.LeafProto{{LeafIndex:1}, {LeafIndex:3}}
-	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:[]int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status:okStatus, Leaves:rpcLeaves}, nil)
+	rpcLeaves := []*trillian.LeafProto{{LeafIndex: 1}, {LeafIndex: 3}}
+	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: []int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status: okStatus, Leaves: rpcLeaves}, nil)
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	req, err := http.NewRequest("GET", "/ct/v1/get-entries?start=1&end=2", nil)
@@ -712,10 +712,10 @@ func TestGetEntriesBackendReturnedNonContiguousRange(t *testing.T) {
 func TestGetEntriesLeafCorrupt(t *testing.T) {
 	client := new(trillian.MockTrillianLogClient)
 
-	rpcLeaves := []*trillian.LeafProto{{LeafIndex:1, LeafHash:[]byte("hash"), LeafData:[]byte("NOT A MERKLE TREE LEAF")}, {LeafIndex:2, LeafHash:[]byte("hash"), LeafData:[]byte("NOT A MERKLE TREE LEAF")}}
-	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:[]int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status:okStatus, Leaves:rpcLeaves}, nil)
+	rpcLeaves := []*trillian.LeafProto{{LeafIndex: 1, LeafHash: []byte("hash"), LeafData: []byte("NOT A MERKLE TREE LEAF")}, {LeafIndex: 2, LeafHash: []byte("hash"), LeafData: []byte("NOT A MERKLE TREE LEAF")}}
+	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: []int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status: okStatus, Leaves: rpcLeaves}, nil)
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	req, err := http.NewRequest("GET", "/ct/v1/get-entries?start=1&end=2", nil)
@@ -741,14 +741,14 @@ func TestGetEntries(t *testing.T) {
 	// To pass validation the leaves we return from our dummy RPC must be valid serialized
 	// ct.MerkleTreeLeaf objects
 	merkleLeaf1 := ct.MerkleTreeLeaf{
-		Version:ct.V1,
-		LeafType:ct.TimestampedEntryLeafType,
-		TimestampedEntry:ct.TimestampedEntry{Timestamp:12345, EntryType:ct.X509LogEntryType, X509Entry:[]byte("certdatacertdata"), Extensions:ct.CTExtensions{}}}
+		Version:          ct.V1,
+		LeafType:         ct.TimestampedEntryLeafType,
+		TimestampedEntry: ct.TimestampedEntry{Timestamp: 12345, EntryType: ct.X509LogEntryType, X509Entry: []byte("certdatacertdata"), Extensions: ct.CTExtensions{}}}
 
 	merkleLeaf2 := ct.MerkleTreeLeaf{
-		Version:ct.V1,
-		LeafType:ct.TimestampedEntryLeafType,
-		TimestampedEntry:ct.TimestampedEntry{Timestamp:67890, EntryType:ct.X509LogEntryType, X509Entry:[]byte("certdat2certdat2"), Extensions:ct.CTExtensions{}}}
+		Version:          ct.V1,
+		LeafType:         ct.TimestampedEntryLeafType,
+		TimestampedEntry: ct.TimestampedEntry{Timestamp: 67890, EntryType: ct.X509LogEntryType, X509Entry: []byte("certdat2certdat2"), Extensions: ct.CTExtensions{}}}
 
 	merkleBytes1, err1 := leafToBytes(merkleLeaf1)
 	merkleBytes2, err2 := leafToBytes(merkleLeaf2)
@@ -757,10 +757,10 @@ func TestGetEntries(t *testing.T) {
 		t.Fatalf("error in test setup for get-entries: %v %v", err1, err2)
 	}
 
-	rpcLeaves := []*trillian.LeafProto{{LeafIndex:1, LeafHash:[]byte("hash"), LeafData:merkleBytes1, ExtraData: []byte("extra1")}, {LeafIndex:2, LeafHash:[]byte("hash"), LeafData:merkleBytes2, ExtraData:[]byte("extra2")}}
-	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex:[]int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status:okStatus, Leaves:rpcLeaves}, nil)
+	rpcLeaves := []*trillian.LeafProto{{LeafIndex: 1, LeafHash: []byte("hash"), LeafData: merkleBytes1, ExtraData: []byte("extra1")}, {LeafIndex: 2, LeafHash: []byte("hash"), LeafData: merkleBytes2, ExtraData: []byte("extra2")}}
+	client.On("GetLeavesByIndex", mock.MatchedBy(deadlineMatcher), &trillian.GetLeavesByIndexRequest{LeafIndex: []int64{1, 2}}, mock.Anything /* []grpc.CallOption */).Return(&trillian.GetLeavesByIndexResponse{Status: okStatus, Leaves: rpcLeaves}, nil)
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	req, err := http.NewRequest("GET", "/ct/v1/get-entries?start=1&end=2", nil)
@@ -872,7 +872,7 @@ func makeAddChainRequestInternal(t *testing.T, handler http.HandlerFunc, path st
 func getEntriesTestHelper(t *testing.T, request string, expectedStatus int, explanation string) {
 	client := new(trillian.MockTrillianLogClient)
 
-	c := CTRequestHandlers{rpcClient:client, timeSource:fakeTimeSource, rpcDeadline:time.Millisecond * 500}
+	c := CTRequestHandlers{rpcClient: client, timeSource: fakeTimeSource, rpcDeadline: time.Millisecond * 500}
 	handler := wrappedGetEntriesHandler(c)
 
 	path := fmt.Sprintf("/ct/v1/get-entries?%s", request)


### PR DESCRIPTION
Implements the handler for get-entries and adds tests for the input range validation, backend RPC failures, backend out of spec responses like dropped leaves from range and corrupt merkle leaves.