### PR TITLE
Log Verifier

### DIFF
--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -1,0 +1,202 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merkle
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// RootMismatchError occurs when an inclusion proof fails.
+type RootMismatchError struct {
+	ExpectedRoot   []byte
+	CalculatedRoot []byte
+}
+
+func (e RootMismatchError) Error() string {
+	return fmt.Sprintf("calculated root:\n%v\n does not match expected root:\n%v", e.CalculatedRoot, e.ExpectedRoot)
+}
+
+// LogVerifier verifies inclusion and consistency proofs for append only logs.
+type LogVerifier struct {
+	hasher TreeHasher
+}
+
+// NewLogVerifier returns a new LogVerifier for a tree.
+func NewLogVerifier(hasher TreeHasher) LogVerifier {
+	return LogVerifier{
+		hasher: hasher,
+	}
+}
+
+// VerifyInclusionProof verifies the correctness of the proof given the passed in information about the tree and leaf.
+func (m LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
+	calcRoot, err := m.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(calcRoot, root) {
+		return RootMismatchError{
+			CalculatedRoot: calcRoot,
+			ExpectedRoot:   root,
+		}
+	}
+	return nil
+}
+
+// RootFromInclusionProof calculates the expected tree root given the proof and leaf.
+// leafIndex starts at 0. treeSize starts at 1.
+func (m LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leaf []byte) ([]byte, error) {
+	if leafIndex >= treeSize {
+		return nil, fmt.Errorf("leafIndex %d > treeSize %d", leafIndex, treeSize)
+	}
+	if leafIndex < 0 || treeSize < 1 {
+		return nil, errors.New("leafIndex < 0 or treeSize < 1")
+	}
+
+	nodeIndex := leafIndex
+	lastNode := treeSize - 1
+	nodeHash := m.hasher.HashLeaf(leaf)
+	proofIndex := 0
+
+	for lastNode > 0 {
+		if proofIndex == len(proof) {
+			return nil, fmt.Errorf("insuficient number of proof components (%d) for treeSize %d", len(proof), treeSize)
+		}
+		if isRightChild(nodeIndex) {
+			nodeHash = m.hasher.HashChildren(proof[proofIndex], nodeHash)
+			proofIndex++
+		} else if nodeIndex < lastNode {
+			nodeHash = m.hasher.HashChildren(nodeHash, proof[proofIndex])
+			proofIndex++
+		} else {
+			// the sibling does not exist and the parent is a dummy copy; do nothing.
+		}
+		nodeIndex = parent(nodeIndex)
+		lastNode = parent(lastNode)
+	}
+	if proofIndex != len(proof) {
+		return nil, fmt.Errorf("invalid proof, expected %d components, but have %d", proofIndex, len(proof))
+	}
+	return nodeHash, nil
+}
+
+// VerifyConsistencyProof checks that the passed in consistency proof is valid between the passed in tree snapshots.
+func (m LogVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
+	if snapshot1 > snapshot2 {
+		return fmt.Errorf("snapshot1 (%d) > snapshot2 (%d)", snapshot1, snapshot2)
+	}
+	if snapshot1 == snapshot2 {
+		if !bytes.Equal(root1, root2) {
+			return RootMismatchError{
+				CalculatedRoot: root1,
+				ExpectedRoot:   root2,
+			}
+		}
+		if len(proof) > 0 {
+			return fmt.Errorf("root1 and root2 match, but proof is non-empty")
+		}
+		// proof ok
+		return nil
+	}
+
+	if snapshot1 == 0 {
+		// Any snapshot greater than 0 is consistent with snapshot 0.
+		if len(proof) > 0 {
+			return fmt.Errorf("expected empty proof, but provided proof has %d components", len(proof))
+		}
+		return nil
+	}
+
+	if len(proof) == 0 {
+		return errors.New("empty proof")
+	}
+
+	node := snapshot1 - 1
+	lastNode := snapshot2 - 1
+	proofIndex := 0
+
+	for isRightChild(node) {
+		node = parent(node)
+		lastNode = parent(lastNode)
+	}
+
+	var node1Hash []byte
+	var node2Hash []byte
+
+	if node > 0 {
+		node1Hash = proof[proofIndex]
+		node2Hash = proof[proofIndex]
+		proofIndex++
+	} else {
+		// The tree at snapshot1 was balanced, nothing to verify for root1.
+		node1Hash = root1
+		node2Hash = root1
+	}
+
+	for node > 0 {
+		if proofIndex == len(proof) {
+			return errors.New("insufficient number of proof components")
+		}
+
+		if isRightChild(node) {
+			node1Hash = m.hasher.HashChildren(proof[proofIndex], node1Hash)
+			node2Hash = m.hasher.HashChildren(proof[proofIndex], node2Hash)
+			proofIndex++
+		} else if node < lastNode {
+			// The sibling only exists in the later tree. The parent in the snapshot1 tree is a dummy copy.
+			node2Hash = m.hasher.HashChildren(node2Hash, proof[proofIndex])
+			proofIndex++
+		} else {
+			// Else the sibling does not exist in either tree. Do nothing.
+		}
+
+		node = parent(node)
+		lastNode = parent(lastNode)
+	}
+
+	// Verify the first root.
+	if !bytes.Equal(node1Hash, root1) {
+		return RootMismatchError{
+			CalculatedRoot: node1Hash,
+			ExpectedRoot:   root1,
+		}
+	}
+
+	for lastNode > 0 {
+		if proofIndex == len(proof) {
+			return errors.New("can't verify newer root; insufficient number of proof components")
+		}
+
+		node2Hash = m.hasher.HashChildren(node2Hash, proof[proofIndex])
+		proofIndex++
+		lastNode = parent(lastNode)
+	}
+
+	// Verify the second root.
+	if !bytes.Equal(node2Hash, root2) {
+		return RootMismatchError{
+			CalculatedRoot: node2Hash,
+			ExpectedRoot:   root2,
+		}
+	}
+	if proofIndex != len(proof) {
+		return errors.New("proof has too many components")
+	}
+
+	// proof ok
+	return nil
+}

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -24,11 +24,101 @@ import (
 	"github.com/google/trillian/crypto"
 )
 
-const (
-	sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+type logProofTestVector struct {
+	h []byte
+	l int
+}
+
+type inclusionProofTestVector struct {
+	leaf, snapshot, proofLength int64
+	proof                       []logProofTestVector
+}
+
+type consistencyTestVector struct {
+	snapshot1, snapshot2, proofLen int64
+	proof                          [3]logProofTestVector
+}
+
+var (
+	sha256EmptyTreeHash = dh("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	inclusionProofs     = []inclusionProofTestVector{
+		{0, 0, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1, 1, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[]logProofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[]logProofTestVector{
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{3,
+			3,
+			1,
+			[]logProofTestVector{
+				{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+				{dh(""), 0},
+				{dh(""), 0}}},
+		{2,
+			5,
+			3,
+			[]logProofTestVector{
+				{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32}},
+		}}
+	consistencyProofs = []consistencyTestVector{
+		{1, 1, 0, [3]logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[3]logProofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[3]logProofTestVector{
+				{dh("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{2,
+			5,
+			2,
+			[3]logProofTestVector{
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh(""), 0}}},
+	}
+	roots = []logProofTestVector{
+		{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+		{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+		{dh("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"), 32},
+		{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32},
+		{dh("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"), 32},
+		{dh("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"), 32},
+		{dh("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"), 32},
+		{dh("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"), 32}}
+	leaves = []logProofTestVector{
+		{dh(""), 0},
+		{dh("00"), 1},
+		{dh("10"), 1},
+		{dh("2021"), 2},
+		{dh("3031"), 2},
+		{dh("40414243"), 4},
+		{dh("5051525354555657"), 8},
+		{dh("606162636465666768696a6b6c6d6e6f"), 16},
+	}
 )
 
-func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
+func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root, leaf []byte) error {
 	// Verify original inclusion proof
 	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
 	if err != nil {
@@ -66,7 +156,7 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 	}
 
 	// Wrong root
-	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, dh(sha256EmptyTreeHash), leaf); err == nil {
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, sha256EmptyTreeHash, leaf); err == nil {
 		return errors.New("incorrectly verified against empty root hash")
 	}
 
@@ -75,7 +165,7 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 	// Modify single element of the proof
 	for i := 0; i < len(proof); i++ {
 		tmp := proof[i]
-		proof[i] = dh(sha256EmptyTreeHash)
+		proof[i] = sha256EmptyTreeHash
 		if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err == nil {
 			return errors.New("incorrectly verified against incorrect inclusion proof")
 		}
@@ -168,7 +258,7 @@ func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1,
 	// Modify single element of the proof
 	for i := 0; i < len(proof); i++ {
 		tmp := proof[i]
-		proof[i] = dh(sha256EmptyTreeHash)
+		proof[i] = sha256EmptyTreeHash
 		if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, proof); err == nil {
 			return errors.New("incorrectly verified against incorrect consistency proof")
 		}
@@ -211,108 +301,6 @@ func getVerifier() LogVerifier {
 	return NewLogVerifier(hasher)
 }
 
-type logProofTestVector struct {
-	h []byte
-	l int
-}
-
-type inclusionProofTestVector struct {
-	leaf, snapshot, proofLength int64
-	proof                       []logProofTestVector
-}
-
-func getInputs() []logProofTestVector {
-	return []logProofTestVector{
-		{dh(""), 0},
-		{dh("00"), 1},
-		{dh("10"), 1},
-		{dh("2021"), 2},
-		{dh("3031"), 2},
-		{dh("40414243"), 4},
-		{dh("5051525354555657"), 8},
-		{dh("606162636465666768696a6b6c6d6e6f"), 16},
-	}
-}
-
-func getInclusionTestVector() []inclusionProofTestVector {
-	return []inclusionProofTestVector{
-		{0, 0, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
-		{1, 1, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
-		{1,
-			8,
-			3,
-			[]logProofTestVector{
-				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
-				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
-				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
-		{6,
-			8,
-			3,
-			[]logProofTestVector{
-				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
-				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
-				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
-		{3,
-			3,
-			1,
-			[]logProofTestVector{
-				{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
-				{dh(""), 0},
-				{dh(""), 0}}},
-		{2,
-			5,
-			3,
-			[]logProofTestVector{
-				{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
-				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
-				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32}},
-		}}
-}
-
-func getRoots() []logProofTestVector {
-	return []logProofTestVector{
-		{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
-		{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
-		{dh("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"), 32},
-		{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32},
-		{dh("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"), 32},
-		{dh("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"), 32},
-		{dh("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"), 32},
-		{dh("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"), 32}}
-}
-
-type consistencyTestVector struct {
-	snapshot1, snapshot2, proofLen int64
-	proof                          [3]logProofTestVector
-}
-
-func getConsistencyProofs() []consistencyTestVector {
-	return []consistencyTestVector{
-		{1, 1, 0, [3]logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
-		{1,
-			8,
-			3,
-			[3]logProofTestVector{
-				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
-				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
-				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
-		{6,
-			8,
-			3,
-			[3]logProofTestVector{
-				{dh("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"), 32},
-				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
-				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
-		{2,
-			5,
-			2,
-			[3]logProofTestVector{
-				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
-				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
-				{dh(""), 0}}},
-	}
-}
-
 func TestVerifyInclusionProof(t *testing.T) {
 	v := getVerifier()
 	path := [][]byte{}
@@ -330,24 +318,19 @@ func TestVerifyInclusionProof(t *testing.T) {
 		t.Fatal("Incorrectly verified invalid path 4")
 	}
 
-	if err := v.VerifyInclusionProof(0, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(0, 0, path, sha256EmptyTreeHash, []byte{}); err == nil {
 		t.Fatal("Incorrectly verified invalid root 1")
 	}
-	if err := v.VerifyInclusionProof(0, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(0, 1, path, sha256EmptyTreeHash, []byte{}); err == nil {
 		t.Fatal("Incorrectly verified invalid root 2")
 	}
-	if err := v.VerifyInclusionProof(1, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(1, 0, path, sha256EmptyTreeHash, []byte{}); err == nil {
 		t.Fatal("Incorrectly verified invalid root 3")
 	}
-	if err := v.VerifyInclusionProof(2, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+	if err := v.VerifyInclusionProof(2, 1, path, sha256EmptyTreeHash, []byte{}); err == nil {
 		t.Fatal("Incorrectly verified invalid root 4")
 	}
 
-	// Known good paths.
-
-	inclusionProofs := getInclusionTestVector()
-	inputs := getInputs()
-	roots := getRoots()
 	// i = 0 is an invalid path.
 	for i := 1; i < 6; i++ {
 		// Construct the path.
@@ -357,7 +340,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		}
 		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
 			roots[inclusionProofs[i].snapshot-1].h,
-			inputs[inclusionProofs[i].leaf-1].h)
+			leaves[inclusionProofs[i].leaf-1].h)
 		if err != nil {
 			t.Fatalf("i=%d: %s", i, err)
 		}
@@ -397,7 +380,7 @@ func TestVerifyConsistencyProof(t *testing.T) {
 		t.Fatal("Incorrectly verified timetravelling proof")
 	}
 
-	root1 = dh(sha256EmptyTreeHash)
+	root1 = sha256EmptyTreeHash
 	// Roots don't match.
 	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
 		t.Fatal("Incorrectly verified mismatched root")
@@ -407,8 +390,8 @@ func TestVerifyConsistencyProof(t *testing.T) {
 	}
 
 	// Roots match but the proof is not empty.
-	root2 = dh(sha256EmptyTreeHash)
-	proof = [][]byte{dh(sha256EmptyTreeHash)}
+	root2 = sha256EmptyTreeHash
+	proof = [][]byte{sha256EmptyTreeHash}
 
 	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
 		t.Fatal("Incorrectly verified non-empty proof")
@@ -420,16 +403,13 @@ func TestVerifyConsistencyProof(t *testing.T) {
 		t.Fatal("Incorrectly verified non-empty proof")
 	}
 
-	// Known good proofs.
-	roots := getRoots()
-	proofs := getConsistencyProofs()
 	for i := 0; i < 4; i++ {
 		proof := [][]byte{}
-		for j := int64(0); j < proofs[i].proofLen; j++ {
-			proof = append(proof, proofs[i].proof[j].h)
+		for j := int64(0); j < consistencyProofs[i].proofLen; j++ {
+			proof = append(proof, consistencyProofs[i].proof[j].h)
 		}
-		snapshot1 := proofs[i].snapshot1
-		snapshot2 := proofs[i].snapshot2
+		snapshot1 := consistencyProofs[i].snapshot1
+		snapshot2 := consistencyProofs[i].snapshot2
 		err := verifierConsistencyCheck(&v, snapshot1, snapshot2,
 			roots[snapshot1-1].h,
 			roots[snapshot2-1].h, proof)

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -1,0 +1,448 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merkle
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/trillian/crypto"
+)
+
+const (
+	sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
+	// Verify original inclusion proof
+	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+	if err != nil {
+		return err
+	}
+	if want := root; !bytes.Equal(got, want) {
+		return fmt.Errorf("got root:\n%x\nexpected:\n%x", got, want)
+	}
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err != nil {
+		return err
+	}
+
+	// Wrong leaf index
+	if err := v.VerifyInclusionProof(leafIndex-1, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex - 1")
+	}
+	if err := v.VerifyInclusionProof(leafIndex+1, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex + 1")
+	}
+	if err := v.VerifyInclusionProof(leafIndex^2, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex ^ 2")
+	}
+
+	// Wrong tree height
+	if err := v.VerifyInclusionProof(leafIndex, treeSize*2, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against treeSize * 2")
+	}
+	if err := v.VerifyInclusionProof(leafIndex, treeSize/2, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against treeSize / 2")
+	}
+
+	// Wrong leaf
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, []byte("WrongLeaf")); err == nil {
+		return errors.New("incorrectly verified against WrongLeaf")
+	}
+
+	// Wrong root
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, dh(sha256EmptyTreeHash), leaf); err == nil {
+		return errors.New("incorrectly verified against empty root hash")
+	}
+
+	// Wrong inclusion proofs
+
+	// Modify single element of the proof
+	for i := 0; i < len(proof); i++ {
+		tmp := proof[i]
+		proof[i] = dh(sha256EmptyTreeHash)
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err == nil {
+			return errors.New("incorrectly verified against incorrect inclusion proof")
+		}
+		proof[i] = tmp
+	}
+
+	// Add garbage at the end
+	wrongProof := append(proof, []byte(""))
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with trailing garbage")
+	}
+
+	wrongProof = append(proof, root)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with trailing root")
+	}
+
+	if len(proof) > 0 {
+		// Remove a node from the end
+		wrongProof = proof[:len(proof)-1]
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+			return errors.New("incorrectly verified against truncated proof")
+		}
+	}
+
+	// Add garbage at the front
+	wrongProof = append([][]byte{{}}, proof...)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	wrongProof = append([][]byte{root}, proof...)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	return nil
+}
+
+func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
+	// Verify original consistency proof
+	err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, root2, proof)
+	if err != nil {
+		return err
+	}
+
+	if len(proof) == 0 {
+		// For simplicity test only non-trivial proofs that have root1 != root2
+		// snapshot1 != 0 and snapshot1 != snapshot2.
+		return nil
+	}
+
+	// Wrong snapshot index
+	if err := v.VerifyConsistencyProof(snapshot1-1, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1-1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1+1, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1+1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1^2, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1^2")
+	}
+
+	// Wrong tree height
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2*2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot2*2")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2/2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot2/2")
+	}
+
+	// Wrong root
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, []byte("WrongRoot"), root2, proof); err == nil {
+		return errors.New("incorrectly verified against wrong root1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, []byte("WrongRoot"), proof); err == nil {
+		return errors.New("incorrectly verified against wrong root2")
+	}
+	// Swap roots
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2*2, root2, root1, proof); err == nil {
+		return errors.New("incorrectly verified against swapped roots")
+	}
+
+	// Wrong consistency proofs
+	// Empty proof
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, [][]byte{}); err == nil {
+		return errors.New("incorrectly verified against empty proof")
+	}
+
+	// Modify single element of the proof
+	for i := 0; i < len(proof); i++ {
+		tmp := proof[i]
+		proof[i] = dh(sha256EmptyTreeHash)
+		if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, proof); err == nil {
+			return errors.New("incorrectly verified against incorrect consistency proof")
+		}
+		proof[i] = tmp
+	}
+
+	// Add garbage at the end
+	wrongProof := append(proof, []byte(""))
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with trailing garbage")
+	}
+
+	wrongProof = append(proof, root1)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with trailing root")
+	}
+
+	// Remove a node from the end
+	wrongProof = proof[:len(proof)-1]
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against truncated proof")
+	}
+
+	// Add garbage at the front
+	wrongProof = append([][]byte{{}}, proof...)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	wrongProof = append([][]byte{proof[0]}, proof...)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	return nil
+}
+
+func getVerifier() LogVerifier {
+	hasher := NewRFC6962TreeHasher(crypto.NewSHA256())
+	return NewLogVerifier(hasher)
+}
+
+type logProofTestVector struct {
+	h []byte
+	l int
+}
+
+type inclusionProofTestVector struct {
+	leaf, snapshot, proofLength int64
+	proof                       []logProofTestVector
+}
+
+func getInputs() []logProofTestVector {
+	return []logProofTestVector{
+		{dh(""), 0},
+		{dh("00"), 1},
+		{dh("10"), 1},
+		{dh("2021"), 2},
+		{dh("3031"), 2},
+		{dh("40414243"), 4},
+		{dh("5051525354555657"), 8},
+		{dh("606162636465666768696a6b6c6d6e6f"), 16},
+	}
+}
+
+func getInclusionTestVector() []inclusionProofTestVector {
+	return []inclusionProofTestVector{
+		{0, 0, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1, 1, 0, []logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[]logProofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[]logProofTestVector{
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{3,
+			3,
+			1,
+			[]logProofTestVector{
+				{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+				{dh(""), 0},
+				{dh(""), 0}}},
+		{2,
+			5,
+			3,
+			[]logProofTestVector{
+				{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32}},
+		}}
+}
+
+func getRoots() []logProofTestVector {
+	return []logProofTestVector{
+		{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+		{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+		{dh("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"), 32},
+		{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32},
+		{dh("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"), 32},
+		{dh("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"), 32},
+		{dh("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"), 32},
+		{dh("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"), 32}}
+}
+
+type consistencyTestVector struct {
+	snapshot1, snapshot2, proofLen int64
+	proof                          [3]logProofTestVector
+}
+
+func getConsistencyProofs() []consistencyTestVector {
+	return []consistencyTestVector{
+		{1, 1, 0, [3]logProofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[3]logProofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[3]logProofTestVector{
+				{dh("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{2,
+			5,
+			2,
+			[3]logProofTestVector{
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh(""), 0}}},
+	}
+}
+
+func TestVerifyInclusionProof(t *testing.T) {
+	v := getVerifier()
+	path := [][]byte{}
+	// Various invalid paths
+	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 1")
+	}
+	if err := v.VerifyInclusionProof(0, 1, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 2")
+	}
+	if err := v.VerifyInclusionProof(1, 0, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 3")
+	}
+	if err := v.VerifyInclusionProof(2, 1, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 4")
+	}
+
+	if err := v.VerifyInclusionProof(0, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 1")
+	}
+	if err := v.VerifyInclusionProof(0, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 2")
+	}
+	if err := v.VerifyInclusionProof(1, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 3")
+	}
+	if err := v.VerifyInclusionProof(2, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 4")
+	}
+
+	// Known good paths.
+
+	inclusionProofs := getInclusionTestVector()
+	inputs := getInputs()
+	roots := getRoots()
+	// i = 0 is an invalid path.
+	for i := 1; i < 6; i++ {
+		// Construct the path.
+		proof := [][]byte{}
+		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
+			proof = append(proof, inclusionProofs[i].proof[j].h)
+		}
+		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
+			roots[inclusionProofs[i].snapshot-1].h,
+			inputs[inclusionProofs[i].leaf-1].h)
+		if err != nil {
+			t.Fatalf("i=%d: %s", i, err)
+		}
+	}
+
+}
+
+func TestVerifyConsistencyProof(t *testing.T) {
+	v := getVerifier()
+
+	proof := [][]byte{}
+	root1 := []byte("don't care")
+	root2 := []byte("don't care")
+
+	// Snapshots that are always consistent
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+	if err := verifierConsistencyCheck(&v, 0, 1, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+
+	// Invalid consistency proofs.
+	// Time travel to the past.
+	if err := verifierConsistencyCheck(&v, 1, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+	if err := verifierConsistencyCheck(&v, 2, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+
+	// Empty proof
+	if err := verifierConsistencyCheck(&v, 1, 2, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+
+	root1 = dh(sha256EmptyTreeHash)
+	// Roots don't match.
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified mismatched root")
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified mismatched root")
+	}
+
+	// Roots match but the proof is not empty.
+	root2 = dh(sha256EmptyTreeHash)
+	proof = [][]byte{dh(sha256EmptyTreeHash)}
+
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+	if err := verifierConsistencyCheck(&v, 0, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+
+	// Known good proofs.
+	roots := getRoots()
+	proofs := getConsistencyProofs()
+	for i := 0; i < 4; i++ {
+		proof := [][]byte{}
+		for j := int64(0); j < proofs[i].proofLen; j++ {
+			proof = append(proof, proofs[i].proof[j].h)
+		}
+		snapshot1 := proofs[i].snapshot1
+		snapshot2 := proofs[i].snapshot2
+		err := verifierConsistencyCheck(&v, snapshot1, snapshot2,
+			roots[snapshot1-1].h,
+			roots[snapshot2-1].h, proof)
+		if err != nil {
+			t.Fatalf("Failed to verify known good proof for i=%d: %s", i, err)
+		}
+	}
+}
+
+func dh(h string) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestVerifyMapInclusionProofWorks(t *testing.T) {
 	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
-	for i, tv := range inclusionProofTestVector {
+	for i, tv := range mapInclusionTestVector {
 		index := testonly.HashKey(tv.Key)
 		if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err != nil {
 			t.Errorf("(test %d) proof verification failed: %v", i, err)
@@ -33,7 +33,7 @@ func TestVerifyMapInclusionProofWorks(t *testing.T) {
 
 func TestVerifyMapInclusionProofCatchesWrongKey(t *testing.T) {
 	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
-	tv := inclusionProofTestVector[0]
+	tv := mapInclusionTestVector[0]
 	tv.Key = "wibble"
 	index := testonly.HashKey(tv.Key)
 	if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err == nil {
@@ -43,7 +43,7 @@ func TestVerifyMapInclusionProofCatchesWrongKey(t *testing.T) {
 
 func TestVerifyMapInclusionProofCatchesWrongValue(t *testing.T) {
 	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
-	tv := inclusionProofTestVector[0]
+	tv := mapInclusionTestVector[0]
 	tv.Value = []byte("wibble")
 	index := testonly.HashKey(tv.Key)
 	if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err == nil {
@@ -53,7 +53,7 @@ func TestVerifyMapInclusionProofCatchesWrongValue(t *testing.T) {
 
 func TestVerifyMapInclusionProofCatchesWrongRoot(t *testing.T) {
 	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
-	tv := inclusionProofTestVector[0]
+	tv := mapInclusionTestVector[0]
 	tv.ExpectedRoot = h.Digest([]byte("wibble"))
 	index := testonly.HashKey(tv.Key)
 	if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err == nil {
@@ -63,7 +63,7 @@ func TestVerifyMapInclusionProofCatchesWrongRoot(t *testing.T) {
 
 func TestVerifyMapInclusionProofCatchesWrongProof(t *testing.T) {
 	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
-	tv := inclusionProofTestVector[0]
+	tv := mapInclusionTestVector[0]
 	tv.Proof[250][15] ^= 0x10
 	index := testonly.HashKey(tv.Key)
 	if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err == nil {
@@ -120,7 +120,7 @@ func TestVerifyMapInclusionProofRejectsInvalidRoot(t *testing.T) {
 }
 
 // Testdata produced with python
-var inclusionProofTestVector = []struct {
+var mapInclusionTestVector = []struct {
 	Key          string
 	Value        []byte
 	Proof        [][]byte


### PR DESCRIPTION
Copy the log verifier from Certificate Transparency and remove anything related to x509.

Also renamed a few things in the map tests to avoid naming collisions. 

Work towards #297 