### PR TITLE
More work to separate raw data and merkle leaf hashes

### DIFF
--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -123,7 +123,7 @@ func queueLeaves(treeID int64, client trillian.TrillianLogClient, params testPar
 		leaf := trillian.LogLeaf{
 			LeafValueHash: hash[:],
 			LeafValue:     data,
-			ExtraData:     nil}
+		}
 		leaves = append(leaves, leaf)
 
 		if len(leaves) >= params.queueBatchSize || (l + 1) == params.leafCount {

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -244,7 +244,7 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params t
 
 			hash := hasher.HashLeaf(response.Leaves[l].LeafValue)
 
-			if got, want := base64.StdEncoding.EncodeToString(hash), base64.StdEncoding.EncodeToString(leaf.MerkleLeafHash); !bytes.Equal(got, want) {
+			if got, want := base64.StdEncoding.EncodeToString(hash), base64.StdEncoding.EncodeToString(leaf.MerkleLeafHash); got != want {
 				return nil, fmt.Errorf("leaf hash mismatch expected got: %s want: %s", got, want)
 			}
 		}

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -121,11 +121,10 @@ func queueLeaves(treeID int64, client trillian.TrillianLogClient, params testPar
 		hash := sha256.Sum256(data)
 
 		leaf := trillian.LogLeaf{
-			// TODO(Martin2112): This should be LeafValueHash but it doesn't exist yet
-			MerkleLeafHash: hash[:],
-			LeafValue:      data,
-			ExtraData:      nil,
-			LeafIndex:      0}
+			LeafValueHash: hash[:],
+			LeafValue:     data,
+			ExtraData:     nil,
+			LeafIndex:     0}
 		leaves = append(leaves, leaf)
 
 		if len(leaves) >= params.queueBatchSize || (l + 1) == params.leafCount {

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -123,8 +123,7 @@ func queueLeaves(treeID int64, client trillian.TrillianLogClient, params testPar
 		leaf := trillian.LogLeaf{
 			LeafValueHash: hash[:],
 			LeafValue:     data,
-			ExtraData:     nil,
-			LeafIndex:     0}
+			ExtraData:     nil}
 		leaves = append(leaves, leaf)
 
 		if len(leaves) >= params.queueBatchSize || (l + 1) == params.leafCount {
@@ -279,6 +278,7 @@ func makeQueueLeavesRequest(logID int64, leaves []trillian.LogLeaf) trillian.Que
 	leafProtos := make([]*trillian.LogLeaf, 0, len(leaves))
 
 	for _, leaf := range leaves {
+		leaf := leaf
 		leafProtos = append(leafProtos, &leaf)
 	}
 

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -244,7 +244,7 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params t
 
 			hash := hasher.HashLeaf(response.Leaves[l].LeafValue)
 
-			if got, want := base64.StdEncoding.EncodeToString(hash), base64.StdEncoding.EncodeToString(leaf.MerkleLeafHash); !bytes.Equal(hash[:], leaf.MerkleLeafHash) {
+			if got, want := base64.StdEncoding.EncodeToString(hash), base64.StdEncoding.EncodeToString(leaf.MerkleLeafHash); !bytes.Equal(got, want) {
 				return nil, fmt.Errorf("leaf hash mismatch expected got: %s want: %s", got, want)
 			}
 		}
@@ -280,9 +280,7 @@ func makeQueueLeavesRequest(logID int64, leaves []trillian.LogLeaf) trillian.Que
 	leafProtos := make([]*trillian.LogLeaf, 0, len(leaves))
 
 	for _, leaf := range leaves {
-		// TODO(Martin2112): This should be using the leaf value hash but it's not there yet
-		proto := trillian.LogLeaf{LeafIndex: leaf.LeafIndex, MerkleLeafHash: leaf.MerkleLeafHash, LeafValue: leaf.LeafValue, ExtraData: leaf.ExtraData}
-		leafProtos = append(leafProtos, &proto)
+		leafProtos = append(leafProtos, &leaf)
 	}
 
 	return trillian.QueueLeavesRequest{LogId: logID, Leaves: leafProtos}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -245,7 +245,6 @@ func (t *logTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLe
 			LeafValueHash: leafHash,
 			LeafValue:     payload,
 			ExtraData:     nil,
-			LeafIndex:     0,
 		}
 		leaves = append(leaves, leaf)
 	}

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -396,7 +396,7 @@ func TestDequeueLeaves(t *testing.T) {
 			t.Fatalf("Dequeued %d leaves but expected to get %d", len(leaves2), leavesToInsert)
 		}
 
-		ensureAllLeafHashesDistinct(leaves2, t)
+		ensureAllLeavesDistinct(leaves2, t)
 
 		tx2.Commit()
 	}
@@ -454,7 +454,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 			t.Fatalf("Dequeued %d leaves but expected to get %d", len(leaves2), leavesToInsert)
 		}
 
-		ensureAllLeafHashesDistinct(leaves2, t)
+		ensureAllLeavesDistinct(leaves2, t)
 
 		tx2.Commit()
 
@@ -471,11 +471,11 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 			t.Fatalf("Dequeued %d leaves but expected to get %d", len(leaves3), leavesToDequeue2)
 		}
 
-		ensureAllLeafHashesDistinct(leaves3, t)
+		ensureAllLeavesDistinct(leaves3, t)
 
 		// Plus the union of the leaf batches should all have distinct hashes
 		leaves4 := append(leaves2, leaves3...)
-		ensureAllLeafHashesDistinct(leaves4, t)
+		ensureAllLeavesDistinct(leaves4, t)
 
 		tx3.Commit()
 	}
@@ -546,7 +546,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 			t.Fatalf("Dequeued %d leaves but expected to get %d", len(leaves2), leavesToInsert)
 		}
 
-		ensureAllLeafHashesDistinct(leaves2, t)
+		ensureAllLeavesDistinct(leaves2, t)
 
 		tx2.Commit()
 	}
@@ -1266,9 +1266,10 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	}
 }
 
-func ensureAllLeafHashesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
-	// All the hashes should be distinct. If only we had maps with slices as keys or sets
-	// or pretty much any kind of usable data structures we could do this properly.
+func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
+	// All the leaf value hashes should be distinct because the leaves were created with distinct
+	// leaf data. If only we had maps with slices as keys or sets or pretty much any kind of usable
+	// data structures we could do this properly.
 	for i := range leaves {
 		for j := range leaves {
 			if i != j && bytes.Equal(leaves[i].LeafValueHash, leaves[j].LeafValueHash) {
@@ -1387,7 +1388,8 @@ func createTestLeaves(n, startSeq int64) []trillian.LogLeaf {
 			MerkleLeafHash: hasher.Digest([]byte(lv)),
 			LeafValue: []byte(lv),
 			ExtraData: []byte(fmt.Sprintf("Extra %d", l)),
-			LeafIndex: int64(startSeq + l)}
+			LeafIndex: int64(startSeq + l),
+		}
 		leaves = append(leaves, leaf)
 	}
 

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -332,7 +332,7 @@ func TestQueueLeavesBadHash(t *testing.T) {
 	leaves := createTestLeaves(leavesToInsert, 20)
 
 	// Deliberately corrupt one of the hashes so it should be rejected
-	leaves[3].MerkleLeafHash = crypto.NewSHA256().Digest([]byte("this cannot be valid"))
+	leaves[3].LeafValueHash = crypto.NewSHA256().Digest([]byte("this cannot be valid"))
 
 	err := tx.QueueLeaves(leaves, fakeQueueTime)
 	tx.Rollback()
@@ -1271,9 +1271,9 @@ func ensureAllLeafHashesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
 	// or pretty much any kind of usable data structures we could do this properly.
 	for i := range leaves {
 		for j := range leaves {
-			if i != j && bytes.Equal(leaves[i].MerkleLeafHash, leaves[j].MerkleLeafHash) {
+			if i != j && bytes.Equal(leaves[i].LeafValueHash, leaves[j].LeafValueHash) {
 				t.Fatalf("Unexpectedly got a duplicate leaf hash: %v %v",
-					leaves[i].MerkleLeafHash, leaves[j].MerkleLeafHash)
+					leaves[i].LeafValueHash, leaves[j].LeafValueHash)
 			}
 		}
 	}
@@ -1383,7 +1383,11 @@ func createTestLeaves(n, startSeq int64) []trillian.LogLeaf {
 	for l := int64(0); l < n; l++ {
 		lv := fmt.Sprintf("Leaf %d", l)
 		leaf := trillian.LogLeaf{
-			MerkleLeafHash: hasher.Digest([]byte(lv)), LeafValue: []byte(lv), ExtraData: []byte(fmt.Sprintf("Extra %d", l)), LeafIndex: int64(startSeq + l)}
+			LeafValueHash: hasher.Digest([]byte(lv)),
+			MerkleLeafHash: hasher.Digest([]byte(lv)),
+			LeafValue: []byte(lv),
+			ExtraData: []byte(fmt.Sprintf("Extra %d", l)),
+			LeafIndex: int64(startSeq + l)}
 		leaves = append(leaves, leaf)
 	}
 


### PR DESCRIPTION
The raw data hash is now sent to the server in its own field when leaves are queued and returned alongside the merkle leaf hash when leaves are retrieved. This avoids using the field for two different things.

Still not entirely decided whether the client computes the merkle leaf hash or the server. Currently the server does it but this could be changed without further changes to the protos.