### PR TITLE
Fix potential crash validating queued log leaves

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -276,7 +276,7 @@ func (t *logTX) QueueLeaves(leaves []trillian.LogLeaf) error {
 			return fmt.Errorf("Queued leaf must have a hash of length %d", t.ts.hashSizeBytes)
 		}
 
-		if len(leaf.SignedEntryTimestamp.Signature.Signature) == 0 {
+		if leaf.SignedEntryTimestamp.Signature == nil || len(leaf.SignedEntryTimestamp.Signature.Signature) == 0 {
 			return errors.New("Queued leaf cannot have an empty signature")
 		}
 	}


### PR DESCRIPTION
Also ensure panic propagates from storage tests that use a deferred check.