### PR TITLE
Try to avoid clashing ports

### DIFF
--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -4,7 +4,7 @@ INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/common.sh
 
 TEST_TREE_ID=1123
-RPC_PORT=34557
+RPC_PORT=44557
 
 echo "Provisioning test log (Tree ID: $TEST_TREE_ID) in database"
 "${SCRIPTS_DIR}"/wipelog.sh ${TEST_TREE_ID}

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -23,9 +23,9 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-var serverPortFlag = flag.Int("port", 8090, "Port to serve log RPC requests on")
+var serverPortFlag = flag.Int("port", 18090, "Port to serve log RPC requests on")
 var exportRPCMetrics = flag.Bool("export_metrics", true, "If true starts HTTP server and exports stats")
-var httpPortFlag = flag.Int("http_port", 8091, "Port to serve HTTP metrics on")
+var httpPortFlag = flag.Int("http_port", 18091, "Port to serve HTTP metrics on")
 
 // TODO(Martin2112): Single private key doesn't really work for multi tenant and we can't use
 // an HSM interface in this way. Deferring these issues for later.


### PR DESCRIPTION
Make default ports for map/log different so there's less
chance of an old instance of one interfering with a new
instance of the other.