### PR TITLE
Use int64 in memoryMerkleTree

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -406,7 +406,7 @@ func checkInclusionProofsAtIndex(index int64, logID int64, tree *merkle.InMemory
 			}
 
 			// Remember that the in memory tree uses 1 based leaf indices
-			path := tree.PathToRootAtSnapshot(int(index+1), int(treeSize))
+			path := tree.PathToRootAtSnapshot(index+1, treeSize)
 
 			if err = compareLogAndTreeProof(resp.Proof, path); err != nil {
 				// The log and tree proof don't match, details in the error
@@ -434,7 +434,9 @@ func checkConsistencyProof(consistParams consistencyProofParams, treeID int64, t
 	}
 
 	// Get the proof from the memory tree
-	proof := tree.SnapshotConsistency((int(consistParams.size1) * params.sequencerBatchSize), (int(consistParams.size2) * params.sequencerBatchSize))
+	proof := tree.SnapshotConsistency(
+		(consistParams.size1 * int64(params.sequencerBatchSize)),
+		(consistParams.size2 * int64(params.sequencerBatchSize)))
 
 	// Compare the proofs, they should be identical
 	return compareLogAndTreeProof(resp.Proof, proof)

--- a/merkle/common.go
+++ b/merkle/common.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merkle
+
+// parent returns the index of the parent node in the parent level of the tree.
+func parent(leafIndex int64) int64 {
+	return leafIndex >> 1
+}
+
+// isRightChild returns true if the node is a right child.
+func isRightChild(leafIndex int64) bool {
+	return leafIndex&1 == 1
+}

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -199,10 +199,10 @@ func TestCompactVsFullTree(t *testing.T) {
 	imt := NewInMemoryMerkleTree(NewRFC6962TreeHasher(crypto.NewSHA256()))
 	nodes := make(map[string][]byte)
 
-	for i := 0; i < 1024; i++ {
+	for i := int64(0); i < 1024; i++ {
 		cmt, err := NewCompactMerkleTreeWithState(
 			NewRFC6962TreeHasher(crypto.NewSHA256()),
-			int64(imt.LeafCount()),
+			imt.LeafCount(),
 			func(depth int, index int64) ([]byte, error) {
 				k, err := nodeKey(depth, index)
 				if err != nil {


### PR DESCRIPTION
This is a PR in preparation for building a LogVerifier. 
We need a common set of tree functions to use in the `merkle` package