### PR TITLE
Remove dependency on disabling ONLY_FULL_GROUP_BY

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,6 @@ of MySQL running and configured
  - to listen on the standard MySQL port 3306 (so `mysql --host=127.0.0.1
    --port=3306` connects OK)
  - not to require a password for the `root` user
- - not to include the
-   [`ONLY_FULL_GROUP_BY` SQL mode](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by)
-   (this is
-   [enabled by default](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting)
-   for MySQL versions >= 5.7 but can be disabled, e.g. with `SET GLOBAL
-   sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));`).
 
 You can then set up the [expected tables](storage/mysql/storage.sql) in a
 `test` database like so:

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -29,7 +29,7 @@ const selectMapLeafSQL string = `
 	SELECT TreeId, KeyHash, MAX(MapRevision) as maxrev
 	FROM MapLeaf t0
 	WHERE t0.KeyHash IN (` + placeholderSQL + `) AND
-	      t0.TreeId = ? AND t0.MapRevision >= ?
+	      t0.TreeId = ? AND t0.MapRevision <= ?
 	GROUP BY t0.TreeId, t0.KeyHash
  ) t2
  ON t1.TreeId=t2.TreeId

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -21,13 +21,20 @@ const selectLatestSignedMapRootSQL string = `SELECT MapHeadTimestamp, RootHash, 
 
 const insertMapLeafSQL string = `INSERT INTO MapLeaf(TreeId, KeyHash, MapRevision, LeafValue) VALUES (?, ?, ?, ?)`
 
-// Note that MapRevision is stored negated, hence the odd equality check below:
-const selectMapLeafSQL string = `SELECT KeyHash, MAX(MapRevision), LeafValue
-	 FROM MapLeaf
-	 WHERE KeyHash IN (` + placeholderSQL + `) AND
-	       TreeId = ? AND
-				 MapRevision >= ?
-	 GROUP BY KeyHash`
+const selectMapLeafSQL string = `
+ SELECT t1.KeyHash, t1.MapRevision, t1.LeafValue
+ FROM MapLeaf t1
+ INNER JOIN
+ (
+	SELECT TreeId, KeyHash, MAX(MapRevision) as maxrev
+	FROM MapLeaf t0
+	WHERE t0.KeyHash IN (` + placeholderSQL + `) AND
+	      t0.TreeId = ? AND t0.MapRevision >= ?
+	GROUP BY t0.TreeId, t0.KeyHash
+ ) t2
+ ON t1.TreeId=t2.TreeId
+ AND t1.KeyHash=t2.KeyHash
+ AND t1.MapRevision=t2.maxrev`
 
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
@@ -117,8 +124,7 @@ func (m *mapTX) Set(keyHash []byte, value trillian.MapLeaf) error {
 	}
 	defer stmt.Close()
 
-	// Note: MapRevision is stored negated:
-	_, err = stmt.Exec(m.ms.mapID, []byte(keyHash), -m.writeRevision, flatValue)
+	_, err = stmt.Exec(m.ms.mapID, []byte(keyHash), m.writeRevision, flatValue)
 	return err
 }
 
@@ -135,9 +141,7 @@ func (m *mapTX) Get(revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, err
 		args = append(args, []byte(k[:]))
 	}
 	args = append(args, m.ms.mapID)
-	// Note: MapRevision is negated when stored to cause more recent revisions to
-	// appear earlier in query results.
-	args = append(args, -revision)
+	args = append(args, revision)
 
 	glog.Infof("args size %d", len(args))
 


### PR DESCRIPTION
in http://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
MYSQL stipulates that it can return _any_ row from a group by clause.
MySQL now produces warnings when queries do not return unique results.
This PR fixes the GetMapLeaf SQL query to return a unique result.

It also stops storing inverted revision numbers since a particular
database ordering is not longer required.