### PR TITLE
Ensure nodes that are not part of the compact merkle tree state

### DIFF
--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -197,6 +197,8 @@ func (c *CompactMerkleTree) AddLeafHash(leafHash trillian.Hash, f setNodeFunc) (
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		hash = c.hasher.HashChildren(c.nodes[bit], hash)
+		// Now, clear this position in the nodes list as the hash it formerly contained will be propogated upwards.
+		c.nodes[bit] = nil
 		// Store the resulting parent hash.
 		f(bit+1, index, hash)
 		// Figure out if we're done:

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -197,10 +197,10 @@ func (c *CompactMerkleTree) AddLeafHash(leafHash trillian.Hash, f setNodeFunc) (
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		hash = c.hasher.HashChildren(c.nodes[bit], hash)
-		// Now, clear this position in the nodes list as the hash it formerly contained will be propogated upwards.
-		c.nodes[bit] = nil
 		// Store the resulting parent hash.
 		f(bit+1, index, hash)
+		// Now, clear this position in the nodes list as the hash it formerly contained will be propogated upwards.
+		c.nodes[bit] = nil
 		// Figure out if we're done:
 		if bit+1 >= len(c.nodes) {
 			// If we're extending the node list then add a new entry with our

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -18,7 +18,7 @@ func getTree() *CompactMerkleTree {
 	return NewCompactMerkleTree(NewRFC6962TreeHasher(trillian.NewSHA256()))
 }
 
-func (c *CompactMerkleTree) checkUnusedNodesInvariant() error {
+func checkUnusedNodesInvariant(c *CompactMerkleTree) error {
 	// The structure of this invariant check mirrors the structure in
 	// NewCompactMerkleTreeWithState in which only the nodes which
 	// should be present for a tree of given size are fetched from the
@@ -29,21 +29,21 @@ func (c *CompactMerkleTree) checkUnusedNodesInvariant() error {
 		for i, n := range c.nodes {
 			expectNil := i != sizeBits-1
 			if expectNil && n != nil {
-				return fmt.Errorf("Perfect Tree size %d has non-nil node at index %d, wanted nil", size, i)
+				return fmt.Errorf("perfect Tree size %d has non-nil node at index %d, wanted nil", size, i)
 			}
 			if !expectNil && n == nil {
-				return fmt.Errorf("Perfect Tree size %d has nil node at index %d, wanted non-nil", size, i)
+				return fmt.Errorf("perfect Tree size %d has nil node at index %d, wanted non-nil", size, i)
 			}
 		}
 	} else {
 		for depth := 0; depth < sizeBits; depth++ {
 			if size&1 == 1 {
 				if c.nodes[depth] == nil {
-					return fmt.Errorf("Imperfect Tree size %d has nil node at index %d, wanted non-nil", c.size, depth)
+					return fmt.Errorf("imperfect Tree size %d has nil node at index %d, wanted non-nil", c.size, depth)
 				}
 			} else {
 				if c.nodes[depth] != nil {
-					return fmt.Errorf("Imperfect Tree size %d has non-nil node at index %d, wanted nil", c.size, depth)
+					return fmt.Errorf("imperfect Tree size %d has non-nil node at index %d, wanted nil", c.size, depth)
 				}
 			}
 			size >>= 1
@@ -72,7 +72,7 @@ func TestAddingLeaves(t *testing.T) {
 
 		for i := 0; i < 8; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, trillian.Hash) {})
-			if err := tree.checkUnusedNodesInvariant(); err != nil {
+			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
 			if got, want := tree.Size(), int64(i+1); got != want {
@@ -92,7 +92,7 @@ func TestAddingLeaves(t *testing.T) {
 		tree := getTree()
 		for i := 0; i < 8; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, trillian.Hash) {})
-			if err := tree.checkUnusedNodesInvariant(); err != nil {
+			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
 		}
@@ -112,7 +112,7 @@ func TestAddingLeaves(t *testing.T) {
 		tree := getTree()
 		for i := 0; i < 3; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, trillian.Hash) {})
-			if err := tree.checkUnusedNodesInvariant(); err != nil {
+			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
 		}
@@ -128,7 +128,7 @@ func TestAddingLeaves(t *testing.T) {
 
 		for i := 3; i < 8; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, trillian.Hash) {})
-			if err := tree.checkUnusedNodesInvariant(); err != nil {
+			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
 		}

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -37,13 +37,13 @@ func MerkleTreeLeafTestRootHashes() []trillian.Hash {
 func CompactMerkleTreeLeafTestNodeHashes() [][]trillian.Hash {
 	return [][]trillian.Hash{
 		[]trillian.Hash{MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=")},
-		[]trillian.Hash{MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
+		[]trillian.Hash{nil, MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
 		[]trillian.Hash{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
-		[]trillian.Hash{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
-		[]trillian.Hash{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
-		[]trillian.Hash{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{nil, nil, MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), nil, MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[]trillian.Hash{nil, MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
 		[]trillian.Hash{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
-		[]trillian.Hash{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="), MustDecodeBase64("XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=")},
+		[]trillian.Hash{nil, nil, nil, MustDecodeBase64("XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=")},
 	}
 }
 


### PR DESCRIPTION
for given tree size are set to nil when new leaves are added.
Check using an invariant after each AddLeaf in the tests.
Fix test data to have nils in the appropriate places.