### PR TITLE
Move t.Fatalf into RunIntegrationTest

### DIFF
--- a/integration/map.go
+++ b/integration/map.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"testing"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
@@ -29,16 +30,16 @@ import (
 )
 
 // RunMapIntegration runs a map integration test using the given map ID and client.
-func RunMapIntegration(ctx context.Context, mapID int64, client trillian.TrillianMapClient) error {
+func RunMapIntegration(ctx context.Context, t *testing.T, mapID int64, client trillian.TrillianMapClient) {
 	{
 		// Ensure we're starting with an empty map
 		r, err := client.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{MapId: mapID})
 		if err != nil {
-			return fmt.Errorf("failed to get empty map head: %v", err)
+			t.Fatalf("failed to get empty map head: %v", err)
 		}
 
 		if got, want := r.MapRoot.MapRevision, int64(0); got != want {
-			return fmt.Errorf("got SMH with revision %d, expected %d", got, want)
+			t.Fatalf("got SMH with revision %d, expected %d", got, want)
 		}
 	}
 
@@ -75,14 +76,14 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 
 			resp, err := client.SetLeaves(ctx, req)
 			if err != nil {
-				return fmt.Errorf("failed to write batch %d: %v", x, err)
+				t.Fatalf("failed to write batch %d: %v", x, err)
 			}
 			glog.Infof("Set %d k/v pairs", len(req.KeyValue))
 			root = resp.MapRoot.RootHash
 			rev++
 		}
 		if expected, got := testonly.MustDecodeBase64(expectedRootB64), root; !bytes.Equal(expected, root) {
-			return fmt.Errorf("expected root %s, got root: %s", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
+			t.Fatalf("expected root %s, got root: %s", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
 
@@ -91,14 +92,14 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 		// Check your head
 		r, err := client.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{MapId: mapID})
 		if err != nil {
-			return fmt.Errorf("failed to get map head: %v", err)
+			t.Fatalf("failed to get map head: %v", err)
 		}
 
 		if got, want := r.MapRoot.MapRevision, int64(numBatches); got != want {
-			return fmt.Errorf("got SMH with revision %d, expected %d", got, want)
+			t.Fatalf("got SMH with revision %d, expected %d", got, want)
 		}
 		if expected, got := testonly.MustDecodeBase64(expectedRootB64), r.MapRoot.RootHash; !bytes.Equal(expected, got) {
-			return fmt.Errorf("expected root %s, got root: %s", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
+			t.Fatalf("expected root %s, got root: %s", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 		glog.Infof("Got expected roothash@%d: %s", r.MapRoot.MapRevision, base64.StdEncoding.EncodeToString(r.MapRoot.RootHash))
 		latestRoot = *r.MapRoot
@@ -124,18 +125,18 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 			}
 			r, err := client.GetLeaves(ctx, &getReq)
 			if err != nil {
-				return fmt.Errorf("failed to get values: %v", err)
+				t.Fatalf("failed to get values: %v", err)
 			}
 			if got, want := len(r.KeyValue), len(getReq.Key); got != want {
-				return fmt.Errorf("got %d values, expected %d", got, want)
+				t.Fatalf("got %d values, expected %d", got, want)
 			}
 			for _, kv := range r.KeyValue {
 				ev := expectedValues[string(kv.KeyValue.Key)]
 				if ev == nil {
-					return fmt.Errorf("unexpected key returned: %v", string(kv.KeyValue.Key))
+					t.Fatalf("unexpected key returned: %v", string(kv.KeyValue.Key))
 				}
 				if got, want := ev, kv.KeyValue.Value.LeafValue; !bytes.Equal(got, want) {
-					return fmt.Errorf("got value %x, expected %x", got, want)
+					t.Fatalf("got value %x, expected %x", got, want)
 				}
 				keyHash := h.HashKey(kv.KeyValue.Key)
 				leafHash := h.HashLeaf(kv.KeyValue.Value.LeafValue)
@@ -144,15 +145,14 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 					proof[i] = v
 				}
 				if err := merkle.VerifyMapInclusionProof(keyHash, leafHash, latestRoot.RootHash, proof, h); err != nil {
-					return fmt.Errorf("inclusion proof failed to verify for key %s: %v", kv.KeyValue.Key, err)
+					t.Fatalf("inclusion proof failed to verify for key %s: %v", kv.KeyValue.Key, err)
 				}
 				delete(expectedValues, string(kv.KeyValue.Key))
 			}
 		}
 		if got := len(expectedValues); got != 0 {
-			return fmt.Errorf("still have %d unmatched expected values remaining", got)
+			t.Fatalf("still have %d unmatched expected values remaining", got)
 		}
 
 	}
-	return nil
 }

--- a/integration/map_integration_test.go
+++ b/integration/map_integration_test.go
@@ -46,7 +46,5 @@ func TestMapIntegration(t *testing.T) {
 	}
 	defer conn.Close()
 	ctx := context.Background()
-	if err := RunMapIntegration(ctx, *mapID, client); err != nil {
-		t.Fatalf("Test failed: %v", err)
-	}
+	RunMapIntegration(ctx, t, *mapID, client)
 }


### PR DESCRIPTION
Failures will now also contain line numbers to facilitate easier debugging