### PR TITLE
Add a generic GRPC server interceptor for collecting basic stats 

### DIFF
--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -1,0 +1,95 @@
+package monitoring
+
+import (
+	"expvar"
+	"fmt"
+	"time"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"github.com/google/trillian/util"
+)
+
+const (
+	nanosToMillisDivisor int64 = 1000000
+
+	requestCountMapName string = "requests-by-handler"
+	successCountMapName string = "success-by-handler"
+	errorCountMapName string = "errors-by-handler"
+	successLatencyTotalMapName string = "successful-total-latency-by-handler-ms"
+	errorLatencyTotalMapName string = "errored-total-latency-by-handler-ms"
+)
+
+type RpcStatsInterceptor struct {
+	baseName                           string
+	timeSource                         util.TimeSource
+	handlerRequestCountMap             *expvar.Map
+	handlerRequestSucceededMap         *expvar.Map
+	handlerRequestErrorsMap            *expvar.Map
+	handlerRequestSuccessfulLatencyMap *expvar.Map
+	handlerRequestFailedLatencyMap     *expvar.Map
+}
+
+func NewRpcStatsInterceptor(timeSource util.TimeSource, application, component string) *RpcStatsInterceptor {
+	return &RpcStatsInterceptor{baseName: fmt.Sprintf("%s/%s", application, component), timeSource: timeSource,
+		handlerRequestCountMap: new(expvar.Map).Init(),
+		handlerRequestSucceededMap: new(expvar.Map).Init(),
+		handlerRequestErrorsMap: new(expvar.Map).Init(),
+		handlerRequestSuccessfulLatencyMap: new(expvar.Map).Init(),
+		handlerRequestFailedLatencyMap: new(expvar.Map).Init()}
+}
+
+func (r RpcStatsInterceptor) nameForMap(name string) string {
+	return fmt.Sprintf("%s/%s", r.baseName, name)
+}
+
+// Publish must be called for stats to be visible. The expvar framework will prevent
+// multiple calls to Publish from succeeding.
+func (r RpcStatsInterceptor) Publish() {
+	expvar.Publish(r.nameForMap(requestCountMapName), r.handlerRequestCountMap)
+	expvar.Publish(r.nameForMap(successCountMapName), r.handlerRequestSucceededMap)
+	expvar.Publish(r.nameForMap(errorCountMapName), r.handlerRequestErrorsMap)
+	expvar.Publish(r.nameForMap(successLatencyTotalMapName), r.handlerRequestSuccessfulLatencyMap)
+	expvar.Publish(r.nameForMap(errorLatencyTotalMapName), r.handlerRequestFailedLatencyMap)
+}
+
+func (r RpcStatsInterceptor) recordFailureLatency(method string, startTime time.Time) {
+	latency := r.timeSource.Now().Sub(startTime)
+	r.handlerRequestErrorsMap.Add(method, 1)
+	r.handlerRequestFailedLatencyMap.Add(method, latency.Nanoseconds() / nanosToMillisDivisor)
+}
+
+// Interceptor returns a UnaryServerInterceptor that can be registered with an RPC server and
+// will record request counts / errors and latencies for that servers handlers
+func (r RpcStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		method := info.FullMethod
+
+		// Increase the request count for the method and start the clock
+		r.handlerRequestCountMap.Add(method, 1)
+		startTime := r.timeSource.Now()
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				// If we reach here then the handler exited via panic, count it as a server failure
+				r.recordFailureLatency(method, startTime)
+			}
+		}()
+
+		// Invoke the actual operation
+		res, err := handler(ctx, req)
+
+		// Record success / failure and latency
+		if (err != nil) {
+			r.recordFailureLatency(method, startTime)
+		} else {
+			latency := r.timeSource.Now().Sub(startTime)
+
+			r.handlerRequestSucceededMap.Add(method, 1)
+			r.handlerRequestSuccessfulLatencyMap.Add(method, latency.Nanoseconds() / nanosToMillisDivisor)
+		}
+
+		// Pass the result of the handler invocation back
+		return res, err
+	}
+}

--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -14,54 +14,54 @@ const (
 	nanosToMillisDivisor int64 = 1000000
 
 	requestCountMapName string = "requests-by-handler"
-	successCountMapName string = "success-by-handler"
-	errorCountMapName string = "errors-by-handler"
-	successLatencyTotalMapName string = "successful-total-latency-by-handler-ms"
-	errorLatencyTotalMapName string = "errored-total-latency-by-handler-ms"
+	requestSucceededCountMapName string = "success-by-handler"
+	requestErrorCountMapName string = "errors-by-handler"
+	requestSucceededLatencyMapName string = "succeeded-request-total-latency-by-handler-ms"
+	requestFailedLatencyMapName string = "failed-request-total-latency-by-handler-ms"
 )
 
-type RpcStatsInterceptor struct {
-	baseName                           string
-	timeSource                         util.TimeSource
-	handlerRequestCountMap             *expvar.Map
-	handlerRequestSucceededMap         *expvar.Map
-	handlerRequestErrorsMap            *expvar.Map
-	handlerRequestSuccessfulLatencyMap *expvar.Map
-	handlerRequestFailedLatencyMap     *expvar.Map
+type RPCStatsInterceptor struct {
+	baseName                          string
+	timeSource                        util.TimeSource
+	handlerRequestCountMap            *expvar.Map
+	handlerRequestSucceededCountMap   *expvar.Map
+	handlerRequestErrorCountMap       *expvar.Map
+	handlerRequestSucceededLatencyMap *expvar.Map
+	handlerRequestFailedLatencyMap    *expvar.Map
 }
 
-func NewRpcStatsInterceptor(timeSource util.TimeSource, application, component string) *RpcStatsInterceptor {
-	return &RpcStatsInterceptor{baseName: fmt.Sprintf("%s/%s", application, component), timeSource: timeSource,
+func NewRPCStatsInterceptor(timeSource util.TimeSource, application, component string) *RPCStatsInterceptor {
+	return &RPCStatsInterceptor{baseName: fmt.Sprintf("%s/%s", application, component), timeSource: timeSource,
 		handlerRequestCountMap: new(expvar.Map).Init(),
-		handlerRequestSucceededMap: new(expvar.Map).Init(),
-		handlerRequestErrorsMap: new(expvar.Map).Init(),
-		handlerRequestSuccessfulLatencyMap: new(expvar.Map).Init(),
+		handlerRequestSucceededCountMap: new(expvar.Map).Init(),
+		handlerRequestErrorCountMap: new(expvar.Map).Init(),
+		handlerRequestSucceededLatencyMap: new(expvar.Map).Init(),
 		handlerRequestFailedLatencyMap: new(expvar.Map).Init()}
 }
 
-func (r RpcStatsInterceptor) nameForMap(name string) string {
+func (r RPCStatsInterceptor) nameForMap(name string) string {
 	return fmt.Sprintf("%s/%s", r.baseName, name)
 }
 
 // Publish must be called for stats to be visible. The expvar framework will prevent
 // multiple calls to Publish from succeeding.
-func (r RpcStatsInterceptor) Publish() {
+func (r RPCStatsInterceptor) Publish() {
 	expvar.Publish(r.nameForMap(requestCountMapName), r.handlerRequestCountMap)
-	expvar.Publish(r.nameForMap(successCountMapName), r.handlerRequestSucceededMap)
-	expvar.Publish(r.nameForMap(errorCountMapName), r.handlerRequestErrorsMap)
-	expvar.Publish(r.nameForMap(successLatencyTotalMapName), r.handlerRequestSuccessfulLatencyMap)
-	expvar.Publish(r.nameForMap(errorLatencyTotalMapName), r.handlerRequestFailedLatencyMap)
+	expvar.Publish(r.nameForMap(requestSucceededCountMapName), r.handlerRequestSucceededCountMap)
+	expvar.Publish(r.nameForMap(requestErrorCountMapName), r.handlerRequestErrorCountMap)
+	expvar.Publish(r.nameForMap(requestSucceededLatencyMapName), r.handlerRequestSucceededLatencyMap)
+	expvar.Publish(r.nameForMap(requestFailedLatencyMapName), r.handlerRequestFailedLatencyMap)
 }
 
-func (r RpcStatsInterceptor) recordFailureLatency(method string, startTime time.Time) {
+func (r RPCStatsInterceptor) recordFailureLatency(method string, startTime time.Time) {
 	latency := r.timeSource.Now().Sub(startTime)
-	r.handlerRequestErrorsMap.Add(method, 1)
+	r.handlerRequestErrorCountMap.Add(method, 1)
 	r.handlerRequestFailedLatencyMap.Add(method, latency.Nanoseconds() / nanosToMillisDivisor)
 }
 
 // Interceptor returns a UnaryServerInterceptor that can be registered with an RPC server and
 // will record request counts / errors and latencies for that servers handlers
-func (r RpcStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
+func (r RPCStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		method := info.FullMethod
 
@@ -73,6 +73,7 @@ func (r RpcStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 			if rec := recover(); rec != nil {
 				// If we reach here then the handler exited via panic, count it as a server failure
 				r.recordFailureLatency(method, startTime)
+				panic(rec)
 			}
 		}()
 
@@ -80,13 +81,13 @@ func (r RpcStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 		res, err := handler(ctx, req)
 
 		// Record success / failure and latency
-		if (err != nil) {
+		if err != nil {
 			r.recordFailureLatency(method, startTime)
 		} else {
 			latency := r.timeSource.Now().Sub(startTime)
 
-			r.handlerRequestSucceededMap.Add(method, 1)
-			r.handlerRequestSuccessfulLatencyMap.Add(method, latency.Nanoseconds() / nanosToMillisDivisor)
+			r.handlerRequestSucceededCountMap.Add(method, 1)
+			r.handlerRequestSucceededLatencyMap.Add(method, latency.Nanoseconds() / nanosToMillisDivisor)
 		}
 
 		// Pass the result of the handler invocation back

--- a/monitoring/rpc_stats_interceptor_test.go
+++ b/monitoring/rpc_stats_interceptor_test.go
@@ -1,0 +1,185 @@
+package monitoring
+
+import (
+	"errors"
+	"expvar"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/trillian/util"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// Arbitrary time for use in tests
+var fakeTime = time.Date(2016, 10, 3, 12, 38, 27, 36, time.UTC)
+
+type recordingUnaryHandler struct {
+	called bool
+	ctx    context.Context
+	req    interface{}
+	resp   interface{}
+	err    error
+}
+
+func (r recordingUnaryHandler) handler() grpc.UnaryHandler {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		r.ctx = ctx
+		r.req = req
+
+		return r.resp, r.err
+	}
+}
+
+type singleRequestTestCase struct {
+	name       string
+	method     string
+	handler    recordingUnaryHandler
+	timeSource util.IncrementingFakeTimeSource
+	panics     bool
+}
+
+// This is an OK request with 500ms latency
+var okRequest500 = singleRequestTestCase{name: "ok request", method: "getmethod", handler: recordingUnaryHandler{req: "OK", err: nil}, timeSource: util.IncrementingFakeTimeSource{BaseTime: fakeTime, Increments: []time.Duration{0, time.Millisecond * 500}}}
+
+// This is an errored request with 3000ms latency
+var errorRequest3000 = singleRequestTestCase{name: "error request", method: "setmethod", handler: recordingUnaryHandler{err: errors.New("Bang!")}, timeSource: util.IncrementingFakeTimeSource{BaseTime: fakeTime, Increments: []time.Duration{0, time.Millisecond * 3000}}}
+
+// This request panics with 1500ms latency
+var panicRequest1500 = singleRequestTestCase{name: "panic request", method: "getmethod", panics: true, handler: recordingUnaryHandler{req: "OK", err: nil}, timeSource: util.IncrementingFakeTimeSource{BaseTime: fakeTime, Increments: []time.Duration{0, time.Millisecond * 1500}}}
+
+var singleRequestTestCases = []singleRequestTestCase{okRequest500, errorRequest3000, panicRequest1500}
+
+func TestSingleRequests(t *testing.T) {
+	for _, req := range singleRequestTestCases {
+		req.execute(t)
+	}
+}
+
+func TestMultipleOKRequestsTotalLatency(t *testing.T) {
+	// We're going to make 3 requests so set up the time source appropriately
+	ts := util.IncrementingFakeTimeSource{BaseTime: fakeTime, Increments: []time.Duration{0, time.Millisecond * 500, 0, time.Millisecond * 2000, 0, time.Millisecond * 1337}}
+	handler := recordingUnaryHandler{resp: "OK", err: nil}
+	stats := NewRpcStatsInterceptor(&ts, "test", "test")
+	i := stats.Interceptor()
+
+	for r := 0; r < 3; r++ {
+		resp, err := i(context.Background(), "wibble", &grpc.UnaryServerInfo{FullMethod: "testmethod"}, handler.handler())
+		if resp != "OK" || err != nil {
+			t.Fatalf("request handler returned an error unexpectedly")
+		}
+	}
+
+	if want, got := "3837", stats.handlerRequestSuccessfulLatencyMap.Get("testmethod").String(); want != got {
+		t.Fatalf("wanted total latency: %s but got: %s", want, got)
+
+	}
+	if !testMapSizeIs(stats.handlerRequestFailedLatencyMap, 0) {
+		t.Fatalf("incorrectly recorded success latency on errors")
+	}
+}
+
+func TestMultipleErrorRequestsTotalLatency(t *testing.T) {
+	// We're going to make 3 requests so set up the time source appropriately
+	ts := util.IncrementingFakeTimeSource{BaseTime: fakeTime, Increments: []time.Duration{0, time.Millisecond * 427, 0, time.Millisecond * 1066, 0, time.Millisecond * 1123}}
+	handler := recordingUnaryHandler{resp: "", err: errors.New("Bang!")}
+	stats := NewRpcStatsInterceptor(&ts, "test", "test")
+	i := stats.Interceptor()
+
+	for r := 0; r < 3; r++ {
+		_, err := i(context.Background(), "wibble", &grpc.UnaryServerInfo{FullMethod: "testmethod"}, handler.handler())
+		if err == nil {
+			t.Fatalf("request handler did not return an error unexpectedly")
+		}
+	}
+
+	if want, got := "2616", stats.handlerRequestFailedLatencyMap.Get("testmethod").String(); want != got {
+		t.Fatalf("wanted total latency: %s but got: %s", want, got)
+	}
+
+	if !testMapSizeIs(stats.handlerRequestSuccessfulLatencyMap, 0) {
+		t.Fatalf("incorrectly recorded success latency on errors")
+	}
+}
+
+func (s singleRequestTestCase) execute(t *testing.T) {
+	stats := NewRpcStatsInterceptor(&s.timeSource, "test", "test")
+	i := stats.Interceptor()
+	resp, err := i(context.Background(), "wibble", &grpc.UnaryServerInfo{FullMethod: s.method}, s.handler.handler())
+
+	// These checks are the that the stats interceptor called the handler and correctly forwarded the
+	// result and error returned by the wrapped request handler
+	if got, want := s.handler.resp, resp; got != want {
+		t.Fatalf("%s: Got result: %v but wanted: %v", s.name, got, want)
+	}
+
+	if (err != nil && s.handler.err == nil) || (err == nil && s.handler.err != nil) {
+		t.Fatalf("%s: Error status was incorrect: %v got %v", s.name, s.handler.err, err)
+	}
+
+	// Now check the resulting state of the stats maps
+
+	// Because we only made a single request there should only be one recorded (with either success or
+	// failure depending on the error status and the other maps should count zero for the method
+	if stats.handlerRequestCountMap.Get(s.method).String() != "1" {
+		t.Fatalf("%s: Expected one request for method but got: %v", stats.handlerRequestCountMap.Get(s.method))
+	}
+
+	expectedTotalLatency := s.timeSource.Increments[1].Nanoseconds() / nanosToMillisDivisor
+
+	var expectOneMap *expvar.Map
+	var expectZeroMap *expvar.Map
+	var expectLatencyMap *expvar.Map
+	var expectNoLatencyMap *expvar.Map
+	var logComment string
+
+	if err == nil {
+		// Request should have been a success
+		expectOneMap = stats.handlerRequestSucceededMap
+		expectZeroMap = stats.handlerRequestErrorsMap
+		expectLatencyMap = stats.handlerRequestSuccessfulLatencyMap
+		expectNoLatencyMap = stats.handlerRequestFailedLatencyMap
+		logComment = "ok"
+	} else {
+		// Request should be recorded as failed
+		expectOneMap = stats.handlerRequestErrorsMap
+		expectZeroMap = stats.handlerRequestSucceededMap
+		expectLatencyMap = stats.handlerRequestFailedLatencyMap
+		expectNoLatencyMap = stats.handlerRequestSuccessfulLatencyMap
+		logComment = "error"
+	}
+
+	// There should only be one key in the expected map and request count map
+	if !testMapSizeIs(expectOneMap, 1) || !testMapSizeIs(expectZeroMap, 0) || !testMapSizeIs(stats.handlerRequestCountMap, 1) {
+		t.Fatalf("%s: Map key counts are incorrect", s.name)
+	}
+
+	if !testMapSizeIs(expectLatencyMap, 1) || !testMapSizeIs(expectNoLatencyMap, 0) {
+		t.Fatalf("%s: Latency map key counts are incorrect", s.name)
+	}
+
+	if expectOneMap.Get(s.method).String() != "1" {
+		t.Fatalf("%s: Expected one %s request for method but got: %v", s.name, logComment, expectOneMap.Get(s.method))
+	}
+
+	if expectZeroMap.Get(s.method) != nil {
+		t.Fatalf("%s: Expected zero %s request for method but got: %v", s.name, logComment, expectZeroMap.Get(s.method))
+	}
+
+	if expectLatencyMap.Get(s.method).String() != fmt.Sprintf("%d", expectedTotalLatency) {
+		t.Fatalf("%s: Expected %s latency: %v but got: %v", s.name, logComment, expectedTotalLatency, expectLatencyMap.Get(s.method))
+	}
+	if expectNoLatencyMap.Get(s.method) != nil {
+		t.Fatalf("%s: Expected %s latency: nil but got: %v", s.name, logComment, expectNoLatencyMap.Get(s.method))
+	}
+}
+
+func testMapSizeIs(mapVar *expvar.Map, expectedSize int) bool {
+	keys := 0
+	mapVar.Do(func(expvar.KeyValue) {
+		keys++
+	})
+
+	return keys == expectedSize
+}

--- a/server/log/main.go
+++ b/server/log/main.go
@@ -97,7 +97,7 @@ func checkDatabaseAccessible(dbUri string) error {
 
 func startRpcServer(listener net.Listener, port int, provider server.LogStorageProviderFunc) *grpc.Server {
 	// Create and publish the RPC stats objects
-	statsInterceptor := monitoring.NewRpcStatsInterceptor(util.SystemTimeSource{}, "ct", "example")
+	statsInterceptor := monitoring.NewRPCStatsInterceptor(util.SystemTimeSource{}, "ct", "example")
 	statsInterceptor.Publish()
 
 	// Create the server, using the interceptor to record stats on the requests

--- a/server/log/main.go
+++ b/server/log/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -13,14 +15,12 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
-	"sync"
-	"github.com/google/trillian/monitoring"
-	"net/http"
 )
 
 var mysqlUriFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test",
@@ -39,6 +39,7 @@ var privateKeyPassword = flag.String("private_key_password", "", "Password for s
 
 // Must hold this lock before accessing the storage map
 var storageMapGuard sync.Mutex
+
 // Map from tree ID to storage impl for that log
 var storageMap = make(map[int64]storage.LogStorage)
 

--- a/server/log/main.go
+++ b/server/log/main.go
@@ -20,11 +20,14 @@ import (
 	"google.golang.org/grpc"
 	"sync"
 	"github.com/google/trillian/monitoring"
+	"net/http"
 )
 
 var mysqlUriFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test",
 	"uri to use with mysql storage")
-var serverPortFlag = flag.Int("port", 8090, "Port to serve log requests on")
+var serverPortFlag = flag.Int("port", 8090, "Port to serve log RPC requests on")
+var exportRpcMetrics = flag.Bool("exportMetrics", true, "If true starts HTTP server and exports stats")
+var httpPortFlag = flag.Int("http_port", 8091, "Port to serve HTTP metrics on")
 var sequencerSleepBetweenRunsFlag = flag.Duration("sequencer_sleep_between_runs", time.Second * 10, "Time to pause after each sequencing pass through all logs")
 var signerSleepBetweenRunsFlag = flag.Duration("signer_sleep_between_runs", time.Second * 120, "Time to pause after each signing pass through all logs")
 var batchSizeFlag = flag.Int("batch_size", 50, "Max number of leaves to process per batch")
@@ -105,6 +108,19 @@ func startRpcServer(listener net.Listener, port int, provider server.LogStorageP
 	return grpcServer
 }
 
+func startHttpServer(port int) error {
+	sock, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return err
+	}
+	go func() {
+		glog.Info("HTTP server starting")
+		http.Serve(sock, nil)
+	}()
+
+	return nil
+}
+
 func awaitSignal(rpcServer *grpc.Server) {
 	// Arrange notification for the standard set of signals used to terminate a server
 	sigs := make(chan os.Signal, 1)
@@ -138,6 +154,16 @@ func main() {
 
 	if err != nil {
 		glog.Fatalf("Failed to load server key: %v", err)
+	}
+
+	// Start HTTP server (optional)
+	if *exportRpcMetrics {
+		err := startHttpServer(*httpPortFlag)
+
+		if err != nil {
+			glog.Fatalf("Failed to start http server on port %d: %v", *httpPortFlag, err)
+			os.Exit(1)
+		}
 	}
 
 	// Set up the listener for the server

--- a/server/trillian_log_server.go
+++ b/server/trillian_log_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"

--- a/util/timesource.go
+++ b/util/timesource.go
@@ -1,6 +1,8 @@
 package util
 
-import "time"
+import (
+	"time"
+)
 
 // TimeSource can provide the current time, or be replaced by a mock in tests to return
 // specific values.
@@ -28,4 +30,21 @@ type FakeTimeSource struct {
 // Now returns the time value this instance contains
 func (f FakeTimeSource) Now() time.Time {
 	return f.FakeTime
+}
+
+// IncrementingFakeTimeSource takes a base time and several increments, which will be applied to
+// the base time each time Now() is called. The first call will return the base time + zeroth
+// increment. If called more times than provided for then it will panic. Does not require that
+// increments increase monotonically.
+type IncrementingFakeTimeSource struct {
+	BaseTime      time.Time
+	Increments    []time.Duration
+	NextIncrement int
+}
+
+func (a *IncrementingFakeTimeSource) Now() time.Time {
+	adjustedTime := a.BaseTime.Add(a.Increments[a.NextIncrement])
+	a.NextIncrement++
+
+	return adjustedTime
 }


### PR DESCRIPTION
Covers total requests / success or fail / total latency of failures and successes mapped by method. Enabled for log, can be added to map with a few lines of code when we know it works correctly.