### PR TITLE
Refactoring to make queue timestamp not provided by database.

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -46,6 +46,8 @@ func NewSequencer(hasher merkle.TreeHasher, timeSource util.TimeSource, logStora
 	return &Sequencer{hasher: hasher, timeSource: timeSource, logStorage: logStorage, keyManager: km}
 }
 
+// SetGuardWindow changes the interval that must elapse between leaves being queued and them
+// being eligible for sequencing. The default is a zero interval.
 func (s *Sequencer) SetGuardWindow(sequencerGuardWindow time.Duration) {
 	s.sequencerGuardWindow = sequencerGuardWindow
 }

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -14,6 +14,9 @@ import (
 	"github.com/google/trillian/util"
 )
 
+// TODO(Martin2112): Add admin support for safely changing params like guard window during operation
+// TODO(Martin2112): Add support for enabling and controlling sequencing as part of admin API
+
 // Sequencer instances are responsible for integrating new leaves into a log.
 // Leaves will be assigned unique sequence numbers when they are processed.
 // There is no strong ordering guarantee but in general entries will be processed
@@ -24,9 +27,9 @@ type Sequencer struct {
 	logStorage storage.LogStorage
 	keyManager crypto.KeyManager
 
-	// These parameters can be safely adjusted during operation
-	// sequencerGuardWindow when set to a non zero duration this establishes a cutoff point for new
-	// entries. Entries newer than the guard window will not be sequenced until they fall outside it.
+	// These parameters could theoretically be adjusted during operation
+	// sequencerGuardWindow is used to ensure entries newer than the guard window will not be
+	// sequenced until they fall outside it. By default there is no guard window.
 	sequencerGuardWindow time.Duration
 }
 

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -4,6 +4,7 @@ package log
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
-	"time"
 )
 
 // Sequencer instances are responsible for integrating new leaves into a log.

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -241,7 +241,7 @@ func TestSequenceWithNothingQueued(t *testing.T) {
 	}
 }
 
-// Tests that the guard interval is being sent to storage correctly. Actual operation of the
+// Tests that the guard interval is being passed to storage correctly. Actual operation of the
 // window is tested by storage tests.
 func TestGuardWindowPassthrough(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -256,11 +256,11 @@ func TestGuardWindowPassthrough(t *testing.T) {
 
 	leaves, err := c.sequencer.SequenceBatch(1, rootNeverExpiresFunc)
 	if leaves != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leaves)
+		t.Fatalf("Expected no leaves sequenced when in guard interval but got: %d", leaves)
 	}
 
 	if err != nil {
-		t.Error("Expected nil return with no work pending in queue")
+		t.Error("Expected nil return with all queued work inside guard interval but got: %v", err)
 	}
 }
 

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
-	"golang.org/x/net/context"
 	"github.com/google/trillian/util"
+	"golang.org/x/net/context"
 )
 
 // TODO: There is no access control in the server yet and clients could easily modify

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -55,7 +55,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
-	mockTx.EXPECT().DequeueLeaves(50).Return([]trillian.LogLeaf{}, nil)
+	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]trillian.LogLeaf{}, nil)
 	mockKeyManager := crypto.NewMockKeyManager(mockCtrl)
 
 	sm := NewSequencerManager(mockKeyManager)
@@ -78,7 +78,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Rollback().AnyTimes().Do(func() { panic(nil) })
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(testRoot0.TreeRevision + 1)
-	mockTx.EXPECT().DequeueLeaves(50).Return([]trillian.LogLeaf{testLeaf0}, nil)
+	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]trillian.LogLeaf{testLeaf0}, nil)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
 	mockTx.EXPECT().UpdateSequencedLeaves([]trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(updatedNodes0).Return(nil)
@@ -111,7 +111,7 @@ func TestSignsIfNoWorkAndRootExpired(t *testing.T) {
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
 	mockTx.EXPECT().LatestSignedLogRoot().AnyTimes().Return(testRoot0, nil)
-	mockTx.EXPECT().DequeueLeaves(50).Return([]trillian.LogLeaf{}, nil)
+	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]trillian.LogLeaf{}, nil)
 	mockTx.EXPECT().StoreSignedLogRoot(updatedRootSignOnly).AnyTimes().Return(nil)
 
 	mockSigner := crypto.NewMockSigner(mockCtrl)

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -103,7 +103,7 @@ func startRPCServer(listener net.Listener, port int, provider server.LogStorageP
 	// Create the server, using the interceptor to record stats on the requests
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(statsInterceptor.Interceptor()))
 
-	logServer := server.NewTrillianLogRPCServer(provider)
+	logServer := server.NewTrillianLogRPCServer(provider, new(util.SystemTimeSource))
 	trillian.RegisterTrillianLogServer(grpcServer, logServer)
 
 	return grpcServer

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -1,8 +1,9 @@
 package storage
 
 import (
-	"github.com/google/trillian"
 	"time"
+
+	"github.com/google/trillian"
 )
 
 // ReadOnlyLogTX provides a read-only view into the Log data.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/google/trillian"
+	"time"
 )
 
 // ReadOnlyLogTX provides a read-only view into the Log data.
@@ -48,14 +49,16 @@ type LogStorage interface {
 // LeafQueuer provides a write-only interface for the queueing (but not necesarily integration) of leaves.
 type LeafQueuer interface {
 	// QueueLeaves enqueues leaves for later integration into the tree.
-	QueueLeaves(leaves []trillian.LogLeaf) error
+	QueueLeaves(leaves []trillian.LogLeaf, queueTimestamp time.Time) error
 }
 
 // LeafDequeuer provides an interface for reading previously queued leaves for integration into the tree.
 type LeafDequeuer interface {
 	// DequeueLeaves will return between [0, limit] leaves from the queue.
 	// Leaves which have been dequeued within a Rolled-back Tx will become available for dequeing again.
-	DequeueLeaves(limit int) ([]trillian.LogLeaf, error)
+	// Leaves queued more recently than the cutoff time will not be returned. This allows for
+	// guard intervals to be configured.
+	DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLeaf, error)
 	UpdateSequencedLeaves([]trillian.LogLeaf) error
 }
 

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -6,6 +6,7 @@ package storage
 import (
 	gomock "github.com/golang/mock/gomock"
 	trillian "github.com/google/trillian"
+	time "time"
 )
 
 // Mock of LogTX interface
@@ -39,15 +40,15 @@ func (_mr *_MockLogTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockLogTX) DequeueLeaves(_param0 int) ([]trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0)
+func (_m *MockLogTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0, _param1)
 	ret0, _ := ret[0].([]trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTXRecorder) DequeueLeaves(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DequeueLeaves", arg0)
+func (_mr *_MockLogTXRecorder) DequeueLeaves(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DequeueLeaves", arg0, arg1)
 }
 
 func (_m *MockLogTX) GetActiveLogIDs() ([]int64, error) {
@@ -148,14 +149,14 @@ func (_mr *_MockLogTXRecorder) LatestSignedLogRoot() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot")
 }
 
-func (_m *MockLogTX) QueueLeaves(_param0 []trillian.LogLeaf) error {
-	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0)
+func (_m *MockLogTX) QueueLeaves(_param0 []trillian.LogLeaf, _param1 time.Time) error {
+	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockLogTXRecorder) QueueLeaves(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "QueueLeaves", arg0)
+func (_mr *_MockLogTXRecorder) QueueLeaves(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "QueueLeaves", arg0, arg1)
 }
 
 func (_m *MockLogTX) Rollback() error {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -16,7 +17,6 @@ import (
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
-	"time"
 )
 
 const getTreePropertiesSQL string = "SELECT AllowsDuplicateLeaves FROM Trees WHERE TreeId=?"

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	"time"
 )
 
 const getTreePropertiesSQL string = "SELECT AllowsDuplicateLeaves FROM Trees WHERE TreeId=?"
@@ -23,13 +24,14 @@ const getTreeParametersSQL string = "SELECT ReadOnlyRequests From TreeControl WH
 const selectQueuedLeavesSQL string = `SELECT LeafValueHash,Payload
 		 FROM Unsequenced
 		 WHERE TreeID=?
-		 ORDER BY QueueTimestamp DESC,LeafValueHash ASC LIMIT ?`
+		 AND QueueTimestampNanos<=?
+		 ORDER BY QueueTimestampNanos DESC,LeafValueHash ASC LIMIT ?`
 const insertUnsequencedLeafSQL string = `INSERT INTO LeafData(TreeId,LeafValueHash,LeafValue)
 		 VALUES(?,?,?) ON DUPLICATE KEY UPDATE LeafValueHash=LeafValueHash`
 const insertUnsequencedLeafSQLNoDuplicates string = `INSERT INTO LeafData(TreeId,LeafValueHash,LeafValue)
 		 VALUES(?,?,?)`
-const insertUnsequencedEntrySQL string = `INSERT INTO Unsequenced(TreeId,LeafValueHash,MessageId,Payload)
-     VALUES(?,?,?,?)`
+const insertUnsequencedEntrySQL string = `INSERT INTO Unsequenced(TreeId,LeafValueHash,MessageId,Payload,QueueTimestampNanos)
+     VALUES(?,?,?,?,?)`
 const insertSequencedLeafSQL string = `INSERT INTO SequencedLeafData(TreeId,LeafValueHash,MerkleLeafHash,SequenceNumber)
 		 VALUES(?,?,?,?)`
 const selectSequencedLeafCountSQL string = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
@@ -57,8 +59,11 @@ var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 
 type mySQLLogStorage struct {
 	*mySQLTreeStorage
 
+	// These options can only sensibly be set when storage is initialized
 	logID           int64
 	allowDuplicates bool
+
+	// These options can reasonably be changed during operation
 	readOnly        bool
 }
 
@@ -203,7 +208,7 @@ func (t *logTX) WriteRevision() int64 {
 	return t.treeTX.writeRevision
 }
 
-func (t *logTX) DequeueLeaves(limit int) ([]trillian.LogLeaf, error) {
+func (t *logTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLeaf, error) {
 	stx, err := t.tx.Prepare(selectQueuedLeavesSQL)
 
 	if err != nil {
@@ -212,7 +217,7 @@ func (t *logTX) DequeueLeaves(limit int) ([]trillian.LogLeaf, error) {
 	}
 
 	leaves := make([]trillian.LogLeaf, 0, limit)
-	rows, err := stx.Query(t.ls.logID, limit)
+	rows, err := stx.Query(t.ls.logID, cutoffTime.UnixNano(), limit)
 
 	if err != nil {
 		glog.Warningf("Failed to select rows for work: %s", err)
@@ -262,7 +267,7 @@ func (t *logTX) DequeueLeaves(limit int) ([]trillian.LogLeaf, error) {
 	return leaves, nil
 }
 
-func (t *logTX) QueueLeaves(leaves []trillian.LogLeaf) error {
+func (t *logTX) QueueLeaves(leaves []trillian.LogLeaf, queueTimestamp time.Time) error {
 	// Don't accept batches if any of the leaves are invalid.
 	for _, leaf := range leaves {
 		if len(leaf.MerkleLeafHash) != t.ts.hashSizeBytes {
@@ -326,7 +331,7 @@ func (t *logTX) QueueLeaves(leaves []trillian.LogLeaf) error {
 		messageID := hasher.Sum(nil)
 
 		_, err = t.tx.Exec(insertUnsequencedEntrySQL,
-			t.ls.logID, leaf.MerkleLeafHash, messageID, leaf.LeafValue)
+			t.ls.logID, leaf.MerkleLeafHash, messageID, leaf.LeafValue, queueTimestamp.UnixNano())
 
 		if err != nil {
 			glog.Warningf("Error inserting into Unsequenced: %s", err)

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -99,13 +99,13 @@ CREATE TABLE IF NOT EXISTS Unsequenced(
   TreeId               INTEGER NOT NULL,
   -- Note that this is a simple SHA256 hash of the raw data used to detect corruption in transit.
   -- It is not the leaf hash output of the treehasher used by the log.
-  LeafValueHash             VARBINARY(255) NOT NULL,
+  LeafValueHash        VARBINARY(255) NOT NULL,
   -- SHA256("queueId"|TreeId|leafValueHash)
   -- We want this to be unique per entry per log, but queryable by FEs so that
   -- we can try to stomp dupe submissions.
   MessageId            BINARY(32) NOT NULL,
   Payload              BLOB NOT NULL,
-  QueueTimestamp       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  QueueTimestampNanos  BIGINT NOT NULL,
   PRIMARY KEY (TreeId, LeafValueHash, MessageId)
 );
 

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -500,7 +500,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 }
 
 // Queues leaves and attempts to dequeue before the guard cutoff allows it. This should
-// return nothing. Then retries with an inclusive guard cutoff and ensures the leaves
+// return nothing. Then retry with an inclusive guard cutoff and ensure the leaves
 // are returned.
 func TestDequeueLeavesGuardInterval(t *testing.T) {
 	logID := createLogID("TestDequeueLeavesGuardInterval")

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -306,7 +306,11 @@ func TestQueueLeaves(t *testing.T) {
 		t.Fatalf("Could not query row count")
 	}
 
-	// Additional check on timestamp being set correctly
+	if leavesToInsert != count {
+		t.Fatalf("Expected %d unsequenced rows but got: %d", leavesToInsert, count)
+	}
+
+	// Additional check on timestamp being set correctly in the database
 	var queueTimestamp int64
 	if err := db.QueryRow("SELECT DISTINCT QueueTimestampNanos FROM Unsequenced WHERE TreeID=?", logID.logID).Scan(&queueTimestamp); err != nil {
 		t.Fatalf("Could not query timestamp")
@@ -314,10 +318,6 @@ func TestQueueLeaves(t *testing.T) {
 
 	if got, want := queueTimestamp, fakeQueueTime.UnixNano(); got != want {
 		t.Fatalf("Incorrect queue timestamp got: %d want: %d", got, want)
-	}
-
-	if leavesToInsert != count {
-		t.Fatalf("Expected %d unsequenced rows but got: %d", leavesToInsert, count)
 	}
 }
 

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage/tools"
+	"time"
 )
 
 var numInsertionsFlag = flag.Int("num_insertions", 10, "Number of entries to insert in the tree")
@@ -63,7 +64,7 @@ func main() {
 		leaves = append(leaves, leaf)
 
 		if len(leaves) >= *queueBatchSizeFlag {
-			err = tx.QueueLeaves(leaves)
+			err = tx.QueueLeaves(leaves, time.Now())
 			leaves = leaves[:0] // starting new batch
 
 			if err != nil {
@@ -74,7 +75,7 @@ func main() {
 
 	// There might be some leaves left over that didn't get queued yet
 	if len(leaves) > 0 {
-		err = tx.QueueLeaves(leaves)
+		err = tx.QueueLeaves(leaves, time.Now())
 
 		if err != nil {
 			panic(err)

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -4,12 +4,12 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	log "github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage/tools"
-	"time"
 )
 
 var numInsertionsFlag = flag.Int("num_insertions", 10, "Number of entries to insert in the tree")


### PR DESCRIPTION
And implement log sequencing guard window. It was very hard to do it
without making the API change. This keeps storage free of knowledge
about times, it just passes through what it's given by higher layers.

Sorry it's a bit big but a lot of it is mechanical changes to test parameters.