### PR TITLE
Hetrogeneous tree stratification

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -19,8 +19,21 @@ type GetSubtreeFunc func(id storage.NodeID) (*storage.SubtreeProto, error)
 // SetSubtreeFunc describes a function which can store a Subtree into storage.
 type SetSubtreesFunc func(s []*storage.SubtreeProto) error
 
+// strataInfo represents a single statum across the tree.
+// It it used inside the SubtreeCache to determine which Subtree prefix should
+// be used for a given NodeID.
+type strataInfo struct {
+	// prefixBytes is the number of prefix bytes above this stratum.
+	prefixBytes int
+	// depth is the depth of this stratum.
+	depth int
+}
+
 // SubtreeCache provides a caching access to Subtree storage.
 type SubtreeCache struct {
+	// prefixLengths contains the strata prefix sizes for each multiple-of-8 tree
+	// size.
+	strataInfo []strataInfo
 	// subtrees contains the Subtree data read from storage, and is updated by
 	// calls to SetNodeHash.
 	subtrees map[string]*storage.SubtreeProto
@@ -39,28 +52,45 @@ type Suffix struct {
 	// bits is the number of bits in the node ID suffix.
 	bits byte
 	// path is the suffix itself.
-	path byte
+	path []byte
 }
 
 func (s Suffix) serialize() string {
-	r := make([]byte, 2)
+	r := make([]byte, 1, 1+(len(s.path)))
 	r[0] = s.bits
-	r[1] = s.path
+	r = append(r, s.path...)
 	return base64.StdEncoding.EncodeToString(r)
 }
-
-const (
-	// strataDepth is the depth of Subtree.
-	strataDepth = 8
-)
 
 // NewSubtreeCache returns a newly intialised cache ready for use.
 // populateSubtree is a function which knows how to populate a subtree's
 // internal nodes given its leaves, and will be called for each subtree loaded
 // from storage.
 // TODO(al): consider supporting different sized subtrees - for now everything's subtrees of 8 levels.
-func NewSubtreeCache(populateSubtree storage.PopulateSubtreeFunc) SubtreeCache {
+func NewSubtreeCache(strata []int, populateSubtree storage.PopulateSubtreeFunc) SubtreeCache {
+	// TODO(al): pass this in
+	maxTreeDepth := 256
+	// Precalculate strata information based on the passed in strata depths:
+	sInfo := make([]strataInfo, 0, maxTreeDepth/8)
+	t := 0
+	for _, s := range strata {
+		if s%8 != 0 {
+			panic(fmt.Errorf("got strata depth of %d, must be a multiple of 8", s))
+		}
+		pb := t / 8
+		for i := 0; i < s; i += 8 {
+			sInfo = append(sInfo, strataInfo{pb, s})
+			t += 8
+		}
+	}
+	// TODO(al): This needs to be passed in, particularly for Map use cases where
+	// we need to know it matches the number of bits in the chosen hash function.
+	if got, want := t, maxTreeDepth; got != want {
+		panic(fmt.Errorf("strata indicate tree of depth %d, but expected %d", got, want))
+	}
+
 	return SubtreeCache{
+		strataInfo:      sInfo,
 		subtrees:        make(map[string]*storage.SubtreeProto),
 		dirtyPrefixes:   make(map[string]bool),
 		mutex:           new(sync.RWMutex),
@@ -68,23 +98,29 @@ func NewSubtreeCache(populateSubtree storage.PopulateSubtreeFunc) SubtreeCache {
 	}
 }
 
+func (s *SubtreeCache) strataInfoForPrefixLength(numBits int) strataInfo {
+	return s.strataInfo[(numBits-1)/8]
+}
+
 // splitNodeID breaks a NodeID out into its prefix and suffix parts.
 // unless ID is 0 bits long, Suffix must always contain at least one bit.
-func splitNodeID(id storage.NodeID) ([]byte, Suffix) {
+func (s *SubtreeCache) splitNodeID(id storage.NodeID) ([]byte, Suffix) {
 	if id.PrefixLenBits == 0 {
-		return []byte{}, Suffix{bits: 0, path: 0}
+		return []byte{}, Suffix{bits: 0, path: []byte{0}}
 	}
-	prefixSplit := (id.PrefixLenBits - 1) / strataDepth
-	s := Suffix{
-		bits: byte((id.PrefixLenBits-1)%strataDepth) + 1,
-		path: id.Path[prefixSplit],
+	a := make([]byte, len(id.Path))
+	copy(a, id.Path)
+	sInfo := s.strataInfoForPrefixLength(id.PrefixLenBits)
+	prefixSplit := sInfo.prefixBytes
+	sfx := Suffix{
+		bits: byte((id.PrefixLenBits-1)%sInfo.depth) + 1,
+		path: a[prefixSplit : prefixSplit+sInfo.depth/8],
 	}
-	s.path &= ((0x01 << s.bits) - 1) << uint(8-s.bits)
+	maskIndex := int((sfx.bits - 1) / 8)
+	maskLowBits := (sfx.bits-1)%8 + 1
+	sfx.path[maskIndex] &= ((0x01 << maskLowBits) - 1) << uint(8-maskLowBits)
 
-	// TODO(al): is all this copying actually necessary?
-	r := make([]byte, prefixSplit)
-	copy(r, id.Path[:prefixSplit])
-	return r, s
+	return a[:prefixSplit], sfx
 }
 
 func (s *SubtreeCache) Preload(ids []storage.NodeID, getSubtrees func(id []storage.NodeID) ([]*storage.SubtreeProto, error)) error {
@@ -95,7 +131,7 @@ func (s *SubtreeCache) Preload(ids []storage.NodeID, getSubtrees func(id []stora
 	want := make(map[string]*storage.NodeID)
 	for _, id := range ids {
 		id := id
-		px, _ := splitNodeID(id)
+		px, _ := s.splitNodeID(id)
 		pxKey := string(px)
 		_, ok := s.subtrees[pxKey]
 		id.PrefixLenBits = len(px) * 8
@@ -129,7 +165,7 @@ func (s *SubtreeCache) GetNodeHash(id storage.NodeID, getSubtree GetSubtreeFunc)
 
 // getNodeHashUnderLock must be called with s.mutex locked.
 func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSubtreeFunc) (trillian.Hash, error) {
-	px, sx := splitNodeID(id)
+	px, sx := s.splitNodeID(id)
 	prefixKey := string(px)
 	c := s.subtrees[prefixKey]
 	if c == nil {
@@ -141,13 +177,14 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 		if err != nil {
 			return nil, err
 		}
+		sInfo := s.strataInfoForPrefixLength(subID.PrefixLenBits)
 		if c == nil {
 			// storage didn't have one for us, so we'll store an empty proto here
 			// incase we try to update it later on (we won't flush it back to
 			// storage unless it's been written to.)
 			c = &storage.SubtreeProto{
 				Prefix:        px,
-				Depth:         strataDepth,
+				Depth:         int32(sInfo.depth),
 				Leaves:        make(map[string][]byte),
 				InternalNodes: make(map[string][]byte),
 			}
@@ -187,7 +224,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h trillian.Hash, getSubtree GetSubtreeFunc) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	px, sx := splitNodeID(id)
+	px, sx := s.splitNodeID(id)
 	prefixKey := string(px)
 	c := s.subtrees[prefixKey]
 	if c == nil {
@@ -259,7 +296,7 @@ func makeSuffixKey(depth int, index int64) (string, error) {
 	if index > 255 || index < 0 {
 		return "", fmt.Errorf("got unsupported index of %d, 0 <= index < 256", index)
 	}
-	sfx := Suffix{byte(depth), byte(index)}
+	sfx := Suffix{byte(depth), []byte{byte(index)}}
 	return sfx.serialize(), nil
 }
 

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -357,11 +357,11 @@ func runLogSubtreeKAT(t *testing.T, data logKATData) {
 
 func TestPrefixLengths(t *testing.T) {
 	strata := []int{8, 8, 16, 32, 64, 128}
-	strataInfo := []strataInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
+	stratumInfo := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
 	c := NewSubtreeCache(strata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(trillian.NewSHA256())))
 
-	if got, want := c.strataInfo, strataInfo; !reflect.DeepEqual(got, want) {
+	if got, want := c.stratumInfo, stratumInfo; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Got prefixLengths of %v, expected %v", got, want)
 	}
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -47,6 +47,8 @@ const selectLeavesByHashSql string = `SELECT l.LeafHash,l.TheData,s.SequenceNumb
 // Same as above except with leaves ordered by sequence so we only incur this cost when necessary
 const selectLeavesByHashOrderedBySequenceSQL string = selectLeavesByHashSql + " ORDER BY s.SequenceNumber"
 
+var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
+
 type mySQLLogStorage struct {
 	mySQLTreeStorage
 
@@ -58,7 +60,7 @@ type mySQLLogStorage struct {
 func NewLogStorage(id trillian.LogID, dbURL string) (storage.LogStorage, error) {
 	// TODO(al): pass this through/configure from DB
 	th := merkle.NewRFC6962TreeHasher(trillian.NewSHA256())
-	ts, err := newTreeStorage(id.TreeID, dbURL, th.Size(), cache.PopulateLogSubtreeNodes(th))
+	ts, err := newTreeStorage(id.TreeID, dbURL, th.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(th))
 	if err != nil {
 		glog.Warningf("Couldn't create a new treeStorage: %s", err)
 		return nil, err

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -28,7 +28,7 @@ const selectMapLeafSQL string = `SELECT KeyHash, MAX(MapRevision), TheData
 				 MapRevision >= ?
 	 GROUP BY KeyHash`
 
-var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
+var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
 type mySQLMapStorage struct {
 	mySQLTreeStorage

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -28,6 +28,8 @@ const selectMapLeafSQL string = `SELECT KeyHash, MAX(MapRevision), TheData
 				 MapRevision >= ?
 	 GROUP BY KeyHash`
 
+var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
+
 type mySQLMapStorage struct {
 	mySQLTreeStorage
 
@@ -41,7 +43,7 @@ func (m *mySQLMapStorage) MapID() trillian.MapID {
 func NewMapStorage(id trillian.MapID, dbURL string) (storage.MapStorage, error) {
 	// TODO(al): pass this through/configure from DB
 	th := merkle.NewRFC6962TreeHasher(trillian.NewSHA256())
-	ts, err := newTreeStorage(id.TreeID, dbURL, th.Size(), cache.PopulateMapSubtreeNodes(th))
+	ts, err := newTreeStorage(id.TreeID, dbURL, th.Size(), defaultMapStrata, cache.PopulateMapSubtreeNodes(th))
 	if err != nil {
 		glog.Warningf("Couldn't create a new treeStorage: %s", err)
 		return nil, err


### PR DESCRIPTION
Allows the storage to use differently sized subtrees depending on their depth in the tree.
Mostly useful for the sparse map, where it's quite unlikely that entries below 80-bits of prefix will have (m)any neighbours in their subtrees.