### PR TITLE
Implements the get-sth handler for CT example

### DIFF
--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -100,7 +100,7 @@ type getEntriesResponse struct {
 }
 
 // getSthResponse is a struct for marshalling get-sth responses. See RFC 6962 Section 4.3
-type getSthResponse struct {
+type getSTHResponse struct {
 	TreeSize        int64  `json:"tree_size"`
 	TimestampMillis int64  `json:"timestamp"`
 	RootHash        []byte `json:"sha256_root_hash"`
@@ -682,8 +682,8 @@ func marshalGetEntriesResponse(rpcResponse *trillian.GetLeavesByIndexResponse) (
 // convertSTHForClientResponse does some simple marshalling from a properly signed CT object
 // to the object we'll use to create the JSON response to a client with the correct RFC
 // field names.
-func convertSTHForClientResponse(sth ct.SignedTreeHead) getSthResponse {
-	return getSthResponse{
+func convertSTHForClientResponse(sth ct.SignedTreeHead) getSTHResponse {
+	return getSTHResponse{
 		TreeSize:        int64(sth.TreeSize),
 		RootHash:        sth.SHA256RootHash[:],
 		TimestampMillis: int64(sth.Timestamp),

--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -183,9 +183,9 @@ func addChainInternal(w http.ResponseWriter, r *http.Request, c CTRequestHandler
 	var sct ct.SignedCertificateTimestamp
 
 	if isPrecert {
-		merkleTreeLeaf, sct, err = SignV1SCTForPrecertificate(c.logKeyManager, validPath[0], c.timeSource.Now())
+		merkleTreeLeaf, sct, err = signV1SCTForPrecertificate(c.logKeyManager, validPath[0], c.timeSource.Now())
 	} else {
-		merkleTreeLeaf, sct, err = SignV1SCTForCertificate(c.logKeyManager, validPath[0], c.timeSource.Now())
+		merkleTreeLeaf, sct, err = signV1SCTForCertificate(c.logKeyManager, validPath[0], c.timeSource.Now())
 	}
 
 	if err != nil {
@@ -280,7 +280,7 @@ func wrappedGetSTHHandler(c CTRequestHandlers) http.HandlerFunc {
 			SHA256RootHash: hashArray}
 
 		// Serialize and sign the STH and make sure this succeeds
-		err = SignV1TreeHead(c.logKeyManager, &sth)
+		err = signV1TreeHead(c.logKeyManager, &sth)
 
 		if err != nil || len(sth.TreeHeadSignature.Signature) == 0 {
 			glog.Warningf("Failed to sign tree head: %v %v", sth, err)
@@ -533,7 +533,7 @@ func marshalLogIDAndSignatureForResponse(sct ct.SignedCertificateTimestamp, km c
 // LeafProto that will be sent to the backend
 func buildLeafProtoForAddChain(merkleLeaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) (trillian.LeafProto, error) {
 	var leafBuffer bytes.Buffer
-	if err := WriteMerkleTreeLeaf(&leafBuffer, merkleLeaf); err != nil {
+	if err := writeMerkleTreeLeaf(&leafBuffer, merkleLeaf); err != nil {
 		glog.Warningf("Failed to serialize merkle leaf: %v", err)
 		return trillian.LeafProto{}, err
 	}

--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -234,7 +234,7 @@ func wrappedAddPreChainHandler(c CTRequestHandlers) http.HandlerFunc {
 	}
 }
 
-func wrappedGetSTHHandler(rpcClient trillian.TrillianLogClient) http.HandlerFunc {
+func wrappedGetSTHHandler(c CTRequestHandlers) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !enforceMethod(w, r, httpMethodGet) {
 			return
@@ -383,7 +383,7 @@ func wrappedGetEntryAndProofHandler(rpcClient trillian.TrillianLogClient) http.H
 func (c CTRequestHandlers) RegisterCTHandlers() {
 	http.HandleFunc(pathFor("add-chain"), wrappedAddChainHandler(c))
 	http.HandleFunc(pathFor("add-pre-chain"), wrappedAddPreChainHandler(c))
-	http.HandleFunc(pathFor("get-sth"), wrappedGetSTHHandler(c.rpcClient))
+	http.HandleFunc(pathFor("get-sth"), wrappedGetSTHHandler(c))
 	http.HandleFunc(pathFor("get-sth-consistency"), wrappedGetSTHConsistencyHandler(c.rpcClient))
 	http.HandleFunc(pathFor("get-proof-by-hash"), wrappedGetProofByHashHandler(c.rpcClient))
 	http.HandleFunc(pathFor("get-entries"), wrappedGetEntriesHandler(c))

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -673,7 +673,7 @@ func TestGetSTH(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "expected http request to succeed: %v", w.Body)
 
 	// Now roundtrip the response and check we got the expected data
-	var parsedJson getSthResponse
+	var parsedJson getSTHResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &parsedJson); err != nil {
 		t.Fatalf("Failed to unmarshal json response: %s", w.Body.Bytes())
 	}

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -349,7 +349,7 @@ func TestAddChainRPCFails(t *testing.T) {
 	chain := createJsonChain(t, *pool)
 
 	// Ignore returned SCT. That's sent to the client and we're testing frontend -> backend interaction
-	merkleLeaf, _, err := SignV1SCTForCertificate(km, pool.RawCertificates()[0], fakeTime)
+	merkleLeaf, _, err := signV1SCTForCertificate(km, pool.RawCertificates()[0], fakeTime)
 
 	if err != nil {
 		t.Fatal(err)
@@ -380,7 +380,7 @@ func TestAddChain(t *testing.T) {
 	chain := createJsonChain(t, *pool)
 
 	// Ignore returned SCT. That's sent to the client and we're testing frontend -> backend interaction
-	merkleLeaf, _, err := SignV1SCTForCertificate(km, pool.RawCertificates()[0], fakeTime)
+	merkleLeaf, _, err := signV1SCTForCertificate(km, pool.RawCertificates()[0], fakeTime)
 
 	if err != nil {
 		t.Fatal(err)
@@ -490,7 +490,7 @@ func TestAddPrecertChainRPCFails(t *testing.T) {
 	chain := createJsonChain(t, *pool)
 
 	// Ignore returned SCT. That's sent to the client and we're testing frontend -> backend interaction
-	merkleLeaf, _, err := SignV1SCTForPrecertificate(km, pool.RawCertificates()[0], fakeTime)
+	merkleLeaf, _, err := signV1SCTForPrecertificate(km, pool.RawCertificates()[0], fakeTime)
 
 	if err != nil {
 		t.Fatal(err)
@@ -528,7 +528,7 @@ func TestAddPrecertChain(t *testing.T) {
 	chain := createJsonChain(t, *pool)
 
 	// Ignore returned SCT. That's sent to the client and we're testing frontend -> backend interaction
-	merkleLeaf, _, err := SignV1SCTForPrecertificate(km, pool.RawCertificates()[0], fakeTime)
+	merkleLeaf, _, err := signV1SCTForPrecertificate(km, pool.RawCertificates()[0], fakeTime)
 
 	if err != nil {
 		t.Fatal(err)
@@ -959,7 +959,7 @@ func createJsonChain(t *testing.T, p PEMCertPool) io.Reader {
 
 func leafProtosForCert(t *testing.T, km crypto.KeyManager, certs []*x509.Certificate, merkleLeaf ct.MerkleTreeLeaf) []*trillian.LeafProto {
 	var b bytes.Buffer
-	if err := WriteMerkleTreeLeaf(&b, merkleLeaf); err != nil {
+	if err := writeMerkleTreeLeaf(&b, merkleLeaf); err != nil {
 		t.Fatalf("failed to serialize leaf: %v", err)
 	}
 
@@ -1034,7 +1034,7 @@ func getEntriesTestHelper(t *testing.T, request string, expectedStatus int, expl
 
 func leafToBytes(leaf ct.MerkleTreeLeaf) ([]byte, error) {
 	var buf bytes.Buffer
-	err := WriteMerkleTreeLeaf(&buf, leaf)
+	err := writeMerkleTreeLeaf(&buf, leaf)
 
 	if err != nil {
 		return []byte{}, err

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -1,0 +1,257 @@
+package ct
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto"
+	"github.com/google/certificate-transparency/go"
+	"github.com/google/certificate-transparency/go/x509"
+)
+
+// SignV1TreeHead signs a tree head for CT. The input STH should have been built from a
+// backend response and already checked for validity.
+func SignV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
+	signer, err := km.Signer()
+
+	if err != nil {
+		return err
+	}
+
+	sthBytes, err := ct.SerializeSTHSignatureInput(*sth)
+
+	if err != nil {
+		return err
+	}
+
+	// TODO(Martin2112): Algorithms shouldn't be hardcoded here, needs more work in key manager
+	trillianSigner := crypto.NewTrillianSigner(trillian.NewSHA256(), trillian.SignatureAlgorithm_RSA, signer)
+
+	signature, err := trillianSigner.Sign(sthBytes)
+
+	if err != nil {
+		return err
+	}
+
+	sth.TreeHeadSignature = ct.DigitallySigned{
+		HashAlgorithm:      ct.SHA256,
+		SignatureAlgorithm: ct.RSA,
+		Signature:          signature.Signature}
+
+	return nil
+}
+
+// SignV1SCTForCertificate creates a MerkleTreeLeaf and builds and signs a V1 CT SCT for a certificate
+// using the key held by a key manager.
+func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+	// Temp SCT for input to the serializer
+	sctInput := getSCTForSignatureInput(t)
+
+	// Build up a MerkleTreeLeaf for the cert
+	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.X509LogEntryType, X509Entry: cert.Raw}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
+
+	return serializeAndSignSCT(km, leaf, sctInput, t)
+}
+
+// SignV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
+// held by a key manager.
+func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+	// Temp SCT for input to the serializer
+	sctInput := getSCTForSignatureInput(t)
+
+	// Build up a LogEntry for the precert
+	// For precerts we need to extract the relevant data from the Certificate container.
+	// This is only possible using the CT specific modified version of X.509.
+	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: cert.RawTBSCertificate}
+
+	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.PrecertLogEntryType, PrecertEntry: precert}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
+
+	return serializeAndSignSCT(km, leaf, sctInput, t)
+}
+
+func serializeAndSignSCT(km crypto.KeyManager, leaf ct.MerkleTreeLeaf, sctInput ct.SignedCertificateTimestamp, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+	// Serialize SCT signature input to get the bytes that need to be signed
+	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf: leaf})
+
+	if err != nil {
+		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
+	}
+
+	// Create a complete SCT including signature
+	sct, err := signSCT(km, t, res)
+
+	return leaf, sct, err
+}
+
+func signSCT(km crypto.KeyManager, t time.Time, sctData []byte) (ct.SignedCertificateTimestamp, error) {
+	signer, err := km.Signer()
+	if err != nil {
+		return ct.SignedCertificateTimestamp{}, err
+	}
+
+	// TODO(Martin2112): Algorithms shouldn't be hardcoded here, needs more work in key manager
+	trillianSigner := crypto.NewTrillianSigner(trillian.NewSHA256(), trillian.SignatureAlgorithm_RSA, signer)
+
+	signature, err := trillianSigner.Sign(sctData)
+
+	if err != nil {
+		return ct.SignedCertificateTimestamp{}, err
+	}
+
+	digitallySigned := ct.DigitallySigned{
+		HashAlgorithm:      ct.SHA256,
+		SignatureAlgorithm: ct.RSA,
+		Signature:          signature.Signature}
+
+	logID, err := GetCTLogID(km)
+
+	if err != nil {
+		return ct.SignedCertificateTimestamp{}, err
+	}
+
+	return ct.SignedCertificateTimestamp{
+		SCTVersion: ct.V1,
+		LogID:      logID,
+		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
+		Extensions: ct.CTExtensions{},
+		Signature:  digitallySigned}, nil
+}
+
+func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
+	return ct.SignedCertificateTimestamp{
+		SCTVersion: ct.V1,
+		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
+		Extensions: ct.CTExtensions{}}
+}
+
+// WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
+// by RFC 6962. The CT go code includes a deserializer but not a serializer so we might as
+// well make this available.
+func WriteTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
+	if err := binary.Write(w, binary.BigEndian, &t.Timestamp); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, &t.EntryType); err != nil {
+		return err
+	}
+	switch t.EntryType {
+	case ct.X509LogEntryType:
+		if err := writeVarBytes(w, t.X509Entry, ct.CertificateLengthBytes); err != nil {
+			return err
+		}
+	case ct.PrecertLogEntryType:
+		if err := binary.Write(w, binary.BigEndian, t.PrecertEntry.IssuerKeyHash); err != nil {
+			return err
+		}
+		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, ct.PreCertificateLengthBytes); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
+	}
+
+	return writeVarBytes(w, t.Extensions, ct.ExtensionsLengthBytes)
+}
+
+// WriteMerkleTreeLeaf writes a MerkleTreeLeaf in the binary format specified by RFC 6962.
+// The CT go code includes a deserializer but not a serializer and we might as well make this
+// available to other users.
+func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
+	if l.Version != ct.V1 {
+		return fmt.Errorf("unknown Version: %d", l.Version)
+	}
+
+	if l.LeafType != ct.TimestampedEntryLeafType {
+		return fmt.Errorf("unknown LeafType: %d", l.LeafType)
+	}
+
+	if err := binary.Write(w, binary.BigEndian, l.Version); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, l.LeafType); err != nil {
+		return err
+	}
+	if err := WriteTimestampedEntry(w, l.TimestampedEntry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// These came from the CT go code. Currently don't want to push changes upstream to make
+// them visible but this is an option for the future.
+
+func writeVarBytes(w io.Writer, value []byte, numLenBytes int) error {
+	if err := writeUint(w, uint64(len(value)), numLenBytes); err != nil {
+		return err
+	}
+	if _, err := w.Write(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeUint(w io.Writer, value uint64, numBytes int) error {
+	buf := make([]uint8, numBytes)
+	for i := 0; i < numBytes; i++ {
+		buf[numBytes - i - 1] = uint8(value & 0xff)
+		value >>= 8
+	}
+	if value != 0 {
+		return errors.New("numBytes was insufficiently large to represent value")
+	}
+	if _, err := w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readUint(r io.Reader, numBytes int) (uint64, error) {
+	var l uint64
+	for i := 0; i < numBytes; i++ {
+		l <<= 8
+		var t uint8
+		if err := binary.Read(r, binary.BigEndian, &t); err != nil {
+			return 0, err
+		}
+		l |= uint64(t)
+	}
+	return l, nil
+}
+
+// Reads a variable length array of bytes from |r|. |numLenBytes| specifies the
+// number of (BigEndian) prefix-bytes which contain the length of the actual
+// array data bytes that follow.
+// Allocates an array to hold the contents and returns a slice view into it if
+// the read was successful, or an error otherwise.
+func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
+	switch {
+	case numLenBytes > 8:
+		return nil, fmt.Errorf("numLenBytes too large (%d)", numLenBytes)
+	case numLenBytes == 0:
+		return nil, errors.New("numLenBytes should be > 0")
+	}
+	l, err := readUint(r, numLenBytes)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, l)
+	n, err := r.Read(data)
+	if err != nil {
+		return nil, err
+	}
+	if n != int(l) {
+		return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
+	}
+	return data, nil
+}
+
+// End of code from CT repository

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -16,7 +16,7 @@ import (
 
 // SignV1TreeHead signs a tree head for CT. The input STH should have been built from a
 // backend response and already checked for validity.
-func SignV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
+func signV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
 	signer, err := km.Signer()
 
 	if err != nil {
@@ -48,7 +48,7 @@ func SignV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
 
 // SignV1SCTForCertificate creates a MerkleTreeLeaf and builds and signs a V1 CT SCT for a certificate
 // using the key held by a key manager.
-func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+func signV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
 	// Temp SCT for input to the serializer
 	sctInput := getSCTForSignatureInput(t)
 
@@ -61,7 +61,7 @@ func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t tim
 
 // SignV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
 // held by a key manager.
-func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
+func signV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
 	// Temp SCT for input to the serializer
 	sctInput := getSCTForSignatureInput(t)
 
@@ -135,7 +135,7 @@ func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
 // WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
 // by RFC 6962. The CT go code includes a deserializer but not a serializer so we might as
 // well make this available.
-func WriteTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
+func writeTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
 	if err := binary.Write(w, binary.BigEndian, &t.Timestamp); err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func WriteTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
 // WriteMerkleTreeLeaf writes a MerkleTreeLeaf in the binary format specified by RFC 6962.
 // The CT go code includes a deserializer but not a serializer and we might as well make this
 // available to other users.
-func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
+func writeMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
 	if l.Version != ct.V1 {
 		return fmt.Errorf("unknown Version: %d", l.Version)
 	}
@@ -179,7 +179,7 @@ func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
 	if err := binary.Write(w, binary.BigEndian, l.LeafType); err != nil {
 		return err
 	}
-	if err := WriteTimestampedEntry(w, l.TimestampedEntry); err != nil {
+	if err := writeTimestampedEntry(w, l.TimestampedEntry); err != nil {
 		return err
 	}
 

--- a/examples/ct/serialize_test.go
+++ b/examples/ct/serialize_test.go
@@ -1,0 +1,182 @@
+package ct
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/certificate-transparency/go/fixchain"
+	"github.com/google/certificate-transparency/go/x509"
+	"github.com/google/trillian/examples/ct/testonly"
+	"github.com/stretchr/testify/assert"
+	"github.com/google/certificate-transparency/go"
+)
+
+func TestSignV1SCTForCertificate(t *testing.T) {
+	cert, err := fixchain.CertificateFromPEM(testonly.LeafSignedByFakeIntermediateCertPem)
+
+	if err != nil {
+		t.Fatalf("failed to set up test cert: %v", err)
+	}
+
+	km := setupMockKeyManager([]byte{0x5, 0x62, 0x4f, 0xb4, 0x9e, 0x32, 0x14, 0xb6, 0xc, 0xb8, 0x51, 0x28, 0x23, 0x93, 0x2c, 0x7a, 0x3d, 0x80, 0x93, 0x5f, 0xcd, 0x76, 0xef, 0x91, 0x6a, 0xaf, 0x1b, 0x8c, 0xe8, 0xb5, 0x2, 0xb5})
+
+	leaf, got, err := SignV1SCTForCertificate(km, cert, fixedTime)
+
+	if err != nil {
+		t.Fatalf("create sct for cert failed", err)
+	}
+
+	logID, err := base64.StdEncoding.DecodeString(ctMockLogID)
+
+	if err != nil {
+		t.Fatalf("failed to decode test log id: %s", ctMockLogID)
+	}
+
+	var idArray [sha256.Size]byte
+	copy(idArray[:], logID)
+
+	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
+		LogID:      ct.SHA256Hash(idArray),
+		Timestamp:  1504786523000000,
+		Extensions: ct.CTExtensions{},
+		Signature: ct.DigitallySigned{
+			HashAlgorithm:      ct.SHA256,
+			SignatureAlgorithm: ct.RSA,
+			Signature:          []byte("signed")}}
+
+	assert.Equal(t, expected, got, "mismatched SCT (cert)")
+
+	// Additional checks that the MerkleTreeLeaf we built is correct
+	assert.Equal(t, ct.V1, leaf.Version, "expected a v1 leaf")
+	assert.Equal(t, ct.TimestampedEntryLeafType, leaf.LeafType, "expected a timestamped entry type")
+	assert.Equal(t, ct.X509LogEntryType, leaf.TimestampedEntry.EntryType, "expected x509 entry type")
+	assert.Equal(t, got.Timestamp, leaf.TimestampedEntry.Timestamp, "entry / sct timestamp mismatch")
+	assert.Equal(t, ct.ASN1Cert(cert.Raw), leaf.TimestampedEntry.X509Entry, "cert bytes mismatch")
+}
+
+func TestSignV1SCTForPrecertificate(t *testing.T) {
+	cert, err := fixchain.CertificateFromPEM(testonly.PrecertPEMValid)
+	_, ok := err.(x509.NonFatalErrors)
+
+	if err != nil && !ok {
+		t.Fatalf("failed to set up test precert: %v", err)
+	}
+
+	km := setupMockKeyManager([]byte{0x77, 0xf3, 0x5c, 0xc6, 0xad, 0x85, 0xfd, 0xe0, 0x38, 0xfd, 0x36, 0x34, 0x5c, 0x1e, 0x45, 0x58, 0x60, 0x95, 0xb1, 0x7c, 0x28, 0xaa, 0xa5, 0xa5, 0x84, 0x96, 0x37, 0x4b, 0xf8, 0xbb, 0xd9, 0x8})
+
+	leaf, got, err := SignV1SCTForPrecertificate(km, cert, fixedTime)
+
+	if err != nil {
+		t.Fatalf("create sct for precert failed", err)
+	}
+
+	logID, err := base64.StdEncoding.DecodeString(ctMockLogID)
+
+	if err != nil {
+		t.Fatalf("failed to decode test log id: %s", ctMockLogID)
+	}
+
+	var idArray [sha256.Size]byte
+	copy(idArray[:], logID)
+
+	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
+		LogID:      ct.SHA256Hash(idArray),
+		Timestamp:  1504786523000000,
+		Extensions: ct.CTExtensions{},
+		Signature: ct.DigitallySigned{HashAlgorithm: ct.SHA256,
+			SignatureAlgorithm: ct.RSA,
+			Signature:          []byte("signed")}}
+
+	assert.Equal(t, expected, got, "mismatched SCT (precert")
+
+	// Additional checks that the MerkleTreeLeaf we built is correct
+	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+
+	assert.Equal(t, ct.V1, leaf.Version, "expected a v1 leaf")
+	assert.Equal(t, ct.TimestampedEntryLeafType, leaf.LeafType, "expected a timestamped entry type")
+	assert.Equal(t, ct.PrecertLogEntryType, leaf.TimestampedEntry.EntryType, "expected precert entry type")
+	assert.Equal(t, got.Timestamp, leaf.TimestampedEntry.Timestamp, "entry / sct timestamp mismatch")
+	assert.Equal(t, keyHash, leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash, "issuer key hash mismatch")
+	assert.Equal(t, cert.RawTBSCertificate, leaf.TimestampedEntry.PrecertEntry.TBSCertificate, "tbs cert mismatch")
+}
+
+func TestSerializeMerkleTreeLeafBadVersion(t *testing.T) {
+	var leaf ct.MerkleTreeLeaf
+
+	leaf.Version = 199 // Out of any expected valid range
+
+	var b bytes.Buffer
+	err := WriteMerkleTreeLeaf(&b, leaf)
+	assert.Error(t, err, "incorrectly serialized leaf with bad version")
+	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
+}
+
+func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
+	var leaf ct.MerkleTreeLeaf
+
+	leaf.Version = ct.V1
+	leaf.LeafType = 212
+
+	var b bytes.Buffer
+	err := WriteMerkleTreeLeaf(&b, leaf)
+	assert.Error(t, err, "incorrectly serialized leaf with bad leaf type")
+	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
+}
+
+func TestSerializeMerkleTreeLeafCert(t *testing.T) {
+	ts := ct.TimestampedEntry{
+		Timestamp:  12345,
+		EntryType:  ct.X509LogEntryType,
+		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
+		Extensions: ct.CTExtensions{}}
+	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
+
+	var buff bytes.Buffer
+	w := bufio.NewWriter(&buff)
+
+	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
+		t.Fatalf("failed to write leaf: %v", err)
+	}
+
+	w.Flush()
+	r := bufio.NewReader(&buff)
+
+	leaf2, err := ct.ReadMerkleTreeLeaf(r)
+
+	if err != nil {
+		t.Fatalf("failed to read leaf: %v", err)
+	}
+
+	assert.Equal(t, leaf, *leaf2, "leaf mismatch after serialization roundtrip (cert)")
+}
+
+func TestSerializeMerkleTreePrecert(t *testing.T) {
+	ts := ct.TimestampedEntry{Timestamp: 12345,
+		EntryType: ct.PrecertLogEntryType,
+		PrecertEntry: ct.PreCert{
+			IssuerKeyHash:  [sha256.Size]byte{0x55, 0x56, 0x57, 0x58, 0x59},
+			TBSCertificate: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23})},
+		Extensions: ct.CTExtensions{}}
+	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
+
+	var buff bytes.Buffer
+	w := bufio.NewWriter(&buff)
+
+	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
+		t.Fatalf("failed to write leaf: %v", err)
+	}
+
+	w.Flush()
+	r := bufio.NewReader(&buff)
+
+	leaf2, err := ct.ReadMerkleTreeLeaf(r)
+
+	if err != nil {
+		t.Fatalf("failed to read leaf: %v", err)
+	}
+
+	assert.Equal(t, leaf, *leaf2, "leaf mismatch after serialization roundtrip (precert)")
+}

--- a/examples/ct/serialize_test.go
+++ b/examples/ct/serialize_test.go
@@ -23,7 +23,7 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 
 	km := setupMockKeyManager([]byte{0x5, 0x62, 0x4f, 0xb4, 0x9e, 0x32, 0x14, 0xb6, 0xc, 0xb8, 0x51, 0x28, 0x23, 0x93, 0x2c, 0x7a, 0x3d, 0x80, 0x93, 0x5f, 0xcd, 0x76, 0xef, 0x91, 0x6a, 0xaf, 0x1b, 0x8c, 0xe8, 0xb5, 0x2, 0xb5})
 
-	leaf, got, err := SignV1SCTForCertificate(km, cert, fixedTime)
+	leaf, got, err := signV1SCTForCertificate(km, cert, fixedTime)
 
 	if err != nil {
 		t.Fatalf("create sct for cert failed", err)
@@ -67,7 +67,7 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 
 	km := setupMockKeyManager([]byte{0x77, 0xf3, 0x5c, 0xc6, 0xad, 0x85, 0xfd, 0xe0, 0x38, 0xfd, 0x36, 0x34, 0x5c, 0x1e, 0x45, 0x58, 0x60, 0x95, 0xb1, 0x7c, 0x28, 0xaa, 0xa5, 0xa5, 0x84, 0x96, 0x37, 0x4b, 0xf8, 0xbb, 0xd9, 0x8})
 
-	leaf, got, err := SignV1SCTForPrecertificate(km, cert, fixedTime)
+	leaf, got, err := signV1SCTForPrecertificate(km, cert, fixedTime)
 
 	if err != nil {
 		t.Fatalf("create sct for precert failed", err)
@@ -109,7 +109,7 @@ func TestSerializeMerkleTreeLeafBadVersion(t *testing.T) {
 	leaf.Version = 199 // Out of any expected valid range
 
 	var b bytes.Buffer
-	err := WriteMerkleTreeLeaf(&b, leaf)
+	err := writeMerkleTreeLeaf(&b, leaf)
 	assert.Error(t, err, "incorrectly serialized leaf with bad version")
 	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
 }
@@ -121,7 +121,7 @@ func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
 	leaf.LeafType = 212
 
 	var b bytes.Buffer
-	err := WriteMerkleTreeLeaf(&b, leaf)
+	err := writeMerkleTreeLeaf(&b, leaf)
 	assert.Error(t, err, "incorrectly serialized leaf with bad leaf type")
 	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
 }
@@ -137,7 +137,7 @@ func TestSerializeMerkleTreeLeafCert(t *testing.T) {
 	var buff bytes.Buffer
 	w := bufio.NewWriter(&buff)
 
-	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
+	if err := writeMerkleTreeLeaf(w, leaf); err != nil {
 		t.Fatalf("failed to write leaf: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestSerializeMerkleTreePrecert(t *testing.T) {
 	var buff bytes.Buffer
 	w := bufio.NewWriter(&buff)
 
-	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
+	if err := writeMerkleTreeLeaf(w, leaf); err != nil {
 		t.Fatalf("failed to write leaf: %v", err)
 	}
 

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -51,7 +51,7 @@ func NewCTLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLog
 // Serialize writes out a CTLogEntry in binary form. This is not an RFC 6962 data structure
 // and is only used internally by the log.
 func (c CTLogEntry) Serialize(w io.Writer) error {
-	if err := WriteMerkleTreeLeaf(w, c.Leaf); err != nil {
+	if err := writeMerkleTreeLeaf(w, c.Leaf); err != nil {
 		return err
 	}
 

--- a/examples/ct/structures.go
+++ b/examples/ct/structures.go
@@ -1,18 +1,14 @@
 package ct
 
-// Code to handle encoding / decoding various data structures used in RFC 6962.
+// Code to handle encoding / decoding various data structures used in RFC 6962. Does not
+// contain the low level serialization.
 
 import (
 	"crypto/sha256"
-	"encoding/binary"
-	"errors"
-	"fmt"
 	"io"
-	"time"
 
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/x509"
-	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
 )
 
@@ -42,124 +38,6 @@ func GetCTLogID(km crypto.KeyManager) ([sha256.Size]byte, error) {
 	return sha256.Sum256(key), nil
 }
 
-func serializeAndSignSCT(km crypto.KeyManager, leaf ct.MerkleTreeLeaf, sctInput ct.SignedCertificateTimestamp, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
-	// Serialize SCT signature input to get the bytes that need to be signed
-	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf: leaf})
-
-	if err != nil {
-		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
-	}
-
-	// Create a complete SCT including signature
-	sct, err := signSCT(km, t, res)
-
-	return leaf, sct, err
-}
-
-func signSCT(km crypto.KeyManager, t time.Time, sctData []byte) (ct.SignedCertificateTimestamp, error) {
-	signer, err := km.Signer()
-	if err != nil {
-		return ct.SignedCertificateTimestamp{}, err
-	}
-
-	// TODO(Martin2112): Algorithms shouldn't be hardcoded here, needs more work in key manager
-	trillianSigner := crypto.NewTrillianSigner(trillian.NewSHA256(), trillian.SignatureAlgorithm_RSA, signer)
-
-	signature, err := trillianSigner.Sign(sctData)
-
-	if err != nil {
-		return ct.SignedCertificateTimestamp{}, err
-	}
-
-	digitallySigned := ct.DigitallySigned{
-		HashAlgorithm:      ct.SHA256,
-		SignatureAlgorithm: ct.RSA,
-		Signature:          signature.Signature}
-
-	logID, err := GetCTLogID(km)
-
-	if err != nil {
-		return ct.SignedCertificateTimestamp{}, err
-	}
-
-	return ct.SignedCertificateTimestamp{
-		SCTVersion: ct.V1,
-		LogID:      logID,
-		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
-		Extensions: ct.CTExtensions{},
-		Signature:  digitallySigned}, nil
-}
-
-// CreateV1SCTForCertificate creates a MerkleTreeLeaf and builds and signs a V1 CT SCT for a certificate
-// using the key held by a key manager.
-func SignV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
-	// Temp SCT for input to the serializer
-	sctInput := getSCTForSignatureInput(t)
-
-	// Build up a MerkleTreeLeaf for the cert
-	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.X509LogEntryType, X509Entry: cert.Raw}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
-
-	return serializeAndSignSCT(km, leaf, sctInput, t)
-}
-
-// CreateV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
-// held by a key manager.
-func SignV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
-	// Temp SCT for input to the serializer
-	sctInput := getSCTForSignatureInput(t)
-
-	// Build up a LogEntry for the precert
-	// For precerts we need to extract the relevant data from the Certificate container.
-	// This is only possible using the CT specific modified version of X.509.
-	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
-	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: cert.RawTBSCertificate}
-
-	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.PrecertLogEntryType, PrecertEntry: precert}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
-
-	return serializeAndSignSCT(km, leaf, sctInput, t)
-}
-
-// SignV1TreeHead signs a tree head for CT. The input STH should have been built from a
-// backend response and already checked for validity.
-func SignV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
-	signer, err := km.Signer()
-
-	if err != nil {
-		return err
-	}
-
-	sthBytes, err := ct.SerializeSTHSignatureInput(*sth)
-
-	if err != nil {
-		return err
-	}
-
-	// TODO(Martin2112): Algorithms shouldn't be hardcoded here, needs more work in key manager
-	trillianSigner := crypto.NewTrillianSigner(trillian.NewSHA256(), trillian.SignatureAlgorithm_RSA, signer)
-
-	signature, err := trillianSigner.Sign(sthBytes)
-
-	if err != nil {
-		return err
-	}
-
-	sth.TreeHeadSignature = ct.DigitallySigned{
-		HashAlgorithm:      ct.SHA256,
-		SignatureAlgorithm: ct.RSA,
-		Signature:          signature.Signature}
-
-	return nil
-}
-
-func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
-	return ct.SignedCertificateTimestamp{
-		SCTVersion: ct.V1,
-		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
-		Extensions: ct.CTExtensions{}}
-}
-
 func NewCTLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLogEntry {
 	chain := []ct.ASN1Cert{}
 
@@ -168,60 +46,6 @@ func NewCTLogEntry(leaf ct.MerkleTreeLeaf, certChain []*x509.Certificate) *CTLog
 	}
 
 	return &CTLogEntry{Leaf: leaf, Chain: chain}
-}
-
-// WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
-// by RFC 6962. The CT go code includes a deserializer but not a serializer so we might as
-// well make this available.
-func WriteTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
-	if err := binary.Write(w, binary.BigEndian, &t.Timestamp); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, &t.EntryType); err != nil {
-		return err
-	}
-	switch t.EntryType {
-	case ct.X509LogEntryType:
-		if err := writeVarBytes(w, t.X509Entry, ct.CertificateLengthBytes); err != nil {
-			return err
-		}
-	case ct.PrecertLogEntryType:
-		if err := binary.Write(w, binary.BigEndian, t.PrecertEntry.IssuerKeyHash); err != nil {
-			return err
-		}
-		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, ct.PreCertificateLengthBytes); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
-	}
-
-	return writeVarBytes(w, t.Extensions, ct.ExtensionsLengthBytes)
-}
-
-// WriteMerkleTreeLeaf writes a MerkleTreeLeaf in the binary format specified by RFC 6962.
-// The CT go code includes a deserializer but not a serializer and we might as well make this
-// available to other users.
-func WriteMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
-	if l.Version != ct.V1 {
-		return fmt.Errorf("unknown Version: %d", l.Version)
-	}
-
-	if l.LeafType != ct.TimestampedEntryLeafType {
-		return fmt.Errorf("unknown LeafType: %d", l.LeafType)
-	}
-
-	if err := binary.Write(w, binary.BigEndian, l.Version); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, l.LeafType); err != nil {
-		return err
-	}
-	if err := WriteTimestampedEntry(w, l.TimestampedEntry); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Serialize writes out a CTLogEntry in binary form. This is not an RFC 6962 data structure
@@ -280,72 +104,3 @@ func (c *CTLogEntry) Deserialize(r io.Reader) error {
 	return nil
 }
 
-// These came from the CT go code. Currently don't want to push changes upstream to make
-// them visible but this is an option for the future.
-
-func writeVarBytes(w io.Writer, value []byte, numLenBytes int) error {
-	if err := writeUint(w, uint64(len(value)), numLenBytes); err != nil {
-		return err
-	}
-	if _, err := w.Write(value); err != nil {
-		return err
-	}
-	return nil
-}
-
-func writeUint(w io.Writer, value uint64, numBytes int) error {
-	buf := make([]uint8, numBytes)
-	for i := 0; i < numBytes; i++ {
-		buf[numBytes-i-1] = uint8(value & 0xff)
-		value >>= 8
-	}
-	if value != 0 {
-		return errors.New("numBytes was insufficiently large to represent value")
-	}
-	if _, err := w.Write(buf); err != nil {
-		return err
-	}
-	return nil
-}
-
-func readUint(r io.Reader, numBytes int) (uint64, error) {
-	var l uint64
-	for i := 0; i < numBytes; i++ {
-		l <<= 8
-		var t uint8
-		if err := binary.Read(r, binary.BigEndian, &t); err != nil {
-			return 0, err
-		}
-		l |= uint64(t)
-	}
-	return l, nil
-}
-
-// Reads a variable length array of bytes from |r|. |numLenBytes| specifies the
-// number of (BigEndian) prefix-bytes which contain the length of the actual
-// array data bytes that follow.
-// Allocates an array to hold the contents and returns a slice view into it if
-// the read was successful, or an error otherwise.
-func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
-	switch {
-	case numLenBytes > 8:
-		return nil, fmt.Errorf("numLenBytes too large (%d)", numLenBytes)
-	case numLenBytes == 0:
-		return nil, errors.New("numLenBytes should be > 0")
-	}
-	l, err := readUint(r, numLenBytes)
-	if err != nil {
-		return nil, err
-	}
-	data := make([]byte, l)
-	n, err := r.Read(data)
-	if err != nil {
-		return nil, err
-	}
-	if n != int(l) {
-		return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
-	}
-	return data, nil
-}
-
-// End of code from CT repository

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -3,18 +3,14 @@ package ct
 import (
 	"bufio"
 	"bytes"
-	"crypto/sha256"
 	"encoding/base64"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/google/certificate-transparency/go"
-	"github.com/google/certificate-transparency/go/fixchain"
-	"github.com/google/certificate-transparency/go/x509"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
-	"github.com/google/trillian/examples/ct/testonly"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -58,173 +54,6 @@ func TestGetCTLogIDNotLoaded(t *testing.T) {
 	_, err := GetCTLogID(km)
 
 	assert.Error(t, err, "expected error when no key loaded")
-}
-
-func TestSignV1SCTForCertificate(t *testing.T) {
-	cert, err := fixchain.CertificateFromPEM(testonly.LeafSignedByFakeIntermediateCertPem)
-
-	if err != nil {
-		t.Fatalf("failed to set up test cert: %v", err)
-	}
-
-	km := setupMockKeyManager([]byte{0x5, 0x62, 0x4f, 0xb4, 0x9e, 0x32, 0x14, 0xb6, 0xc, 0xb8, 0x51, 0x28, 0x23, 0x93, 0x2c, 0x7a, 0x3d, 0x80, 0x93, 0x5f, 0xcd, 0x76, 0xef, 0x91, 0x6a, 0xaf, 0x1b, 0x8c, 0xe8, 0xb5, 0x2, 0xb5})
-
-	leaf, got, err := SignV1SCTForCertificate(km, cert, fixedTime)
-
-	if err != nil {
-		t.Fatalf("create sct for cert failed", err)
-	}
-
-	logID, err := base64.StdEncoding.DecodeString(ctMockLogID)
-
-	if err != nil {
-		t.Fatalf("failed to decode test log id: %s", ctMockLogID)
-	}
-
-	var idArray [sha256.Size]byte
-	copy(idArray[:], logID)
-
-	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
-		LogID:      ct.SHA256Hash(idArray),
-		Timestamp:  1504786523000000,
-		Extensions: ct.CTExtensions{},
-		Signature: ct.DigitallySigned{
-			HashAlgorithm:      ct.SHA256,
-			SignatureAlgorithm: ct.RSA,
-			Signature:          []byte("signed")}}
-
-	assert.Equal(t, expected, got, "mismatched SCT (cert)")
-
-	// Additional checks that the MerkleTreeLeaf we built is correct
-	assert.Equal(t, ct.V1, leaf.Version, "expected a v1 leaf")
-	assert.Equal(t, ct.TimestampedEntryLeafType, leaf.LeafType, "expected a timestamped entry type")
-	assert.Equal(t, ct.X509LogEntryType, leaf.TimestampedEntry.EntryType, "expected x509 entry type")
-	assert.Equal(t, got.Timestamp, leaf.TimestampedEntry.Timestamp, "entry / sct timestamp mismatch")
-	assert.Equal(t, ct.ASN1Cert(cert.Raw), leaf.TimestampedEntry.X509Entry, "cert bytes mismatch")
-}
-
-func TestSignV1SCTForPrecertificate(t *testing.T) {
-	cert, err := fixchain.CertificateFromPEM(testonly.PrecertPEMValid)
-	_, ok := err.(x509.NonFatalErrors)
-
-	if err != nil && !ok {
-		t.Fatalf("failed to set up test precert: %v", err)
-	}
-
-	km := setupMockKeyManager([]byte{0x77, 0xf3, 0x5c, 0xc6, 0xad, 0x85, 0xfd, 0xe0, 0x38, 0xfd, 0x36, 0x34, 0x5c, 0x1e, 0x45, 0x58, 0x60, 0x95, 0xb1, 0x7c, 0x28, 0xaa, 0xa5, 0xa5, 0x84, 0x96, 0x37, 0x4b, 0xf8, 0xbb, 0xd9, 0x8})
-
-	leaf, got, err := SignV1SCTForPrecertificate(km, cert, fixedTime)
-
-	if err != nil {
-		t.Fatalf("create sct for precert failed", err)
-	}
-
-	logID, err := base64.StdEncoding.DecodeString(ctMockLogID)
-
-	if err != nil {
-		t.Fatalf("failed to decode test log id: %s", ctMockLogID)
-	}
-
-	var idArray [sha256.Size]byte
-	copy(idArray[:], logID)
-
-	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
-		LogID:      ct.SHA256Hash(idArray),
-		Timestamp:  1504786523000000,
-		Extensions: ct.CTExtensions{},
-		Signature: ct.DigitallySigned{HashAlgorithm: ct.SHA256,
-			SignatureAlgorithm: ct.RSA,
-			Signature:          []byte("signed")}}
-
-	assert.Equal(t, expected, got, "mismatched SCT (precert")
-
-	// Additional checks that the MerkleTreeLeaf we built is correct
-	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
-
-	assert.Equal(t, ct.V1, leaf.Version, "expected a v1 leaf")
-	assert.Equal(t, ct.TimestampedEntryLeafType, leaf.LeafType, "expected a timestamped entry type")
-	assert.Equal(t, ct.PrecertLogEntryType, leaf.TimestampedEntry.EntryType, "expected precert entry type")
-	assert.Equal(t, got.Timestamp, leaf.TimestampedEntry.Timestamp, "entry / sct timestamp mismatch")
-	assert.Equal(t, keyHash, leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash, "issuer key hash mismatch")
-	assert.Equal(t, cert.RawTBSCertificate, leaf.TimestampedEntry.PrecertEntry.TBSCertificate, "tbs cert mismatch")
-}
-
-func TestSerializeMerkleTreeLeafBadVersion(t *testing.T) {
-	var leaf ct.MerkleTreeLeaf
-
-	leaf.Version = 199 // Out of any expected valid range
-
-	var b bytes.Buffer
-	err := WriteMerkleTreeLeaf(&b, leaf)
-	assert.Error(t, err, "incorrectly serialized leaf with bad version")
-	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
-}
-
-func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
-	var leaf ct.MerkleTreeLeaf
-
-	leaf.Version = ct.V1
-	leaf.LeafType = 212
-
-	var b bytes.Buffer
-	err := WriteMerkleTreeLeaf(&b, leaf)
-	assert.Error(t, err, "incorrectly serialized leaf with bad leaf type")
-	assert.Zero(t, len(b.Bytes()), "wrote data when serializing invalid object")
-}
-
-func TestSerializeMerkleTreeLeafCert(t *testing.T) {
-	ts := ct.TimestampedEntry{
-		Timestamp:  12345,
-		EntryType:  ct.X509LogEntryType,
-		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
-		Extensions: ct.CTExtensions{}}
-	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
-
-	var buff bytes.Buffer
-	w := bufio.NewWriter(&buff)
-
-	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
-		t.Fatalf("failed to write leaf: %v", err)
-	}
-
-	w.Flush()
-	r := bufio.NewReader(&buff)
-
-	leaf2, err := ct.ReadMerkleTreeLeaf(r)
-
-	if err != nil {
-		t.Fatalf("failed to read leaf: %v", err)
-	}
-
-	assert.Equal(t, leaf, *leaf2, "leaf mismatch after serialization roundtrip (cert)")
-}
-
-func TestSerializeMerkleTreePrecert(t *testing.T) {
-	ts := ct.TimestampedEntry{Timestamp: 12345,
-		EntryType: ct.PrecertLogEntryType,
-		PrecertEntry: ct.PreCert{
-			IssuerKeyHash:  [sha256.Size]byte{0x55, 0x56, 0x57, 0x58, 0x59},
-			TBSCertificate: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23})},
-		Extensions: ct.CTExtensions{}}
-	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
-
-	var buff bytes.Buffer
-	w := bufio.NewWriter(&buff)
-
-	if err := WriteMerkleTreeLeaf(w, leaf); err != nil {
-		t.Fatalf("failed to write leaf: %v", err)
-	}
-
-	w.Flush()
-	r := bufio.NewReader(&buff)
-
-	leaf2, err := ct.ReadMerkleTreeLeaf(r)
-
-	if err != nil {
-		t.Fatalf("failed to read leaf: %v", err)
-	}
-
-	assert.Equal(t, leaf, *leaf2, "leaf mismatch after serialization roundtrip (precert)")
 }
 
 func TestSerializeCTLogEntry(t *testing.T) {

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -264,6 +264,14 @@ func TestSerializeCTLogEntry(t *testing.T) {
 
 // Creates a mock key manager for use in interaction tests
 func setupMockKeyManager(toSign []byte) *crypto.MockKeyManager {
+	mockKeyManager := setupMockKeyManagerForSth(toSign)
+	mockKeyManager.On("GetRawPublicKey").Return([]byte("key"), nil)
+
+	return mockKeyManager
+}
+
+// As above but we don't expect the call for a public key as we don't need it for an STH
+func setupMockKeyManagerForSth(toSign []byte) *crypto.MockKeyManager {
 	hasher := trillian.NewSHA256()
 	mockKeyManager := new(crypto.MockKeyManager)
 	mockSigner := new(crypto.MockSigner)
@@ -272,7 +280,6 @@ func setupMockKeyManager(toSign []byte) *crypto.MockKeyManager {
 			return true
 		}), toSign, hasher).Return([]byte("signed"), nil)
 	mockKeyManager.On("Signer").Return(mockSigner, nil)
-	mockKeyManager.On("GetRawPublicKey").Return([]byte("key"), nil)
 
 	return mockKeyManager
 }


### PR DESCRIPTION
Adds the get-sth handler and adds a set of tests for several possible backend failures including receiving an invalid tree size or root hash.