### PR TITLE
Make MySQLURFlag public

### DIFF
--- a/extension/builtin/default_registry.go
+++ b/extension/builtin/default_registry.go
@@ -10,17 +10,19 @@ import (
 	"github.com/google/trillian/storage/mysql"
 )
 
-var mysqlURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "uri to use with mysql storage")
+// MySQLURIFlag is the mysql db connection string.
+var MySQLURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test",
+	"uri to use with mysql storage")
 
 // Default implementation of extension.Registry.
 type defaultRegistry struct{}
 
 func (r defaultRegistry) GetLogStorage(treeID int64) (storage.LogStorage, error) {
-	return mysql.NewLogStorage(treeID, *mysqlURIFlag)
+	return mysql.NewLogStorage(treeID, *MySQLURIFlag)
 }
 
 func (r defaultRegistry) GetMapStorage(treeID int64) (storage.MapStorage, error) {
-	return mysql.NewMapStorage(treeID, *mysqlURIFlag)
+	return mysql.NewMapStorage(treeID, *MySQLURIFlag)
 }
 
 // NewDefaultExtensionRegistry returns the default extension.Registry implementation, which is

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -18,13 +18,13 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-var MySQLURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "")
+var mySQLURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "")
 
 func main() {
 	flag.Parse()
 	glog.Info("Starting...")
 	mapID := int64(1)
-	ms, err := mysql.NewMapStorage(mapID, *MySQLURIFlag)
+	ms, err := mysql.NewMapStorage(mapID, *mySQLURIFlag)
 	if err != nil {
 		glog.Fatalf("Failed to open mysql storage: %v", err)
 	}

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -18,13 +18,13 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-var mysqlURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "")
+var MySQLURIFlag = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "")
 
 func main() {
 	flag.Parse()
 	glog.Info("Starting...")
 	mapID := int64(1)
-	ms, err := mysql.NewMapStorage(mapID, *mysqlURIFlag)
+	ms, err := mysql.NewMapStorage(mapID, *MySQLURIFlag)
 	if err != nil {
 		glog.Fatalf("Failed to open mysql storage: %v", err)
 	}


### PR DESCRIPTION
This allows tests to set the database connection flag directly. 
This change is temporary while the extension library is being updated to allow passing a direct db connection.