### PR TITLE
Fix integration tests

### DIFF
--- a/integration/ct_integration_test.sh
+++ b/integration/ct_integration_test.sh
@@ -3,6 +3,10 @@ set -e
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/common.sh
 
+yes | "${SCRIPTS_DIR}"/resetdb.sh
+echo "Provisioning test log (Tree ID: 0) in database"
+"${SCRIPTS_DIR}"/createlog.sh 0
+
 # Default to one RPC server and one HTTP server.
 RPC_SERVER_COUNT=${1:-1}
 HTTP_SERVER_COUNT=${2:-1}

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/common.sh
 

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -6,9 +6,11 @@ INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 TEST_TREE_ID=1123
 RPC_PORT=34557
 
-echo "Provisioning test log (Tree ID: $TEST_TREE_ID) in database"
-"${SCRIPTS_DIR}"/wipelog.sh ${TEST_TREE_ID}
-"${SCRIPTS_DIR}"/createlog.sh ${TEST_TREE_ID}
+yes | "${SCRIPTS_DIR}"/resetdb.sh
+for tid in 0 $TEST_TREE_ID; do
+  echo "Provisioning test log (Tree ID: $tid) in database"
+  "${SCRIPTS_DIR}"/createlog.sh ${tid}
+done
 
 echo "Starting Log RPC server on port ${RPC_PORT}"
 pushd "${TRILLIAN_ROOT}" > /dev/null

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -7,7 +7,7 @@ TEST_TREE_ID=123
 RPC_PORT=34556
 
 echo "Provisioning test map (Tree ID: $TEST_TREE_ID) in database"
-"${SCRIPTS_DIR}"/wipemap.sh ${TEST_TREE_ID}
+yes | "${SCRIPTS_DIR}"/resetdb.sh
 "${SCRIPTS_DIR}"/createmap.sh ${TEST_TREE_ID}
 
 echo "Starting Map RPC server on port ${RPC_PORT}"

--- a/scripts/createlog.sh
+++ b/scripts/createlog.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
-if [ "$#" -ne 1 ]; then
+set -eu
+
+if [ $# -ne 1 ]; then
     echo "Usage: $0 <logid>"
 fi
-TESTDBOPTS="-u test --password=zaphod -D test"
+
+TESTDBOPTS='-u test --password=zaphod -D test'
 TREE_ID=$1
+
 # Create a new Log storage row for the given tree ID.
 mysql ${TESTDBOPTS} -e "INSERT INTO Trees VALUES (${TREE_ID}, 1, 'LOG', 'SHA256', 'SHA256', false)"
+mysql ${TESTDBOPTS} -e "INSERT INTO TreeControl VALUES (${TREE_ID},false,false,false,1,1)"

--- a/scripts/wipelog.sh
+++ b/scripts/wipelog.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
-if [ "$#" -ne 1 ]; then
+set -eu
+
+if [ $# -ne 1 ]; then
     echo "Usage: $0 <logid>"
 fi
-TESTDBOPTS="-u test --password=zaphod -D test"
+
+TESTDBOPTS='-u test --password=zaphod -D test'
 TREE_ID=$1
+
 # Wipe all Log storage rows for the given tree ID.
 mysql ${TESTDBOPTS} -e "DELETE FROM Unsequenced WHERE TreeId = ${TREE_ID}"
 mysql ${TESTDBOPTS} -e "DELETE FROM TreeHead WHERE TreeId = ${TREE_ID}"
 mysql ${TESTDBOPTS} -e "DELETE FROM SequencedLeafData WHERE TreeId = ${TREE_ID}"
 mysql ${TESTDBOPTS} -e "DELETE FROM LeafData WHERE TreeId = ${TREE_ID}"
+mysql ${TESTDBOPTS} -e "DELETE FROM TreeControl WHERE TreeId = ${TREE_ID}"
 mysql ${TESTDBOPTS} -e "DELETE FROM Trees WHERE TreeId = ${TREE_ID}"

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -134,6 +134,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 	// TODO(Martin2112): Pass tree size as snapshot size to proof recomputation when implemented
 	// and remove this check.
 	if treeSize != req.TreeSize {
+		tx.Rollback()
 		return nil, errRehashNotSupported
 	}
 


### PR DESCRIPTION
* Create Tree #0 before integration tests (servers use it for healthcheck)
* Add 'set -e' to integration_test.sh (it wasn't failing in some cases)
* resetdb.sh called before integration tests (fixes sequencer TreeControl
  warnings)
* Added a missing tx.Rollback() call (fixes 'too many conns' error)