### PR TITLE
Remove leftover code from handler

### DIFF
--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -625,8 +625,6 @@ func wrappedGetEntryAndProofHandler(c CTRequestHandlers) http.HandlerFunc {
 			sendHttpError(w, http.StatusInternalServerError, err)
 			return
 		}
-
-		http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
 	}
 }
 


### PR DESCRIPTION
Turns out this doesn't stop it working because the http header is written when the body is but it's still wrong.