### PR TITLE
Rewrite the skip level code in merkle path calculations

### DIFF
--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -3,8 +3,12 @@ package merkle
 import (
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian/storage"
 )
+
+// Verbosity level for logging of debug related items
+const vLevel = 2
 
 // CalcInclusionProofNodeAddresses returns the tree node IDs needed to
 // build an inclusion proof for a specified leaf and tree size. The maxBitLen parameter
@@ -37,10 +41,10 @@ func CalcInclusionProofNodeAddresses(treeSize, index int64, maxBitLen int) ([]st
 			proof = append(proof, n)
 		} else if sibling == lastNodeAtLevel {
 			// The tree may skip levels because it's not completely filled in. These nodes
-			// don't exist
-			drop := depth - subtreeDepth(treeSize, depth-1)
-			sibling = sibling << uint(drop)
-			n, err := storage.NewNodeIDForTreeCoords(int64(depth-drop), sibling, maxBitLen)
+			// don't exist in storage, the value we want is a copy of a node further down
+			// (multiple levels may be skipped).
+			l, sibling := skipMissingLevels(treeSize, lastNodeAtLevel, depth, node)
+			n, err := storage.NewNodeIDForTreeCoords(int64(l), sibling, maxBitLen)
 			if err != nil {
 				return nil, err
 			}
@@ -76,17 +80,21 @@ func CalcConsistencyProofNodeAddresses(previousTreeSize, treeSize int64, maxBitL
 func snapshotConsistency(snapshot1, snapshot2 int64, maxBitLen int) ([]storage.NodeID, error) {
 	proof := make([]storage.NodeID, 0, bitLen(snapshot2)+1)
 
+	glog.V(vLevel).Infof("snapshotConsistency: %d -> %d", snapshot1, snapshot2)
+
 	level := 0
 	node := snapshot1 - 1
 
 	// Compute the (compressed) path to the root of snapshot2.
 	// Everything left of 'node' is equal in both trees; no need to record.
 	for (node & 1) != 0 {
+		glog.V(vLevel).Infof("Move up: l:%d n:%d", level, node)
 		node >>= 1
 		level++
 	}
 
 	if node != 0 {
+		glog.V(vLevel).Infof("Not root snapshot1: %d", node)
 		// Not at the root of snapshot 1, record the node
 		n, err := storage.NewNodeIDForTreeCoords(int64(level), node, maxBitLen)
 		if err != nil {
@@ -104,13 +112,14 @@ func snapshotConsistency(snapshot1, snapshot2 int64, maxBitLen int) ([]storage.N
 }
 
 func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitLen int) ([]storage.NodeID, error) {
+	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot: N:%d, L:%d, S:%d", node, level, snapshot)
 	proof := make([]storage.NodeID, 0, bitLen(snapshot)+1)
 
 	if snapshot == 0 {
 		return proof, nil
 	}
 
-	// Index of the last node.
+	// Index of the last node (if the level is fully populated).
 	lastNode := (snapshot - 1) >> uint(level)
 
 	// Move up, recording the sibling of the current node at each level.
@@ -118,6 +127,7 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 		sibling := node ^ 1
 		if sibling < lastNode {
 			// The sibling is not the last node of the level in the snapshot tree
+			glog.V(vLevel).Infof("Not last: S:%d L:%d", sibling, level)
 			n, err := storage.NewNodeIDForTreeCoords(int64(level), sibling, maxBitLen)
 			if err != nil {
 				return nil, err
@@ -129,18 +139,20 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 			// referencing a snapshot at a point before additional leaves were added to the tree causing
 			// some nodes to be overwritten. We have versioned tree nodes so this isn't necessary,
 			// we won't see any hashes written since the snapshot point. However we do have to account
-			// for missing levels in the tree.
+			// for missing levels in the tree. This can only occur on the rightmost tree nodes because
+			// this is the only area of the tree that is not fully populated.
+			glog.V(vLevel).Infof("Last: S:%d L:%d", sibling, level)
 
-			drop := 0
-			if level > 0 {
-				drop = level - subtreeDepth(snapshot, level-1)
-			}
-			sibling = sibling << uint(drop)
-			n, err := storage.NewNodeIDForTreeCoords(int64(level-drop), sibling, maxBitLen)
+			// Account for non existent nodes - these can only be the right most node at an
+			// intermediate (non leaf) level in the tree so will always be a right sibling.
+			l, sibling := skipMissingLevels(snapshot, lastNode, level, node)
+			n, err := storage.NewNodeIDForTreeCoords(int64(l), sibling, maxBitLen)
 			if err != nil {
 				return nil, err
 			}
 			proof = append(proof, n)
+		} else {
+			glog.V(vLevel).Infof("Nonexistent: S:%d L:%d", sibling, level)
 		}
 
 		// Sibling > lastNode so does not exist, move up
@@ -152,19 +164,59 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 	return proof, nil
 }
 
-// subtreeDepth calculates the depth of a subtree, used at the right of the tree which
-// may not be completely populated
-func subtreeDepth(size int64, bits int) int {
-	for b := bitLen(size) - 1; b > bits; b-- {
-		size = size &^ (1 << uint(b))
+// lastNodeWritten determines if the last node is present in storage for a given Merkle tree size
+// and level in the tree (0 = leaves, increasing towards the root). This is determined by
+// examining the bits of the last valid leaf index in a tree of the specified size. Zero bits
+// indicate nodes that are not stored at that tree size.
+//
+// Example:
+//
+//             hash2
+//             /  \
+//            /    \
+//           /      \
+//          /        \
+//         /          \
+//        k            [X]
+//       / \             \
+//      /   \             \
+//     /     \             \
+//    g       h           [X]
+//   / \     / \         /
+//   a b     c d        e
+//   | |     | |        |
+//   d0 d1   d2 d3      d4
+//
+// Tree size = 5, last index = 4 in binary = 100, append 1 for leaves = 1001.
+// Reading down the RHS: present, not present, not present, present = 1001. So when
+// attempting to fetch the sibling of k the tree should be descended twice to fetch
+// 'e'.
+func lastNodeWritten(d, ts int64) bool {
+	if d == 0 {
+		// Leaves always exist
+		return true
 	}
 
-	// determine tree height for the remaining bits.
-	p2 := bitLen(size) - 1
-	size = size &^ (1 << uint(p2))
-	if bitLen(size) > 0 {
-		p2++
+	// Last index is size - 1, we shift one to avoid special case (leaves always present)
+	bits := uint64(ts - 1)
+	// Test the bit in the path for the requested level
+	mask := uint64(1) << uint64(d-1)
+
+	return bits&mask != 0
+}
+
+// skipMissingLevels moves down the tree a level towards the leaves until the node exists. This
+// must terminate successfully as we will eventually reach the leaves, which are always written
+// and are at level 0. Missing nodes are intermediate nodes with one child, hence their value
+// is the same as the node lower down the tree as there is nothing to hash it with.
+func skipMissingLevels(snapshot, lastNode int64, level int, node int64) (int, int64) {
+	sibling := node ^ 1
+	for level > 0 && (node&1) == 0 && sibling == lastNode && !lastNodeWritten(int64(level), snapshot) {
+		level -= 1
+		sibling = sibling + sibling
+		lastNode = (snapshot - 1) >> uint(level)
+		glog.Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
 	}
 
-	return p2
+	return level, sibling
 }

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -212,7 +212,7 @@ func lastNodeWritten(d, ts int64) bool {
 func skipMissingLevels(snapshot, lastNode int64, level int, node int64) (int, int64) {
 	sibling := node ^ 1
 	for level > 0 && (node&1) == 0 && sibling == lastNode && !lastNodeWritten(int64(level), snapshot) {
-		level -= 1
+		level--
 		sibling = sibling + sibling
 		lastNode = (snapshot - 1) >> uint(level)
 		glog.Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -258,7 +258,7 @@ func skipMissingLevels(snapshot, lastNode int64, level int, node int64) (int, in
 		level--
 		sibling *= 2
 		lastNode = (snapshot - 1) >> uint(level)
-		glog.Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
+		glog.V(vLevel).Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
 	}
 
 	return level, sibling

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -37,6 +37,9 @@ var lastNodeWrittenVec = []struct {
 	{15, "11101"},
 }
 
+// For the path test tests at tree sizes up to this value
+const testUpToTreeSize = 99
+
 // Expected inclusion proof paths built by examination of the example 7 leaf tree in RFC 6962:
 //
 //                hash              <== Level 3
@@ -296,6 +299,26 @@ func TestLastNodeWritten(t *testing.T) {
 
 		if got, want := str, testCase.result; got != want {
 			t.Errorf("lastNodeWritten(%d) got: %s, want: %s", testCase.ts, got, want)
+		}
+	}
+}
+
+func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
+	for ts := 1; ts < testUpToTreeSize; ts++ {
+		for i := ts; i < ts; i++ {
+			if _, err := CalcInclusionProofNodeAddresses(int64(ts), int64(i), 64); err != nil {
+				t.Errorf("CalcInclusionProofNodeAddresses(ts:%d, i:%d) = %v", ts, i, err)
+			}
+		}
+	}
+}
+
+func TestConsistencySucceedsUpToTreeSize(t *testing.T) {
+	for s1 := 1; s1 < testUpToTreeSize; s1++ {
+		for s2 := s1 + 1; s2 < testUpToTreeSize; s2++ {
+			if _, err := CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), 64); err != nil {
+				t.Errorf("CalcConsistencyProofNodeAddresses(%d, %d) = %v", s1, s2, err)
+			}
 		}
 	}
 }

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -3,6 +3,8 @@ package merkle
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 )
@@ -22,6 +24,17 @@ type consistencyProofTestData struct {
 	priorTreeSize int64
 	treeSize      int64
 	expectedProof []storage.NodeID
+}
+
+var lastNodeWrittenVec = []struct {
+	ts     int64
+	result string
+}{
+	{3, "101"},
+	{5, "1001"},
+	{11, "10101"},
+	{14, "11011"},
+	{15, "11101"},
 }
 
 // Expected inclusion proof paths built by examination of the example 7 leaf tree in RFC 6962:
@@ -74,6 +87,24 @@ var expectedConsistencyProofFromSize1To2 = []storage.NodeID{
 	//        |                 | |
 	//        d0               d0 d1
 	testonly.MustCreateNodeIDForTreeCoords(0, 1, 64), // b
+}
+var expectedConsistencyProofFromSize1To4 = []storage.NodeID{
+	//
+	//
+	//  hash0=a      =>           hash1=k
+	//        |                  /   \
+	//        d0                /     \
+	//                         /      \
+	//                         /       \
+	//                         g       h
+	//                        / \     / \
+	//                        a b     c d
+	//                        | |     | |
+	//                       d0 d1   d2 d3
+	//
+	//
+	testonly.MustCreateNodeIDForTreeCoords(0, 1, 64), // b
+	testonly.MustCreateNodeIDForTreeCoords(1, 1, 64), // h
 }
 var expectedConsistencyProofFromSize3To7 = []storage.NodeID{
 	//                                             hash
@@ -158,6 +189,7 @@ var pathTestBad = []auditPathTestData{
 // These should compute the expected consistency proofs
 var consistencyTests = []consistencyProofTestData{
 	{1, 2, expectedConsistencyProofFromSize1To2},
+	{1, 4, expectedConsistencyProofFromSize1To4},
 	{6, 7, expectedConsistencyProofFromSize6To7},
 	{3, 7, expectedConsistencyProofFromSize3To7},
 	{4, 7, expectedConsistencyProofFromSize4To7}}
@@ -186,7 +218,7 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 			t.Fatalf("unexpected error calculating path %v: %v", testCase, err)
 		}
 
-		comparePaths(t, path, testCase.expectedPath)
+		comparePaths(t, fmt.Sprintf("i(%d,%d)", testCase.leafIndex, testCase.treeSize), path, testCase.expectedPath)
 	}
 }
 
@@ -213,10 +245,10 @@ func TestCalcConsistencyProofNodeAddresses(t *testing.T) {
 		proof, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, 64)
 
 		if err != nil {
-			t.Fatalf("failed to calculate inclusion proof from %d to %d: %v", testCase.priorTreeSize, testCase.treeSize, err)
+			t.Fatalf("failed to calculate consistency proof from %d to %d: %v", testCase.priorTreeSize, testCase.treeSize, err)
 		}
 
-		comparePaths(t, proof, testCase.expectedProof)
+		comparePaths(t, fmt.Sprintf("c(%d, %d)", testCase.priorTreeSize, testCase.treeSize), proof, testCase.expectedProof)
 	}
 }
 
@@ -239,14 +271,31 @@ func TestCalcConsistencyProofNodeAddressesRejectsBadBitLen(t *testing.T) {
 	}
 }
 
-func comparePaths(t *testing.T, got, expected []storage.NodeID) {
+func comparePaths(t *testing.T, desc string, got, expected []storage.NodeID) {
 	if len(expected) != len(got) {
-		t.Fatalf("expected %d nodes in path but got %d: %v", len(expected), len(got), got)
+		t.Fatalf("%s: expected %d nodes in path but got %d: %v", desc, len(expected), len(got), got)
 	}
 
 	for i := 0; i < len(expected); i++ {
 		if !expected[i].Equivalent(got[i]) {
-			t.Fatalf("expected node %v at position %d but got %v", expected[i], i, got[i])
+			t.Fatalf("%s: expected node %v (%v) at position %d but got %v (%v)", desc, expected[i], expected[i].CoordString(), i, got[i], got[i].CoordString())
+		}
+	}
+}
+
+func TestLastNodeWritten(t *testing.T) {
+	for _, testCase := range lastNodeWrittenVec {
+		str := ""
+		for d := int64(len(testCase.result) - 1); d >= 0; d-- {
+			if lastNodeWritten(d, testCase.ts) {
+				str += "1"
+			} else {
+				str += "0"
+			}
+		}
+
+		if got, want := str, testCase.result; got != want {
+			t.Errorf("lastNodeWritten(%d) got: %s, want: %s", testCase.ts, got, want)
 		}
 	}
 }

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -290,7 +290,7 @@ func TestLastNodeWritten(t *testing.T) {
 	for _, testCase := range lastNodeWrittenVec {
 		str := ""
 		for d := int64(len(testCase.result) - 1); d >= 0; d-- {
-			if lastNodeWritten(d, testCase.ts) {
+			if lastNodePresent(d, testCase.ts) {
 				str += "1"
 			} else {
 				str += "0"

--- a/storage/types.go
+++ b/storage/types.go
@@ -147,6 +147,19 @@ func (n *NodeID) String() string {
 	return r.String()
 }
 
+// CoordString returns a string representation assuming that the NodeID represents a
+// tree coordinate. Using this on a NodeID for a sparse Merkle tree will give incorrect
+// results. Intended for debugging purposes, the format could change.
+func (n *NodeID) CoordString() string {
+	d := uint64(n.PathLenBits - n.PrefixLenBits)
+	i := uint64(0)
+	for _, p := range n.Path {
+		i = (i << uint64(8)) + uint64(p)
+	}
+
+	return fmt.Sprintf("[d:%d, i:%d]", d, i>>d)
+}
+
 // Siblings returns the siblings of the given node.
 func (n *NodeID) Siblings() []NodeID {
 	r := make([]NodeID, n.PrefixLenBits, n.PrefixLenBits)

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -200,3 +200,19 @@ func TestNodeNotEquivalentDifferentPrefix(t *testing.T) {
 		t.Fatalf("%v incorrecly Equivalent with %v", n1, n2)
 	}
 }
+
+// It's important to have confidence in the CoordString output as it's used in debugging
+func TestCoordString(t *testing.T) {
+	// Test some roundtrips for various depths and indices
+	for d := 0; d < 37; d++ {
+		for i := 0; i < 117; i++ {
+			n, err := NewNodeIDForTreeCoords(int64(d), int64(i), 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := n.CoordString(), fmt.Sprintf("[d:%d, i:%d]", d, i); got != want {
+				t.Errorf("n.CoordString() got: %v, want: %v", got, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Now is explicitly based on the tree shape at the snapshot size and hopefully easier to read. Should be read in conjunction with ```compact_merkle_tree```, which is where node writes come from. Add a few
more tests, more should be written.