### PR TITLE
Move test hashes used in compact_merkle_tree_test.go into testonly/

### DIFF
--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -12,38 +12,13 @@ import (
 	"github.com/google/trillian/testonly"
 )
 
-func getInputs() []trillian.Hash {
-	return []trillian.Hash{
-		trillian.Hash(""), trillian.Hash("\x00"), trillian.Hash("\x10"), trillian.Hash("\x20\x21"), trillian.Hash("\x30\x31"),
-		trillian.Hash("\x40\x41\x42\x43"), trillian.Hash("\x50\x51\x52\x53\x54\x55\x56\x57"),
-		trillian.Hash("\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f")}
-}
-
-func getTestRoots() []trillian.Hash {
-	return []trillian.Hash{
-		// constants from C++ test: https://github.com/google/certificate-transparency/blob/master/cpp/merkletree/merkle_tree_test.cc#L277
-		testonly.MustHexDecode("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
-		testonly.MustHexDecode("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"),
-		testonly.MustHexDecode("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"),
-		testonly.MustHexDecode("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
-		testonly.MustHexDecode("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"),
-		testonly.MustHexDecode("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"),
-		testonly.MustHexDecode("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"),
-		testonly.MustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
-}
-
-func emptyTreeHash() trillian.Hash {
-	const sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	return testonly.MustHexDecode(sha256EmptyTreeHash)
-}
-
 func getTree() *CompactMerkleTree {
 	return NewCompactMerkleTree(NewRFC6962TreeHasher(trillian.NewSHA256()))
 }
 
 func TestAddingLeaves(t *testing.T) {
-	inputs := getInputs()
-	roots := getTestRoots()
+	inputs := testonly.GetInputs()
+	roots := testonly.GetTestRoots()
 	// We test the "same" thing 3 different ways this is to ensure than any lazy
 	// update strategy being employed by the implementation doesn't affect the
 	// api-visible calculation of root & size.
@@ -53,7 +28,7 @@ func TestAddingLeaves(t *testing.T) {
 		if got, want := tree.Size(), int64(0); got != want {
 			t.Fatalf("Got size of %d, expected %d", got, want)
 		}
-		if got, want := tree.CurrentRoot(), emptyTreeHash(); !bytes.Equal(got, want) {
+		if got, want := tree.CurrentRoot(), testonly.EmptyTreeHash(); !bytes.Equal(got, want) {
 			t.Fatalf("Got root of %v, expected %v", got, want)
 		}
 

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -17,8 +17,8 @@ func getTree() *CompactMerkleTree {
 }
 
 func TestAddingLeaves(t *testing.T) {
-	inputs := testonly.GetInputs()
-	roots := testonly.GetTestRoots()
+	inputs := testonly.MerkleTreeLeafTestInputs()
+	roots := testonly.MerkleTreeLeafTestRootHashes()
 	// We test the "same" thing 3 different ways this is to ensure than any lazy
 	// update strategy being employed by the implementation doesn't affect the
 	// api-visible calculation of root & size.
@@ -28,7 +28,7 @@ func TestAddingLeaves(t *testing.T) {
 		if got, want := tree.Size(), int64(0); got != want {
 			t.Fatalf("Got size of %d, expected %d", got, want)
 		}
-		if got, want := tree.CurrentRoot(), testonly.EmptyTreeHash(); !bytes.Equal(got, want) {
+		if got, want := tree.CurrentRoot(), testonly.EmptyMerkleTreeRootHash(); !bytes.Equal(got, want) {
 			t.Fatalf("Got root of %v, expected %v", got, want)
 		}
 

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -4,14 +4,21 @@ import (
 	"github.com/google/trillian"
 )
 
-func GetInputs() []trillian.Hash {
+// MerkleTreeLeafTestInputs returns a slice of leaf inputs that may be used in
+// compact merkle tree test cases.  They are intended to be added successively,
+// so that after each addition the corresponding root from MerkleTreeLeafTestRoots
+// gives the expected Merkle tree root hash.
+func MerkleTreeLeafTestInputs() []trillian.Hash {
 	return []trillian.Hash{
 		trillian.Hash(""), trillian.Hash("\x00"), trillian.Hash("\x10"), trillian.Hash("\x20\x21"), trillian.Hash("\x30\x31"),
 		trillian.Hash("\x40\x41\x42\x43"), trillian.Hash("\x50\x51\x52\x53\x54\x55\x56\x57"),
 		trillian.Hash("\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f")}
 }
 
-func GetTestRoots() []trillian.Hash {
+// MerkleTreeLeafTestRootHashes returns a slice of Merkle tree root hashes that
+// correspond to the expected tree state for the leaf additions returned by
+// MerkleTreeLeafTestInputs(), as described above.
+func MerkleTreeLeafTestRootHashes() []trillian.Hash {
 	return []trillian.Hash{
 		// constants from C++ test: https://github.com/google/certificate-transparency/blob/master/cpp/merkletree/merkle_tree_test.cc#L277
 		MustHexDecode("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
@@ -24,7 +31,9 @@ func GetTestRoots() []trillian.Hash {
 		MustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
 }
 
-func EmptyTreeHash() trillian.Hash {
+// EmptyMerkleTreeRootHash returns the expected root hash for an empty Merkle Tree
+// that uses SHA-256 hashing.
+func EmptyMerkleTreeRootHash() trillian.Hash {
 	const sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	return MustHexDecode(sha256EmptyTreeHash)
 }

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -1,0 +1,30 @@
+package testonly
+
+import (
+	"github.com/google/trillian"
+)
+
+func GetInputs() []trillian.Hash {
+	return []trillian.Hash{
+		trillian.Hash(""), trillian.Hash("\x00"), trillian.Hash("\x10"), trillian.Hash("\x20\x21"), trillian.Hash("\x30\x31"),
+		trillian.Hash("\x40\x41\x42\x43"), trillian.Hash("\x50\x51\x52\x53\x54\x55\x56\x57"),
+		trillian.Hash("\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f")}
+}
+
+func GetTestRoots() []trillian.Hash {
+	return []trillian.Hash{
+		// constants from C++ test: https://github.com/google/certificate-transparency/blob/master/cpp/merkletree/merkle_tree_test.cc#L277
+		MustHexDecode("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
+		MustHexDecode("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"),
+		MustHexDecode("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"),
+		MustHexDecode("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
+		MustHexDecode("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"),
+		MustHexDecode("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"),
+		MustHexDecode("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"),
+		MustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
+}
+
+func EmptyTreeHash() trillian.Hash {
+	const sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	return MustHexDecode(sha256EmptyTreeHash)
+}


### PR DESCRIPTION
This is so they can be re-used in other tests.