### PR TITLE
Client with (partially) verified QueueLeaf

### DIFF
--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Backoff specifies the parameters of the backoff algorithm.
+type Backoff struct {
+	Min    time.Duration
+	Max    time.Duration
+	Factor float64
+	Jitter bool
+	x      int
+}
+
+// Duration returns the time to wait on duration x.
+func (b *Backoff) Duration() time.Duration {
+	// min( min * factor ^ x , max)
+	minNanos := float64(b.Min.Nanoseconds())
+	maxNanos := float64(b.Max.Nanoseconds())
+	nanos := math.Min(minNanos*math.Pow(b.Factor, float64(b.x)), maxNanos)
+	if b.Jitter {
+		// Generate a number in the range [b.Min, b.Max]
+		r := rand.Float64()*(maxNanos-minNanos) + minNanos
+		nanos = nanos - r
+	}
+	b.x++
+	return time.Duration(nanos) * time.Nanosecond
+}

--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -32,7 +32,7 @@ type Backoff struct {
 // Duration returns the time to wait on duration x.
 // Every time Duration is called, the returned value will exponentially increase by Factor
 // until Backoff.Max. If Jitter is enabled, will wait an additional random value between
-// 0 and factor^x * min
+// 0 and factor^x * min, capped by Backoff.Max.
 func (b *Backoff) Duration() time.Duration {
 	// min( min * factor ^ x , max)
 	minNanos := float64(b.Min.Nanoseconds())

--- a/client/backoff/backoff_test.go
+++ b/client/backoff/backoff_test.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoff(t *testing.T) {
+	b := Backoff{
+		Min:    time.Duration(1),
+		Max:    time.Duration(100),
+		Factor: 2,
+	}
+	for _, test := range []struct {
+		b     Backoff
+		times int
+		want  time.Duration
+	}{
+		{b, 1, time.Duration(1)},
+		{b, 2, time.Duration(2)},
+		{b, 3, time.Duration(4)},
+		{b, 4, time.Duration(8)},
+		{b, 8, time.Duration(100)},
+	} {
+		test.b.Reset()
+		var got time.Duration
+		for i := 0; i < test.times; i++ {
+			got = test.b.Duration()
+		}
+		if got != test.want {
+			t.Errorf("Duration() %v times: %v, want %v", test.times, got, test.want)
+		}
+	}
+}
+
+func TestJitter(t *testing.T) {
+	b := Backoff{
+		Min:    time.Duration(1) * time.Second,
+		Max:    time.Duration(100) * time.Second,
+		Factor: 2,
+		Jitter: true,
+	}
+	for _, test := range []struct {
+		b     Backoff
+		times int
+		min   time.Duration
+		max   time.Duration
+	}{
+		{b, 1, time.Duration(1) * time.Second, time.Duration(2) * time.Second},
+		{b, 2, time.Duration(2) * time.Second, time.Duration(4) * time.Second},
+		{b, 3, time.Duration(4) * time.Second, time.Duration(8) * time.Second},
+		{b, 4, time.Duration(8) * time.Second, time.Duration(16) * time.Second},
+		{b, 8, time.Duration(100) * time.Second, time.Duration(200) * time.Second},
+	} {
+		test.b.Reset()
+		var got1 time.Duration
+		for i := 0; i < test.times; i++ {
+			got1 = test.b.Duration()
+		}
+		if got1 < test.min || got1 > test.max {
+			t.Errorf("Duration() %v times, want  %v < %v < %v", test.times, test.min, got1, test.max)
+		}
+
+		// Ensure a random value is being produced.
+		test.b.Reset()
+		var got2 time.Duration
+		for i := 0; i < test.times; i++ {
+			got2 = test.b.Duration()
+		}
+		if got1 == got2 {
+			t.Errorf("Duration() %v times == Duration() %v times, want  %v != %v",
+				test.times, test.times, got1, got2)
+		}
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/client/backoff"
 	"github.com/google/trillian/merkle"
-	"github.com/jpillora/Backoff"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -18,40 +18,152 @@ package client
 import (
 	"context"
 	"crypto/sha256"
+	"time"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle"
+	"github.com/jpillora/Backoff"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // LogClient represents a client for a given Trillian log instance.
 type LogClient struct {
-	LogID  int64
-	client trillian.TrillianLogClient
+	LogID    int64
+	client   trillian.TrillianLogClient
+	hasher   merkle.TreeHasher
+	STR      trillian.SignedLogRoot
+	MaxTries int
 }
 
 // New returns a new LogClient.
-func New(logID int64, cc *grpc.ClientConn) *LogClient {
+func New(logID int64, cc *grpc.ClientConn, hasher merkle.TreeHasher) *LogClient {
 	return &LogClient{
-		LogID:  logID,
-		client: trillian.NewTrillianLogClient(cc),
+		LogID:    logID,
+		client:   trillian.NewTrillianLogClient(cc),
+		hasher:   hasher,
+		MaxTries: 3,
 	}
 }
 
-// AddLeaf adds leaf to the append only log. It blocks until a verifiable response is received.
+// AddLeaf adds leaf to the append only log.
+// Blocks until it gets a verifiable response.
 func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
+	// Fetch the current STR so we can detect when we update.
+	if err := c.UpdateSTR(ctx); err != nil {
+		return err
+	}
+
+	leaf := buildLeaf(data)
+	err := c.queueLeaf(ctx, leaf)
+	switch {
+	case grpc.Code(err) == codes.AlreadyExists:
+		// If the leaf already exists, don't wait for an update.
+		return c.getInclusionProof(ctx, leaf.MerkleLeafHash, c.STR.TreeSize)
+	case err != nil:
+		return err
+	default:
+		err := grpc.Errorf(codes.NotFound, "Pre-loop condition")
+		for i := 0; grpc.Code(err) == codes.NotFound && i < c.MaxTries; i++ {
+			// Wait for TreeSize to update.
+			if err := c.waitForSTRUpdate(ctx, c.MaxTries); err != nil {
+				return err
+			}
+
+			// Get proof by hash.
+			err = c.getInclusionProof(ctx, leaf.MerkleLeafHash, c.STR.TreeSize)
+		}
+		return err
+	}
+}
+
+// waitForSTRUpdate repeatedly fetches the STR until the TreeSize changes
+// or until a maximum number of attempts has been tried.
+func (c *LogClient) waitForSTRUpdate(ctx context.Context, attempts int) error {
+	b := &backoff.Backoff{
+		Min:    100 * time.Millisecond,
+		Max:    10 * time.Second,
+		Factor: 2,
+		Jitter: true,
+	}
+	startTreeSize := c.STR.TreeSize
+	for i := 0; ; i++ {
+		if err := c.UpdateSTR(ctx); err != nil {
+			return err
+		}
+		if c.STR.TreeSize > startTreeSize {
+			return nil
+		}
+		if i >= (attempts - 1) {
+			return grpc.Errorf(codes.DeadlineExceeded,
+				"UpdateSTR().TreeSize: %v, want > %v. Tried %v times.",
+				c.STR.TreeSize, startTreeSize, i+1)
+		}
+		time.Sleep(b.Duration())
+	}
+}
+
+// UpdateSTR retrieves the current SignedLogRoot and verifies it.
+func (c *LogClient) UpdateSTR(ctx context.Context) error {
+	req := &trillian.GetLatestSignedLogRootRequest{
+		LogId: c.LogID,
+	}
+	resp, err := c.client.GetLatestSignedLogRoot(ctx, req)
+	if err != nil {
+		return err
+	}
+	// TODO(gdbelvin): Verify SignedLogRoot
+
+	c.STR = *resp.SignedLogRoot
+	return nil
+}
+
+func (c *LogClient) getInclusionProof(ctx context.Context, leafHash []byte, treeSize int64) error {
+	req := &trillian.GetInclusionProofByHashRequest{
+		LogId:    c.LogID,
+		LeafHash: leafHash,
+		TreeSize: treeSize,
+	}
+	resp, err := c.client.GetInclusionProofByHash(ctx, req)
+	if err != nil {
+		return err
+	}
+	for _, proof := range resp.Proof {
+		neighbors := convertProof(proof)
+		v := merkle.NewLogVerifier(c.hasher)
+		if err := v.VerifyInclusionProof(proof.LeafIndex, treeSize, neighbors, c.STR.RootHash, leafHash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// convertProof returns a slice of neighbor nodes from a trillian Proof.
+// TODO(martin): adjust the public API to do this in the server before returing a proof.
+func convertProof(proof *trillian.Proof) [][]byte {
+	neighbors := make([][]byte, len(proof.ProofNode))
+	for i, node := range proof.ProofNode {
+		neighbors[i] = node.NodeHash
+	}
+	return neighbors
+}
+
+func buildLeaf(data []byte) *trillian.LogLeaf {
 	hash := sha256.Sum256(data)
 	leaf := &trillian.LogLeaf{
 		LeafValue:        data,
 		MerkleLeafHash:   hash[:],
 		LeafIdentityHash: hash[:],
 	}
+	return leaf
+}
+
+func (c *LogClient) queueLeaf(ctx context.Context, leaf *trillian.LogLeaf) error {
+	// Queue Leaf
 	req := trillian.QueueLeafRequest{
 		LogId: c.LogID,
 		Leaf:  leaf,
 	}
 	_, err := c.client.QueueLeaf(ctx, &req)
-	// TODO(gdbelvin): Get proof by hash
-	// TODO(gdbelvin): backoff with jitter
-	// TODO(gdbelvin): verify proof
 	return err
 }

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -205,6 +205,7 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	// current one is too old. If there's work to be done then we'll be creating a root anyway.
 	if len(leaves) == 0 {
 		// We have nothing to integrate into the tree
+		glog.Infof("No leaves sequenced in this signing operation.")
 		return 0, tx.Commit()
 	}
 

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -43,8 +43,8 @@ func NewLogVerifier(hasher TreeHasher) LogVerifier {
 }
 
 // VerifyInclusionProof verifies the correctness of the proof given the passed in information about the tree and leaf.
-func (v LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
-	calcRoot, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+func (v LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]byte, root []byte, leafHash []byte) error {
+	calcRoot, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leafHash)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (v LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]b
 // RootFromInclusionProof calculates the expected tree root given the proof and leaf.
 // leafIndex starts at 0.  treeSize is the number of nodes in the tree.
 // proof is an array of neighbor nodes from the bottom to the root.
-func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leaf []byte) ([]byte, error) {
+func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leafHash []byte) ([]byte, error) {
 	if leafIndex < 0 {
 		return nil, errors.New("invalid leafIndex < 0")
 	}
@@ -73,7 +73,7 @@ func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][
 	}
 
 	cntIndex := leafIndex
-	cntHash := v.hasher.HashLeaf(leaf)
+	cntHash := leafHash
 	proofIndex := 0
 
 	// Tree is numbered as follows, where nodes at each level are counted from left to right.

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -118,35 +118,35 @@ var (
 	}
 )
 
-func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root, leaf []byte) error {
+func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root, leafHash []byte) error {
 	// Verify original inclusion proof
-	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leafHash)
 	if err != nil {
 		return err
 	}
 	if want := root; !bytes.Equal(got, want) {
 		return fmt.Errorf("got root:\n%x\nexpected:\n%x", got, want)
 	}
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err != nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leafHash); err != nil {
 		return err
 	}
 
 	// Wrong leaf index
-	if err := v.VerifyInclusionProof(leafIndex-1, treeSize, proof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex-1, treeSize, proof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against leafIndex - 1")
 	}
-	if err := v.VerifyInclusionProof(leafIndex+1, treeSize, proof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex+1, treeSize, proof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against leafIndex + 1")
 	}
-	if err := v.VerifyInclusionProof(leafIndex^2, treeSize, proof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex^2, treeSize, proof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against leafIndex ^ 2")
 	}
 
 	// Wrong tree height
-	if err := v.VerifyInclusionProof(leafIndex, treeSize*2, proof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize*2, proof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against treeSize * 2")
 	}
-	if err := v.VerifyInclusionProof(leafIndex, treeSize/2, proof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize/2, proof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against treeSize / 2")
 	}
 
@@ -156,7 +156,7 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 	}
 
 	// Wrong root
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, sha256EmptyTreeHash, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, sha256EmptyTreeHash, leafHash); err == nil {
 		return errors.New("incorrectly verified against empty root hash")
 	}
 
@@ -166,7 +166,7 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 	for i := 0; i < len(proof); i++ {
 		tmp := proof[i]
 		proof[i] = sha256EmptyTreeHash
-		if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err == nil {
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leafHash); err == nil {
 			return errors.New("incorrectly verified against incorrect inclusion proof")
 		}
 		proof[i] = tmp
@@ -174,31 +174,31 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 
 	// Add garbage at the end
 	wrongProof := append(proof, []byte(""))
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against proof with trailing garbage")
 	}
 
 	wrongProof = append(proof, root)
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against proof with trailing root")
 	}
 
 	if len(proof) > 0 {
 		// Remove a node from the end
 		wrongProof = proof[:len(proof)-1]
-		if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leafHash); err == nil {
 			return errors.New("incorrectly verified against truncated proof")
 		}
 	}
 
 	// Add garbage at the front
 	wrongProof = append([][]byte{{}}, proof...)
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against proof with preceding garbage")
 	}
 
 	wrongProof = append([][]byte{root}, proof...)
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leafHash); err == nil {
 		return errors.New("incorrectly verified against proof with preceding garbage")
 	}
 
@@ -300,16 +300,16 @@ func TestVerifyInclusionProof(t *testing.T) {
 	v := NewLogVerifier(testonly.Hasher)
 	path := [][]byte{}
 	// Various invalid paths
-	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{1}); err == nil {
 		t.Fatal("Incorrectly verified invalid path 1")
 	}
-	if err := v.VerifyInclusionProof(0, 1, path, []byte{}, []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(0, 1, path, []byte{}, []byte{1}); err == nil {
 		t.Fatal("Incorrectly verified invalid path 2")
 	}
-	if err := v.VerifyInclusionProof(1, 0, path, []byte{}, []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(1, 0, path, []byte{}, []byte{1}); err == nil {
 		t.Fatal("Incorrectly verified invalid path 3")
 	}
-	if err := v.VerifyInclusionProof(2, 1, path, []byte{}, []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(2, 1, path, []byte{}, []byte{1}); err == nil {
 		t.Fatal("Incorrectly verified invalid path 4")
 	}
 
@@ -333,9 +333,9 @@ func TestVerifyInclusionProof(t *testing.T) {
 		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
 			proof = append(proof, inclusionProofs[i].proof[j].h)
 		}
+		leafHash := testonly.Hasher.HashLeaf(leaves[inclusionProofs[i].leaf-1].h)
 		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
-			roots[inclusionProofs[i].snapshot-1].h,
-			leaves[inclusionProofs[i].leaf-1].h)
+			roots[inclusionProofs[i].snapshot-1].h, leafHash)
 		if err != nil {
 			t.Fatalf("i=%d: %s", i, err)
 		}

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -36,7 +36,7 @@ type TreeHasher interface {
 }
 
 var hashTypes = map[string]TreeHasher{
-	RFC6962SHA256Type: rfc6962.TreeHasher{crypto.SHA256},
+	RFC6962SHA256Type: rfc6962.TreeHasher{Hash: crypto.SHA256},
 }
 
 // Factory supports fetching custom hashers based on tree types.

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -137,9 +137,6 @@ func (l LogOperationManager) OperationLoop() {
 
 	// Outer loop, runs until terminated
 	for {
-		// Wait for the configured time before going for another pass
-		time.Sleep(l.context.sleepBetweenRuns)
-
 		// TODO(alcutter): want a child context with deadline here?
 		quit := l.getLogsAndExecutePass(l.context.ctx)
 
@@ -150,5 +147,8 @@ func (l LogOperationManager) OperationLoop() {
 			glog.Infof("Log operation manager shutting down")
 			return
 		}
+
+		// Wait for the configured time before going for another pass
+		time.Sleep(l.context.sleepBetweenRuns)
 	}
 }

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -37,19 +37,20 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-var serverPortFlag = flag.Int("port", 8090, "Port to serve log RPC requests on")
-var exportRPCMetrics = flag.Bool("export_metrics", true, "If true starts HTTP server and exports stats")
-var httpPortFlag = flag.Int("http_port", 8091, "Port to serve HTTP metrics on")
+var (
+	serverPortFlag                = flag.Int("port", 8090, "Port to serve log RPC requests on")
+	exportRPCMetrics              = flag.Bool("export_metrics", true, "If true starts HTTP server and exports stats")
+	httpPortFlag                  = flag.Int("http_port", 8091, "Port to serve HTTP metrics on")
+	sequencerSleepBetweenRunsFlag = flag.Duration("sequencer_sleep_between_runs", time.Second*10, "Time to pause after each sequencing pass through all logs")
+	batchSizeFlag                 = flag.Int("batch_size", 50, "Max number of leaves to process per batch")
+	numSeqFlag                    = flag.Int("num_sequencers", 10, "Number of sequencers to run in parallel")
+	sequencerGuardWindowFlag      = flag.Duration("sequencer_guard_window", 0, "If set, the time elapsed before submitted leaves are eligible for sequencing")
 
-var sequencerSleepBetweenRunsFlag = flag.Duration("sequencer_sleep_between_runs", time.Second*10, "Time to pause after each sequencing pass through all logs")
-var batchSizeFlag = flag.Int("batch_size", 50, "Max number of leaves to process per batch")
-var numSeqFlag = flag.Int("num_sequencers", 10, "Number of sequencers to run in parallel")
-var sequencerGuardWindowFlag = flag.Duration("sequencer_guard_window", 0, "If set, the time elapsed before submitted leaves are eligible for sequencing")
-
-// TODO(Martin2112): Single private key doesn't really work for multi tenant and we can't use
-// an HSM interface in this way. Deferring these issues for later.
-var privateKeyFile = flag.String("private_key_file", "", "File containing a PEM encoded private key")
-var privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
+	// TODO(Martin2112): Single private key doesn't really work for multi tenant and we can't use
+	// an HSM interface in this way. Deferring these issues for later.
+	privateKeyFile     = flag.String("private_key_file", "", "File containing a PEM encoded private key")
+	privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
+)
 
 // TODO(codingllama): Consider moving to server creation
 func checkDatabaseAccessible(registry extension.Registry) error {

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -23,29 +23,31 @@ import (
 	"github.com/google/trillian/storage"
 )
 
-// LogTree is a valid, LOG-type trillian.Tree for tests.
-var LogTree *trillian.Tree = &trillian.Tree{
-	TreeState:          trillian.TreeState_ACTIVE,
-	TreeType:           trillian.TreeType_LOG,
-	HashStrategy:       trillian.HashStrategy_RFC_6962,
-	HashAlgorithm:      trillian.HashAlgorithm_SHA256,
-	SignatureAlgorithm: trillian.SignatureAlgorithm_ECDSA,
-	DuplicatePolicy:    trillian.DuplicatePolicy_DUPLICATES_NOT_ALLOWED,
-	DisplayName:        "Llamas Log",
-	Description:        "Registry of publicly-owned llamas",
-}
+var (
+	// LogTree is a valid, LOG-type trillian.Tree for tests.
+	LogTree = &trillian.Tree{
+		TreeState:          trillian.TreeState_ACTIVE,
+		TreeType:           trillian.TreeType_LOG,
+		HashStrategy:       trillian.HashStrategy_RFC_6962,
+		HashAlgorithm:      trillian.HashAlgorithm_SHA256,
+		SignatureAlgorithm: trillian.SignatureAlgorithm_ECDSA,
+		DuplicatePolicy:    trillian.DuplicatePolicy_DUPLICATES_NOT_ALLOWED,
+		DisplayName:        "Llamas Log",
+		Description:        "Registry of publicly-owned llamas",
+	}
 
-// MapTree is a valid, MAP-type trillian.Tree for tests.
-var MapTree *trillian.Tree = &trillian.Tree{
-	TreeState:          trillian.TreeState_ACTIVE,
-	TreeType:           trillian.TreeType_MAP,
-	HashStrategy:       trillian.HashStrategy_RFC_6962,
-	HashAlgorithm:      trillian.HashAlgorithm_SHA256,
-	SignatureAlgorithm: trillian.SignatureAlgorithm_ECDSA,
-	DuplicatePolicy:    trillian.DuplicatePolicy_DUPLICATES_ALLOWED,
-	DisplayName:        "Llamas Map",
-	Description:        "Key Transparency map for all your digital llama needs.",
-}
+	// MapTree is a valid, MAP-type trillian.Tree for tests.
+	MapTree = &trillian.Tree{
+		TreeState:          trillian.TreeState_ACTIVE,
+		TreeType:           trillian.TreeType_MAP,
+		HashStrategy:       trillian.HashStrategy_RFC_6962,
+		HashAlgorithm:      trillian.HashAlgorithm_SHA256,
+		SignatureAlgorithm: trillian.SignatureAlgorithm_ECDSA,
+		DuplicatePolicy:    trillian.DuplicatePolicy_DUPLICATES_ALLOWED,
+		DisplayName:        "Llamas Map",
+		Description:        "Key Transparency map for all your digital llama needs.",
+	}
+)
 
 // AdminStorageTester runs a suite of tests against AdminStorage implementations.
 type AdminStorageTester struct {
@@ -136,7 +138,7 @@ func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 		}
 		wantTree = *storedTree
 		if !reflect.DeepEqual(newTree, &wantTree) {
-			t.Errorf("%v: newTree = %v, wantTree = %v", i, newTree, &wantTree)
+			t.Errorf("%v: newTree = \n%v, wantTree = \n%v", i, newTree, &wantTree)
 		}
 		if err := readOnlyTX.Commit(); err != nil {
 			t.Errorf("%v: Commit() = %v, want = nil", i, err)

--- a/testonly/hasher.go
+++ b/testonly/hasher.go
@@ -26,7 +26,7 @@ import (
 
 // Hasher is the default hasher for tests.
 // TODO: Make this a custom algorithm to decouple hashing from coded defaults.
-var Hasher = rfc6962.TreeHasher{crypto.SHA256}
+var Hasher = rfc6962.TreeHasher{Hash: crypto.SHA256}
 
 // HashKey converts a map key into a map index using SHA256.
 // This preserves tests that precomputed indexes based on SHA256.

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -15,15 +15,19 @@
 package integration
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/extension/builtin"
 	"github.com/google/trillian/server"
+	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
 )
@@ -33,12 +37,25 @@ const (
 	mysqlRootURI  = "root@tcp(127.0.0.1:3306)/"
 )
 
+var (
+	privateKeyFile     = "../testdata/log-rpc-server.privkey.pem"
+	privateKeyPassword = "towel"
+	sequencerWindow    = time.Duration(0)
+	batchSize          = 50
+	sleep              = time.Duration(0)
+	signInterval       = time.Duration(0)
+	timeSource         = util.SystemTimeSource{}
+	ctx                = context.Background()
+)
+
 // LogEnv is a test environment that contains both a log server and a connection to it.
 type LogEnv struct {
-	grpcServer *grpc.Server
-	logServer  *server.TrillianLogRPCServer
-	ClientConn *grpc.ClientConn
-	DB         *sql.DB
+	grpcServer   *grpc.Server
+	logServer    *server.TrillianLogRPCServer
+	LogOperation server.LogOperation
+	Sequencer    *server.LogOperationManager
+	ClientConn   *grpc.ClientConn
+	DB           *sql.DB
 }
 
 // listen opens a random high numbered port for listening.
@@ -112,9 +129,20 @@ func NewLogEnv(testID string) (*LogEnv, error) {
 		return nil, err
 	}
 
+	// Start Log Server.
 	grpcServer := grpc.NewServer()
 	logServer := server.NewTrillianLogRPCServer(registry, timesource)
 	trillian.RegisterTrillianLogServer(grpcServer, logServer)
+
+	// Start Sequencer.
+	keyManager, err := crypto.LoadPasswordProtectedPrivateKey(privateKeyFile, privateKeyPassword)
+	if err != nil {
+		return nil, err
+	}
+	sequencerManager := server.NewSequencerManager(keyManager, registry,
+		sequencerWindow)
+	sequencerTask := server.NewLogOperationManagerForTest(ctx, registry,
+		batchSize, sleep, signInterval, timeSource, sequencerManager)
 
 	// Listen and start server.
 	addr, lis, err := listen()
@@ -130,15 +158,28 @@ func NewLogEnv(testID string) (*LogEnv, error) {
 	}
 
 	return &LogEnv{
-		grpcServer: grpcServer,
-		logServer:  logServer,
-		ClientConn: cc,
-		DB:         db,
+		grpcServer:   grpcServer,
+		logServer:    logServer,
+		ClientConn:   cc,
+		DB:           db,
+		LogOperation: sequencerManager,
+		Sequencer:    sequencerTask,
 	}, nil
 }
 
 // Close shuts down the server.
 func (env *LogEnv) Close() {
-	env.grpcServer.Stop()
+	env.ClientConn.Close()
+	env.grpcServer.GracefulStop()
 	env.DB.Close()
+}
+
+// CreateLog creates a log and signs the first empty tree head.
+func (env *LogEnv) CreateLog(logID int64) error {
+	if err := mysql.CreateTree(logID, env.DB); err != nil {
+		return err
+	}
+	// Sign the first empty tree head.
+	env.Sequencer.OperationLoop()
+	return nil
 }

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -142,7 +142,7 @@ func NewLogEnv(testID string) (*LogEnv, error) {
 	sequencerManager := server.NewSequencerManager(keyManager, registry,
 		sequencerWindow)
 	sequencerTask := server.NewLogOperationManagerForTest(ctx, registry,
-		batchSize, sleep, signInterval, timeSource, sequencerManager)
+		batchSize, sleep, timeSource, sequencerManager)
 
 	// Listen and start server.
 	addr, lis, err := listen()


### PR DESCRIPTION
Client AddLeaf:
- Fetches current Signed Tree Root
- Queues the leaf
- Waits for an STR update
- TODO: Verify STR
- Fetch and verify inclusion proof

Integration test improvements:
- LogEnv also creates a signer
- Graceful server shutdown
- Adjust VerifyMerkleTree to accept a LeafHash rather than LeafData.

Contributes to #297 