### PR TITLE
Add rehashing support for inclusion + consistency proofs.

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -171,7 +171,7 @@ func RunLogIntegration(client trillian.TrillianLogClient, params TestParameters)
 
 		// Only do this if the batch size changes when halved
 		if params.queueBatchSize > 1 {
-			if err := checkConsistencyProof(consistParams, params.treeID, tree, client, params, int64(params.queueBatchSize / 2)); err != nil {
+			if err := checkConsistencyProof(consistParams, params.treeID, tree, client, params, int64(params.queueBatchSize/2)); err != nil {
 				return fmt.Errorf("log consistency for %v: proof checks failed (Non STH size): %v", consistParams, err)
 			}
 		}
@@ -405,7 +405,7 @@ func checkInclusionProofsAtIndex(index int64, logID int64, tree *merkle.InMemory
 		}
 
 		// Remember that the in memory tree uses 1 based leaf indices
-		path := tree.PathToRootAtSnapshot(index + 1, treeSize)
+		path := tree.PathToRootAtSnapshot(index+1, treeSize)
 
 		if err = compareLogAndTreeProof(resp.Proof, path); err != nil {
 			// The log and tree proof don't match, details in the error

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -19,10 +19,12 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/storage"
+	"github.com/vektra/errors"
 )
 
-// Verbosity level for logging of debug related items
+// Verbosity levels for logging of debug related items
 const vLevel = 2
+const vvLevel = 4
 
 // NodeFetch bundles a nodeID with additional information on how to use the node to construct the
 // correct proof.
@@ -39,12 +41,12 @@ func (n NodeFetch) Equivalent(other NodeFetch) bool {
 // CalcInclusionProofNodeAddresses returns the tree node IDs needed to
 // build an inclusion proof for a specified leaf and tree size. The maxBitLen parameter
 // is copied into all the returned nodeIDs.
-func CalcInclusionProofNodeAddresses(treeSize, index int64, maxBitLen int) ([]NodeFetch, error) {
-	if index >= treeSize || index < 0 || treeSize < 1 || maxBitLen < 0 {
-		return []NodeFetch{}, fmt.Errorf("invalid params ts: %d index: %d, bitlen:%d", treeSize, index, maxBitLen)
+func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+	if snapshot > treeSize || index >= snapshot || index < 0 || snapshot < 1 || maxBitLen < 0 {
+		return []NodeFetch{}, fmt.Errorf("invalid params s: %d index: %d ts: %d, bitlen:%d", snapshot, index, treeSize, maxBitLen)
 	}
 
-	return pathFromNodeToRootAtSnapshot(index, 0, treeSize, maxBitLen)
+	return pathFromNodeToRootAtSnapshot(index, 0, snapshot, treeSize, maxBitLen)
 }
 
 // CalcConsistencyProofNodeAddresses returns the tree node IDs needed to
@@ -53,19 +55,17 @@ func CalcInclusionProofNodeAddresses(treeSize, index int64, maxBitLen int) ([]No
 // the input tree sizes correspond to valid tree heads. All returned NodeIDs are tree
 // coordinates within the new tree. It is assumed that they will be fetched from storage
 // at a revision corresponding to the STH associated with the treeSize parameter.
-func CalcConsistencyProofNodeAddresses(previousTreeSize, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
-	if previousTreeSize > treeSize || previousTreeSize < 1 || treeSize < 1 || maxBitLen <= 0 {
-		return []NodeFetch{}, fmt.Errorf("invalid params prior: %d treesize: %d, bitlen:%d", previousTreeSize, treeSize, maxBitLen)
+func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+	if snapshot1 > snapshot2 || snapshot1 > treeSize || snapshot2 > treeSize || snapshot1 < 1 || snapshot2 < 1 || maxBitLen <= 0 {
+		return []NodeFetch{}, fmt.Errorf("invalid params s1: %d s2: %d tss: %d, bitlen:%d", snapshot1, snapshot2, treeSize, maxBitLen)
 	}
 
-	return snapshotConsistency(previousTreeSize, treeSize, maxBitLen)
+	return snapshotConsistency(snapshot1, snapshot2, treeSize, maxBitLen)
 }
 
 // snapshotConsistency does the calculation of consistency proof node addresses between
 // two snapshots. Based on the C++ code used by CT but adjusted to fit our situation.
-// In particular the code does not need to handle the case where overwritten node hashes
-// must be recursively computed because we have versioned nodes.
-func snapshotConsistency(snapshot1, snapshot2 int64, maxBitLen int) ([]NodeFetch, error) {
+func snapshotConsistency(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
 	proof := make([]NodeFetch, 0, bitLen(snapshot2)+1)
 
 	glog.V(vLevel).Infof("snapshotConsistency: %d -> %d", snapshot1, snapshot2)
@@ -76,13 +76,13 @@ func snapshotConsistency(snapshot1, snapshot2 int64, maxBitLen int) ([]NodeFetch
 	// Compute the (compressed) path to the root of snapshot2.
 	// Everything left of 'node' is equal in both trees; no need to record.
 	for (node & 1) != 0 {
-		glog.V(vLevel).Infof("Move up: l:%d n:%d", level, node)
+		glog.V(vvLevel).Infof("Move up: l:%d n:%d", level, node)
 		node >>= 1
 		level++
 	}
 
 	if node != 0 {
-		glog.V(vLevel).Infof("Not root snapshot1: %d", node)
+		glog.V(vvLevel).Infof("Not root snapshot1: %d", node)
 		// Not at the root of snapshot 1, record the node
 		n, err := storage.NewNodeIDForTreeCoords(int64(level), node, maxBitLen)
 		if err != nil {
@@ -92,15 +92,15 @@ func snapshotConsistency(snapshot1, snapshot2 int64, maxBitLen int) ([]NodeFetch
 	}
 
 	// Now append the path from this node to the root of snapshot2.
-	p, err := pathFromNodeToRootAtSnapshot(node, level, snapshot2, maxBitLen)
+	p, err := pathFromNodeToRootAtSnapshot(node, level, snapshot2, treeSize, maxBitLen)
 	if err != nil {
 		return nil, err
 	}
 	return append(proof, p...), nil
 }
 
-func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitLen int) ([]NodeFetch, error) {
-	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot: N:%d, L:%d, S:%d", node, level, snapshot)
+func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot: N:%d, L:%d, S:%d TS:%d", node, level, snapshot, treeSize)
 	proof := make([]NodeFetch, 0, bitLen(snapshot)+1)
 
 	if snapshot == 0 {
@@ -115,7 +115,7 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 		sibling := node ^ 1
 		if sibling < lastNode {
 			// The sibling is not the last node of the level in the snapshot tree
-			glog.V(vLevel).Infof("Not last: S:%d L:%d", sibling, level)
+			glog.V(vvLevel).Infof("Not last: S:%d L:%d", sibling, level)
 			n, err := storage.NewNodeIDForTreeCoords(int64(level), sibling, maxBitLen)
 			if err != nil {
 				return nil, err
@@ -123,24 +123,36 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 			proof = append(proof, NodeFetch{NodeID: n})
 		} else if sibling == lastNode {
 			// The sibling is the last node of the level in the snapshot tree.
-			// In the C++ code we'd potentially recompute the node value here because we could be
-			// referencing a snapshot at a point before additional leaves were added to the tree causing
-			// some nodes to be overwritten. We have versioned tree nodes so this isn't necessary,
-			// we won't see any hashes written since the snapshot point. However we do have to account
-			// for missing levels in the tree. This can only occur on the rightmost tree nodes because
-			// this is the only area of the tree that is not fully populated.
-			glog.V(vLevel).Infof("Last: S:%d L:%d", sibling, level)
+			// We might need to recompute a previous hash value here. This can only occur on the
+			// rightmost tree nodes because this is the only area of the tree that is not fully populated.
+			glog.V(vvLevel).Infof("Last: S:%d L:%d", sibling, level)
 
-			// Account for non existent nodes - these can only be the rightmost node at an
-			// intermediate (non leaf) level in the tree so will always be a right sibling.
-			l, sibling := skipMissingLevels(snapshot, lastNode, level, node)
-			n, err := storage.NewNodeIDForTreeCoords(int64(l), sibling, maxBitLen)
-			if err != nil {
-				return nil, err
+			if snapshot == treeSize {
+				// No recomputation required as we're using the tree in its current state
+				// Account for non existent nodes - these can only be the rightmost node at an
+				// intermediate (non leaf) level in the tree so will always be a right sibling.
+				n, err := siblingIDSkipLevels(snapshot, lastNode, level, node, maxBitLen)
+				if err != nil {
+					return nil, err
+				}
+				proof = append(proof, NodeFetch{NodeID: n})
+			} else {
+				// We need to recompute this node, as it was at the prior snapshot point. We record
+				// the additional fetches needed to do this later
+				rehashFetches, err := recomputePastSnapshot(snapshot, treeSize, level, maxBitLen)
+				if err != nil {
+					return []NodeFetch{}, err
+				}
+
+				// Extra check that the recomputation produced one node
+				if err = checkRecomputation(rehashFetches); err != nil {
+					return []NodeFetch{}, err
+				}
+
+				proof = append(proof, rehashFetches...)
 			}
-			proof = append(proof, NodeFetch{NodeID: n})
 		} else {
-			glog.V(vLevel).Infof("Nonexistent: S:%d L:%d", sibling, level)
+			glog.V(vvLevel).Infof("Nonexistent: S:%d L:%d", sibling, level)
 		}
 
 		// Sibling > lastNode so does not exist, move up
@@ -150,6 +162,112 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot int64, maxBitL
 	}
 
 	return proof, nil
+}
+
+// recomputePastSnapshot does the work to recalculate nodes that need to be rehashed because the
+// tree state at the snapshot size differs from the size we've stored it at. The calculations
+// also need to take into account missing levels, see the tree diagrams in this file.
+// If called with snapshot equal to the tree size returns empty. Otherwise, assuming no errors,
+// the output of this should always be exactly one node. Either a copy of one of the nodes in
+// the tree or a rehashing of multiple nodes to a single result node.
+func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen int) ([]NodeFetch, error) {
+	glog.V(vLevel).Infof("recompute s:%d ts:%d level:%d", snapshot, treeSize, nodeLevel)
+
+	fetches := []NodeFetch{}
+
+	if snapshot == treeSize {
+		// Nothing to do
+		return []NodeFetch{}, nil
+	} else if snapshot > treeSize {
+		return fetches, fmt.Errorf("recomputePastSnapshot: %d does not exist for tree of size %d", snapshot, treeSize)
+	}
+
+	// We're recomputing the right hand path, the one to the last leaf
+	level := 0
+	// This is the index of the last node in the snapshot
+	lastNode := snapshot - 1
+	// This is the index of the last node that actually exists in the underlying tree
+	lastNodeAtLevel := treeSize - 1
+
+	// Work up towards, the root we may find the node we need without needing to rehash if
+	// it turns out that the left siblings and parents exist all the way up to the level we're
+	// recalculating.
+	for (lastNode & 1) != 0 {
+		if nodeLevel == level {
+			// Then we want a copy of the node at this level
+			glog.V(vvLevel).Infof("copying l:%d ln:%d", level, lastNode)
+			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
+			if err != nil {
+				return []NodeFetch{}, err
+			}
+
+			glog.V(vvLevel).Infof("copy node at %s", nodeID.CoordString())
+			return append(fetches, NodeFetch{Rehash: false, NodeID: nodeID}), nil
+		}
+
+		// Left sibling and parent exist at this snapshot and don't need to be rehashed
+		glog.V(vvLevel).Infof("move up ln:%d level:%d", lastNode, level)
+		lastNode >>= 1
+		lastNodeAtLevel >>= 1
+		level++
+	}
+
+	glog.V(vvLevel).Infof("done ln:%d level:%d", lastNode, level)
+
+	// lastNode is now the index of a left sibling with no right sibling. This is where the
+	// rehashing starts
+	savedNodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
+	glog.V(vvLevel).Infof("root for recompute is: %s", savedNodeID.CoordString())
+	if err != nil {
+		return []NodeFetch{}, err
+	}
+
+	if nodeLevel == level {
+		glog.V(vvLevel).Info("emit root (1)")
+		return append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID}), nil
+	}
+
+	rehash := false
+	rootEmitted := false
+
+	for lastNode != 0 {
+		glog.V(vvLevel).Infof("in loop level:%d ln:%d lnal:%d", level, lastNode, lastNodeAtLevel)
+
+		if (lastNode & 1) != 0 {
+			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, (lastNode-1)^1, maxBitlen)
+			if err != nil {
+				return []NodeFetch{}, err
+			}
+
+			if !rehash && !rootEmitted {
+				glog.V(vvLevel).Info("emit root (2)")
+				fetches = append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID})
+				rootEmitted = true
+			}
+
+			glog.V(vvLevel).Infof("rehash with %s", nodeID.CoordString())
+			fetches = append(fetches, NodeFetch{Rehash: true, NodeID: nodeID})
+			rehash = true
+		}
+
+		lastNode >>= 1
+		lastNodeAtLevel >>= 1
+		level++
+
+		if nodeLevel == level && !rootEmitted {
+			glog.V(vvLevel).Info("emit root (3)")
+			return append(fetches, NodeFetch{Rehash: rehash, NodeID: savedNodeID}), nil
+		}
+
+		// Exit early if we've gone far enough up the tree to hit the level we're recomputing
+		if level == nodeLevel {
+			glog.V(vvLevel).Infof("returning fetches early: %v", fetches)
+			return fetches, nil
+		}
+	}
+
+	glog.V(vvLevel).Infof("returning fetches: %v", fetches)
+	return fetches, nil
 }
 
 // lastNodeWritten determines if the last node is present in storage for a given Merkle tree size
@@ -245,8 +363,38 @@ func skipMissingLevels(snapshot, lastNode int64, level int, node int64) (int, in
 		level--
 		sibling *= 2
 		lastNode = (snapshot - 1) >> uint(level)
-		glog.V(vLevel).Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
+		glog.V(vvLevel).Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
 	}
 
 	return level, sibling
+}
+
+// checkRecomputation carries out an additional check that the results of recomputePastSnapshot
+// are valid. There must be at least one fetch. All fetches must have the same rehash state and if
+// there is only one fetch then it must not be a rehash. If all checks pass then the fetches
+// represent one node after rehashing is completed.
+func checkRecomputation(fetches []NodeFetch) error {
+	if len(fetches) == 0 {
+		return errors.New("recomputePastSnapshot returned nothing")
+	} else if len(fetches) == 1 {
+		if fetches[0].Rehash {
+			return errors.New("recomputePastSnapshot returned invalid rehash")
+		}
+	} else {
+		for i := range fetches {
+			if i > 0 && fetches[i].Rehash != fetches[0].Rehash {
+				return errors.New("recomputePastSnapshot returned multiple nodes")
+			}
+		}
+	}
+
+	return nil
+}
+
+// siblingIDSkipLevels creates a new NodeID for the supplied node, accounting for levels skipped
+// in storage. Note that it returns an ID for the node sibling so care should be taken to pass the
+// correct value for the node parameter.
+func siblingIDSkipLevels(snapshot, lastNode int64, level int, node int64, maxBitLen int) (storage.NodeID, error) {
+	l, sibling := skipMissingLevels(snapshot, lastNode, level, node)
+	return storage.NewNodeIDForTreeCoords(int64(l), sibling, maxBitLen)
 }

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -250,7 +250,7 @@ func TestBitLen(t *testing.T) {
 
 func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	for _, testCase := range pathTests {
-		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, 64)
+		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize, 64)
 
 		if err != nil {
 			t.Fatalf("unexpected error calculating path %v: %v", testCase, err)
@@ -262,7 +262,7 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 
 func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
 	for _, testCase := range pathTestBad {
-		_, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, 64)
+		_, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize, 64)
 
 		if err == nil {
 			t.Fatalf("incorrectly accepted bad params: %v", testCase)
@@ -271,7 +271,7 @@ func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
 }
 
 func TestCalcInclusionProofNodeAddressesRejectsBadBitLen(t *testing.T) {
-	_, err := CalcInclusionProofNodeAddresses(7, 3, -64)
+	_, err := CalcInclusionProofNodeAddresses(7, 3, 7, -64)
 
 	if err == nil {
 		t.Fatal("incorrectly accepted -ve maxBitLen")
@@ -280,7 +280,7 @@ func TestCalcInclusionProofNodeAddressesRejectsBadBitLen(t *testing.T) {
 
 func TestCalcConsistencyProofNodeAddresses(t *testing.T) {
 	for _, testCase := range consistencyTests {
-		proof, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, 64)
+		proof, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize, 64)
 
 		if err != nil {
 			t.Fatalf("failed to calculate consistency proof from %d to %d: %v", testCase.priorTreeSize, testCase.treeSize, err)
@@ -292,7 +292,7 @@ func TestCalcConsistencyProofNodeAddresses(t *testing.T) {
 
 func TestCalcConsistencyProofNodeAddressesBadInputs(t *testing.T) {
 	for _, testCase := range consistencyTestsBad {
-		_, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, 64)
+		_, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize, 64)
 
 		if err == nil {
 			t.Fatalf("consistency path calculation accepted bad input: %v", testCase)
@@ -301,8 +301,8 @@ func TestCalcConsistencyProofNodeAddressesBadInputs(t *testing.T) {
 }
 
 func TestCalcConsistencyProofNodeAddressesRejectsBadBitLen(t *testing.T) {
-	_, err := CalcConsistencyProofNodeAddresses(6, 7, -1)
-	_, err2 := CalcConsistencyProofNodeAddresses(6, 7, 0)
+	_, err := CalcConsistencyProofNodeAddresses(6, 7, 7, -1)
+	_, err2 := CalcConsistencyProofNodeAddresses(6, 7, 7, 0)
 
 	if err == nil || err2 == nil {
 		t.Fatalf("consistency path calculation accepted bad bitlen: %v %v", err, err2)
@@ -341,7 +341,7 @@ func TestLastNodeWritten(t *testing.T) {
 func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
 	for ts := 1; ts < testUpToTreeSize; ts++ {
 		for i := ts; i < ts; i++ {
-			if _, err := CalcInclusionProofNodeAddresses(int64(ts), int64(i), 64); err != nil {
+			if _, err := CalcInclusionProofNodeAddresses(int64(ts), int64(i), int64(ts), 64); err != nil {
 				t.Errorf("CalcInclusionProofNodeAddresses(ts:%d, i:%d) = %v", ts, i, err)
 			}
 		}
@@ -351,7 +351,7 @@ func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
 func TestConsistencySucceedsUpToTreeSize(t *testing.T) {
 	for s1 := 1; s1 < testUpToTreeSize; s1++ {
 		for s2 := s1 + 1; s2 < testUpToTreeSize; s2++ {
-			if _, err := CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), 64); err != nil {
+			if _, err := CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), int64(s2), 64); err != nil {
 				t.Errorf("CalcConsistencyProofNodeAddresses(%d, %d) = %v", s1, s2, err)
 			}
 		}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -222,7 +222,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 		return nil, fmt.Errorf("%s: second tree size (%d) must be > first tree size (%d)", util.LogIDPrefix(ctx), req.SecondTreeSize, req.FirstTreeSize)
 	}
 
-	tx, err := t.prepareReadOnlyStorageTx(req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,6 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 		return nil, err
 	}
 
-	// TODO(Martin2112): Should pass actual tree size as param3 but we don't have it yet
 	nodeFetches, err := merkle.CalcConsistencyProofNodeAddresses(req.FirstTreeSize, req.SecondTreeSize, secondTreeSize, proofMaxBitLen)
 	if err != nil {
 		return nil, err

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -487,7 +487,6 @@ func validateLeafHashes(leafHashes [][]byte) bool {
 // an RPC response
 func getInclusionProofForLeafIndexAtRevision(tx storage.ReadOnlyLogTX, snapshot, treeRevision, treeSize, leafIndex int64) (trillian.Proof, error) {
 	// We have the tree size and leaf index so we know the nodes that we need to serve the proof
-	// TODO(Martin2112): Not sure about hardcoding maxBitLen here
 	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize, proofMaxBitLen)
 	if err != nil {
 		return trillian.Proof{}, err

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -489,7 +489,7 @@ func validateLeafHashes(leafHashes [][]byte) bool {
 func getInclusionProofForLeafIndexAtRevision(tx storage.ReadOnlyLogTX, snapshot, treeRevision, treeSize, leafIndex int64) (trillian.Proof, error) {
 	// We have the tree size and leaf index so we know the nodes that we need to serve the proof
 	// TODO(Martin2112): Not sure about hardcoding maxBitLen here
-	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(treeSize, leafIndex, snapshot, proofMaxBitLen)
+	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize, proofMaxBitLen)
 	if err != nil {
 		return trillian.Proof{}, err
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -714,8 +714,8 @@ func TestGetProofByHashWrongNodeReturned(t *testing.T) {
 
 	_, err := server.GetInclusionProofByHash(context.Background(), &getInclusionProofByHashRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "expected node") || !strings.Contains(err.Error(), "at proof pos 1") {
-		t.Fatalf("get inclusion proof by hash returned no or wrong error when get nodes returns wrong count: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
+		t.Fatalf("get inclusion proof by hash returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }
 
@@ -891,8 +891,8 @@ func TestGetProofByIndexWrongNodeReturned(t *testing.T) {
 
 	_, err := server.GetInclusionProof(context.Background(), &getInclusionProofByIndexRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "expected node") || !strings.Contains(err.Error(), "at proof pos 1") {
-		t.Fatalf("get inclusion proof by index returned no or wrong error when get nodes returns wrong count: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
+		t.Fatalf("get inclusion proof by index returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }
 
@@ -1368,7 +1368,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongNode(t *testing.T) {
 
 	_, err := server.GetConsistencyProof(context.Background(), &getConsistencyProofRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "at proof pos 0") {
+	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
 		t.Fatalf("get consistency proof returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1274,29 +1274,12 @@ func TestGetConsistencyProofBeginTXFails(t *testing.T) {
 	test.executeBeginFailsTest(t)
 }
 
-func TestGetConsistencyProofGetTreeRevision1Fails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
-		func(t *storage.MockLogTX) {
-			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest25.FirstTreeSize).Return(int64(0), int64(0), errors.New("STORAGE"))
-		},
-		func(s *TrillianLogRPCServer) error {
-			_, err := s.GetConsistencyProof(context.Background(), &getConsistencyProofRequest25)
-			return err
-		})
-
-	test.executeStorageFailureTest(t)
-}
-
 func TestGetConsistencyProofGetTreeRevision2Fails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
 		func(t *storage.MockLogTX) {
-			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest25.FirstTreeSize).Return(int64(11), getConsistencyProofRequest25.FirstTreeSize, nil)
 			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest25.SecondTreeSize).Return(int64(0), int64(0), errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
@@ -1313,7 +1296,6 @@ func TestGetConsistencyProofGetNodesFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
 		func(t *storage.MockLogTX) {
-			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.FirstTreeSize).Return(int64(3), getConsistencyProofRequest7.FirstTreeSize, nil)
 			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.SecondTreeSize).Return(int64(5), getConsistencyProofRequest7.SecondTreeSize, nil)
 			t.EXPECT().GetMerkleNodes(int64(5), nodeIdsConsistencySize4ToSize7).Return([]storage.Node{}, errors.New("STORAGE"))
 		},
@@ -1333,7 +1315,6 @@ func TestGetConsistencyProofGetNodesReturnsWrongCount(t *testing.T) {
 	mockTx := storage.NewMockLogTX(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
-	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.FirstTreeSize).Return(int64(3), getConsistencyProofRequest7.FirstTreeSize, nil)
 	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.SecondTreeSize).Return(int64(5), getConsistencyProofRequest7.SecondTreeSize, nil)
 	// The server expects one node from storage but we return two
 	mockTx.EXPECT().GetMerkleNodes(int64(5), nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
@@ -1357,7 +1338,6 @@ func TestGetConsistencyProofGetNodesReturnsWrongNode(t *testing.T) {
 	mockTx := storage.NewMockLogTX(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
-	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.FirstTreeSize).Return(int64(3), getConsistencyProofRequest7.FirstTreeSize, nil)
 	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.SecondTreeSize).Return(int64(5), getConsistencyProofRequest7.SecondTreeSize, nil)
 	// Return an unexpected node that wasn't requested
 	mockTx.EXPECT().GetMerkleNodes(int64(5), nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(1, 2, 64), NodeRevision: 3}}, nil)
@@ -1379,7 +1359,6 @@ func TestGetConsistencyProofCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
 		func(t *storage.MockLogTX) {
-			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.FirstTreeSize).Return(int64(3), getConsistencyProofRequest7.FirstTreeSize, nil)
 			t.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.SecondTreeSize).Return(int64(5), getConsistencyProofRequest7.SecondTreeSize, nil)
 			t.EXPECT().GetMerkleNodes(int64(5), nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3}}, nil)
 		},
@@ -1399,7 +1378,6 @@ func TestGetConsistencyProof(t *testing.T) {
 	mockTx := storage.NewMockLogTX(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
-	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.FirstTreeSize).Return(int64(3), getConsistencyProofRequest7.FirstTreeSize, nil)
 	mockTx.EXPECT().GetTreeRevisionIncludingSize(getConsistencyProofRequest7.SecondTreeSize).Return(int64(5), getConsistencyProofRequest7.SecondTreeSize, nil)
 	mockTx.EXPECT().GetMerkleNodes(int64(5), nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}}, nil)
 	mockTx.EXPECT().Commit().Return(nil)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -714,7 +714,7 @@ func TestGetProofByHashWrongNodeReturned(t *testing.T) {
 
 	_, err := server.GetInclusionProofByHash(context.Background(), &getInclusionProofByHashRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
+	if err == nil || !strings.Contains(err.Error(), "expected node ") {
 		t.Fatalf("get inclusion proof by hash returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }
@@ -891,7 +891,7 @@ func TestGetProofByIndexWrongNodeReturned(t *testing.T) {
 
 	_, err := server.GetInclusionProof(context.Background(), &getInclusionProofByIndexRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
+	if err == nil || !strings.Contains(err.Error(), "expected node ") {
 		t.Fatalf("get inclusion proof by index returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }
@@ -1274,7 +1274,7 @@ func TestGetConsistencyProofBeginTXFails(t *testing.T) {
 	test.executeBeginFailsTest(t)
 }
 
-func TestGetConsistencyProofGetTreeRevision2Fails(t *testing.T) {
+func TestGetConsistencyProofGetTreeRevisionForSecondTreeSizeFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1348,7 +1348,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongNode(t *testing.T) {
 
 	_, err := server.GetConsistencyProof(context.Background(), &getConsistencyProofRequest7)
 
-	if err == nil || !strings.Contains(err.Error(), "didn't return it") {
+	if err == nil || !strings.Contains(err.Error(), "expected node ") {
 		t.Fatalf("get consistency proof returned no or wrong error when get nodes returns wrong node: %v", err)
 	}
 }

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -15,53 +15,155 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 )
 
 // fetchNodesAndBuildProof is used by both inclusion and consistency proofs. It fetches the nodes
 // from storage and converts them into the proof proto that will be returned to the client.
+// This includes rehashing where necessary to serve proofs for tree sizes between stored tree
+// revisions. This code only relies on the NodeReader interface so can be tested without
+// a complete storage implementation.
 func fetchNodesAndBuildProof(tx storage.NodeReader, treeRevision, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (trillian.Proof, error) {
-	// TODO(Martin2112): Implement the rehashing. Currently just fetches the nodes and ignores this
-	proofNodeIDs := make([]storage.NodeID, 0, len(proofNodeFetches))
-
-	for _, fetch := range proofNodeFetches {
-		proofNodeIDs = append(proofNodeIDs, fetch.NodeID)
-
-		// TODO(Martin2112): Remove this when rehashing is implemented
-		if fetch.Rehash {
-			return trillian.Proof{}, errors.New("proof requires rehashing but it's not implemented yet")
-		}
-	}
-
-	proofNodes, err := tx.GetMerkleNodes(treeRevision, proofNodeIDs)
+	proofNodes, err := dedupAndFetchNodes(tx, treeRevision, proofNodeFetches)
 	if err != nil {
 		return trillian.Proof{}, err
 	}
 
-	if len(proofNodes) != len(proofNodeIDs) {
-		return trillian.Proof{}, fmt.Errorf("expected %d nodes in proof but got %d", len(proofNodeIDs), len(proofNodes))
-	}
-
-	proof := make([]*trillian.Node, 0, len(proofNodeIDs))
+	r := newRehasher()
 	for i, node := range proofNodes {
-		// additional check that the correct node was returned
-		if !node.NodeID.Equivalent(proofNodeIDs[i]) {
-			return trillian.Proof{}, fmt.Errorf("expected node %v at proof pos %d but got %v", proofNodeIDs[i], i, node.NodeID)
-		}
-
-		idBytes, err := proto.Marshal(node.NodeID.AsProto())
-		if err != nil {
-			return trillian.Proof{}, err
-		}
-
-		proof = append(proof, &trillian.Node{NodeId: idBytes, NodeHash: node.Hash, NodeRevision: node.NodeRevision})
+		r.process(node, proofNodeFetches[i])
 	}
 
-	return trillian.Proof{LeafIndex: leafIndex, ProofNode: proof}, nil
+	return r.rehashedProof(leafIndex)
+}
+
+// rehasher bundles the rehashing logic into a simple state machine
+type rehasher struct {
+	th         merkle.TreeHasher
+	rehashing  bool
+	rehashNode storage.Node
+	proof      []*trillian.Node
+	proofError error
+}
+
+// init must be called before the rehasher is used or reused
+func newRehasher() *rehasher {
+	return &rehasher{
+		// TODO(Martin2112): TreeHasher must be selected based on log config.
+		th: merkle.NewRFC6962TreeHasher(crypto.NewSHA256()),
+	}
+}
+
+func (r *rehasher) process(node storage.Node, fetch merkle.NodeFetch) {
+	switch {
+	case !r.rehashing && fetch.Rehash:
+		// Start of a rehashing chain
+		r.startRehashing(node)
+
+	case r.rehashing && !fetch.Rehash:
+		// End of a rehash chain, resulting in a rehashed proof node
+		r.endRehashing()
+		// And the current node needs to be added to the proof
+		r.emitNode(node)
+
+	case r.rehashing && fetch.Rehash:
+		// Continue with rehashing, update the node we're recomputing
+		r.rehashNode.Hash = r.th.HashChildren(node.Hash, r.rehashNode.Hash)
+
+	default:
+		// Not rehashing, just pass the node through
+		r.emitNode(node)
+	}
+}
+
+func (r *rehasher) emitNode(node storage.Node) {
+	idBytes, err := proto.Marshal(node.NodeID.AsProto())
+	if err != nil {
+		r.proofError = err
+	}
+	r.proof = append(r.proof, &trillian.Node{NodeId: idBytes, NodeHash: node.Hash, NodeRevision: node.NodeRevision})
+}
+
+func (r *rehasher) startRehashing(node storage.Node) {
+	r.rehashNode = storage.Node{Hash: node.Hash}
+	r.rehashing = true
+}
+
+func (r *rehasher) endRehashing() {
+	if r.rehashing {
+		r.proof = append(r.proof, &trillian.Node{NodeHash: r.rehashNode.Hash})
+		r.rehashing = false
+	}
+}
+
+func (r *rehasher) rehashedProof(leafIndex int64) (trillian.Proof, error) {
+	r.endRehashing()
+	return trillian.Proof{LeafIndex: leafIndex, ProofNode: r.proof}, r.proofError
+}
+
+// dedupAndFetchNodes() removes duplicates from the set of fetches and then passes the result to
+// storage. After writng this code I realised I don't have a solid proof that fetches for Merkle
+// paths could involve duplicate nodes so it could be that this isn't ever useful. Further
+// thought is required.
+func dedupAndFetchNodes(tx storage.NodeReader, treeRevision int64, fetches []merkle.NodeFetch) ([]storage.Node, error) {
+	// To start with we remove any duplicate fetches
+	m := make(map[string]storage.NodeID)
+	proofNodeIDs := make([]storage.NodeID, 0, len(fetches))
+
+	// Remove duplicates, preserving the order of the input otherwise
+	for _, fetch := range fetches {
+		if _, ok := m[fetch.NodeID.String()]; !ok {
+			// First time we've seen the ID
+			m[fetch.NodeID.String()] = fetch.NodeID
+			proofNodeIDs = append(proofNodeIDs, fetch.NodeID)
+		}
+	}
+
+	if len(proofNodeIDs) < len(fetches) {
+		glog.V(2).Infof("deduplication saved %d node fetch(es)", len(fetches) - len(proofNodeIDs))
+	}
+
+	// Use the deduplicated list of nodeIDs in the storage fetch
+	proofNodes, err := tx.GetMerkleNodes(treeRevision, proofNodeIDs)
+	if err != nil {
+		return []storage.Node{}, err
+	}
+
+	if len(proofNodes) != len(proofNodeIDs) {
+		return []storage.Node{}, fmt.Errorf("expected %d nodes from storage but got %d", len(proofNodeIDs), len(proofNodes))
+	}
+
+	// Then rebuild what we would have got if we'd fetched the duplicates
+	nodes := make([]storage.Node, 0, len(fetches))
+	nm := make(map[string]storage.Node)
+
+	for _, node := range proofNodes {
+		nm[node.NodeID.String()] = node
+	}
+
+	for _, fetch := range fetches {
+		node, ok := nm[fetch.NodeID.String()]
+
+		if !ok {
+			return []storage.Node{}, fmt.Errorf("wanted node ID: %s but storage didn't return it", fetch.NodeID.String())
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	for i, node := range nodes {
+		// additional check that the correct node was returned
+		if !node.NodeID.Equivalent(fetches[i].NodeID) {
+			return []storage.Node{}, fmt.Errorf("expected node %v at proof pos %d but got %v", fetches[i], i, node.NodeID)
+		}
+	}
+
+	return nodes, nil
 }

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -127,7 +127,7 @@ func dedupAndFetchNodes(tx storage.NodeReader, treeRevision int64, fetches []mer
 	}
 
 	if len(proofNodeIDs) < len(fetches) {
-		glog.V(2).Infof("deduplication saved %d node fetch(es)", len(fetches) - len(proofNodeIDs))
+		glog.V(2).Infof("deduplication saved %d node fetch(es)", len(fetches)-len(proofNodeIDs))
 	}
 
 	// Use the deduplicated list of nodeIDs in the storage fetch

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -130,7 +130,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
-			{TreeRevision: testTreeRevision, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+			{TreeRevision: testTreeRevision, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
 		for s := int64(2); s <= int64(ts); s++ {
@@ -180,7 +180,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 			}
 
 			// Use the highest tree revision that should be available from the node reader
-			proof, err := fetchNodesAndBuildProof(r, testTreeRevision + 3, l, fetches)
+			proof, err := fetchNodesAndBuildProof(r, testTreeRevision+3, l, fetches)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -205,7 +205,7 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
-			{TreeRevision: testTreeRevision, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+			{TreeRevision: testTreeRevision, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
 		for s1 := int64(2); s1 < int64(ts); s1++ {

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -210,7 +210,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
-			{TreeRevision: 3, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+			{TreeRevision: 3, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
 		for s := 2; s <= ts; s++ {
@@ -226,7 +226,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 				}
 
 				// We use +1 here because of the 1 based leaf indexing of this implementation
-				refProof := mt.PathToRootAtSnapshot(l + 1, s)
+				refProof := mt.PathToRootAtSnapshot(l+1, s)
 
 				if got, want := len(proof.ProofNode), len(refProof); got != want {
 					t.Fatalf("(%d, %d, %d): got proof len: %d, want: %d: %v\n%v", ts, s, l, got, want, fetches, refProof)
@@ -265,7 +265,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 			}
 
 			// We use +1 here because of the 1 based leaf indexing of this implementation
-			refProof := mt.PathToRootAtSnapshot(l + 1, s)
+			refProof := mt.PathToRootAtSnapshot(l+1, s)
 
 			if got, want := len(proof.ProofNode), len(refProof); got != want {
 				t.Fatalf("(%d, %d, %d): got proof len: %d, want: %d: %v\n%v", 32, s, l, got, want, fetches, refProof)
@@ -284,7 +284,7 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
-			{TreeRevision: 3, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+			{TreeRevision: 3, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
 		for s1 := 2; s1 < ts; s1++ {
@@ -334,7 +334,7 @@ func mustCreateNodeID(depth, node int64) storage.NodeID {
 }
 
 func expandLeaves(n, m int) []string {
-	leaves := make([]string, 0, m - n + 1)
+	leaves := make([]string, 0, m-n+1)
 	for l := n; l <= m; l++ {
 		leaves = append(leaves, fmt.Sprintf("Leaf %d", l))
 	}
@@ -349,7 +349,7 @@ func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) string {
 }
 
 func treeAtSize(n int) *merkle.InMemoryMerkleTree {
-	leaves := expandLeaves(0, n - 1)
+	leaves := expandLeaves(0, n-1)
 	mt := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
 
 	for _, leaf := range leaves {

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -1,0 +1,360 @@
+package server
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testonly"
+)
+
+// rehashTest encapsulates one test case for the rehasher in isolation. Input data like the storage
+// hashes and revisions can be arbitrary but the nodes should have distinct values
+type rehashTest struct {
+	desc    string
+	index   int64
+	nodes   []storage.Node
+	fetches []merkle.NodeFetch
+	output  trillian.Proof
+}
+
+// Raw hashes for dummy storage nodes
+var h1 = th.HashLeaf([]byte("Hash 1"))
+var h2 = th.HashLeaf([]byte("Hash 2"))
+var h3 = th.HashLeaf([]byte("Hash 3"))
+var h4 = th.HashLeaf([]byte("Hash 4"))
+var h5 = th.HashLeaf([]byte("Hash 5"))
+
+// And the dummy nodes themselves
+var sn1 = storage.Node{NodeID: storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
+var sn2 = storage.Node{NodeID: storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
+var sn3 = storage.Node{NodeID: storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
+var sn4 = storage.Node{NodeID: storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
+var sn5 = storage.Node{NodeID: storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
+
+// And the output proof nodes expected for them if they are passed through without rehashing
+var n1 = &trillian.Node{NodeHash: h1, NodeId: mustMarshalNodeID(sn1.NodeID), NodeRevision: sn1.NodeRevision}
+var n2 = &trillian.Node{NodeHash: h2, NodeId: mustMarshalNodeID(sn2.NodeID), NodeRevision: sn2.NodeRevision}
+var n3 = &trillian.Node{NodeHash: h3, NodeId: mustMarshalNodeID(sn3.NodeID), NodeRevision: sn3.NodeRevision}
+var n4 = &trillian.Node{NodeHash: h4, NodeId: mustMarshalNodeID(sn4.NodeID), NodeRevision: sn4.NodeRevision}
+var n5 = &trillian.Node{NodeHash: h5, NodeId: mustMarshalNodeID(sn5.NodeID), NodeRevision: sn5.NodeRevision}
+
+// Nodes containing composite hashes. They don't have node ids or revisions as they're recomputed
+var n1n2 = &trillian.Node{NodeHash: th.HashChildren(h2, h1)}
+var n2n3 = &trillian.Node{NodeHash: th.HashChildren(h3, h2)}
+var n2n3n4 = &trillian.Node{NodeHash: th.HashChildren(h4, th.HashChildren(h3, h2))}
+var n4n5 = &trillian.Node{NodeHash: th.HashChildren(h5, h4)}
+
+var rehashTests = []rehashTest{
+	{
+		desc:    "no rehash",
+		index:   int64(126),
+		nodes:   []storage.Node{sn1, sn2, sn3},
+		fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: false}, {Rehash: false}},
+		output: trillian.Proof{
+			LeafIndex: int64(126),
+			ProofNode: []*trillian.Node{n1, n2, n3},
+		},
+	},
+	{
+		desc:    "single rehash",
+		index:   int64(999),
+		nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+		fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: false}},
+		output: trillian.Proof{
+			LeafIndex: int64(999),
+			ProofNode: []*trillian.Node{n1, n2n3, n4, n5},
+		},
+	},
+	{
+		desc:    "single rehash at end",
+		index:   int64(11),
+		nodes:   []storage.Node{sn1, sn2, sn3},
+		fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}},
+		output: trillian.Proof{
+			LeafIndex: int64(11),
+			ProofNode: []*trillian.Node{n1, n2n3},
+		},
+	},
+	{
+		desc:    "single rehash multiple nodes",
+		index:   int64(23),
+		nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+		fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: true}, {Rehash: false}},
+		output: trillian.Proof{
+			LeafIndex: int64(23),
+			ProofNode: []*trillian.Node{n1, n2n3n4, n5},
+		},
+	},
+	{
+		desc:    "multiple rehash",
+		index:   int64(45),
+		nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+		fetches: []merkle.NodeFetch{{Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: true}, {Rehash: true}},
+		output: trillian.Proof{
+			LeafIndex: int64(45),
+			ProofNode: []*trillian.Node{n1n2, n3, n4n5},
+		},
+	},
+}
+
+// Test data used to test node fech deduplication in isolation
+type dedupTest struct {
+	desc         string
+	input        []merkle.NodeFetch // input fetches to deduper
+	storageIDs   []storage.NodeID   // ids sent to storage layer
+	storageNodes []storage.Node     // nodes returned by storage layer
+	storageError error              // error returned by storage layer
+	result       []storage.Node     // expected result with dupes reinstated
+}
+
+// Contents of these don't really matter as long as they have distinct IDs
+var f11 = merkle.NodeFetch{NodeID: mustCreateNodeID(1, 1)}
+var f12 = merkle.NodeFetch{NodeID: mustCreateNodeID(1, 2)}
+var f31 = merkle.NodeFetch{NodeID: mustCreateNodeID(3, 1)}
+
+var n11 = storage.Node{NodeID: f11.NodeID, NodeRevision: 37}
+var n12 = storage.Node{NodeID: f12.NodeID, NodeRevision: 37}
+var n31 = storage.Node{NodeID: f31.NodeID, NodeRevision: 37}
+
+var dedupTests = []dedupTest{
+	{
+		desc:         "no dupes",
+		input:        []merkle.NodeFetch{f11, f12, f31},
+		storageIDs:   []storage.NodeID{f11.NodeID, f12.NodeID, f31.NodeID},
+		storageNodes: []storage.Node{n11, n12, n31},
+		result:       []storage.Node{n11, n12, n31},
+	},
+	{
+		desc:         "one dupe",
+		input:        []merkle.NodeFetch{f11, f12, f31, f11},
+		storageIDs:   []storage.NodeID{f11.NodeID, f12.NodeID, f31.NodeID},
+		storageNodes: []storage.Node{n11, n12, n31},
+		result:       []storage.Node{n11, n12, n31, n11},
+	},
+	{
+		desc:         "multi dupe",
+		input:        []merkle.NodeFetch{f11, f12, f11, f11, f31, f11},
+		storageIDs:   []storage.NodeID{f11.NodeID, f12.NodeID, f31.NodeID},
+		storageNodes: []storage.Node{n11, n12, n31},
+		result:       []storage.Node{n11, n12, n11, n11, n31, n11},
+	},
+	{
+		desc:         "storage fail",
+		input:        []merkle.NodeFetch{f11, f12, f11, f11, f31, f11},
+		storageIDs:   []storage.NodeID{f11.NodeID, f12.NodeID, f31.NodeID},
+		storageNodes: []storage.Node{},
+		storageError: errors.New("storage"),
+	},
+	{
+		desc:         "storage wrong node",
+		input:        []merkle.NodeFetch{f11, f12, f11, f11, f31, f11},
+		storageIDs:   []storage.NodeID{f11.NodeID, f12.NodeID, f31.NodeID},
+		storageNodes: []storage.Node{},
+		storageError: errors.New("storage"),
+	},
+}
+
+func TestRehasher(t *testing.T) {
+	for _, rehashTest := range rehashTests {
+		r := newRehasher()
+		for i, node := range rehashTest.nodes {
+			r.process(node, rehashTest.fetches[i])
+		}
+
+		want := rehashTest.output
+		got, err := r.rehashedProof(rehashTest.index)
+
+		if err != nil {
+			t.Fatalf("rehash test %s unexpected error: %v", rehashTest.desc, err)
+		}
+
+		if !proto.Equal(&got, &want) {
+			t.Errorf("rehash test %s:\ngot: %v\nwant: %v", rehashTest.desc, got, want)
+		}
+	}
+}
+
+func TestDedupFetcher(t *testing.T) {
+	for _, dedupTest := range dedupTests {
+		ctrl := gomock.NewController(t)
+		tx := storage.NewMockLogTX(ctrl)
+		tx.EXPECT().GetMerkleNodes(int64(37), dedupTest.storageIDs).Return(dedupTest.storageNodes, dedupTest.storageError)
+		nodes, err := dedupAndFetchNodes(tx, 37, dedupTest.input)
+
+		if err == nil && dedupTest.storageError != nil {
+			t.Fatalf("%s: got nil, want error: %v", dedupTest.desc, err)
+		}
+
+		if err != nil && dedupTest.storageError == nil {
+			t.Fatalf("%s: got error: %v, want nil", dedupTest.desc, err)
+		}
+
+		if got, want := nodes, dedupTest.result; len(want) > 0 && !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: got: %v, want: %v", dedupTest.desc, got, want)
+		}
+
+		ctrl.Finish()
+	}
+}
+
+func TestTree32InclusionProofFetchAll(t *testing.T) {
+	for ts := 2; ts <= 32; ts++ {
+		mt := treeAtSize(ts)
+		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
+			{TreeRevision: 3, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+		})
+
+		for s := 2; s <= ts; s++ {
+			for l := 0; l < s; l++ {
+				fetches, err := merkle.CalcInclusionProofNodeAddresses(int64(s), int64(l), int64(ts), 64)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				proof, err := fetchNodesAndBuildProof(r, 3, int64(l), fetches)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// We use +1 here because of the 1 based leaf indexing of this implementation
+				refProof := mt.PathToRootAtSnapshot(l + 1, s)
+
+				if got, want := len(proof.ProofNode), len(refProof); got != want {
+					t.Fatalf("(%d, %d, %d): got proof len: %d, want: %d: %v\n%v", ts, s, l, got, want, fetches, refProof)
+				}
+
+				for i := 0; i < len(proof.ProofNode); i++ {
+					if got, want := hex.EncodeToString(proof.ProofNode[i].NodeHash), hex.EncodeToString(refProof[i].Value.Hash()); got != want {
+						t.Fatalf("(%d, %d, %d): %d got proof node: %s, want: %s l:%d fetches: %v", ts, s, l, i, got, want, len(proof.ProofNode), fetches)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
+	mt := treeAtSize(32)
+	// The reader is built up with multiple batches, 4 batches x 8 leaves each
+	r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
+		{TreeRevision: 3, Leaves: expandLeaves(0, 7), ExpectedRoot: expectedRootAtSize(treeAtSize(8))},
+		{TreeRevision: 4, Leaves: expandLeaves(8, 15), ExpectedRoot: expectedRootAtSize(treeAtSize(16))},
+		{TreeRevision: 5, Leaves: expandLeaves(16, 23), ExpectedRoot: expectedRootAtSize(treeAtSize(24))},
+		{TreeRevision: 6, Leaves: expandLeaves(24, 31), ExpectedRoot: expectedRootAtSize(mt)},
+	})
+
+	for s := 2; s <= 32; s++ {
+		for l := 0; l < s; l++ {
+			fetches, err := merkle.CalcInclusionProofNodeAddresses(int64(s), int64(l), 32, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			proof, err := fetchNodesAndBuildProof(r, 6, int64(l), fetches)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// We use +1 here because of the 1 based leaf indexing of this implementation
+			refProof := mt.PathToRootAtSnapshot(l + 1, s)
+
+			if got, want := len(proof.ProofNode), len(refProof); got != want {
+				t.Fatalf("(%d, %d, %d): got proof len: %d, want: %d: %v\n%v", 32, s, l, got, want, fetches, refProof)
+			}
+
+			for i := 0; i < len(proof.ProofNode); i++ {
+				if got, want := hex.EncodeToString(proof.ProofNode[i].NodeHash), hex.EncodeToString(refProof[i].Value.Hash()); got != want {
+					t.Fatalf("(%d, %d, %d): %d got proof node: %s, want: %s l:%d fetches: %v", 32, s, l, i, got, want, len(proof.ProofNode), fetches)
+				}
+			}
+		}
+	}
+}
+
+func TestTree32ConsistencyProofFetchAll(t *testing.T) {
+	for ts := 2; ts <= 32; ts++ {
+		mt := treeAtSize(ts)
+		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
+			{TreeRevision: 3, Leaves: expandLeaves(0, ts - 1), ExpectedRoot: expectedRootAtSize(mt)},
+		})
+
+		for s1 := 2; s1 < ts; s1++ {
+			for s2 := s1 + 1; s2 < ts; s2++ {
+				fetches, err := merkle.CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), int64(ts), 64)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				proof, err := fetchNodesAndBuildProof(r, 3, int64(s1), fetches)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				refProof := mt.SnapshotConsistency(s1, s2)
+
+				if got, want := len(proof.ProofNode), len(refProof); got != want {
+					t.Fatalf("(%d, %d, %d): got proof len: %d, want: %d: %v\n%v", ts, s1, s2, got, want, fetches, refProof)
+				}
+
+				for i := 0; i < len(proof.ProofNode); i++ {
+					if got, want := hex.EncodeToString(proof.ProofNode[i].NodeHash), hex.EncodeToString(refProof[i].Value.Hash()); got != want {
+						t.Fatalf("(%d, %d, %d): %d got proof node: %s, want: %s l:%d fetches: %v", ts, s1, s2, i, got, want, len(proof.ProofNode), fetches)
+					}
+				}
+			}
+		}
+	}
+}
+
+func mustMarshalNodeID(nodeID storage.NodeID) []byte {
+	idBytes, err := proto.Marshal(nodeID.AsProto())
+	if err != nil {
+		panic(err)
+	}
+
+	return idBytes
+}
+
+func mustCreateNodeID(depth, node int64) storage.NodeID {
+	nodeID, err := storage.NewNodeIDForTreeCoords(depth, node, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	return nodeID
+}
+
+func expandLeaves(n, m int) []string {
+	leaves := make([]string, 0, m - n + 1)
+	for l := n; l <= m; l++ {
+		leaves = append(leaves, fmt.Sprintf("Leaf %d", l))
+	}
+
+	return leaves
+}
+
+// expectedRootAtSize uses the in memory tree, the tree built with Compact Merkle Tree should
+// have the same root.
+func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) string {
+	return hex.EncodeToString(mt.CurrentRoot().Hash())
+}
+
+func treeAtSize(n int) *merkle.InMemoryMerkleTree {
+	leaves := expandLeaves(0, n - 1)
+	mt := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+
+	for _, leaf := range leaves {
+		mt.AddLeaf([]byte(leaf))
+	}
+
+	return mt
+}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -130,9 +130,9 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 			{TreeRevision: 3, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
-		for s := 2; s <= ts; s++ {
-			for l := 0; l < s; l++ {
-				fetches, err := merkle.CalcInclusionProofNodeAddresses(int64(s), int64(l), int64(ts), 64)
+		for s := int64(2); s <= int64(ts); s++ {
+			for l := int64(0); l < s; l++ {
+				fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, int64(ts), 64)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -169,14 +169,14 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 		{TreeRevision: 6, Leaves: expandLeaves(24, 31), ExpectedRoot: expectedRootAtSize(mt)},
 	})
 
-	for s := 2; s <= 32; s++ {
-		for l := 0; l < s; l++ {
-			fetches, err := merkle.CalcInclusionProofNodeAddresses(int64(s), int64(l), 32, 64)
+	for s := int64(2); s <= 32; s++ {
+		for l := int64(0); l < s; l++ {
+			fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, 32, 64)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			proof, err := fetchNodesAndBuildProof(r, 6, int64(l), fetches)
+			proof, err := fetchNodesAndBuildProof(r, 6, l, fetches)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -204,9 +204,9 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 			{TreeRevision: 3, Leaves: expandLeaves(0, ts-1), ExpectedRoot: expectedRootAtSize(mt)},
 		})
 
-		for s1 := 2; s1 < ts; s1++ {
-			for s2 := s1 + 1; s2 < ts; s2++ {
-				fetches, err := merkle.CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), int64(ts), 64)
+		for s1 := int64(2); s1 < int64(ts); s1++ {
+			for s2 := int64(s1 + 1); s2 < int64(ts); s2++ {
+				fetches, err := merkle.CalcConsistencyProofNodeAddresses(s1, s2, int64(ts), 64)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -51,10 +51,10 @@ func NewFakeNodeReader(mappings []NodeMapping, treeSize, treeRevision int64) *Fa
 	return &FakeNodeReader{nodeMap: nodeMap, treeSize: treeSize, treeRevision: treeRevision}
 }
 
-// GetTreeRevisionAtSize implements the corresponding NodeReader API.
-func (f FakeNodeReader) GetTreeRevisionAtSize(treeSize int64) (int64, error) {
-	if f.treeSize != treeSize {
-		return int64(0), fmt.Errorf("GetTreeRevisionAtSize() got treeSize:%d, want: %d", treeSize, f.treeSize)
+// GetTreeRevisionIncludingSize implements the corresponding NodeReader API.
+func (f FakeNodeReader) GetTreeRevisionIncludingSize(treeSize int64) (int64, error) {
+	if f.treeSize < treeSize {
+		return int64(0), fmt.Errorf("GetTreeRevisionIncludingSize() got treeSize:%d, want: >= %d", treeSize, f.treeSize)
 	}
 
 	return f.treeRevision, nil
@@ -169,15 +169,15 @@ func (m MultiFakeNodeReader) readerForNodeID(nodeID storage.NodeID, revision int
 	return nil
 }
 
-// GetTreeRevisionAtSize implements the corresponding NodeReader API.
-func (m MultiFakeNodeReader) GetTreeRevisionAtSize(treeSize int64) (int64, error) {
+// GetTreeRevisionIncludingSize implements the corresponding NodeReader API.
+func (m MultiFakeNodeReader) GetTreeRevisionIncludingSize(treeSize int64) (int64, int64, error) {
 	for i := len(m.readers) - 1; i >= 0; i-- {
-		if m.readers[i].treeSize == treeSize {
-			return m.readers[i].treeRevision, nil
+		if m.readers[i].treeSize >= treeSize {
+			return m.readers[i].treeRevision, m.readers[i].treeSize, nil
 		}
 	}
 
-	return int64(0), fmt.Errorf("want revision for tree size: %d but it doesn't exist", treeSize)
+	return int64(0), int64(0), fmt.Errorf("want revision for tree size: %d but it doesn't exist", treeSize)
 }
 
 // GetMerkleNodes implements the corresponding NodeReader API.


### PR DESCRIPTION
This allows us to serve proofs at arbitrary tree sizes. Snapshot recomputation annotates portions of the path that require rehashing and this is then used to recalculate a subtree node when storage returns the nodes. Add some proof tests at the node / path calculation level to improve coverage. If proofs are at STH corresponding sizes the new code paths are not taken so probably safe! 

Sorry this PR is a bit big but it was proving tricky to separate out.