### PR TITLE
Remove cipher/NewHasher

### DIFF
--- a/crypto/hashers.go
+++ b/crypto/hashers.go
@@ -26,7 +26,7 @@ var hashLookup = map[trillian.HashAlgorithm]crypto.Hash{
 	trillian.HashAlgorithm_SHA256: crypto.SHA256,
 }
 
-var cipherLookup = map[crypto.Hash]trillian.HashAlgorithm{
+var reverseHashLookup = map[crypto.Hash]trillian.HashAlgorithm{
 	crypto.SHA256: trillian.HashAlgorithm_SHA256,
 }
 
@@ -34,7 +34,7 @@ var cipherLookup = map[crypto.Hash]trillian.HashAlgorithm{
 func LookupHash(hash trillian.HashAlgorithm) (crypto.Hash, error) {
 	hasher, ok := hashLookup[hash]
 	if !ok {
-		return 0, fmt.Errorf("Unsupported hash algorithm %v", hash)
+		return 0, fmt.Errorf("unsupported hash algorithm %v", hash)
 	}
 	return hasher, nil
 }

--- a/crypto/hashers.go
+++ b/crypto/hashers.go
@@ -15,46 +15,26 @@
 package crypto
 
 import (
-	gocrypto "crypto"
+	"crypto"
 	_ "crypto/sha256" // Register the SHA256 algorithm
 	"fmt"
 
 	"github.com/google/trillian"
 )
 
-// Hasher is the interface which must be implemented by hashers.
-type Hasher struct {
-	gocrypto.Hash
-	alg trillian.HashAlgorithm
+var hashLookup = map[trillian.HashAlgorithm]crypto.Hash{
+	trillian.HashAlgorithm_SHA256: crypto.SHA256,
 }
 
-// NewHasher creates a Hasher instance for the specified algorithm.
-func NewHasher(alg trillian.HashAlgorithm) (Hasher, error) {
-	switch alg {
-	case trillian.HashAlgorithm_SHA256:
-		return Hasher{gocrypto.SHA256, alg}, nil
+var cipherLookup = map[crypto.Hash]trillian.HashAlgorithm{
+	crypto.SHA256: trillian.HashAlgorithm_SHA256,
+}
+
+// LookupHash returns the go crypto hash algorithm associated with the trillian hash enum.
+func LookupHash(hash trillian.HashAlgorithm) (crypto.Hash, error) {
+	hasher, ok := hashLookup[hash]
+	if !ok {
+		return 0, fmt.Errorf("Unsupported hash algorithm %v", hash)
 	}
-	return Hasher{}, fmt.Errorf("unsupported hash algorithm %v", alg)
-}
-
-// Digest calculates the digest of b according to the underlying algorithm.
-func (h Hasher) Digest(b []byte) []byte {
-	hr := h.New()
-	hr.Write(b)
-	return hr.Sum([]byte{})
-}
-
-// NewSHA256 creates a Hasher instance for a stateless SHA256 hashing function.
-func NewSHA256() Hasher {
-	h, err := NewHasher(trillian.HashAlgorithm_SHA256)
-	if err != nil {
-		// the only error we could get would be "unsupported hash algo", and since we know we support SHA256 that "can't" happen, right?
-		panic(err)
-	}
-	return h
-}
-
-// HashAlgorithm returns an identifier for the underlying hash algorithm for a Hasher instance.
-func (h Hasher) HashAlgorithm() trillian.HashAlgorithm {
-	return h.alg
+	return hasher, nil
 }

--- a/crypto/key_manager.go
+++ b/crypto/key_manager.go
@@ -39,6 +39,8 @@ type KeyManager interface {
 	Signer() (crypto.Signer, error)
 	// SignatureAlgorithm returns the value that identifies the signature algorithm.
 	SignatureAlgorithm() trillian.SignatureAlgorithm
+	// HashAlgorithm returns the type of hash that will be used for signing with this key.
+	HashAlgorithm() trillian.HashAlgorithm
 	// GetPublicKey returns the public key previously loaded. It is an error to call this
 	// before a public key has been loaded
 	GetPublicKey() (crypto.PublicKey, error)
@@ -71,6 +73,13 @@ func (k PEMKeyManager) NewPEMKeyManager(key crypto.PrivateKey) *PEMKeyManager {
 // SignatureAlgorithm identifies the signature algorithm used by this key manager.
 func (k PEMKeyManager) SignatureAlgorithm() trillian.SignatureAlgorithm {
 	return k.signatureAlgorithm
+}
+
+// HashAlgorithm identifies the signature algorithm used by this key manager.
+func (k PEMKeyManager) HashAlgorithm() trillian.HashAlgorithm {
+	// TODO: Save the hash algorithm in the key serialization.
+	// Return a default hash algorithm for now.
+	return trillian.HashAlgorithm_SHA256
 }
 
 // LoadPrivateKey loads a private key from a PEM encoded string, decrypting it if necessary

--- a/crypto/key_manager.go
+++ b/crypto/key_manager.go
@@ -75,7 +75,7 @@ func (k PEMKeyManager) SignatureAlgorithm() trillian.SignatureAlgorithm {
 	return k.signatureAlgorithm
 }
 
-// HashAlgorithm identifies the signature algorithm used by this key manager.
+// HashAlgorithm identifies the hash algorithm used to sign objects.
 func (k PEMKeyManager) HashAlgorithm() trillian.HashAlgorithm {
 	// TODO: Save the hash algorithm in the key serialization.
 	// Return a default hash algorithm for now.

--- a/crypto/key_manager_test.go
+++ b/crypto/key_manager_test.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/asn1"
@@ -37,7 +38,7 @@ func TestLoadDemoECDSAKeyAndSign(t *testing.T) {
 	// Obviously in real code we wouldn't use a fixed seed
 	randSource := rand.New(rand.NewSource(42))
 
-	hasher := NewSHA256()
+	hasher := crypto.SHA256
 
 	err := km.LoadPrivateKey(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass)
 

--- a/crypto/mock_key_manager.go
+++ b/crypto/mock_key_manager.go
@@ -52,6 +52,16 @@ func (_mr *_MockKeyManagerRecorder) GetRawPublicKey() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRawPublicKey")
 }
 
+func (_m *MockKeyManager) HashAlgorithm() trillian.HashAlgorithm {
+	ret := _m.ctrl.Call(_m, "HashAlgorithm")
+	ret0, _ := ret[0].(trillian.HashAlgorithm)
+	return ret0
+}
+
+func (_mr *_MockKeyManagerRecorder) HashAlgorithm() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HashAlgorithm")
+}
+
 func (_m *MockKeyManager) SignatureAlgorithm() trillian.SignatureAlgorithm {
 	ret := _m.ctrl.Call(_m, "SignatureAlgorithm")
 	ret0, _ := ret[0].(trillian.SignatureAlgorithm)

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -37,7 +37,7 @@ const (
 // Signer is responsible for signing log-related data and producing the appropriate
 // application specific signature objects.
 type Signer struct {
-	hasher       Hasher
+	hasher       crypto.Hash
 	signer       crypto.Signer
 	sigAlgorithm trillian.SignatureAlgorithm
 }
@@ -45,13 +45,21 @@ type Signer struct {
 // NewSigner creates a new Signer wrapping up a hasher and a signer. For the moment
 // we only support SHA256 hashing and either ECDSA or RSA signing but this is not enforced
 // here.
-func NewSigner(hasher Hasher, signatureAlgorithm trillian.SignatureAlgorithm, signer crypto.Signer) *Signer {
-	return &Signer{hasher, signer, signatureAlgorithm}
+func NewSigner(hashAlgo trillian.HashAlgorithm, sigAlgo trillian.SignatureAlgorithm, signer crypto.Signer) *Signer {
+	h, ok := hashLookup[hashAlgo]
+	if !ok {
+		// TODO(gbelvin): return error from Signer.
+		panic("unsupported hash algorithm")
+	}
+
+	return &Signer{h, signer, sigAlgo}
 }
 
 // Sign obtains a signature after first hashing the input data.
 func (s Signer) Sign(data []byte) (trillian.DigitallySigned, error) {
-	digest := s.hasher.Digest(data)
+	h := s.hasher.New()
+	h.Write(data)
+	digest := h.Sum(nil)
 
 	if len(digest) != s.hasher.Size() {
 		return trillian.DigitallySigned{}, fmt.Errorf("hasher returned unexpected digest length: %d, %d",
@@ -66,7 +74,7 @@ func (s Signer) Sign(data []byte) (trillian.DigitallySigned, error) {
 
 	return trillian.DigitallySigned{
 		SignatureAlgorithm: s.sigAlgorithm,
-		HashAlgorithm:      s.hasher.HashAlgorithm(),
+		HashAlgorithm:      cipherLookup[s.hasher],
 		Signature:          sig}, nil
 }
 

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -74,7 +74,7 @@ func (s Signer) Sign(data []byte) (trillian.DigitallySigned, error) {
 
 	return trillian.DigitallySigned{
 		SignatureAlgorithm: s.sigAlgorithm,
-		HashAlgorithm:      cipherLookup[s.hasher],
+		HashAlgorithm:      reverseHashLookup[s.hasher],
 		Signature:          sig}, nil
 }
 

--- a/crypto/verifier_test.go
+++ b/crypto/verifier_test.go
@@ -52,12 +52,7 @@ func TestSignVerify(t *testing.T) {
 			t.Errorf("Signer()=(_,%v), want (_,nil)", err)
 			continue
 		}
-		hasher, err := NewHasher(test.HashAlgo)
-		if err != nil {
-			t.Errorf("NewHasher(%v)=(_,%v), want (_,nil)", test.HashAlgo, err)
-			continue
-		}
-		signer := NewSigner(hasher, test.SigAlgo, kmsigner)
+		signer := NewSigner(test.HashAlgo, test.SigAlgo, kmsigner)
 
 		// Sign and Verify.
 		msg := []byte("foo")

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -90,6 +90,7 @@ func setupTest(t *testing.T, pemRoots []string) handlerTestInfo {
 	info.km = crypto.NewMockKeyManager(info.mockCtrl)
 	info.km.EXPECT().GetRawPublicKey().AnyTimes().Return([]byte("key"), nil)
 	info.km.EXPECT().SignatureAlgorithm().AnyTimes().Return(trillian.SignatureAlgorithm_ECDSA)
+	info.km.EXPECT().HashAlgorithm().AnyTimes().Return(trillian.HashAlgorithm_SHA256)
 	info.client = mockclient.NewMockTrillianLogClient(info.mockCtrl)
 	info.roots = NewPEMCertPool()
 	for _, pemRoot := range pemRoots {

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -25,7 +25,7 @@ func signV1TreeHead(km crypto.KeyManager, sth *ct.SignedTreeHead) error {
 		return err
 	}
 
-	trillianSigner := crypto.NewSigner(crypto.NewSHA256(), km.SignatureAlgorithm(), signer)
+	trillianSigner := crypto.NewSigner(km.HashAlgorithm(), km.SignatureAlgorithm(), signer)
 
 	signature, err := trillianSigner.Sign(sthBytes)
 	if err != nil {
@@ -124,7 +124,7 @@ func signSCT(km crypto.KeyManager, t time.Time, sctData []byte) (ct.SignedCertif
 		return ct.SignedCertificateTimestamp{}, fmt.Errorf("failed to retrieve signer: %v", err)
 	}
 
-	trillianSigner := crypto.NewSigner(crypto.NewSHA256(), km.SignatureAlgorithm(), signer)
+	trillianSigner := crypto.NewSigner(km.HashAlgorithm(), km.SignatureAlgorithm(), signer)
 
 	signature, err := trillianSigner.Sign(sctData)
 	if err != nil {

--- a/examples/ct/structures_test.go
+++ b/examples/ct/structures_test.go
@@ -95,6 +95,7 @@ func setupMockKeyManager(ctrl *gomock.Controller, toSign []byte) *crypto.MockKey
 	mockKeyManager := setupMockKeyManagerForSth(ctrl, toSign)
 	mockKeyManager.EXPECT().GetRawPublicKey().AnyTimes().Return([]byte("key"), nil)
 	mockKeyManager.EXPECT().SignatureAlgorithm().AnyTimes().Return(trillian.SignatureAlgorithm_ECDSA)
+	mockKeyManager.EXPECT().HashAlgorithm().AnyTimes().Return(trillian.HashAlgorithm_SHA256)
 
 	return mockKeyManager
 }

--- a/integration/log.go
+++ b/integration/log.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 )
 
@@ -256,7 +255,7 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params T
 	}
 
 	for currentLeaf < params.leafCount {
-		hasher := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+		hasher := merkle.NewRFC6962TreeHasher()
 
 		// We have to allow for the last batch potentially being a short one
 		numLeaves := params.leafCount - currentLeaf
@@ -455,8 +454,8 @@ func makeGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *trill
 func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParameters) *merkle.InMemoryMerkleTree {
 	// Build the same tree with two different Merkle implementations as an additional check. We don't
 	// just rely on the compact tree as the server uses the same code so bugs could be masked
-	compactTree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
-	merkleTree := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	compactTree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
+	merkleTree := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher())
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.
 	for l := params.startLeaf; l < params.leafCount; l++ {

--- a/integration/map.go
+++ b/integration/map.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/testonly"
 )
@@ -89,7 +88,7 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 
 	// Check values
 	// Mix up the ordering of requests
-	h := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher())
 	randIndexes := make([][]byte, len(tests))
 	for i, r := range rand.Perm(len(tests)) {
 		randIndexes[i] = tests[r].Index

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -154,7 +154,7 @@ func (s Sequencer) createRootSignature(ctx context.Context, root trillian.Signed
 		return trillian.DigitallySigned{}, err
 	}
 
-	trillianSigner := crypto.NewSigner(s.hasher.Hasher, s.keyManager.SignatureAlgorithm(), signer)
+	trillianSigner := crypto.NewSigner(s.keyManager.HashAlgorithm(), s.keyManager.SignatureAlgorithm(), signer)
 
 	signature, err := trillianSigner.SignLogRoot(root)
 	if err != nil {

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"context"
+	gocrypto "crypto"
 	"errors"
 	"fmt"
 	"testing"
@@ -30,7 +31,7 @@ import (
 	"github.com/google/trillian/util"
 )
 
-var treeHasher = merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+var treeHasher = merkle.NewRFC6962TreeHasher()
 
 // These can be shared between tests as they're never modified
 var testLeaf16Data = []byte("testdataforleaf")
@@ -218,7 +219,8 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	if params.setupSigner {
 		mockSigner := crypto.NewMockSigner(ctrl)
-		mockSigner.EXPECT().Sign(gomock.Any(), params.dataToSign, treeHasher.Hasher).AnyTimes().Return(params.signingResult, params.signingError)
+		mockKeyManager.EXPECT().HashAlgorithm().AnyTimes().Return(trillian.HashAlgorithm_SHA256)
+		mockSigner.EXPECT().Sign(gomock.Any(), params.dataToSign, gocrypto.SHA256).AnyTimes().Return(params.signingResult, params.signingError)
 		mockKeyManager.EXPECT().Signer().AnyTimes().Return(mockSigner, params.keyManagerError)
 		mockKeyManager.EXPECT().SignatureAlgorithm().AnyTimes().Return(trillian.SignatureAlgorithm_ECDSA)
 	}

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -23,13 +23,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 )
 
 func getTree() *CompactMerkleTree {
-	return NewCompactMerkleTree(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	return NewCompactMerkleTree(NewRFC6962TreeHasher())
 }
 
 func checkUnusedNodesInvariant(c *CompactMerkleTree) error {
@@ -169,7 +168,7 @@ func fixedHashGetNodeFunc(depth int, index int64) ([]byte, error) {
 }
 
 func TestLoadingTreeFailsNodeFetch(t *testing.T) {
-	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(crypto.NewSHA256()), 237, failingGetNodeFunc, []byte("notimportant"))
+	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(), 237, failingGetNodeFunc, []byte("notimportant"))
 
 	if err == nil || !strings.Contains(err.Error(), "bang") {
 		t.Errorf("Did not return correctly on failed node fetch: %v", err)
@@ -179,7 +178,7 @@ func TestLoadingTreeFailsNodeFetch(t *testing.T) {
 func TestLoadingTreeFailsBadRootHash(t *testing.T) {
 	// Supply a root hash that can't possibly match the result of the SHA 256 hashing on our dummy
 	// data
-	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(crypto.NewSHA256()), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
+	_, err := NewCompactMerkleTreeWithState(NewRFC6962TreeHasher(), 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
 	_, ok := err.(RootHashMismatchError)
 
 	if err == nil || !ok {
@@ -196,12 +195,12 @@ func nodeKey(d int, i int64) (string, error) {
 }
 
 func TestCompactVsFullTree(t *testing.T) {
-	imt := NewInMemoryMerkleTree(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	imt := NewInMemoryMerkleTree(NewRFC6962TreeHasher())
 	nodes := make(map[string][]byte)
 
 	for i := int64(0); i < 1024; i++ {
 		cmt, err := NewCompactMerkleTreeWithState(
-			NewRFC6962TreeHasher(crypto.NewSHA256()),
+			NewRFC6962TreeHasher(),
 			imt.LeafCount(),
 			func(depth int, index int64) ([]byte, error) {
 				k, err := nodeKey(depth, index)
@@ -270,7 +269,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 	b64e := func(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
 
 	for _, test := range tests {
-		tree := NewCompactMerkleTree(NewRFC6962TreeHasher(crypto.NewSHA256()))
+		tree := NewCompactMerkleTree(NewRFC6962TreeHasher())
 		for i := int64(0); i < test.size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
 			tree.AddLeaf(l, func(int, int64, []byte) {})

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -22,7 +22,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/testonly"
 )
 
@@ -48,7 +47,7 @@ func createHStar2Leaves(th TreeHasher, values map[string]string) []HStar2LeafHas
 }
 
 func TestHStar2EmptyRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 	root, err := s.HStar2Root(s.hasher.Size()*8, []HStar2LeafHash{})
 	if err != nil {
@@ -69,7 +68,7 @@ var simpleTestVector = []struct{ k, v, rootB64 string }{
 }
 
 func TestHStar2SimpleDataSetKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 
 	m := make(map[string]string)
@@ -89,7 +88,7 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 // TestHStar2GetSet ensures that we get the same roots as above when we
 // incrementally calculate roots.
 func TestHStar2GetSet(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 
 	// Node cache is shared between tree builds and in effect plays the role of
 	// the TreeStorage layer.
@@ -124,7 +123,7 @@ func TestHStar2GetSet(t *testing.T) {
 // Checks that we calculate the same empty root hash as a 256-level tree has
 // when calculating top subtrees using an appropriate offset.
 func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 
 	for size := 1; size < 255; size++ {
@@ -145,7 +144,7 @@ func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
 // 256-prefixSize, and can be passed in as leaves to top-subtree calculation.
 func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HStar2LeafHash {
 	var ret []HStar2LeafHash
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 	for i := range lh {
 		prefix := new(big.Int).Rsh(lh[i].Index, uint(s.hasher.Size()*8-prefixSize))
@@ -168,7 +167,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HS
 // (single top subtree of size n, and multipl bottom subtrees of size 256-n)
 // still arrives at the same Known Answers for root hash.
 func TestHStar2OffsetRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 
 	m := make(map[string]string)
@@ -195,7 +194,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 }
 
 func TestHStar2NegativeTreeLevelOffset(t *testing.T) {
-	th := NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := NewRFC6962TreeHasher()
 	s := NewHStar2(th)
 
 	_, err := s.HStar2Nodes(32, -1, []HStar2LeafHash{},

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
-	"github.com/google/trillian/crypto"
 )
 
 type logProofTestVector struct {
@@ -297,7 +295,7 @@ func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1,
 }
 
 func getVerifier() LogVerifier {
-	hasher := NewRFC6962TreeHasher(crypto.NewSHA256())
+	hasher := NewRFC6962TreeHasher()
 	return NewLogVerifier(hasher)
 }
 

--- a/merkle/map_hasher_test.go
+++ b/merkle/map_hasher_test.go
@@ -18,8 +18,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"testing"
-
-	"github.com/google/trillian/crypto"
 )
 
 // Expected root hash of an empty sparse Merkle tree.
@@ -36,7 +34,7 @@ func emptyMapRoot() []byte {
 }
 
 func TestNullHashes(t *testing.T) {
-	mh := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	mh := NewMapHasher(NewRFC6962TreeHasher())
 	emptyRoot := mh.HashChildren(mh.nullHashes[0], mh.nullHashes[0])
 	if got, want := emptyRoot, emptyMapRoot(); !bytes.Equal(got, want) {
 		t.Fatalf("Expected empty root of %v, got %v", want, got)

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -17,12 +17,11 @@ package merkle
 import (
 	"testing"
 
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/testonly"
 )
 
 func TestVerifyMapInclusionProofWorks(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	for i, tv := range mapInclusionTestVector {
 		index := testonly.HashKey(tv.Key)
 		if err := VerifyMapInclusionProof(index, h.HashLeaf(tv.Value), tv.ExpectedRoot, tv.Proof, h); err != nil {
@@ -32,7 +31,7 @@ func TestVerifyMapInclusionProofWorks(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofCatchesWrongKey(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	tv := mapInclusionTestVector[0]
 	tv.Key = "wibble"
 	index := testonly.HashKey(tv.Key)
@@ -42,7 +41,7 @@ func TestVerifyMapInclusionProofCatchesWrongKey(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofCatchesWrongValue(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	tv := mapInclusionTestVector[0]
 	tv.Value = []byte("wibble")
 	index := testonly.HashKey(tv.Key)
@@ -52,7 +51,7 @@ func TestVerifyMapInclusionProofCatchesWrongValue(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofCatchesWrongRoot(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	tv := mapInclusionTestVector[0]
 	tv.ExpectedRoot = h.Digest([]byte("wibble"))
 	index := testonly.HashKey(tv.Key)
@@ -62,7 +61,7 @@ func TestVerifyMapInclusionProofCatchesWrongRoot(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofCatchesWrongProof(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	tv := mapInclusionTestVector[0]
 	tv.Proof[250][15] ^= 0x10
 	index := testonly.HashKey(tv.Key)
@@ -72,7 +71,7 @@ func TestVerifyMapInclusionProofCatchesWrongProof(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofRejectsShortProof(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	index := testonly.HashKey("hi")
 	err := VerifyMapInclusionProof(index, h.HashLeaf([]byte("there")), h.Digest([]byte("root")), [][]byte{h.Digest([]byte("shorty"))}, h)
 	if err == nil {
@@ -81,7 +80,7 @@ func TestVerifyMapInclusionProofRejectsShortProof(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofRejectsExcess(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	p := make([][]byte, h.Size()*8+1)
 	index := testonly.HashKey("hi")
 	err := VerifyMapInclusionProof(index, h.HashLeaf([]byte("there")), h.Digest([]byte("root")), p, h)
@@ -91,7 +90,7 @@ func TestVerifyMapInclusionProofRejectsExcess(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofRejectsInvalidKeyHash(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	p := make([][]byte, h.Size()*8)
 	err := VerifyMapInclusionProof([]byte("peppo"), h.HashLeaf([]byte("there")), h.Digest([]byte("root")), p, h)
 	if err == nil {
@@ -100,7 +99,7 @@ func TestVerifyMapInclusionProofRejectsInvalidKeyHash(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofRejectsInvalidLeafHash(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	p := make([][]byte, h.Size()*8)
 	index := testonly.HashKey("key")
 	err := VerifyMapInclusionProof(index, []byte("peppo"), h.Digest([]byte("root")), p, h)
@@ -110,7 +109,7 @@ func TestVerifyMapInclusionProofRejectsInvalidLeafHash(t *testing.T) {
 }
 
 func TestVerifyMapInclusionProofRejectsInvalidRoot(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	h := NewMapHasher(NewRFC6962TreeHasher())
 	p := make([][]byte, h.Size()*8)
 	index := testonly.HashKey("hi")
 	err := VerifyMapInclusionProof(index, h.HashLeaf([]byte("there")), []byte("peppo"), p, h)

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-
-	"github.com/google/trillian/crypto"
 )
 
 // Note test inputs came from the values used by the C++ code. The original
@@ -120,7 +118,7 @@ func decodeHexStringOrPanic(hs string) []byte {
 }
 
 func makeEmptyTree() *InMemoryMerkleTree {
-	return NewInMemoryMerkleTree(NewRFC6962TreeHasher(crypto.NewSHA256()))
+	return NewInMemoryMerkleTree(NewRFC6962TreeHasher())
 }
 
 func makeFuzzTestData() [][]byte {

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/mock/gomock"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 )
@@ -82,13 +81,13 @@ func newTX(tx storage.MapTX) func() (storage.TreeTX, error) {
 
 func getSparseMerkleTreeReaderWithMockTX(ctrl *gomock.Controller, rev int64) (*SparseMerkleTreeReader, *storage.MockMapTX) {
 	tx := storage.NewMockMapTX(ctrl)
-	return NewSparseMerkleTreeReader(rev, NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256())), tx), tx
+	return NewSparseMerkleTreeReader(rev, NewMapHasher(NewRFC6962TreeHasher()), tx), tx
 }
 
 func getSparseMerkleTreeWriterWithMockTX(ctrl *gomock.Controller, rev int64) (*SparseMerkleTreeWriter, *storage.MockMapTX) {
 	tx := storage.NewMockMapTX(ctrl)
 	tx.EXPECT().WriteRevision().AnyTimes().Return(rev)
-	tree, err := NewSparseMerkleTreeWriter(rev, NewMapHasher(NewRFC6962TreeHasher(crypto.NewSHA256())), newTX(tx))
+	tree, err := NewSparseMerkleTreeWriter(rev, NewMapHasher(NewRFC6962TreeHasher()), newTX(tx))
 	if err != nil {
 		panic(err)
 	}

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -39,7 +39,7 @@ const (
 	RFC6962NodeHashPrefix = 1
 )
 
-// TreeHasher is a set of domain separated hashers for creating Merkle tree hashes.
+// TreeHasher implements the RFC6962 tree hashing algorithm.
 type TreeHasher struct {
 	crypto.Hash
 }

--- a/merkle/tree_hasher_test.go
+++ b/merkle/tree_hasher_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/testonly"
 )
 
@@ -38,7 +37,7 @@ func ensureHashMatches(expected, actual []byte, testCase string, t *testing.T) {
 }
 
 func TestRfc6962Hasher(t *testing.T) {
-	hasher := NewRFC6962TreeHasher(crypto.NewSHA256())
+	hasher := NewRFC6962TreeHasher()
 
 	ensureHashMatches(testonly.MustHexDecode(rfc6962EmptyHashHex), hasher.HashEmpty(), "RFC962 Empty", t)
 	ensureHashMatches(testonly.MustHexDecode(rfc6962LeafL123456HashHex), hasher.HashLeaf([]byte("L123456")), "RFC6962 Leaf", t)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
@@ -75,7 +74,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	}
 
 	// TODO(al): TreeHasher must be selected based on log config.
-	th := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := merkle.NewRFC6962TreeHasher()
 	for i := range leaves {
 		leaves[i].MerkleLeafHash = th.HashLeaf(leaves[i].LeafValue)
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -23,13 +23,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 )
 
-var th = merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+var th = merkle.NewRFC6962TreeHasher()
 
 var logID1 = int64(1)
 var logID2 = int64(2)

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 )
@@ -56,7 +55,7 @@ type rehasher struct {
 func newRehasher() *rehasher {
 	return &rehasher{
 		// TODO(Martin2112): TreeHasher must be selected based on log config.
-		th: merkle.NewRFC6962TreeHasher(crypto.NewSHA256()),
+		th: merkle.NewRFC6962TreeHasher(),
 	}
 }
 

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
@@ -298,7 +297,7 @@ func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) string {
 
 func treeAtSize(n int) *merkle.InMemoryMerkleTree {
 	leaves := expandLeaves(0, n-1)
-	mt := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	mt := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher())
 	for _, leaf := range leaves {
 		mt.AddLeaf([]byte(leaf))
 	}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -291,8 +291,8 @@ func expandLeaves(n, m int) []string {
 
 // expectedRootAtSize uses the in memory tree, the tree built with Compact Merkle Tree should
 // have the same root.
-func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) string {
-	return hex.EncodeToString(mt.CurrentRoot().Hash())
+func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) []byte {
+	return mt.CurrentRoot().Hash()
 }
 
 func treeAtSize(n int) *merkle.InMemoryMerkleTree {

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -72,7 +72,7 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 		ctx := util.NewLogContext(logctx.ctx, logID)
 
 		// TODO(Martin2112): Allow for different tree hashers to be used by different logs
-		sequencer := log.NewSequencer(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()), logctx.timeSource, storage, s.keyManager)
+		sequencer := log.NewSequencer(merkle.NewRFC6962TreeHasher(), logctx.timeSource, storage, s.keyManager)
 		sequencer.SetGuardWindow(s.guardWindow)
 
 		leaves, err := sequencer.SequenceBatch(ctx, logID, logctx.batchSize)

--- a/server/vmap/trillian_map_server.go
+++ b/server/vmap/trillian_map_server.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
@@ -28,7 +27,7 @@ func NewTrillianMapServer(registry extension.Registry) *TrillianMapServer {
 
 func (t *TrillianMapServer) getHasherForMap(mapID int64) (merkle.MapHasher, error) {
 	// TODO(al): actually return tailored hashers.
-	return merkle.NewMapHasher(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), nil
+	return merkle.NewMapHasher(merkle.NewRFC6962TreeHasher()), nil
 }
 
 // GetLeaves implements the GetLeaves RPC method.

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
@@ -42,7 +43,7 @@ var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
 func TestSplitNodeID(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 	for i, v := range splitTestVector {
 		n := storage.NewNodeIDFromHash(v.inPath)
 		n.PrefixLenBits = v.inPathLenBits
@@ -67,7 +68,7 @@ func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 
 	nodeID := storage.NewNodeIDFromHash([]byte("1234"))
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
@@ -96,7 +97,7 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 
 	nodeIDs := []storage.NodeID{
 		storage.NewNodeIDFromHash([]byte("1234")),
@@ -149,7 +150,7 @@ func TestCacheFlush(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 
 	h := "0123456789abcdef0123456789abcdef"
 	nodeID := storage.NewNodeIDFromHash([]byte(h))
@@ -234,7 +235,7 @@ func TestSuffixSerializeFormat(t *testing.T) {
 }
 
 func TestRepopulateLogSubtree(t *testing.T) {
-	hasher := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+	hasher := merkle.NewRFC6962TreeHasher()
 	populateTheThing := PopulateLogSubtreeNodes(hasher)
 	cmt := merkle.NewCompactMerkleTree(hasher)
 	cmtStorage := storagepb.SubtreeProto{
@@ -246,7 +247,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		Leaves: make(map[string][]byte),
 		Depth:  int32(defaultLogStrata[0]),
 	}
-	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareLogSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareLogSubtreeWrite())
 	for numLeaves := int64(1); numLeaves <= 256; numLeaves++ {
 		// clear internal nodes
 		s.InternalNodes = make(map[string][]byte)
@@ -300,7 +301,7 @@ func TestPrefixLengths(t *testing.T) {
 	strata := []int{8, 8, 16, 32, 64, 128}
 	stratumInfo := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
-	c := NewSubtreeCache(strata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(strata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 
 	if got, want := c.stratumInfo, stratumInfo; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Got prefixLengths of %v, expected %v", got, want)
@@ -308,7 +309,7 @@ func TestPrefixLengths(t *testing.T) {
 }
 
 func TestGetStratumInfo(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher(crypto.NewSHA256())), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
 	testVec := []struct {
 		depth int
 		info  stratumInfo

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -153,7 +152,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64) (stor
 	if err := m.db.QueryRow(getTreePropertiesSQL, treeID).Scan(&allowDuplicates); err != nil {
 		return nil, fmt.Errorf("failed to get tree row for treeID %v: %s", treeID, err)
 	}
-	th := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := merkle.NewRFC6962TreeHasher()
 
 	ttx, err := m.beginTreeTx(ctx, treeID, th.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(th), cache.PrepareLogSubtreeWrite())
 	if err != nil {

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"runtime/debug"
@@ -13,7 +14,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/storage"
 	"reflect"
 )
@@ -1141,13 +1141,14 @@ func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
 // Creates some test leaves with predictable data
 func createTestLeaves(n, startSeq int64) []trillian.LogLeaf {
 	var leaves []trillian.LogLeaf
-	hasher := crypto.NewSHA256()
-
 	for l := int64(0); l < n; l++ {
 		lv := fmt.Sprintf("Leaf %d", l+startSeq)
+		h := sha256.New()
+		h.Write([]byte(lv))
+		leafHash := h.Sum(nil)
 		leaf := trillian.LogLeaf{
-			LeafIdentityHash: hasher.Digest([]byte(lv)),
-			MerkleLeafHash:   hasher.Digest([]byte(lv)),
+			LeafIdentityHash: leafHash,
+			MerkleLeafHash:   leafHash,
 			LeafValue:        []byte(lv),
 			ExtraData:        []byte(fmt.Sprintf("Extra %d", l)),
 			LeafIndex:        int64(startSeq + l),

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -51,7 +50,7 @@ func NewMapStorage(db *sql.DB) (storage.MapStorage, error) {
 
 func (m *mySQLMapStorage) Begin(ctx context.Context, treeID int64) (storage.MapTX, error) {
 	// TODO(codingllama): Validate treeType, read hash algorithm from storage
-	th := merkle.NewRFC6962TreeHasher(crypto.NewSHA256())
+	th := merkle.NewRFC6962TreeHasher()
 
 	ttx, err := m.beginTreeTx(ctx, treeID, th.Size(), defaultMapStrata, cache.PopulateMapSubtreeNodes(th), cache.PrepareMapSubtreeWrite())
 	if err != nil {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 )
@@ -210,7 +209,7 @@ func createSomeNodes(testName string, treeID int64) []storage.Node {
 }
 
 func createLogNodesForTreeAtSize(ts, rev int64) []storage.Node {
-	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
 	nodeMap := make(map[string]storage.Node)
 	for l := 0; l < int(ts); l++ {
 		// We're only interested in the side effects of adding leaves - the node updates

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -1,11 +1,10 @@
 package testonly
 
 import (
+	"encoding/hex"
 	"fmt"
 
-	"encoding/hex"
 	"github.com/golang/glog"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 )
@@ -113,7 +112,7 @@ func NewMultiFakeNodeReader(readers []FakeNodeReader) *MultiFakeNodeReader {
 // code. To help guard against this we check the tree root hash after each batch has been
 // processed. The supplied batches should be in ascending order of tree revision.
 func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader {
-	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
 	readers := make([]FakeNodeReader, 0, len(batches))
 
 	lastBatchRevision := int64(0)

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -1,7 +1,7 @@
 package testonly
 
 import (
-	"encoding/hex"
+	"bytes"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -97,7 +97,7 @@ type MultiFakeNodeReader struct {
 type LeafBatch struct {
 	TreeRevision int64
 	Leaves       []string
-	ExpectedRoot string
+	ExpectedRoot []byte
 }
 
 // NewMultiFakeNodeReader creates a MultiFakeNodeReader delegating to a number of FakeNodeReaders
@@ -139,8 +139,8 @@ func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader 
 		}
 
 		// Sanity check the tree root hash against the one we expect to see.
-		if got, want := hex.EncodeToString(tree.CurrentRoot()), batch.ExpectedRoot; got != want {
-			panic(fmt.Errorf("NewMultiFakeNodeReaderFromLeaves() got root: %s, want: %s (%v)", got, want, batch))
+		if got, want := tree.CurrentRoot(), batch.ExpectedRoot; !bytes.Equal(got, want) {
+			panic(fmt.Errorf("NewMultiFakeNodeReaderFromLeaves() got root: %x, want: %x (%v)", got, want, batch))
 		}
 
 		// Unroll the update map to []NodeMappings to retain the most recent node update within

--- a/trillian.pb.go
+++ b/trillian.pb.go
@@ -100,7 +100,7 @@ const (
 	TreeState_UNKNOWN_TREE_STATE TreeState = 0
 	// Active trees are able to respond to both read and write requests.
 	TreeState_ACTIVE TreeState = 1
-	// Frozen trees are only able to respond to read requests, writting to a
+	// Frozen trees are only able to respond to read requests, writing to a
 	// frozen tree is forbidden.
 	TreeState_FROZEN TreeState = 2
 	// Tree was been deleted, therefore is invisible and acts similarly to a

--- a/trillian.proto
+++ b/trillian.proto
@@ -43,7 +43,7 @@ enum TreeState {
   // Active trees are able to respond to both read and write requests.
   ACTIVE = 1;
 
-  // Frozen trees are only able to respond to read requests, writting to a
+  // Frozen trees are only able to respond to read requests, writing to a
   // frozen tree is forbidden.
   FROZEN = 2;
 

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/mysql"
@@ -36,7 +35,7 @@ func main() {
 		glog.Fatalf("Failed create MapStorage: %v", err)
 	}
 
-	hasher := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher(crypto.NewSHA256()))
+	hasher := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher())
 
 	testVecs := []struct {
 		batchSize       int


### PR DESCRIPTION
Simplify hashing algorithms by using native go hashing objects.

De-couple signature hashing from tree hashing.
 - The de-couple removed lots of `import github.com/google/trillian/crypto` imports across many files. 

Prepares the repo for a simplified hasher interface.

Preparation work for #331