### PR TITLE
integration: don't use Go build tags

### DIFF
--- a/integration/ct_integration_test.go
+++ b/integration/ct_integration_test.go
@@ -1,5 +1,3 @@
-//+build integration
-
 package integration
 
 import (
@@ -47,6 +45,9 @@ var verifier = merkletree.NewMerkleVerifier(func(data []byte) []byte {
 
 func TestCTIntegration(t *testing.T) {
 	flag.Parse()
+	if *logConfigFlag == "" {
+		t.Skip("Integration test skipped as no log config provided")
+	}
 	if *seed == -1 {
 		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
 	}

--- a/integration/ct_integration_test.sh
+++ b/integration/ct_integration_test.sh
@@ -48,7 +48,7 @@ set -e
 
 echo "Running test(s)"
 set +e
-go test -v -tags=integration -run ".*CT.*" --timeout=5m ./integration --log_config ${CT_CFG} --ct_http_server="localhost:${CT_PORT}" --testdata=${TESTDATA}
+go test -v -run ".*CT.*" --timeout=5m ./integration --log_config ${CT_CFG} --ct_http_server="localhost:${CT_PORT}" --testdata=${TESTDATA}
 RESULT=$?
 set -e
 

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -1,5 +1,3 @@
-//+build integration
-
 package integration
 
 import (
@@ -21,7 +19,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-var treeIDFlag = flag.Int64("treeid", 3, "The tree id to use")
+var treeIDFlag = flag.Int64("treeid", -1, "The tree id to use")
 var serverFlag = flag.String("log_rpc_server", "localhost:8092", "Server address:port")
 var queueLeavesFlag = flag.Bool("queue_leaves", true, "If true queues leaves, false just reads from the log")
 var awaitSequencingFlag = flag.Bool("await_sequencing", true, "If true then waits until log size is at least num_leaves")
@@ -68,6 +66,9 @@ var consistencyProofBadTestParams = []consistencyProofParams{{0, 0}, {-1, 0}, {1
 
 func TestLogIntegration(t *testing.T) {
 	flag.Parse()
+	if *treeIDFlag == -1 {
+		t.Skip("Integration test skipped as no tree ID provided")
+	}
 
 	// Step 0 - Initialize and connect to log server
 	treeID := *treeIDFlag

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -24,7 +24,7 @@ waitForServerStartup ${RPC_PORT}
 # Run the test(s):
 cd ${INTEGRATION_DIR}
 set +e
-go test -tags=integration -run ".*Log.*" --timeout=5m ./ --treeid ${TEST_TREE_ID} --log_rpc_server="localhost:${RPC_PORT}"
+go test -run ".*Log.*" --timeout=5m ./ --treeid ${TEST_TREE_ID} --log_rpc_server="localhost:${RPC_PORT}"
 RESULT=$?
 set -e
 

--- a/integration/map_integration_test.go
+++ b/integration/map_integration_test.go
@@ -1,5 +1,3 @@
-//+build integration
-
 package integration
 
 import (
@@ -20,7 +18,7 @@ import (
 )
 
 var server = flag.String("map_rpc_server", "localhost:8091", "Server address:port")
-var mapID = flag.Int64("map_id", 1, "Trillian MapID to use for test")
+var mapID = flag.Int64("map_id", -1, "Trillian MapID to use for test")
 
 func getClient() (*grpc.ClientConn, trillian.TrillianMapClient, error) {
 	conn, err := grpc.Dial(*server, grpc.WithInsecure())
@@ -31,6 +29,11 @@ func getClient() (*grpc.ClientConn, trillian.TrillianMapClient, error) {
 }
 
 func TestMapIntegration(t *testing.T) {
+	flag.Parse()
+	if *mapID == -1 {
+		t.Skip("Integration test skipped as no map ID provided")
+	}
+
 	conn, client, err := getClient()
 	if err != nil {
 		t.Fatalf("Failed to get map client: %v", err)

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -24,7 +24,7 @@ waitForServerStartup ${RPC_PORT}
 # Run the test(s):
 cd ${INTEGRATION_DIR}
 set +e
-go test -tags=integration -run ".*Map.*" --timeout=5m ./ --map_id ${TEST_TREE_ID} --map_rpc_server="localhost:${RPC_PORT}"
+go test -run ".*Map.*" --timeout=5m ./ --map_id ${TEST_TREE_ID} --map_rpc_server="localhost:${RPC_PORT}"
 RESULT=$?
 set -e
 


### PR DESCRIPTION
Instead of using '//+build integration' tags, instead require
one of the command-line options to be set to a non-default
value.  This means that "go test ./..." etc. will still build
and execute the integration tests, but they will be immediately
skipped.