### PR TITLE
Remove TreeHasher.Digest

### DIFF
--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -107,10 +107,9 @@ func NewCompactMerkleTreeWithState(hasher TreeHasher, size int64, f GetNodeFunc,
 
 // NewCompactMerkleTree creates a new CompactMerkleTree with size zero. This always succeeds.
 func NewCompactMerkleTree(hasher TreeHasher) *CompactMerkleTree {
-	emptyHash := hasher.Digest([]byte{})
 	r := CompactMerkleTree{
 		hasher: hasher,
-		root:   emptyHash[:],
+		root:   hasher.HashEmpty(),
 		nodes:  make([][]byte, 0),
 		size:   0,
 	}

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -28,7 +28,7 @@ import (
 // append-only logs, but adds support for nil/"default" proof nodes.
 //
 // Returns nil on a successful verification, and an error otherwise.
-func VerifyMapInclusionProof(index []byte, leafHash []byte, expectedRoot []byte, proof [][]byte, h MapHasher) error {
+func VerifyMapInclusionProof(index, leafHash, expectedRoot []byte, proof [][]byte, h MapHasher) error {
 	hBits := h.Size() * 8
 
 	if got, want := len(proof), hBits; got != want {
@@ -39,9 +39,6 @@ func VerifyMapInclusionProof(index []byte, leafHash []byte, expectedRoot []byte,
 	}
 	if got, want := len(leafHash)*8, hBits; got != want {
 		return fmt.Errorf("invalid leafHash length %d, expected %d", got, want)
-	}
-	if got, want := len(expectedRoot)*8, hBits; got != want {
-		return fmt.Errorf("invalid expectedRoot length %d, expected %d", got, want)
 	}
 
 	// TODO(al): Remove this dep on storage, since clients will want to use this code.

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -52,28 +52,24 @@ func NewRFC6962TreeHasher() TreeHasher {
 
 // HashEmpty returns the hash of an empty element for the tree
 func (t TreeHasher) HashEmpty() []byte {
-	return t.Digest([]byte{})
+	return t.New().Sum(nil)
 }
 
 // HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
 // The data in leaf is prefixed by the LeafHashPrefix.
 func (t TreeHasher) HashLeaf(leaf []byte) []byte {
-	return t.Digest(append([]byte{RFC6962LeafHashPrefix}, leaf...))
+	h := t.New()
+	h.Write([]byte{RFC6962LeafHashPrefix})
+	h.Write(leaf)
+	return h.Sum(nil)
 }
 
 // HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
 // The hashed structure is NodeHashPrefix||l||r.
 func (t TreeHasher) HashChildren(l, r []byte) []byte {
-	hr := t.New()
-	hr.Write([]byte{RFC6962NodeHashPrefix})
-	hr.Write(l)
-	hr.Write(r)
-	return hr.Sum(nil)
-}
-
-// Digest calculates the digest of b according to the underlying algorithm.
-func (t TreeHasher) Digest(b []byte) []byte {
-	hr := t.New()
-	hr.Write(b)
-	return hr.Sum(nil)
+	h := t.New()
+	h.Write([]byte{RFC6962NodeHashPrefix})
+	h.Write(l)
+	h.Write(r)
+	return h.Sum(nil)
 }

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -251,7 +251,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		s.InternalNodes = make(map[string][]byte)
 
 		leaf := []byte(fmt.Sprintf("this is leaf %d", numLeaves))
-		leafHash := hasher.Digest(leaf)
+		leafHash := hasher.HashLeaf(leaf)
 		cmt.AddLeafHash(leafHash, func(depth int, index int64, h []byte) {
 			n, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 8)
 			if err != nil {


### PR DESCRIPTION
Partial work towards #331

Future Hasher API does not have a Digest function.
This PR removes it in preparation for that.

The code base that mostly used Digest was the Map tests
which I converted to table driven tests for clarity and
ease of code maintenance.