### PR TITLE
Add error returns to compact tree set node func etc.

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -113,16 +113,20 @@ func (s Sequencer) sequenceLeaves(mt *merkle.CompactMerkleTree, leaves []*trilli
 	nodeMap := make(map[string]storage.Node)
 	// Update the tree state and sequence the leaves and assign sequence numbers to the new leaves
 	for i, leaf := range leaves {
-		seq := mt.AddLeafHash(leaf.MerkleLeafHash, func(depth int, index int64, hash []byte) {
+		seq, err := mt.AddLeafHash(leaf.MerkleLeafHash, func(depth int, index int64, hash []byte) error {
 			nodeID, err := storage.NewNodeIDForTreeCoords(int64(depth), index, maxTreeDepth)
 			if err != nil {
-				return
+				return err
 			}
 			nodeMap[nodeID.String()] = storage.Node{
 				NodeID: nodeID,
 				Hash:   hash,
 			}
+			return nil
 		})
+		if err != nil {
+			return nil, nil, err
+		}
 		// The leaf has now been sequenced.
 		leaves[i].LeafIndex = seq
 		// Store leaf hash in the Merkle tree too:

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -176,7 +176,7 @@ func (c *CompactMerkleTree) AddLeaf(data []byte, f setNodeFunc) (int64, []byte, 
 	h := c.hasher.HashLeaf(data)
 	seq, err := c.AddLeafHash(h, f)
 	if err != nil {
-		return -1, nil, err
+		return 0, nil, err
 	}
 	return seq, h, err
 }

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -175,6 +175,9 @@ func (c *CompactMerkleTree) recalculateRoot(f setNodeFunc) error {
 func (c *CompactMerkleTree) AddLeaf(data []byte, f setNodeFunc) (int64, []byte, error) {
 	h := c.hasher.HashLeaf(data)
 	seq, err := c.AddLeafHash(h, f)
+	if err != nil {
+		return -1, nil, err
+	}
 	return seq, h, err
 }
 

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -95,7 +95,9 @@ func NewCompactMerkleTreeWithState(hasher TreeHasher, size int64, f GetNodeFunc,
 			}
 			size >>= 1
 		}
-		r.recalculateRoot(func(depth int, index int64, hash []byte) {})
+		r.recalculateRoot(func(depth int, index int64, hash []byte) error {
+			return nil
+		})
 	}
 	if !bytes.Equal(r.root, expectedRoot) {
 		log.Warningf("Corrupt state, expected root %s, got %s", hex.EncodeToString(expectedRoot[:]), hex.EncodeToString(r.root[:]))
@@ -136,11 +138,11 @@ func (c CompactMerkleTree) DumpNodes() {
 	}
 }
 
-type setNodeFunc func(depth int, index int64, hash []byte)
+type setNodeFunc func(depth int, index int64, hash []byte) error
 
-func (c *CompactMerkleTree) recalculateRoot(f setNodeFunc) {
+func (c *CompactMerkleTree) recalculateRoot(f setNodeFunc) error {
 	if c.size == 0 {
-		return
+		return nil
 	}
 
 	index := c.size
@@ -157,39 +159,45 @@ func (c *CompactMerkleTree) recalculateRoot(f setNodeFunc) {
 				first = false
 			} else {
 				newRoot = c.hasher.HashChildren(c.nodes[bit], newRoot)
-				f(bit+1, index, newRoot)
+				if err := f(bit+1, index, newRoot); err != nil {
+					return err
+				}
 			}
 		}
 		mask <<= 1
 	}
 	c.root = newRoot
+	return nil
 }
 
 // AddLeaf calculates the leafhash of |data| and appends it to the tree.
 // |f| is a callback which will be called multiple times with the full MerkleTree coordinates of nodes whose hash should be updated.
-func (c *CompactMerkleTree) AddLeaf(data []byte, f setNodeFunc) (int64, []byte) {
+func (c *CompactMerkleTree) AddLeaf(data []byte, f setNodeFunc) (int64, []byte, error) {
 	h := c.hasher.HashLeaf(data)
-	return c.AddLeafHash(h, f), h
+	seq, err := c.AddLeafHash(h, f)
+	return seq, h, err
 }
 
 // AddLeafHash adds the specified |leafHash| to the tree.
 // |f| is a callback which will be called multiple times with the full MerkleTree coordinates of nodes whose hash should be updated.
-func (c *CompactMerkleTree) AddLeafHash(leafHash []byte, f setNodeFunc) (assignedSeq int64) {
+func (c *CompactMerkleTree) AddLeafHash(leafHash []byte, f setNodeFunc) (int64, error) {
 	defer func() {
 		c.size++
 		// TODO(al): do this lazily
 		c.recalculateRoot(f)
 	}()
 
-	assignedSeq = c.size
+	assignedSeq := c.size
 	index := assignedSeq
 
-	f(0, index, leafHash)
+	if err := f(0, index, leafHash); err != nil {
+		return 0, err
+	}
 
 	if c.size == 0 {
 		// new tree
 		c.nodes = append(c.nodes, leafHash)
-		return
+		return assignedSeq, nil
 	}
 
 	// Initialize our running hash value to the leaf hash
@@ -204,14 +212,18 @@ func (c *CompactMerkleTree) AddLeafHash(leafHash []byte, f setNodeFunc) (assigne
 			// Don't re-write the leaf hash node (we've done it above already)
 			if bit > 0 {
 				// Store the leaf hash node
-				f(bit, index, hash)
+				if err := f(bit, index, hash); err != nil {
+					return 0, err
+				}
 			}
-			return
+			return assignedSeq, nil
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		hash = c.hasher.HashChildren(c.nodes[bit], hash)
 		// Store the resulting parent hash.
-		f(bit+1, index, hash)
+		if err := f(bit+1, index, hash); err != nil {
+			return 0, err
+		}
 		// Now, clear this position in the nodes list as the hash it formerly contained will be propogated upwards.
 		c.nodes[bit] = nil
 		// Figure out if we're done:
@@ -219,20 +231,19 @@ func (c *CompactMerkleTree) AddLeafHash(leafHash []byte, f setNodeFunc) (assigne
 			// If we're extending the node list then add a new entry with our
 			// running hash, and we're done.
 			c.nodes = append(c.nodes, hash)
-			return
+			return assignedSeq, nil
 		} else if t&0x02 == 0 {
 			// If the node above us is unused at this tree size, then store our
 			// running hash there, and we're done.
 			c.nodes[bit+1] = hash
-			return
+			return assignedSeq, nil
 		}
 		// Otherwise, go around again.
 		bit++
 	}
 	// We should never get here, because that'd mean we had a running hash which
 	// we've not stored somewhere.
-	log.Fatal("AddLeaf failed.")
-	return
+	return 0, fmt.Errorf("AddLeaf failed running hash not cleared: h: %v seq: %d", leafHash, assignedSeq)
 }
 
 // Size returns the current size of the tree, that is, the number of leaves ever added to the tree.

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -80,7 +80,9 @@ func TestAddingLeaves(t *testing.T) {
 		}
 
 		for i := 0; i < 8; i++ {
-			tree.AddLeaf(inputs[i], func(int, int64, []byte) {})
+			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
+				return nil
+			})
 			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
@@ -100,7 +102,9 @@ func TestAddingLeaves(t *testing.T) {
 		// Second tree, add nodes all at once
 		tree := NewCompactMerkleTree(testonly.Hasher)
 		for i := 0; i < 8; i++ {
-			tree.AddLeaf(inputs[i], func(int, int64, []byte) {})
+			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
+				return nil
+			})
 			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
@@ -120,7 +124,9 @@ func TestAddingLeaves(t *testing.T) {
 		// Third tree, add nodes in two chunks
 		tree := NewCompactMerkleTree(testonly.Hasher)
 		for i := 0; i < 3; i++ {
-			tree.AddLeaf(inputs[i], func(int, int64, []byte) {})
+			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
+				return nil
+			})
 			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
@@ -136,7 +142,9 @@ func TestAddingLeaves(t *testing.T) {
 		}
 
 		for i := 3; i < 8; i++ {
-			tree.AddLeaf(inputs[i], func(int, int64, []byte) {})
+			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
+				return nil
+			})
 			if err := checkUnusedNodesInvariant(tree); err != nil {
 				t.Fatalf("UnusedNodesInvariant check failed: %v", err)
 			}
@@ -218,14 +226,18 @@ func TestCompactVsFullTree(t *testing.T) {
 
 		iSeq, iHash := imt.AddLeaf(newLeaf)
 
-		cSeq, cHash := cmt.AddLeaf(newLeaf,
-			func(depth int, index int64, hash []byte) {
+		cSeq, cHash, err := cmt.AddLeaf(newLeaf,
+			func(depth int, index int64, hash []byte) error {
 				k, err := nodeKey(depth, index)
 				if err != nil {
-					t.Errorf("failed to create nodeID: %v", err)
+					return fmt.Errorf("failed to create nodeID: %v", err)
 				}
 				nodes[k] = hash
+				return nil
 			})
+		if err != nil {
+			t.Fatalf("mt update failed: %v", err)
+		}
 
 		// In-Memory tree is 1-based for sequence numbers, since it's based on the original CT C++ impl.
 		if got, want := iSeq, i+1; got != want {
@@ -268,7 +280,9 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 		tree := NewCompactMerkleTree(testonly.Hasher)
 		for i := int64(0); i < test.size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
-			tree.AddLeaf(l, func(int, int64, []byte) {})
+			tree.AddLeaf(l, func(int, int64, []byte) error {
+				return nil
+			})
 		}
 		if got, want := tree.CurrentRoot(), test.wantRoot; !bytes.Equal(got, want) {
 			t.Errorf("Test (treesize=%v) got root %v, want %v", test.size, b64e(got), b64e(want))

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -145,8 +145,8 @@ func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader 
 				nID, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 64)
 
 				if err != nil {
-					return (fmt.Errorf("failed to create a nodeID for tree - should not happen d:%d i:%d",
-						depth, index))
+					return fmt.Errorf("failed to create a nodeID for tree - should not happen d:%d i:%d",
+						depth, index)
 				}
 
 				nodeMap[nID.String()] = storage.Node{NodeID: nID, NodeRevision: batch.TreeRevision, Hash: hash}

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -141,15 +141,16 @@ func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader 
 		nodeMap := make(map[string]storage.Node)
 		for _, leaf := range batch.Leaves {
 			// We're only interested in the side effects of adding leaves - the node updates
-			tree.AddLeaf([]byte(leaf), func(depth int, index int64, hash []byte) {
+			tree.AddLeaf([]byte(leaf), func(depth int, index int64, hash []byte) error {
 				nID, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 64)
 
 				if err != nil {
-					panic(fmt.Errorf("failed to create a nodeID for tree - should not happen d:%d i:%d",
+					return (fmt.Errorf("failed to create a nodeID for tree - should not happen d:%d i:%d",
 						depth, index))
 				}
 
 				nodeMap[nID.String()] = storage.Node{NodeID: nID, NodeRevision: batch.TreeRevision, Hash: hash}
+				return nil
 			})
 		}
 


### PR DESCRIPTION
Allows some panics / TODOs to be removed and fixes that some errors could previously be ignored.