### PR TITLE
travis: just go get proto subpackage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - export CC="gcc-4.8"
   - go install github.com/golang/mock/mockgen
   - go get -u github.com/golang/lint/golint
-  - go get -u github.com/golang/protobuf/...
+  - go get -u github.com/golang/protobuf/proto/...
   - MOCKFILES=$(find . -name mock_\*.go)
   - rm ${MOCKFILES}
   - PBFILES=$(find . -name \*.pb.go)


### PR DESCRIPTION
Getting the whole github.com/golang/protobuf/... repo is giving errors
around the descriptor/ subpackage, so be more specific.