### PR TITLE
Move treeID parameter from GetStorage methods to tx.Begin / tx.Snapshot

### DIFF
--- a/extension/builtin/default_registry.go
+++ b/extension/builtin/default_registry.go
@@ -20,14 +20,12 @@ type defaultRegistry struct {
 	db *sql.DB
 }
 
-// TODO(codingllama): Get rid of the error return
-func (r defaultRegistry) GetLogStorage(treeID int64) (storage.LogStorage, error) {
-	return mysql.NewLogStorage(treeID, r.db)
+func (r *defaultRegistry) GetLogStorage() (storage.LogStorage, error) {
+	return mysql.NewLogStorage(r.db)
 }
 
-// TODO(codingllama): Get rid of the error return
-func (r defaultRegistry) GetMapStorage(treeID int64) (storage.MapStorage, error) {
-	return mysql.NewMapStorage(treeID, r.db)
+func (r *defaultRegistry) GetMapStorage() (storage.MapStorage, error) {
+	return mysql.NewMapStorage(r.db)
 }
 
 // NewDefaultExtensionRegistry returns the default extension.Registry implementation, which is

--- a/extension/mock_registry.go
+++ b/extension/mock_registry.go
@@ -29,24 +29,24 @@ func (_m *MockRegistry) EXPECT() *_MockRegistryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockRegistry) GetLogStorage(_param0 int64) (storage.LogStorage, error) {
-	ret := _m.ctrl.Call(_m, "GetLogStorage", _param0)
+func (_m *MockRegistry) GetLogStorage() (storage.LogStorage, error) {
+	ret := _m.ctrl.Call(_m, "GetLogStorage")
 	ret0, _ := ret[0].(storage.LogStorage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRegistryRecorder) GetLogStorage(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLogStorage", arg0)
+func (_mr *_MockRegistryRecorder) GetLogStorage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLogStorage")
 }
 
-func (_m *MockRegistry) GetMapStorage(_param0 int64) (storage.MapStorage, error) {
-	ret := _m.ctrl.Call(_m, "GetMapStorage", _param0)
+func (_m *MockRegistry) GetMapStorage() (storage.MapStorage, error) {
+	ret := _m.ctrl.Call(_m, "GetMapStorage")
 	ret0, _ := ret[0].(storage.MapStorage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRegistryRecorder) GetMapStorage(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMapStorage", arg0)
+func (_mr *_MockRegistryRecorder) GetMapStorage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMapStorage")
 }

--- a/extension/registry.go
+++ b/extension/registry.go
@@ -25,9 +25,9 @@ type Registry interface {
 
 	// GetLogStorage returns a configured storage.LogStorage instance for the specified tree ID or an
 	// error if the storage cannot be set up.
-	GetLogStorage(treeID int64) (storage.LogStorage, error)
+	GetLogStorage() (storage.LogStorage, error)
 
 	// GetMapStorage returns a configured storage.MapStorage instance for the specified tree ID or an
 	// error if the storage cannot be set up.
-	GetMapStorage(treeID int64) (storage.MapStorage, error)
+	GetMapStorage() (storage.MapStorage, error)
 }

--- a/integration/ct_integration_test.sh
+++ b/integration/ct_integration_test.sh
@@ -19,8 +19,9 @@ BASE_RPC_PORT=36961
 BASE_HTTP_PORT=6961
 LB_PORT=46962
 
+port=${BASE_RPC_PORT}
 for ((i=0; i < RPC_SERVER_COUNT; i++)); do
-  port=$((BASE_RPC_PORT + i))
+  port=$((port + 2))
   if [[ $i -eq 0 ]]; then
     RPC_PORTS="${port}"
     RPC_SERVERS="localhost:${port}"
@@ -30,8 +31,9 @@ for ((i=0; i < RPC_SERVER_COUNT; i++)); do
   fi
 done
 
+port=${BASE_HTTP_PORT}
 for ((i=0; i < HTTP_SERVER_COUNT; i++)); do
-  port=$((BASE_HTTP_PORT + i))
+  port=$((port + 1))
   if [[ $i -eq 0 ]]; then
     CT_PORTS="${port}"
     CT_SERVERS="localhost:${port}"

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -93,9 +93,7 @@ func NewLogOperationManagerForTest(ctx context.Context, registry extension.Regis
 }
 
 func (l LogOperationManager) getLogsAndExecutePass(ctx context.Context) bool {
-	// TODO(Martin2112) using log ID zero because we don't have an id for metadata ops
-	// this API could improved
-	provider, err := l.context.registry.GetLogStorage(0)
+	provider, err := l.context.registry.GetLogStorage()
 
 	// If we get an error, we can't do anything but wait until the next run through
 	if err != nil {
@@ -103,7 +101,8 @@ func (l LogOperationManager) getLogsAndExecutePass(ctx context.Context) bool {
 		return false
 	}
 
-	tx, err := provider.Begin(ctx)
+	// TODO(codingllama): A treeID shouldn't be necessary here
+	tx, err := provider.Begin(ctx, 0)
 
 	if err != nil {
 		glog.Warningf("Failed to get tx for run: %v", err)

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -32,7 +32,8 @@ func TestLogOperationManagerBeginFails(t *testing.T) {
 
 	mockTx := storage.NewMockLogTX(ctrl)
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, errors.New("TX"))
+	// TODO(codingllama): A treeID shouldn't be necessary here
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, errors.New("TX"))
 
 	mockLogOp := NewMockLogOperation(ctrl)
 
@@ -50,7 +51,8 @@ func TestLogOperationManagerGetLogsFails(t *testing.T) {
 	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{}, errors.New("getactivelogs"))
 	mockTx.EXPECT().Rollback().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): A treeID shouldn't be necessary here
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 
 	mockLogOp := NewMockLogOperation(ctrl)
 
@@ -68,7 +70,8 @@ func TestLogOperationManagerCommitFails(t *testing.T) {
 	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("commit"))
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): A treeID shouldn't be necessary here
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 
 	mockLogOp := NewMockLogOperation(ctrl)
 
@@ -105,7 +108,8 @@ func TestLogOperationManagerPassesIDs(t *testing.T) {
 	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{logID1, logID2}, nil)
 	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): A treeID shouldn't be necessary here
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 
 	mockLogOp := NewMockLogOperation(ctrl)
 	mockLogOp.EXPECT().ExecutePass([]int64{logID1, logID2}, logOpMgrContextMatcher{50}).Return(false)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -398,12 +398,12 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 }
 
 func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int64) (storage.LogTX, error) {
-	s, err := t.registry.GetLogStorage(treeID)
+	s, err := t.registry.GetLogStorage()
 	if err != nil {
 		return nil, err
 	}
 
-	tx, err := s.Begin(ctx)
+	tx, err := s.Begin(ctx, treeID)
 	if err != nil {
 		return nil, err
 	}
@@ -412,12 +412,12 @@ func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int6
 }
 
 func (t *TrillianLogRPCServer) prepareReadOnlyStorageTx(ctx context.Context, treeID int64) (storage.ReadOnlyLogTX, error) {
-	s, err := t.registry.GetLogStorage(treeID)
+	s, err := t.registry.GetLogStorage()
 	if err != nil {
 		return nil, err
 	}
 
-	tx, err := s.Snapshot(ctx)
+	tx, err := s.Snapshot(ctx, treeID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -66,7 +66,7 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 		// so deferring it
 		storage, err := s.registry.GetLogStorage()
 		if err != nil {
-			glog.Warningf("%s: failed acquiring log storage: %v", logID, err)
+			glog.Warningf("%s: failed to acquire log storage: %v", logID, err)
 			continue
 		}
 		ctx := util.NewLogContext(logctx.ctx, logID)

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -62,15 +62,14 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 		default:
 		}
 
-		storage, err := s.registry.GetLogStorage(logID)
-		ctx := util.NewLogContext(logctx.ctx, logID)
-
 		// TODO(Martin2112): Honor the sequencing enabled in log parameters, needs an API change
 		// so deferring it
+		storage, err := s.registry.GetLogStorage()
 		if err != nil {
-			glog.Warningf("%s: Storage provider failed for id because: %v", util.LogIDPrefix(ctx), err)
+			glog.Warningf("%s: failed acquiring log storage: %v", logID, err)
 			continue
 		}
+		ctx := util.NewLogContext(logctx.ctx, logID)
 
 		// TODO(Martin2112): Allow for different tree hashers to be used by different logs
 		sequencer := log.NewSequencer(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()), logctx.timeSource, storage, s.keyManager)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -104,7 +103,8 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockTx := storage.NewMockLogTX(mockCtrl)
 	logID := int64(1)
 
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): Do we need a logID here?
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
@@ -139,7 +139,8 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().UpdateSequencedLeaves([]trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(updatedNodes0).Return(nil)
 	mockTx.EXPECT().StoreSignedLogRoot(updatedRoot).Return(nil)
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): Do we need a logID here?
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 
 	mockSigner := crypto.NewMockSigner(mockCtrl)
 	mockSigner.EXPECT().Sign(gomock.Any(), []byte{23, 147, 61, 51, 131, 170, 136, 10, 82, 12, 93, 42, 98, 88, 131, 100, 101, 187, 124, 189, 202, 207, 66, 137, 95, 117, 205, 34, 109, 242, 103, 248}, hasher).Return([]byte("signed"), nil)
@@ -159,7 +160,8 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	mockTx := storage.NewMockLogTX(mockCtrl)
 	logID := int64(1)
 
-	mockStorage.EXPECT().Begin(gomock.Any()).Return(mockTx, nil)
+	// TODO(codingllama): Do we need a logID here?
+	mockStorage.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
@@ -174,11 +176,8 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 }
 
 func mockStorageProviderForSequencer(mockStorage storage.LogStorage) testonly.GetLogStorageFunc {
-	return func(id int64) (storage.LogStorage, error) {
-		if id >= 0 && id <= 1 {
-			return mockStorage, nil
-		}
-		return nil, fmt.Errorf("BADLOGID: %d", id)
+	return func() (storage.LogStorage, error) {
+		return mockStorage, nil
 	}
 }
 

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -37,6 +37,7 @@ var sequencerGuardWindowFlag = flag.Duration("sequencer_guard_window", 0, "If se
 var privateKeyFile = flag.String("private_key_file", "", "File containing a PEM encoded private key")
 var privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
 
+// TODO(codingllama): Consider moving to server creation
 func checkDatabaseAccessible(registry extension.Registry) error {
 	logStorage, err := registry.GetLogStorage()
 	if err != nil {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -38,15 +38,14 @@ var privateKeyFile = flag.String("private_key_file", "", "File containing a PEM 
 var privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
 
 func checkDatabaseAccessible(registry extension.Registry) error {
-	// TODO(Martin2112): Have to pass a tree ID when we just want metadata. API mismatch
-	logStorage, err := registry.GetLogStorage(int64(0))
+	logStorage, err := registry.GetLogStorage()
 	if err != nil {
-		// This is probably something fundamentally wrong
 		return err
 	}
 
+	// TODO(codingllama): A treeID shouldn't be necessary here
 	ctx := context.TODO()
-	tx, err := logStorage.Begin(ctx)
+	tx, err := logStorage.Begin(ctx, 0)
 	if err != nil {
 		// Out of resources maybe?
 		return err

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -33,6 +33,7 @@ var httpPortFlag = flag.Int("http_port", 8091, "Port to serve HTTP metrics on")
 var privateKeyFile = flag.String("private_key_file", "", "File containing a PEM encoded private key")
 var privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
 
+// TODO(codingllama): Consider moving to server creation
 func checkDatabaseAccessible(registry extension.Registry) error {
 	mapStorage, err := registry.GetMapStorage()
 	if err != nil {

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -34,15 +34,15 @@ var privateKeyFile = flag.String("private_key_file", "", "File containing a PEM 
 var privateKeyPassword = flag.String("private_key_password", "", "Password for server private key")
 
 func checkDatabaseAccessible(registry extension.Registry) error {
-	// TODO(Martin2112): Have to pass a tree ID when we just want metadata. API mismatch
-	mapStorage, err := registry.GetMapStorage(int64(0))
+	mapStorage, err := registry.GetMapStorage()
 	if err != nil {
 		// This is probably something fundamentally wrong
 		return err
 	}
 
+	// TODO(codingllama): We shouldn't use a mapID here
 	ctx := context.TODO()
-	tx, err := mapStorage.Begin(ctx)
+	tx, err := mapStorage.Begin(ctx, 0)
 	if err != nil {
 		// Out of resources maybe?
 		return err

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -48,7 +48,7 @@ type ReadOnlyLogStorage interface {
 	// Commit must be called when the caller is finished with the returned object,
 	// and values read through it should only be propagated if Commit returns
 	// without error.
-	Snapshot(ctx context.Context) (ReadOnlyLogTX, error)
+	Snapshot(ctx context.Context, treeID int64) (ReadOnlyLogTX, error)
 }
 
 // LogStorage should be implemented by concrete storage mechanisms which want to support Logs.
@@ -59,7 +59,7 @@ type LogStorage interface {
 	// Either Commit or Rollback must be called when the caller is finished with
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
-	Begin(ctx context.Context) (LogTX, error)
+	Begin(ctx context.Context, treeID int64) (LogTX, error)
 }
 
 // LeafQueuer provides a write-only interface for the queueing (but not necessarily integration) of leaves.

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -45,10 +45,7 @@ type ReadOnlyMapStorage interface {
 	// Commit must be called when the caller is finished with the returned object,
 	// and values read through it should only be propagated if Commit returns
 	// without error.
-	Snapshot(ctx context.Context) (ReadOnlyMapTX, error)
-
-	// Returns the MapID this storage relates to.
-	MapID() int64
+	Snapshot(ctx context.Context, treeID int64) (ReadOnlyMapTX, error)
 }
 
 // MapStorage should be implemented by concrete storage mechanisms which want to support Maps
@@ -58,7 +55,7 @@ type MapStorage interface {
 	// Either Commit or Rollback must be called when the caller is finished with
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
-	Begin(ctx context.Context) (MapTX, error)
+	Begin(ctx context.Context, treeID int64) (MapTX, error)
 }
 
 // Setter allows the setting of key->value pairs on the map.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -562,36 +562,26 @@ func (_m *MockMapStorage) EXPECT() *_MockMapStorageRecorder {
 	return _m.recorder
 }
 
-func (_m *MockMapStorage) Begin(_param0 context.Context) (MapTX, error) {
-	ret := _m.ctrl.Call(_m, "Begin", _param0)
+func (_m *MockMapStorage) Begin(_param0 context.Context, _param1 int64) (MapTX, error) {
+	ret := _m.ctrl.Call(_m, "Begin", _param0, _param1)
 	ret0, _ := ret[0].(MapTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMapStorageRecorder) Begin(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Begin", arg0)
+func (_mr *_MockMapStorageRecorder) Begin(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Begin", arg0, arg1)
 }
 
-func (_m *MockMapStorage) MapID() int64 {
-	ret := _m.ctrl.Call(_m, "MapID")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-func (_mr *_MockMapStorageRecorder) MapID() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MapID")
-}
-
-func (_m *MockMapStorage) Snapshot(_param0 context.Context) (ReadOnlyMapTX, error) {
-	ret := _m.ctrl.Call(_m, "Snapshot", _param0)
+func (_m *MockMapStorage) Snapshot(_param0 context.Context, _param1 int64) (ReadOnlyMapTX, error) {
+	ret := _m.ctrl.Call(_m, "Snapshot", _param0, _param1)
 	ret0, _ := ret[0].(ReadOnlyMapTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMapStorageRecorder) Snapshot(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Snapshot", arg0)
+func (_mr *_MockMapStorageRecorder) Snapshot(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Snapshot", arg0, arg1)
 }
 
 // Mock of LogStorage interface
@@ -615,24 +605,24 @@ func (_m *MockLogStorage) EXPECT() *_MockLogStorageRecorder {
 	return _m.recorder
 }
 
-func (_m *MockLogStorage) Begin(_param0 context.Context) (LogTX, error) {
-	ret := _m.ctrl.Call(_m, "Begin", _param0)
+func (_m *MockLogStorage) Begin(_param0 context.Context, _param1 int64) (LogTX, error) {
+	ret := _m.ctrl.Call(_m, "Begin", _param0, _param1)
 	ret0, _ := ret[0].(LogTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogStorageRecorder) Begin(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Begin", arg0)
+func (_mr *_MockLogStorageRecorder) Begin(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Begin", arg0, arg1)
 }
 
-func (_m *MockLogStorage) Snapshot(_param0 context.Context) (ReadOnlyLogTX, error) {
-	ret := _m.ctrl.Call(_m, "Snapshot", _param0)
+func (_m *MockLogStorage) Snapshot(_param0 context.Context, _param1 int64) (ReadOnlyLogTX, error) {
+	ret := _m.ctrl.Call(_m, "Snapshot", _param0, _param1)
 	ret0, _ := ret[0].(ReadOnlyLogTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogStorageRecorder) Snapshot(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Snapshot", arg0)
+func (_mr *_MockLogStorageRecorder) Snapshot(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Snapshot", arg0, arg1)
 }

--- a/storage/mysql/log_admin.go
+++ b/storage/mysql/log_admin.go
@@ -2,11 +2,6 @@ package mysql
 
 import (
 	"database/sql"
-	"fmt"
-
-	"github.com/google/trillian/crypto"
-	"github.com/google/trillian/merkle"
-	"github.com/google/trillian/storage/cache"
 )
 
 const (
@@ -31,14 +26,8 @@ const (
 // CreateTree instantiates a new log with default parameters.
 // TODO(codinglama): Move to admin API when the admin API is created.
 func CreateTree(treeID int64, db *sql.DB) error {
-	// TODO(codinglama) replace with a GetDatabase from the new extension API when LogID is removed.
-	th := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
-	m, err := newTreeStorage(treeID, db, th.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(th))
-	if err != nil {
-		return fmt.Errorf("couldn't create a new treeStorage: %s", err)
-	}
 	// Insert Tree Row
-	stmt, err := m.db.Prepare(setTreePropertiesSQL)
+	stmt, err := db.Prepare(setTreePropertiesSQL)
 	if err != nil {
 		return err
 	}
@@ -48,7 +37,7 @@ func CreateTree(treeID int64, db *sql.DB) error {
 		return err
 	}
 	// Insert Tree Control Row
-	stmt2, err := m.db.Prepare(setTreeParametersSQL)
+	stmt2, err := db.Prepare(setTreeParametersSQL)
 	if err != nil {
 		return err
 	}
@@ -62,15 +51,8 @@ func CreateTree(treeID int64, db *sql.DB) error {
 
 // DeleteTree deletes a tree by the treeID.
 func DeleteTree(treeID int64, db *sql.DB) error {
-	// TODO(codinglama) replace with a GetDatabase from the new extension API when LogID is removed.
-	th := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
-	m, err := newTreeStorage(treeID, db, th.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(th))
-	if err != nil {
-		return fmt.Errorf("couldn't create a new treeStorage: %s", err)
-	}
-
 	for _, sql := range []string{deleteTreeControlSQL, deleteTreeSQL} {
-		stmt, err := m.db.Prepare(sql)
+		stmt, err := db.Prepare(sql)
 		if err != nil {
 			return err
 		}

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -32,20 +32,16 @@ type mapIDAndTest struct {
 // Explicit test for node id conversion to / from protos.
 func TestNodeIDSerialization(t *testing.T) {
 	nodeID := storage.NodeID{Path: []byte("hello"), PrefixLenBits: 3, PathLenBits: 40}
-	serializedBytes, err := encodeNodeID(nodeID)
 
+	serializedBytes, err := encodeNodeID(nodeID)
 	if err != nil {
 		t.Fatalf("Failed to serialize NodeID: %v, %v", nodeID, err)
 	}
 
 	nodeID2, err := decodeNodeID(serializedBytes)
-
 	if err != nil {
 		t.Fatalf("Failed to deserialize NodeID: %v, %v", nodeID, err)
 	}
-
-	t.Logf("1:\n%v (%s)\n2:\n%v (%s)", nodeID, nodeID.String(), *nodeID2, nodeID2.String())
-
 	if expected, got := nodeID.String(), nodeID2.String(); expected != got {
 		t.Errorf("Round trip of nodeID failed: %v %v", expected, got)
 	}
@@ -67,7 +63,7 @@ func TestNodeRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
 	{
-		tx, err := s.Begin(ctx)
+		tx, err := s.Begin(ctx, logID.logID)
 		forceWriteRevision(writeRevision, tx)
 		if err != nil {
 			t.Fatalf("Failed to Begin: %s", err)
@@ -88,7 +84,7 @@ func TestNodeRoundTrip(t *testing.T) {
 	}
 
 	{
-		tx, err := s.Begin(ctx)
+		tx, err := s.Begin(ctx, logID.logID)
 
 		if err != nil {
 			t.Fatalf("Failed to Begin: %s", err)
@@ -225,7 +221,7 @@ func prepareTestLogStorage(db *sql.DB, logID logIDAndTest, t *testing.T) storage
 	if err := CreateTree(logID.logID, db); err != nil {
 		t.Fatalf("Failed to create new log storage: %s", err)
 	}
-	s, err := NewLogStorage(logID.logID, db)
+	s, err := NewLogStorage(db)
 	if err != nil {
 		t.Fatalf("Failed to open log storage: %s", err)
 	}

--- a/storage/tools/fetch_leaves/main.go
+++ b/storage/tools/fetch_leaves/main.go
@@ -33,36 +33,30 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	storage, err := registry.GetLogStorage(*treeIDFlag)
+	storage, err := registry.GetLogStorage()
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
-
-	tx, err := storage.Snapshot(ctx)
-
+	tx, err := storage.Snapshot(ctx, *treeIDFlag)
 	if err != nil {
 		panic(err)
 	}
 
 	leafCount, err := tx.GetSequencedLeafCount()
-
 	if err != nil {
 		panic(err)
 	}
-
 	log.Infof("Sequenced leaf count in storage is: %d", leafCount)
 
 	if len(*leafHashHex) > 0 {
 		hash, err := hex.DecodeString(*leafHashHex)
-
 		if err != nil {
 			panic(err)
 		}
 
 		fetchedLeaves, err := tx.GetLeavesByHash([][]byte{hash}, false)
-
 		if err != nil {
 			panic(err)
 		}
@@ -81,7 +75,6 @@ func main() {
 		}
 
 		fetchedLeaves, err := tx.GetLeavesByIndex(leaves)
-
 		if err != nil {
 			panic(err)
 		}
@@ -91,9 +84,7 @@ func main() {
 		}
 	}
 
-	err = tx.Commit()
-
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		panic(err)
 	}
 }

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -41,21 +41,18 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	storage, err := registry.GetLogStorage(*treeIDFlag)
+	storage, err := registry.GetLogStorage()
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
-
-	tx, err := storage.Begin(ctx)
-
+	tx, err := storage.Begin(ctx, *treeIDFlag)
 	if err != nil {
 		panic(err)
 	}
 
 	leaves := []trillian.LogLeaf{}
-
 	for l := 0; l < *numInsertionsFlag; l++ {
 		// Leaf data based in the sequence number so we can check the hashes
 		leafNumber := *startInsertFromFlag + l
@@ -84,16 +81,12 @@ func main() {
 
 	// There might be some leaves left over that didn't get queued yet
 	if len(leaves) > 0 {
-		err = tx.QueueLeaves(leaves, time.Now())
-
-		if err != nil {
+		if err := tx.QueueLeaves(leaves, time.Now()); err != nil {
 			panic(err)
 		}
 	}
 
-	err = tx.Commit()
-
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		panic(err)
 	}
 }

--- a/testonly/extension.go
+++ b/testonly/extension.go
@@ -25,36 +25,36 @@ var errNotImplemented = errors.New("not implemented")
 
 // GetLogStorageFunc returns a storage.LogStorage or fails.
 // Used as an implementation of extension.Registry.GetLogStorage in tests.
-type GetLogStorageFunc func(int64) (storage.LogStorage, error)
+type GetLogStorageFunc func() (storage.LogStorage, error)
 
 // GetMapStorageFunc returns a storage.MapStorage or fails.
 // Used as an implementation of extension.Registry.GetMapStorage in tests.
-type GetMapStorageFunc func(int64) (storage.MapStorage, error)
+type GetMapStorageFunc func() (storage.MapStorage, error)
 
 type testRegistry struct {
 	getLogStorageFunc GetLogStorageFunc
 	getMapStorageFunc GetMapStorageFunc
 }
 
-func defaultGetLogStorage(int64) (storage.LogStorage, error) {
+func defaultGetLogStorage() (storage.LogStorage, error) {
 	return nil, errNotImplemented
 }
 
-func defaultGetMapStorage(int64) (storage.MapStorage, error) {
+func defaultGetMapStorage() (storage.MapStorage, error) {
 	return nil, errNotImplemented
 }
 
-func (r testRegistry) GetLogStorage(treeID int64) (storage.LogStorage, error) {
-	return r.getLogStorageFunc(treeID)
+func (r testRegistry) GetLogStorage() (storage.LogStorage, error) {
+	return r.getLogStorageFunc()
 }
 
-func (r testRegistry) GetMapStorage(treeID int64) (storage.MapStorage, error) {
-	return r.getMapStorageFunc(treeID)
+func (r testRegistry) GetMapStorage() (storage.MapStorage, error) {
+	return r.getMapStorageFunc()
 }
 
 // NewRegistryWithLogStorage returns an extension.Registry backed by ls.
 func NewRegistryWithLogStorage(ls storage.LogStorage) extension.Registry {
-	return NewRegistryWithLogProvider(func(int64) (storage.LogStorage, error) { return ls, nil })
+	return NewRegistryWithLogProvider(func() (storage.LogStorage, error) { return ls, nil })
 }
 
 // NewRegistryWithLogProvider returns an extension.Registry whose GetLogStorage function is

--- a/util/context.go
+++ b/util/context.go
@@ -39,6 +39,15 @@ func NewMapContext(ctx context.Context, mapID int64) context.Context {
 	return context.WithValue(ctx, mapIDKey, mapID)
 }
 
+// LogID returns the log ID within the context or an error.
+func LogID(ctx context.Context) (int64, error) {
+	logID, ok := ctx.Value(logIDKey).(int64)
+	if !ok {
+		return 0, fmt.Errorf("cannot read logID from ctx: %v", ctx)
+	}
+	return logID, nil
+}
+
 // LogIDPrefix returns an identifier for the log associated with ctx in a form
 // suitable for use as a diagnostic prefix.
 func LogIDPrefix(ctx context.Context) string {

--- a/util/context.go
+++ b/util/context.go
@@ -40,6 +40,7 @@ func NewMapContext(ctx context.Context, mapID int64) context.Context {
 }
 
 // LogID returns the log ID within the context or an error.
+// TODO(codingllama): Remove LogID and use an explicit parameter
 func LogID(ctx context.Context) (int64, error) {
 	logID, ok := ctx.Value(logIDKey).(int64)
 	if !ok {

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	mapID := int64(1)
-	ms, err := mysql.NewMapStorage(mapID, db)
+	ms, err := mysql.NewMapStorage(db)
 	if err != nil {
 		glog.Fatalf("Failed create MapStorage: %v", err)
 	}
@@ -68,13 +68,13 @@ func main() {
 
 	var root []byte
 	for x := 0; x < numBatches; x++ {
-		tx, err := ms.Begin(ctx)
+		tx, err := ms.Begin(ctx, mapID)
 		if err != nil {
 			glog.Fatalf("Failed to Begin() a new tx: %v", err)
 		}
 		w, err := merkle.NewSparseMerkleTreeWriter(tx.WriteRevision(), hasher,
 			func() (storage.TreeTX, error) {
-				return ms.Begin(ctx)
+				return ms.Begin(ctx, mapID)
 			})
 		if err != nil {
 			glog.Fatalf("Failed to create new SMTWriter: %v", err)


### PR DESCRIPTION
Currently we have a storage-per-tree abstraction. This replaces that abstraction
with transaction-per-tree. A future PR will allow us to create transactions not
tied to a particular tree. An example would be not having to rely on tree #0
being present during server startup.

A few other changes made here are:
* Make sequencer read the logID from the context (sequencer instances are not
  per-tree anymore)
* Make sequencer tests use an explicit logID (the ID was buried in mocks, so it
  didn't need to / wasn't set)
* Use spread out ports in ct_integration_test (fixes some flakiness I've been
  experiencing locally).
* Added a few tests for Begin/Snapshot (some to expanded in the future)
* A few cosmetic changes (moving "if err != nil" closer to the declaration of
  err, mostly)

I'm happy to make follow up changes, but I'd like to have them addressed in
separate PRs, as much as possible. Due to the size of the refactor, the sooner
it lands the better for us all.