### PR TITLE
Return an empty list of node hashes when the compact merkle tree size is a power of 2

### DIFF
--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -230,7 +230,7 @@ func (c CompactMerkleTree) Size() int64 {
 // Hashes returns a copy of the set of node hashes that comprise the compact representation of the tree.
 func (c CompactMerkleTree) Hashes() [][]byte {
 	if isPerfectTree(c.size) {
-		return [][]byte{}
+		return nil
 	}
 	n := make([][]byte, len(c.nodes))
 	copy(n, c.nodes)

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -229,6 +229,9 @@ func (c CompactMerkleTree) Size() int64 {
 
 // Hashes returns a copy of the set of node hashes that comprise the compact representation of the tree.
 func (c CompactMerkleTree) Hashes() [][]byte {
+	if isPerfectTree(c.size) {
+		return [][]byte{}
+	}
 	n := make([][]byte, len(c.nodes))
 	copy(n, c.nodes)
 	return n

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -32,14 +32,14 @@ func MerkleTreeLeafTestRootHashes() [][]byte {
 // MerkleTreeLeafTestInputs(), as described above.
 func CompactMerkleTreeLeafTestNodeHashes() [][][]byte {
 	return [][][]byte{
-		[][]byte{MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=")},
-		[][]byte{nil, MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
+		[][]byte{}, // perfect tree size, 2^0
+		[][]byte{}, // perfect tree size, 2^1
 		[][]byte{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
-		[][]byte{nil, nil, MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
+		[][]byte{}, // perfect tree size, 2^2
 		[][]byte{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), nil, MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
 		[][]byte{nil, MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
 		[][]byte{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
-		[][]byte{nil, nil, nil, MustDecodeBase64("XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=")},
+		[][]byte{}, // perfect tree size, 2^3
 	}
 }
 

--- a/testonly/compact_merkle_tree.go
+++ b/testonly/compact_merkle_tree.go
@@ -32,14 +32,14 @@ func MerkleTreeLeafTestRootHashes() [][]byte {
 // MerkleTreeLeafTestInputs(), as described above.
 func CompactMerkleTreeLeafTestNodeHashes() [][][]byte {
 	return [][][]byte{
-		[][]byte{}, // perfect tree size, 2^0
-		[][]byte{}, // perfect tree size, 2^1
+		nil, // perfect tree size, 2^0
+		nil, // perfect tree size, 2^1
 		[][]byte{MustDecodeBase64("ApjRIpBtz8EIkstTpzmS/FufST6kybrbJ7eRtBJ6f+c="), MustDecodeBase64("+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=")},
-		[][]byte{}, // perfect tree size, 2^2
+		nil, // perfect tree size, 2^2
 		[][]byte{MustDecodeBase64("vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="), nil, MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
 		[][]byte{nil, MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
 		[][]byte{MustDecodeBase64("sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="), MustDecodeBase64("DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o="), MustDecodeBase64("037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=")},
-		[][]byte{}, // perfect tree size, 2^3
+		nil, // perfect tree size, 2^3
 	}
 }
 


### PR DESCRIPTION
Dipping my toes into this code base with (what seems to me) a rather simple issue, feel free to tell me I've misunderstood the problem!

This change reuses the existing `isPerfectTree` method to check if the tree size is a power of two in `CompactMerkleTree.Hashes` and returns `[][]byte{}` if so. Also updates tests to reflect this new behavior.

Fixes #200.