### PR TITLE
Remove a testing.Logf() line that spoils otherwise quiet test output

### DIFF
--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -378,12 +378,11 @@ func testSparseTreeFetches(t *testing.T, vec sparseTestVector) {
 		readMutex.Lock()
 
 		// calculate the set of expected node reads.
-		for i, kv := range vec.kv {
+		for _, kv := range vec.kv {
 			keyHash := w.hasher.HashKey([]byte(kv.k))
 			nodeID := storage.NewNodeIDFromHash(keyHash)
 			leafNodeIDs = append(leafNodeIDs, nodeID)
 			sibs := nodeID.Siblings()
-			t.Logf("hash %d: %s", i, nodeID.String())
 
 			// start with the set of siblings of all leaves:
 			for j := range sibs {


### PR DESCRIPTION
I assume this isn't needed anymore; shout if it was being kept for some reason.