### PR TITLE
Handler refactor to centralize logging and error handling

### DIFF
--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -77,18 +77,6 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// This is only needed to convert the handler to a HandlerFunc for tests and can be removed
-// when all the handlers are updated.
-func (fn appHandler) AsHandleFunc() (http.HandlerFunc) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		status, err := fn(w, r)
-
-		if status != http.StatusOK {
-			sendHttpError(w, status, err)
-		}
-	}
-}
-
 // CTRequestHandlers provides HTTP handler functions for CT V1 as defined in RFC 6962
 // and functionality to translate CT client requests into forms that can be served by a
 // log backend RPC service.

--- a/examples/ct/ct_handlers.go
+++ b/examples/ct/ct_handlers.go
@@ -237,7 +237,7 @@ func addChainInternal(w http.ResponseWriter, r *http.Request, c CTRequestHandler
 	}
 
 	if err != nil {
-		return http.StatusInternalServerError, fmt.Errorf("Failed to create / serialize SCT or Merkle leaf: %v %v", sct, err)
+		return http.StatusInternalServerError, fmt.Errorf("failed to create / serialize SCT or Merkle leaf: %v %v", sct, err)
 	}
 
 	// Inputs validated, pass the request on to the back end after hashing and serializing
@@ -381,14 +381,14 @@ func wrappedGetSTHConsistencyHandler(c CTRequestHandlers) appHandler {
 		jsonData, err := json.Marshal(&jsonResponse)
 
 		if err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Failed to marshal get-sth-consistency resp: %v because %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to marshal get-sth-consistency resp: %v because %v", jsonResponse, err)
 		}
 
 		_, err = w.Write(jsonData)
 
 		if err != nil {
 			// Probably too late for this as headers might have been written but we don't know for sure
-			return http.StatusInternalServerError, fmt.Errorf("Failed to write get-sth-consistency resp: %v because %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to write get-sth-consistency resp: %v because %v", jsonResponse, err)
 		}
 
 		return http.StatusOK, nil
@@ -447,14 +447,14 @@ func wrappedGetProofByHashHandler(c CTRequestHandlers) appHandler {
 
 		if err != nil {
 			glog.Warningf("Failed to marshal get-proof-by-hash resp: %v", proofResponse)
-			return http.StatusInternalServerError, fmt.Errorf("Failed to marshal get-proof-by-hash resp: %v, error: %v", proofResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to marshal get-proof-by-hash resp: %v, error: %v", proofResponse, err)
 		}
 
 		_, err = w.Write(jsonData)
 
 		if err != nil {
 			// Probably too late for this as headers might have been written but we don't know for sure
-			return http.StatusInternalServerError, fmt.Errorf("Failed to write get-proof-by-hash resp: %v", proofResponse)
+			return http.StatusInternalServerError, fmt.Errorf("failed to write get-proof-by-hash resp: %v", proofResponse)
 		}
 
 		return http.StatusOK, nil
@@ -473,7 +473,7 @@ func wrappedGetEntriesHandler(c CTRequestHandlers) appHandler {
 		startIndex, endIndex, err := parseAndValidateGetEntriesRange(r, maxGetEntriesAllowed)
 
 		if err != nil {
-			return http.StatusBadRequest, fmt.Errorf("Bad range on get-entries request: %v", err)
+			return http.StatusBadRequest, fmt.Errorf("bad range on get-entries request: %v", err)
 		}
 
 		// Now make a request to the backend to get the relevant leaves
@@ -493,11 +493,11 @@ func wrappedGetEntriesHandler(c CTRequestHandlers) appHandler {
 		// range exceeds the tree size etc. so we could get fewer leaves than we requested but
 		// never more and never anything outside the requested range.
 		if expected, got := len(requestIndices), len(response.Leaves); got > expected {
-			return http.StatusInternalServerError, fmt.Errorf("Backend returned too many leaves: %d v %d", got, expected)
+			return http.StatusInternalServerError, fmt.Errorf("backend returned too many leaves: %d v %d", got, expected)
 		}
 
 		if err := isResponseContiguousRange(response, startIndex, endIndex); err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Backend get-entries range received from backend non contiguous: %v", err)
+			return http.StatusInternalServerError, fmt.Errorf("backend get-entries range received from backend non contiguous: %v", err)
 		}
 
 		// Now we've checked the response and it seems to be valid we need to serialize the
@@ -506,14 +506,14 @@ func wrappedGetEntriesHandler(c CTRequestHandlers) appHandler {
 		jsonResponse, err := marshalGetEntriesResponse(response)
 
 		if err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Failed to process leaves returned from backend: %v", err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to process leaves returned from backend: %v", err)
 		}
 
 		w.Header().Set(contentTypeHeader, contentTypeJSON)
 		jsonData, err := json.Marshal(&jsonResponse)
 
 		if err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Failed to marshal get-entries resp: %v because: %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to marshal get-entries resp: %v because: %v", jsonResponse, err)
 		}
 
 		_, err = w.Write(jsonData)
@@ -521,7 +521,7 @@ func wrappedGetEntriesHandler(c CTRequestHandlers) appHandler {
 		if err != nil {
 
 			// Probably too late for this as headers might have been written but we don't know for sure
-			return http.StatusInternalServerError, fmt.Errorf("Failed to write get-entries resp: %v because: %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to write get-entries resp: %v because: %v", jsonResponse, err)
 		}
 
 		return http.StatusOK, nil
@@ -581,7 +581,7 @@ func wrappedGetEntryAndProofHandler(c CTRequestHandlers) appHandler {
 
 		// Apply some checks that we got reasonable data from the backend
 		if response.Proof == nil || response.Leaf == nil || len(response.Proof.ProofNode) == 0 || len(response.Leaf.LeafData) == 0 {
-			return http.StatusInternalServerError, fmt.Errorf("RPC bad response, possible extra info: %v", response)
+			return http.StatusInternalServerError, fmt.Errorf("got RPC bad response, possible extra info: %v", response)
 		}
 
 		// Build and marshall the response to the client
@@ -594,7 +594,7 @@ func wrappedGetEntryAndProofHandler(c CTRequestHandlers) appHandler {
 		jsonData, err := json.Marshal(&jsonResponse)
 
 		if err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Failed to marshal get-entry-and-proof resp: %v because: %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to marshal get-entry-and-proof resp: %v because: %v", jsonResponse, err)
 		}
 
 		_, err = w.Write(jsonData)
@@ -602,7 +602,7 @@ func wrappedGetEntryAndProofHandler(c CTRequestHandlers) appHandler {
 		if err != nil {
 
 			// Probably too late for this as headers might have been written but we don't know for sure
-			return http.StatusInternalServerError, fmt.Errorf("Failed to write get-entry-and-proof resp: %v because: %v", jsonResponse, err)
+			return http.StatusInternalServerError, fmt.Errorf("failed to write get-entry-and-proof resp: %v because: %v", jsonResponse, err)
 		}
 
 		return http.StatusOK, nil
@@ -648,13 +648,13 @@ func verifyAddChain(req addChainRequest, w http.ResponseWriter, trustedRoots PEM
 	if err != nil {
 		// We rejected it because the cert failed checks or we could not find a path to a root etc.
 		// Lots of possible causes for errors
-		return nil, fmt.Errorf("Chain failed to verify: %v because: %v", req, err)
+		return nil, fmt.Errorf("chain failed to verify: %v because: %v", req, err)
 	}
 
 	isPrecert, err := IsPrecertificate(validPath[0])
 
 	if err != nil {
-		return nil, fmt.Errorf("Precert test failed: %v", err)
+		return nil, fmt.Errorf("precert test failed: %v", err)
 	}
 
 	// The type of the leaf must match the one the handler expects
@@ -731,13 +731,13 @@ func marshalAndWriteAddChainResponse(sct ct.SignedCertificateTimestamp, km crypt
 	jsonData, err := json.Marshal(&resp)
 
 	if err != nil {
-		return fmt.Errorf("Failed to marshal add-chain resp: %v because: %v", resp, err)
+		return fmt.Errorf("failed to marshal add-chain resp: %v because: %v", resp, err)
 	}
 
 	_, err = w.Write(jsonData)
 
 	if err != nil {
-		return fmt.Errorf("Failed to write add-chain resp: %v", resp)
+		return fmt.Errorf("failed to write add-chain resp: %v", resp)
 	}
 
 	return nil

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -133,7 +133,7 @@ func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []han
 		{"get-sth", wrappedGetSTHHandler(c).AsHandleFunc()},
 		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c).AsHandleFunc()},
 		{"get-proof-by-hash", wrappedGetProofByHashHandler(c).AsHandleFunc()},
-		{"get-entries", wrappedGetEntriesHandler(c)},
+		{"get-entries", wrappedGetEntriesHandler(c).AsHandleFunc()},
 		{"get-roots", wrappedGetRootsHandler(trustedRoots).AsHandleFunc()},
 		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c)}}
 }
@@ -863,7 +863,7 @@ func TestGetEntriesRanges(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		handler(w, req)
+		handler.ServeHTTP(w, req)
 
 		if expected, got := testCase.expectedStatus, w.Code; expected != got {
 			t.Fatalf("expected status %d, got %d for test case %s", expected, got, testCase.explanation)
@@ -898,7 +898,7 @@ func TestGetEntriesErrorFromBackend(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for backend error, got %v. Body: %v", want, got, w.Body)
@@ -927,7 +927,7 @@ func TestGetEntriesBackendReturnedExtraLeaves(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("expected %v for backend too many leaves, got %v. Body: %v", want, got, w.Body)
@@ -956,7 +956,7 @@ func TestGetEntriesBackendReturnedNonContiguousRange(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("expected %v for backend too many leaves, got %v. Body: %v", want, got, w.Body)
@@ -985,7 +985,7 @@ func TestGetEntriesLeafCorrupt(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	// We should still have received the data though it failed to deserialize.
 	if got, want := w.Code, http.StatusOK; got != want {
@@ -1051,7 +1051,7 @@ func TestGetEntries(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusOK; got != want {
 		t.Fatalf("Expected  %v for valid get-entries result, got %v. Body: %v", want, got, w.Body)
@@ -1596,7 +1596,7 @@ func getEntriesTestHelper(t *testing.T, request string, expectedStatus int, expl
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 	
 	if expected, got := expectedStatus, w.Code; expected != got {
 		t.Fatalf("expected status %d, got %d for test case %s", expected, got, explanation)

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -135,7 +135,7 @@ func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []han
 		{"get-proof-by-hash", wrappedGetProofByHashHandler(c).AsHandleFunc()},
 		{"get-entries", wrappedGetEntriesHandler(c).AsHandleFunc()},
 		{"get-roots", wrappedGetRootsHandler(trustedRoots).AsHandleFunc()},
-		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c)}}
+		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c).AsHandleFunc()}}
 }
 
 func allPostHandlersForTest(client trillian.TrillianLogClient) []handlerAndPath {
@@ -1286,7 +1286,7 @@ func TestGetEntryAndProofBadParams(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		handler(w, req)
+		handler.ServeHTTP(w, req)
 
 		if got, want := w.Code, http.StatusBadRequest; got != want {
 			t.Fatalf("expected %v for get-entry-and-proof with params [%s], got %v. Body: %v", want, requestParamString, got, w.Body)
@@ -1337,7 +1337,7 @@ func TestGetEntryAndProofBackendFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-entry-and-proof when backend fails, got %v. Body: %v", want, got, w.Body)
@@ -1395,7 +1395,7 @@ func TestGetEntryAndProofBackendBadResponse(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-entry-and-proof when backend fails, got %v. Body: %v", want, got, w.Body)
@@ -1468,7 +1468,7 @@ func TestGetEntryAndProof(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusOK; got != want {
 		t.Fatalf("Expected %v for get-entry-and-proof, got %v. Body: %v", want, got, w.Body)

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -147,8 +147,8 @@ func allPostHandlersForTest(client trillian.TrillianLogClient) []handlerAndPath 
 	}
 
 	return []handlerAndPath{
-		{"add-chain", wrappedAddChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})},
-		{"add-pre-chain", wrappedAddPreChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})}}
+		{"add-chain", wrappedAddChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool}).AsHandleFunc()},
+		{"add-pre-chain", wrappedAddPreChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool}).AsHandleFunc()}}
 }
 
 func TestPostHandlersOnlyAcceptPost(t *testing.T) {
@@ -1566,14 +1566,14 @@ func makeAddChainRequest(t *testing.T, reqHandlers CTRequestHandlers, body io.Re
 	return makeAddChainRequestInternal(t, handler, "add-chain", body)
 }
 
-func makeAddChainRequestInternal(t *testing.T, handler http.HandlerFunc, path string, body io.Reader) *httptest.ResponseRecorder {
+func makeAddChainRequestInternal(t *testing.T, handler appHandler, path string, body io.Reader) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", fmt.Sprintf("http://example.com/ct/v1/%s", path), body)
 	if err != nil {
 		t.Fatalf("Test request setup failed: %v", err)
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	return w
 }

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -125,17 +125,17 @@ const invalidLeafString string = "NOT A MERKLE TREE LEAF"
 
 type handlerAndPath struct {
 	path    string
-	handler http.HandlerFunc
+	handler appHandler
 }
 
 func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []handlerAndPath {
 	return []handlerAndPath{
-		{"get-sth", wrappedGetSTHHandler(c).AsHandleFunc()},
-		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c).AsHandleFunc()},
-		{"get-proof-by-hash", wrappedGetProofByHashHandler(c).AsHandleFunc()},
-		{"get-entries", wrappedGetEntriesHandler(c).AsHandleFunc()},
-		{"get-roots", wrappedGetRootsHandler(trustedRoots).AsHandleFunc()},
-		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c).AsHandleFunc()}}
+		{"get-sth", wrappedGetSTHHandler(c)},
+		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c)},
+		{"get-proof-by-hash", wrappedGetProofByHashHandler(c)},
+		{"get-entries", wrappedGetEntriesHandler(c)},
+		{"get-roots", wrappedGetRootsHandler(trustedRoots)},
+		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c)}}
 }
 
 func allPostHandlersForTest(client trillian.TrillianLogClient) []handlerAndPath {
@@ -147,8 +147,8 @@ func allPostHandlersForTest(client trillian.TrillianLogClient) []handlerAndPath 
 	}
 
 	return []handlerAndPath{
-		{"add-chain", wrappedAddChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool}).AsHandleFunc()},
-		{"add-pre-chain", wrappedAddPreChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool}).AsHandleFunc()}}
+		{"add-chain", wrappedAddChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})},
+		{"add-pre-chain", wrappedAddPreChainHandler(CTRequestHandlers{rpcClient: client, trustedRoots: pool})}}
 }
 
 func TestPostHandlersOnlyAcceptPost(t *testing.T) {

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -130,7 +130,7 @@ type handlerAndPath struct {
 
 func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []handlerAndPath {
 	return []handlerAndPath{
-		{"get-sth", wrappedGetSTHHandler(c)},
+		{"get-sth", wrappedGetSTHHandler(c).AsHandleFunc()},
 		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c)},
 		{"get-proof-by-hash", wrappedGetProofByHashHandler(c)},
 		{"get-entries", wrappedGetEntriesHandler(c)},
@@ -667,12 +667,12 @@ func TestGetSTHBackendErrorFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v, got %v", want, got)
 	}
-	if want, in := "backendfailure", w.Body.String(); !strings.Contains(in, want) {
+	if want, in := "rpc failed", w.Body.String(); !strings.Contains(in, want) {
 		t.Fatalf("Expected to find %s within %s", want, in)
 	}
 }
@@ -697,7 +697,7 @@ func TestGetSTHInvalidBackendTreeSizeFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Got %v expected %v", got, want)
@@ -726,7 +726,7 @@ func TestGetSTHMissingRootHashFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Got %v expected %v", got, want)
@@ -759,7 +759,7 @@ func TestGetSTHSigningFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Got %v expected %v", got, want)
@@ -788,7 +788,7 @@ func TestGetSTH(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusOK; got != want {
 		t.Fatalf("Got %v expected %v", got, want)

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -132,7 +132,7 @@ func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []han
 	return []handlerAndPath{
 		{"get-sth", wrappedGetSTHHandler(c).AsHandleFunc()},
 		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c).AsHandleFunc()},
-		{"get-proof-by-hash", wrappedGetProofByHashHandler(c)},
+		{"get-proof-by-hash", wrappedGetProofByHashHandler(c).AsHandleFunc()},
 		{"get-entries", wrappedGetEntriesHandler(c)},
 		{"get-roots", wrappedGetRootsHandler(trustedRoots).AsHandleFunc()},
 		{"get-entry-and-proof", wrappedGetEntryAndProofHandler(c)}}
@@ -1108,7 +1108,7 @@ func TestGetProofByHashBadRequests(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		handler(w, req)
+		handler.ServeHTTP(w, req)
 
 		if got, want := w.Code, http.StatusBadRequest; got != want {
 			t.Fatalf("Expected %v for get-proof-by-hash with params [%s], got %v. Body: %v", want, requestParamString, got, w.Body)
@@ -1132,7 +1132,7 @@ func TestGetProofByHashBackendFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-proof-by-hash when backend fails, got %v. Body: %v", want, got, w.Body)
@@ -1162,7 +1162,7 @@ func TestGetProofByHashBackendMultipleProofs(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	// Should be OK if backend returns multiple proofs and we should get the first one
 	if got, want := w.Code, http.StatusOK; got != want {
@@ -1198,7 +1198,7 @@ func TestGetProofByHashBackendReturnsMissingHash(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-proof-by-hash when backend returns missing hash, got %v. Body: %v", want, got, w.Body)
@@ -1227,7 +1227,7 @@ func TestGetProofByHash(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusOK; got != want {
 		t.Fatalf("Expected %v for get-proof-by-hash, got %v. Body: %v", want, got, w.Body)

--- a/examples/ct/ct_handlers_test.go
+++ b/examples/ct/ct_handlers_test.go
@@ -131,7 +131,7 @@ type handlerAndPath struct {
 func allGetHandlersForTest(trustedRoots *PEMCertPool, c CTRequestHandlers) []handlerAndPath {
 	return []handlerAndPath{
 		{"get-sth", wrappedGetSTHHandler(c).AsHandleFunc()},
-		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c)},
+		{"get-sth-consistency", wrappedGetSTHConsistencyHandler(c).AsHandleFunc()},
 		{"get-proof-by-hash", wrappedGetProofByHashHandler(c)},
 		{"get-entries", wrappedGetEntriesHandler(c)},
 		{"get-roots", wrappedGetRootsHandler(trustedRoots, c.rpcClient)},
@@ -1263,7 +1263,7 @@ func TestGetSTHConsistencyBadParams(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		handler(w, req)
+		handler.ServeHTTP(w, req)
 
 		if got, want := w.Code, http.StatusBadRequest; got != want {
 			t.Fatalf("Expected %v for get-sth-consistency with params [%s], got %v. Body: %v", want, requestParamString, got, w.Body)
@@ -1312,7 +1312,7 @@ func TestGetSTHConsistencyBackendRPCFails(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-sth-consistency when backend fails, got %v. Body: %v", want, got, w.Body)
@@ -1368,7 +1368,7 @@ func TestGetSTHConsistencyBackendReturnsInvalidProof(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if got, want := w.Code, http.StatusInternalServerError; got != want {
 		t.Fatalf("Expected %v for get-sth-consistency when backend fails, got %v. Body: %v", want, got, w.Body)
@@ -1422,7 +1422,7 @@ func TestGetSTHConsistency(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	handler(w, req)
+	handler.ServeHTTP(w, req)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This is along the lines suggested on the Go blog. The handlers now return errors instead of setting the HTTP state. They're also required to return a status code. The adapter logs all the errors so duplicate code has been removed.