### PR TITLE
Fix the broken table of contents link to the 'use-cases' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Trillian: General Transparency
      - [Map Mode](#map-mode)
      - [Log Mode](#log-mode)
      - [Personalities](#personalities)
- - [Use Cases](#use=cases)
+ - [Use Cases](#use-cases)
      - [Certificate Transparency Log](#certificate-transparency-log)
      - [Verifiable Log-Derived Map](#verifiable-log-derived-map)
 


### PR DESCRIPTION
There was a typo in the table of contents link to the use-cases section.