### PR TITLE
Add 'func (c CompactMerkleTree) Hashes() []trillian.Hash'

### DIFF
--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -225,6 +225,14 @@ func (c CompactMerkleTree) Size() int64 {
 	return c.size
 }
 
+// Hashes returns a copy of the set of node hashes that comprise the compact representation of the tree.
+func (c CompactMerkleTree) Hashes() []trillian.Hash {
+	n := make([]trillian.Hash, len(c.nodes))
+	copy(n, c.nodes)
+	return n
+}
+
+// Depth returns the number of levels in the tree.
 func (c CompactMerkleTree) Depth() int {
 	if c.size == 0 {
 		return 0

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -19,6 +20,8 @@ func getTree() *CompactMerkleTree {
 func TestAddingLeaves(t *testing.T) {
 	inputs := testonly.MerkleTreeLeafTestInputs()
 	roots := testonly.MerkleTreeLeafTestRootHashes()
+	hasheses := testonly.CompactMerkleTreeLeafTestNodeHashes()
+
 	// We test the "same" thing 3 different ways this is to ensure than any lazy
 	// update strategy being employed by the implementation doesn't affect the
 	// api-visible calculation of root & size.
@@ -40,6 +43,9 @@ func TestAddingLeaves(t *testing.T) {
 			if got, want := tree.CurrentRoot(), roots[i]; !bytes.Equal(got, want) {
 				t.Fatalf("Expected root of %v, got %v", got, want)
 			}
+			if got, want := tree.Hashes(), hasheses[i]; !reflect.DeepEqual(got, want) {
+				t.Fatalf("Expected hashes %v, got %v", got, want)
+			}
 		}
 	}
 
@@ -55,6 +61,9 @@ func TestAddingLeaves(t *testing.T) {
 		if got, want := tree.CurrentRoot(), roots[7]; !bytes.Equal(got, want) {
 			t.Fatalf("Expected root of %v, got %v", got, want)
 		}
+		if got, want := tree.Hashes(), hasheses[7]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Expected hashes %v, got %v", got, want)
+		}
 	}
 
 	{
@@ -69,6 +78,9 @@ func TestAddingLeaves(t *testing.T) {
 		if got, want := tree.CurrentRoot(), roots[2]; !bytes.Equal(got, want) {
 			t.Fatalf("Expected root of %v, got %v", got, want)
 		}
+		if got, want := tree.Hashes(), hasheses[2]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Expected hashes %v, got %v", got, want)
+		}
 
 		for i := 3; i < 8; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, trillian.Hash) {})
@@ -78,6 +90,9 @@ func TestAddingLeaves(t *testing.T) {
 		}
 		if got, want := tree.CurrentRoot(), roots[7]; !bytes.Equal(got, want) {
 			t.Fatalf("Expected root of %v, got %v", got, want)
+		}
+		if got, want := tree.Hashes(), hasheses[7]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Expected hashes %v, got %v", got, want)
 		}
 	}
 }

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -31,6 +31,22 @@ func MerkleTreeLeafTestRootHashes() []trillian.Hash {
 		MustHexDecode("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328")}
 }
 
+// CompactMerkleTreeLeafTestNodeHashes returns the CompactMerkleTree.node state
+// that must result after each of the leaf additions returned by
+// MerkleTreeLeafTestInputs(), as described above.
+func CompactMerkleTreeLeafTestNodeHashes() [][]trillian.Hash {
+	return [][]trillian.Hash{
+		[]trillian.Hash{MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=")},
+		[]trillian.Hash{MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
+		[]trillian.Hash{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
+		[]trillian.Hash{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="), MustDecodeBase64("XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=")},
+	}
+}
+
 // EmptyMerkleTreeRootHash returns the expected root hash for an empty Merkle Tree
 // that uses SHA-256 hashing.
 func EmptyMerkleTreeRootHash() trillian.Hash {


### PR DESCRIPTION
For safety, Hashes() returns a copy of the tree's internal 'nodes' array.
It might be used e.g. when serializing the CompactMerkleTree state.
