### PR TITLE
gRPC reflection for grpc_cli

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 var serverPortFlag = flag.Int("port", 8090, "Port to serve log RPC requests on")
@@ -67,6 +68,8 @@ func startRPCServer(listener net.Listener, port int, registry extension.Registry
 
 	logServer := server.NewTrillianLogRPCServer(registry, new(util.SystemTimeSource))
 	trillian.RegisterTrillianLogServer(grpcServer, logServer)
+
+	reflection.Register(grpcServer)
 
 	return grpcServer
 }

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/trillian/extension/builtin"
 	"github.com/google/trillian/server/vmap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 var serverPortFlag = flag.Int("port", 8090, "Port to serve log RPC requests on")
@@ -54,6 +55,7 @@ func startRPCServer(listener net.Listener, port int, registry extension.Registry
 	grpcServer := grpc.NewServer()
 	mapServer := vmap.NewTrillianMapServer(registry)
 	trillian.RegisterTrillianMapServer(grpcServer, mapServer)
+	reflection.Register(grpcServer)
 
 	return grpcServer
 }


### PR DESCRIPTION
grpc_cli is a nice little tool that allows for convenient interactions like this
```
grpc_cli ls localhost:8090
trillian.TrillianLog
grpc.reflection.v1alpha.ServerReflection
```

```
grpc_cli ls localhost:8090 trillian.TrillianLog
QueueLeaves
GetInclusionProof
GetInclusionProofByHash
GetConsistencyProof
GetLatestSignedLogRoot
GetSequencedLeafCount
GetLeavesByIndex
GetLeavesByHash
GetLeavesByLeafValueHash
GetEntryAndProof
```