### PR TITLE
examples/ct: update for CT repo changes

### DIFF
--- a/examples/ct/ctmapper/mapper/mapper.go
+++ b/examples/ct/ctmapper/mapper/mapper.go
@@ -74,7 +74,7 @@ func (m *CTMapper) oneMapperRun() (bool, error) {
 	glog.Infof("Fetching entries [%d, %d] from log", startEntry, endEntry)
 
 	// Get the entries from the log:
-	logEntries, err := m.ct.GetEntries(startEntry, endEntry)
+	logEntries, err := m.ct.GetEntries(context.Background(), startEntry, endEntry)
 	if err != nil {
 		return false, err
 	}
@@ -95,7 +95,7 @@ func (m *CTMapper) oneMapperRun() (bool, error) {
 		}
 		switch entry.Leaf.TimestampedEntry.EntryType {
 		case ct.X509LogEntryType:
-			cert, err := x509.ParseCertificate(entry.Leaf.TimestampedEntry.X509Entry)
+			cert, err := x509.ParseCertificate(entry.Leaf.TimestampedEntry.X509Entry.Data)
 			if err != nil {
 				glog.Warningf("Can't parse cert at index %d, continuing anyway because this is a toy", entry.Index)
 				continue

--- a/examples/ct/ctmapper/mapper/mapper.go
+++ b/examples/ct/ctmapper/mapper/mapper.go
@@ -74,7 +74,7 @@ func (m *CTMapper) oneMapperRun() (bool, error) {
 	glog.Infof("Fetching entries [%d, %d] from log", startEntry, endEntry)
 
 	// Get the entries from the log:
-	logEntries, err := m.ct.GetEntries(context.Background(), startEntry, endEntry)
+	logEntries, err := m.ct.GetEntries(startEntry, endEntry)
 	if err != nil {
 		return false, err
 	}

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -49,15 +49,14 @@ func signV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t tim
 	sctInput := getSCTForSignatureInput(t)
 
 	// Build up a MerkleTreeLeaf for the cert
-	timestampedEntry := ct.TimestampedEntry{
-		Timestamp: sctInput.Timestamp,
-		EntryType: ct.X509LogEntryType,
-		X509Entry: &ct.ASN1Cert{Data: cert.Raw},
-	}
 	leaf := ct.MerkleTreeLeaf{
-		Version:          ct.V1,
-		LeafType:         ct.TimestampedEntryLeafType,
-		TimestampedEntry: &timestampedEntry,
+		Version:  ct.V1,
+		LeafType: ct.TimestampedEntryLeafType,
+		TimestampedEntry: &ct.TimestampedEntry{
+			Timestamp: sctInput.Timestamp,
+			EntryType: ct.X509LogEntryType,
+			X509Entry: &ct.ASN1Cert{Data: cert.Raw},
+		},
 	}
 
 	return serializeAndSignSCT(km, leaf, sctInput, t)

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -2,10 +2,6 @@ package ct
 
 import (
 	"crypto/sha256"
-	"encoding/binary"
-	"errors"
-	"fmt"
-	"io"
 	"time"
 
 	ct "github.com/google/certificate-transparency/go"
@@ -53,13 +49,21 @@ func signV1SCTForCertificate(km crypto.KeyManager, cert *x509.Certificate, t tim
 	sctInput := getSCTForSignatureInput(t)
 
 	// Build up a MerkleTreeLeaf for the cert
-	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.X509LogEntryType, X509Entry: cert.Raw}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
+	timestampedEntry := ct.TimestampedEntry{
+		Timestamp: sctInput.Timestamp,
+		EntryType: ct.X509LogEntryType,
+		X509Entry: &ct.ASN1Cert{Data: cert.Raw},
+	}
+	leaf := ct.MerkleTreeLeaf{
+		Version:          ct.V1,
+		LeafType:         ct.TimestampedEntryLeafType,
+		TimestampedEntry: &timestampedEntry,
+	}
 
 	return serializeAndSignSCT(km, leaf, sctInput, t)
 }
 
-// SignV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
+// signV1SCTForPrecertificate builds and signs a V1 CT SCT for a pre-certificate using the key
 // held by a key manager.
 func signV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
 	// Temp SCT for input to the serializer
@@ -71,8 +75,8 @@ func signV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t 
 	keyHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	precert := ct.PreCert{IssuerKeyHash: keyHash, TBSCertificate: cert.RawTBSCertificate}
 
-	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.PrecertLogEntryType, PrecertEntry: precert}
-	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: timestampedEntry}
+	timestampedEntry := ct.TimestampedEntry{Timestamp: sctInput.Timestamp, EntryType: ct.PrecertLogEntryType, PrecertEntry: &precert}
+	leaf := ct.MerkleTreeLeaf{Version: ct.V1, LeafType: ct.TimestampedEntryLeafType, TimestampedEntry: &timestampedEntry}
 
 	return serializeAndSignSCT(km, leaf, sctInput, t)
 }
@@ -80,7 +84,6 @@ func signV1SCTForPrecertificate(km crypto.KeyManager, cert *x509.Certificate, t 
 func serializeAndSignSCT(km crypto.KeyManager, leaf ct.MerkleTreeLeaf, sctInput ct.SignedCertificateTimestamp, t time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error) {
 	// Serialize SCT signature input to get the bytes that need to be signed
 	res, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf: leaf})
-
 	if err != nil {
 		return ct.MerkleTreeLeaf{}, ct.SignedCertificateTimestamp{}, err
 	}
@@ -117,7 +120,7 @@ func signSCT(km crypto.KeyManager, t time.Time, sctData []byte) (ct.SignedCertif
 
 	return ct.SignedCertificateTimestamp{
 		SCTVersion: ct.V1,
-		LogID:      logID,
+		LogID:      ct.LogID{KeyID: logID},
 		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
 		Extensions: ct.CTExtensions{},
 		Signature:  digitallySigned}, nil
@@ -129,127 +132,3 @@ func getSCTForSignatureInput(t time.Time) ct.SignedCertificateTimestamp {
 		Timestamp:  uint64(t.UnixNano() / millisPerNano), // spec uses millisecond timestamps
 		Extensions: ct.CTExtensions{}}
 }
-
-// WriteTimestampedEntry writes out a TimestampedEntry structure in the binary format defined
-// by RFC 6962. The CT go code includes a deserializer but not a serializer so we might as
-// well make this available.
-func writeTimestampedEntry(w io.Writer, t ct.TimestampedEntry) error {
-	if err := binary.Write(w, binary.BigEndian, &t.Timestamp); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, &t.EntryType); err != nil {
-		return err
-	}
-	switch t.EntryType {
-	case ct.X509LogEntryType:
-		if err := writeVarBytes(w, t.X509Entry, ct.CertificateLengthBytes); err != nil {
-			return err
-		}
-	case ct.PrecertLogEntryType:
-		if err := binary.Write(w, binary.BigEndian, t.PrecertEntry.IssuerKeyHash); err != nil {
-			return err
-		}
-		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, ct.PreCertificateLengthBytes); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
-	}
-
-	return writeVarBytes(w, t.Extensions, ct.ExtensionsLengthBytes)
-}
-
-// WriteMerkleTreeLeaf writes a MerkleTreeLeaf in the binary format specified by RFC 6962.
-// The CT go code includes a deserializer but not a serializer and we might as well make this
-// available to other users.
-func writeMerkleTreeLeaf(w io.Writer, l ct.MerkleTreeLeaf) error {
-	if l.Version != ct.V1 {
-		return fmt.Errorf("unknown Version: %d", l.Version)
-	}
-
-	if l.LeafType != ct.TimestampedEntryLeafType {
-		return fmt.Errorf("unknown LeafType: %d", l.LeafType)
-	}
-
-	if err := binary.Write(w, binary.BigEndian, l.Version); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, l.LeafType); err != nil {
-		return err
-	}
-	if err := writeTimestampedEntry(w, l.TimestampedEntry); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// These came from the CT go code. Currently don't want to push changes upstream to make
-// them visible but this is an option for the future.
-
-func writeVarBytes(w io.Writer, value []byte, numLenBytes int) error {
-	if err := writeUint(w, uint64(len(value)), numLenBytes); err != nil {
-		return err
-	}
-	if _, err := w.Write(value); err != nil {
-		return err
-	}
-	return nil
-}
-
-func writeUint(w io.Writer, value uint64, numBytes int) error {
-	buf := make([]uint8, numBytes)
-	for i := 0; i < numBytes; i++ {
-		buf[numBytes-i-1] = uint8(value & 0xff)
-		value >>= 8
-	}
-	if value != 0 {
-		return errors.New("numBytes was insufficiently large to represent value")
-	}
-	if _, err := w.Write(buf); err != nil {
-		return err
-	}
-	return nil
-}
-
-func readUint(r io.Reader, numBytes int) (uint64, error) {
-	var l uint64
-	for i := 0; i < numBytes; i++ {
-		l <<= 8
-		var t uint8
-		if err := binary.Read(r, binary.BigEndian, &t); err != nil {
-			return 0, err
-		}
-		l |= uint64(t)
-	}
-	return l, nil
-}
-
-// Reads a variable length array of bytes from |r|. |numLenBytes| specifies the
-// number of (BigEndian) prefix-bytes which contain the length of the actual
-// array data bytes that follow.
-// Allocates an array to hold the contents and returns a slice view into it if
-// the read was successful, or an error otherwise.
-func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
-	switch {
-	case numLenBytes > 8:
-		return nil, fmt.Errorf("numLenBytes too large (%d)", numLenBytes)
-	case numLenBytes == 0:
-		return nil, errors.New("numLenBytes should be > 0")
-	}
-	l, err := readUint(r, numLenBytes)
-	if err != nil {
-		return nil, err
-	}
-	data := make([]byte, l)
-	n, err := r.Read(data)
-	if err != nil {
-		return nil, err
-	}
-	if n != int(l) {
-		return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
-	}
-	return data, nil
-}
-
-// End of code from CT repository

--- a/examples/ct/serialize_test.go
+++ b/examples/ct/serialize_test.go
@@ -1,7 +1,6 @@
 package ct
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
@@ -21,7 +20,6 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	cert, err := fixchain.CertificateFromPEM(testonly.LeafSignedByFakeIntermediateCertPem)
-
 	if err != nil {
 		t.Fatalf("failed to set up test cert: %v", err)
 	}
@@ -29,13 +27,11 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 	km := setupMockKeyManager(mockCtrl, []byte{0x5, 0x62, 0x4f, 0xb4, 0x9e, 0x32, 0x14, 0xb6, 0xc, 0xb8, 0x51, 0x28, 0x23, 0x93, 0x2c, 0x7a, 0x3d, 0x80, 0x93, 0x5f, 0xcd, 0x76, 0xef, 0x91, 0x6a, 0xaf, 0x1b, 0x8c, 0xe8, 0xb5, 0x2, 0xb5})
 
 	leaf, got, err := signV1SCTForCertificate(km, cert, fixedTime)
-
 	if err != nil {
 		t.Fatalf("create sct for cert failed: %v", err)
 	}
 
 	logID, err := base64.StdEncoding.DecodeString(ctMockLogID)
-
 	if err != nil {
 		t.Fatalf("failed to decode test log id: %s", ctMockLogID)
 	}
@@ -43,15 +39,18 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 	var idArray [sha256.Size]byte
 	copy(idArray[:], logID)
 
-	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
-		LogID:      ct.SHA256Hash(idArray),
+	expected := ct.SignedCertificateTimestamp{
+		SCTVersion: 0,
+		LogID:      ct.LogID{KeyID: ct.SHA256Hash(idArray)},
 		Timestamp:  1504786523000000,
 		Extensions: ct.CTExtensions{},
 		Signature: ct.DigitallySigned{
 			Algorithm: tls.SignatureAndHashAlgorithm{
 				Hash:      tls.SHA256,
 				Signature: tls.RSA},
-			Signature: []byte("signed")}}
+			Signature: []byte("signed"),
+		},
+	}
 
 	if !reflect.DeepEqual(got, expected) {
 		t.Fatalf("Mismatched SCT (cert), got %v, expected %v", got, expected)
@@ -70,8 +69,8 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 	if got, want := leaf.TimestampedEntry.Timestamp, got.Timestamp; got != want {
 		t.Fatalf("Entry / sct timestamp mismatch; got %v, expected %v", got, want)
 	}
-	if got, want := leaf.TimestampedEntry.X509Entry, ct.ASN1Cert(cert.Raw); !reflect.DeepEqual(got, want) {
-		t.Fatalf("Cert bytes mismatch, got %v, expected %v", got, want)
+	if got, want := leaf.TimestampedEntry.X509Entry.Data, cert.Raw; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Cert bytes mismatch, got %x, expected %x", got, want)
 	}
 }
 
@@ -104,7 +103,7 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 	copy(idArray[:], logID)
 
 	expected := ct.SignedCertificateTimestamp{SCTVersion: 0,
-		LogID:      ct.SHA256Hash(idArray),
+		LogID:      ct.LogID{KeyID: ct.SHA256Hash(idArray)},
 		Timestamp:  1504786523000000,
 		Extensions: ct.CTExtensions{},
 		Signature: ct.DigitallySigned{
@@ -138,95 +137,5 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 	}
 	if got, want := leaf.TimestampedEntry.PrecertEntry.TBSCertificate, cert.RawTBSCertificate; !bytes.Equal(got, want) {
 		t.Fatalf("TBS cert mismatch, got %v, expected %v", got, want)
-	}
-}
-
-func TestSerializeMerkleTreeLeafBadVersion(t *testing.T) {
-	var leaf ct.MerkleTreeLeaf
-
-	leaf.Version = 199 // Out of any expected valid range
-
-	var b bytes.Buffer
-	err := writeMerkleTreeLeaf(&b, leaf)
-	if err == nil {
-		t.Fatal("Incorrectly serialized leaf with bad version")
-	}
-	if got := len(b.Bytes()); got != 0 {
-		t.Fatalf("Wrote %d bytes of data when serializing invalid object, expected 0", got)
-	}
-}
-
-func TestSerializeMerkleTreeLeafBadType(t *testing.T) {
-	var leaf ct.MerkleTreeLeaf
-
-	leaf.Version = ct.V1
-	leaf.LeafType = 212
-
-	var b bytes.Buffer
-	err := writeMerkleTreeLeaf(&b, leaf)
-	if err == nil {
-		t.Fatal("Incorrectly serialized leaf with bad leaf type")
-	}
-	if got := len(b.Bytes()); got != 0 {
-		t.Fatalf("Wrote %d bytes of data when serializing invalid object, expected 0", got)
-	}
-}
-
-func TestSerializeMerkleTreeLeafCert(t *testing.T) {
-	ts := ct.TimestampedEntry{
-		Timestamp:  12345,
-		EntryType:  ct.X509LogEntryType,
-		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
-		Extensions: ct.CTExtensions{}}
-	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
-
-	var buff bytes.Buffer
-	w := bufio.NewWriter(&buff)
-
-	if err := writeMerkleTreeLeaf(w, leaf); err != nil {
-		t.Fatalf("failed to write leaf: %v", err)
-	}
-
-	w.Flush()
-	r := bufio.NewReader(&buff)
-
-	leaf2, err := ct.ReadMerkleTreeLeaf(r)
-
-	if err != nil {
-		t.Fatalf("failed to read leaf: %v", err)
-	}
-
-	if a, b := leaf, *leaf2; !reflect.DeepEqual(a, b) {
-		t.Fatalf("Leaf mismatch after serialization roundtrip (cert), %v != %v", a, b)
-	}
-}
-
-func TestSerializeMerkleTreePrecert(t *testing.T) {
-	ts := ct.TimestampedEntry{Timestamp: 12345,
-		EntryType: ct.PrecertLogEntryType,
-		PrecertEntry: ct.PreCert{
-			IssuerKeyHash:  [sha256.Size]byte{0x55, 0x56, 0x57, 0x58, 0x59},
-			TBSCertificate: ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23})},
-		Extensions: ct.CTExtensions{}}
-	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
-
-	var buff bytes.Buffer
-	w := bufio.NewWriter(&buff)
-
-	if err := writeMerkleTreeLeaf(w, leaf); err != nil {
-		t.Fatalf("failed to write leaf: %v", err)
-	}
-
-	w.Flush()
-	r := bufio.NewReader(&buff)
-
-	leaf2, err := ct.ReadMerkleTreeLeaf(r)
-
-	if err != nil {
-		t.Fatalf("failed to read leaf: %v", err)
-	}
-
-	if a, b := leaf, *leaf2; !reflect.DeepEqual(a, b) {
-		t.Fatalf("Leaf mismatch after serialization roundtrip (precert), %v != %v", a, b)
 	}
 }

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -81,7 +81,7 @@ func TestSerializeLogEntry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to deserialize log entry: %v", err)
 		} else if len(rest) > 0 {
-			t.Fatalf("trailing data after serialized log entry")
+			t.Error("trailing data after serialized log entry")
 		}
 
 		if !reflect.DeepEqual(logEntry, logEntry2) {

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -1,8 +1,6 @@
 package ct
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/base64"
 	"reflect"
 	"testing"
@@ -10,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	ct "github.com/google/certificate-transparency/go"
+	"github.com/google/certificate-transparency/go/tls"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
 )
@@ -64,31 +63,25 @@ func TestSerializeLogEntry(t *testing.T) {
 	ts := ct.TimestampedEntry{
 		Timestamp:  12345,
 		EntryType:  ct.X509LogEntryType,
-		X509Entry:  ct.ASN1Cert([]byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}),
+		X509Entry:  &ct.ASN1Cert{Data: []byte{0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23}},
 		Extensions: ct.CTExtensions{}}
-	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: ts}
+	leaf := ct.MerkleTreeLeaf{LeafType: ct.TimestampedEntryLeafType, Version: ct.V1, TimestampedEntry: &ts}
 
 	for chainLength := 1; chainLength < 10; chainLength++ {
 		chain := createCertChain(chainLength)
 
-		var buff bytes.Buffer
-		w := bufio.NewWriter(&buff)
-
 		logEntry := LogEntry{Leaf: leaf, Chain: chain}
-		err := logEntry.Serialize(w)
-
+		entryData, err := tls.Marshal(logEntry)
 		if err != nil {
 			t.Fatalf("failed to serialize log entry: %v", err)
 		}
 
-		w.Flush()
-		r := bufio.NewReader(&buff)
-
 		var logEntry2 LogEntry
-		err = logEntry2.Deserialize(r)
-
+		rest, err := tls.Unmarshal(entryData, &logEntry2)
 		if err != nil {
 			t.Fatalf("failed to deserialize log entry: %v", err)
+		} else if len(rest) > 0 {
+			t.Fatalf("trailing data after serialized log entry")
 		}
 
 		if !reflect.DeepEqual(logEntry, logEntry2) {
@@ -127,7 +120,7 @@ func createCertChain(numCerts int) []ct.ASN1Cert {
 			certBytes[i] = byte(c)
 		}
 
-		chain = append(chain, ct.ASN1Cert(certBytes))
+		chain = append(chain, ct.ASN1Cert{Data: certBytes})
 	}
 
 	return chain


### PR DESCRIPTION
CT repo is about to [convert](https://github.com/google/certificate-transparency/pull/1345) to use the tls encoding library throughout; update Trillian to match.