### PR TITLE
Create Hasher Factory

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/testonly"
 )
 
 // TestParameters bundles up all the settings for a test run
@@ -255,8 +256,6 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params T
 	}
 
 	for currentLeaf < params.leafCount {
-		hasher := merkle.NewRFC6962TreeHasher()
-
 		// We have to allow for the last batch potentially being a short one
 		numLeaves := params.leafCount - currentLeaf
 
@@ -300,7 +299,7 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params T
 
 			delete(leafDataPresenceMap, string(leaf.LeafValue))
 
-			hash := hasher.HashLeaf(leaf.LeafValue)
+			hash := testonly.Hasher.HashLeaf(leaf.LeafValue)
 
 			if got, want := hex.EncodeToString(hash), hex.EncodeToString(leaf.MerkleLeafHash); got != want {
 				return nil, fmt.Errorf("leaf %d hash mismatch expected got: %s want: %s", leaf.LeafIndex, got, want)
@@ -454,8 +453,8 @@ func makeGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *trill
 func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParameters) *merkle.InMemoryMerkleTree {
 	// Build the same tree with two different Merkle implementations as an additional check. We don't
 	// just rely on the compact tree as the server uses the same code so bugs could be masked
-	compactTree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
-	merkleTree := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher())
+	compactTree := merkle.NewCompactMerkleTree(testonly.Hasher)
+	merkleTree := merkle.NewInMemoryMerkleTree(testonly.Hasher)
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.
 	for l := params.startLeaf; l < params.leafCount; l++ {

--- a/integration/map.go
+++ b/integration/map.go
@@ -88,7 +88,7 @@ func RunMapIntegration(ctx context.Context, mapID int64, client trillian.Trillia
 
 	// Check values
 	// Mix up the ordering of requests
-	h := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher())
+	h := merkle.NewMapHasher(testonly.Hasher)
 	randIndexes := make([][]byte, len(tests))
 	for i, r := range rand.Perm(len(tests)) {
 		randIndexes[i] = tests[r].Index

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -25,17 +25,17 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
-	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
 )
 
-var treeHasher = merkle.NewRFC6962TreeHasher()
-
 // These can be shared between tests as they're never modified
 var testLeaf16Data = []byte("testdataforleaf")
-var testLeaf16 = trillian.LogLeaf{MerkleLeafHash: treeHasher.HashLeaf(testLeaf16Data), LeafValue: testLeaf16Data, ExtraData: nil, LeafIndex: 16}
+var testLeaf16 = trillian.LogLeaf{
+	MerkleLeafHash: testonly.Hasher.HashLeaf(testLeaf16Data),
+	LeafValue:      testLeaf16Data,
+	ExtraData:      nil, LeafIndex: 16}
 
 // RootHash can't be nil because that's how the sequencer currently detects that there was no stored tree head.
 var testRoot16 = trillian.SignedLogRoot{TreeSize: 16, TreeRevision: 5, RootHash: []byte{}}
@@ -146,7 +146,7 @@ type testContext struct {
 
 // This gets modified so tests need their own copies
 func getLeaf42() trillian.LogLeaf {
-	testLeaf42Hash := treeHasher.HashLeaf(testLeaf16Data)
+	testLeaf42Hash := testonly.Hasher.HashLeaf(testLeaf16Data)
 	return trillian.LogLeaf{MerkleLeafHash: testLeaf42Hash, LeafValue: testLeaf16Data, ExtraData: nil, LeafIndex: 42}
 }
 
@@ -225,7 +225,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 		mockKeyManager.EXPECT().SignatureAlgorithm().AnyTimes().Return(trillian.SignatureAlgorithm_ECDSA)
 	}
 
-	sequencer := NewSequencer(treeHasher, util.FakeTimeSource{FakeTime: fakeTimeForTest}, mockStorage, mockKeyManager)
+	sequencer := NewSequencer(testonly.Hasher, util.FakeTimeSource{FakeTime: fakeTimeForTest}, mockStorage, mockKeyManager)
 
 	return testContext{mockTx: mockTx, mockStorage: mockStorage, mockKeyManager: mockKeyManager, sequencer: sequencer}, util.NewLogContext(context.Background(), params.logID)
 }

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -27,7 +27,7 @@ import (
 
 // This root was calculated with the C++/Python sparse Merkle tree code in the
 // github.com/google/certificate-transparency repo.
-const sparseEmptyRootHashB64 = "xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo="
+var sparseEmptyRootHashB64 = testonly.MustDecodeBase64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")
 
 // createHStar2Leaves builds a list of HStar2LeafHash structs suitable for
 // passing into a the HStar2 sparse Merkle tree implementation.
@@ -47,39 +47,40 @@ func createHStar2Leaves(th TreeHasher, values map[string]string) []HStar2LeafHas
 }
 
 func TestHStar2EmptyRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 	root, err := s.HStar2Root(s.hasher.Size()*8, []HStar2LeafHash{})
 	if err != nil {
 		t.Fatalf("Failed to calculate root: %v", err)
 	}
-	if expected, got := testonly.MustDecodeBase64(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
-		t.Fatalf("Expected empty root:\n%v\nGot:\n%v", expected, got)
+	if got, want := root, sparseEmptyRootHashB64; !bytes.Equal(got, want) {
+		t.Fatalf("Expected empty root. Got: \n%x\nWant:\n%x", got, want)
 	}
 }
 
 // Some known answers for incrementally adding key/value pairs to a sparse tree.
 // rootB64 is the incremental root after adding the corresponding k/v pair, and
 // all k/v pairs which come before it.
-var simpleTestVector = []struct{ k, v, rootB64 string }{
-	{"a", "0", "nP1psZp1bu3jrY5Yv89rI+w5ywe9lLqI2qZi5ibTSF0="},
-	{"b", "1", "EJ1Rw6DQT9bDn2Zbn7u+9/j799PSdqT9gfBymS9MBZY="},
-	{"a", "2", "2rAZz4HJAMJqJ5c8ClS4wEzTP71GTdjMZMe1rKWPA5o="},
+var simpleTestVector = []struct {
+	k, v string
+	root []byte
+}{
+	{"a", "0", testonly.MustDecodeBase64("nP1psZp1bu3jrY5Yv89rI+w5ywe9lLqI2qZi5ibTSF0=")},
+	{"b", "1", testonly.MustDecodeBase64("EJ1Rw6DQT9bDn2Zbn7u+9/j799PSdqT9gfBymS9MBZY=")},
+	{"a", "2", testonly.MustDecodeBase64("2rAZz4HJAMJqJ5c8ClS4wEzTP71GTdjMZMe1rKWPA5o=")},
 }
 
 func TestHStar2SimpleDataSetKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 
 	m := make(map[string]string)
 	for i, x := range simpleTestVector {
 		m[x.k] = x.v
-		values := createHStar2Leaves(th, m)
+		values := createHStar2Leaves(testonly.Hasher, m)
 		root, err := s.HStar2Root(s.hasher.Size()*8, values)
 		if err != nil {
 			t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 		}
-		if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
+		if expected, got := x.root, root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -88,17 +89,15 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 // TestHStar2GetSet ensures that we get the same roots as above when we
 // incrementally calculate roots.
 func TestHStar2GetSet(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-
 	// Node cache is shared between tree builds and in effect plays the role of
 	// the TreeStorage layer.
 	cache := make(map[string][]byte)
 
 	for i, x := range simpleTestVector {
-		s := NewHStar2(th)
+		s := NewHStar2(testonly.Hasher)
 		m := make(map[string]string)
 		m[x.k] = x.v
-		values := createHStar2Leaves(th, m)
+		values := createHStar2Leaves(testonly.Hasher, m)
 		// ensure we're going incrementally, one leaf at a time.
 		if len(values) != 1 {
 			t.Fatalf("Should only have 1 leaf per run, got %d", len(values))
@@ -114,7 +113,7 @@ func TestHStar2GetSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 		}
-		if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
+		if expected, got := x.root, root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -123,8 +122,7 @@ func TestHStar2GetSet(t *testing.T) {
 // Checks that we calculate the same empty root hash as a 256-level tree has
 // when calculating top subtrees using an appropriate offset.
 func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 
 	for size := 1; size < 255; size++ {
 		root, err := s.HStar2Nodes(size, s.hasher.Size()*8-size, []HStar2LeafHash{},
@@ -133,7 +131,7 @@ func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to calculate root %v", err)
 		}
-		if expected, got := testonly.MustDecodeBase64(sparseEmptyRootHashB64), root; !bytes.Equal(expected, got) {
+		if expected, got := sparseEmptyRootHashB64, root; !bytes.Equal(expected, got) {
 			t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 		}
 	}
@@ -144,8 +142,7 @@ func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
 // 256-prefixSize, and can be passed in as leaves to top-subtree calculation.
 func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HStar2LeafHash {
 	var ret []HStar2LeafHash
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 	for i := range lh {
 		prefix := new(big.Int).Rsh(lh[i].Index, uint(s.hasher.Size()*8-prefixSize))
 		b := lh[i].Index.Bytes()
@@ -167,8 +164,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HS
 // (single top subtree of size n, and multipl bottom subtrees of size 256-n)
 // still arrives at the same Known Answers for root hash.
 func TestHStar2OffsetRootKAT(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 
 	m := make(map[string]string)
 
@@ -178,7 +174,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 		// requirement.
 		for size := 24; size < 256; size += 8 {
 			m[x.k] = x.v
-			intermediates := rootsForTrimmedKeys(t, size, createHStar2Leaves(th, m))
+			intermediates := rootsForTrimmedKeys(t, size, createHStar2Leaves(testonly.Hasher, m))
 
 			root, err := s.HStar2Nodes(size, s.hasher.Size()*8-size, intermediates,
 				func(int, *big.Int) ([]byte, error) { return nil, nil },
@@ -186,7 +182,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to calculate root at iteration %d: %v", i, err)
 			}
-			if expected, got := testonly.MustDecodeBase64(x.rootB64), root; !bytes.Equal(expected, got) {
+			if expected, got := x.root, root; !bytes.Equal(expected, got) {
 				t.Fatalf("Expected root:\n%v\nGot:\n%v", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 			}
 		}
@@ -194,8 +190,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 }
 
 func TestHStar2NegativeTreeLevelOffset(t *testing.T) {
-	th := NewRFC6962TreeHasher()
-	s := NewHStar2(th)
+	s := NewHStar2(testonly.Hasher)
 
 	_, err := s.HStar2Nodes(32, -1, []HStar2LeafHash{},
 		func(int, *big.Int) ([]byte, error) { return nil, nil },

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -27,6 +27,7 @@ import (
 
 // This root was calculated with the C++/Python sparse Merkle tree code in the
 // github.com/google/certificate-transparency repo.
+// TODO(alcutter): replace with hash-dependent computation. How is this computed?
 var sparseEmptyRootHashB64 = testonly.MustDecodeBase64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")
 
 // createHStar2Leaves builds a list of HStar2LeafHash structs suitable for

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/google/trillian/testonly"
 )
 
 type logProofTestVector struct {
@@ -294,13 +296,8 @@ func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1,
 	return nil
 }
 
-func getVerifier() LogVerifier {
-	hasher := NewRFC6962TreeHasher()
-	return NewLogVerifier(hasher)
-}
-
 func TestVerifyInclusionProof(t *testing.T) {
-	v := getVerifier()
+	v := NewLogVerifier(testonly.Hasher)
 	path := [][]byte{}
 	// Various invalid paths
 	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{}); err == nil {
@@ -347,7 +344,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 }
 
 func TestVerifyConsistencyProof(t *testing.T) {
-	v := getVerifier()
+	v := NewLogVerifier(testonly.Hasher)
 
 	proof := [][]byte{}
 	root1 := []byte("don't care")

--- a/merkle/map_hasher_test.go
+++ b/merkle/map_hasher_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"testing"
+
+	"github.com/google/trillian/testonly"
 )
 
 // Expected root hash of an empty sparse Merkle tree.
@@ -34,7 +36,7 @@ func emptyMapRoot() []byte {
 }
 
 func TestNullHashes(t *testing.T) {
-	mh := NewMapHasher(NewRFC6962TreeHasher())
+	mh := NewMapHasher(testonly.Hasher)
 	emptyRoot := mh.HashChildren(mh.nullHashes[0], mh.nullHashes[0])
 	if got, want := emptyRoot, emptyMapRoot(); !bytes.Equal(got, want) {
 		t.Fatalf("Expected empty root of %v, got %v", want, got)

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestVerifyMap(t *testing.T) {
-	h := NewMapHasher(NewRFC6962TreeHasher())
+	h := NewMapHasher(testonly.Hasher)
 	tv := mapInclusionTestVector[0]
 
 	// Copy the bad proof so we don't mess up the good proof.

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"github.com/google/trillian/testonly"
 )
 
 // Note test inputs came from the values used by the C++ code. The original
@@ -118,7 +120,7 @@ func decodeHexStringOrPanic(hs string) []byte {
 }
 
 func makeEmptyTree() *InMemoryMerkleTree {
-	return NewInMemoryMerkleTree(NewRFC6962TreeHasher())
+	return NewInMemoryMerkleTree(testonly.Hasher)
 }
 
 func makeFuzzTestData() [][]byte {

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rfc6962
+
+import "crypto"
+
+// Domain separation prefixes
+const (
+	RFC6962LeafHashPrefix = 0
+	RFC6962NodeHashPrefix = 1
+)
+
+// TreeHasher implements the RFC6962 tree hashing algorithm.
+type TreeHasher struct {
+	crypto.Hash
+}
+
+// HashEmpty returns the hash of an empty element for the tree
+func (t TreeHasher) HashEmpty() []byte {
+	return t.New().Sum(nil)
+}
+
+// HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
+// The data in leaf is prefixed by the LeafHashPrefix.
+func (t TreeHasher) HashLeaf(leaf []byte) []byte {
+	h := t.New()
+	h.Write([]byte{RFC6962LeafHashPrefix})
+	h.Write(leaf)
+	return h.Sum(nil)
+}
+
+// HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+func (t TreeHasher) HashChildren(l, r []byte) []byte {
+	h := t.New()
+	h.Write([]byte{RFC6962NodeHashPrefix})
+	h.Write(l)
+	h.Write(r)
+	return h.Sum(nil)
+}

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -81,13 +81,13 @@ func newTX(tx storage.MapTreeTX) func() (storage.TreeTX, error) {
 
 func getSparseMerkleTreeReaderWithMockTX(ctrl *gomock.Controller, rev int64) (*SparseMerkleTreeReader, *storage.MockMapTreeTX) {
 	tx := storage.NewMockMapTreeTX(ctrl)
-	return NewSparseMerkleTreeReader(rev, NewMapHasher(NewRFC6962TreeHasher()), tx), tx
+	return NewSparseMerkleTreeReader(rev, NewMapHasher(testonly.Hasher), tx), tx
 }
 
 func getSparseMerkleTreeWriterWithMockTX(ctrl *gomock.Controller, rev int64) (*SparseMerkleTreeWriter, *storage.MockMapTreeTX) {
 	tx := storage.NewMockMapTreeTX(ctrl)
 	tx.EXPECT().WriteRevision().AnyTimes().Return(rev)
-	tree, err := NewSparseMerkleTreeWriter(rev, NewMapHasher(NewRFC6962TreeHasher()), newTX(tx))
+	tree, err := NewSparseMerkleTreeWriter(rev, NewMapHasher(testonly.Hasher), newTX(tx))
 	if err != nil {
 		panic(err)
 	}
@@ -112,7 +112,7 @@ func (r rootNodeMatcher) String() string {
 func getEmptyRootNode() storage.Node {
 	return storage.Node{
 		NodeID:       storage.NewEmptyNodeID(0),
-		Hash:         testonly.MustDecodeBase64(sparseEmptyRootHashB64),
+		Hash:         sparseEmptyRootHashB64,
 		NodeRevision: 0,
 	}
 }
@@ -573,7 +573,7 @@ func DISABLEDTestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 		h := make([]HashKeyValue, batchSize)
 		for y := 0; y < batchSize; y++ {
 			h[y].HashedKey = testonly.HashKey(fmt.Sprintf("key-%d-%d", x, y))
-			h[y].HashedValue = w.hasher.TreeHasher.HashLeaf([]byte(fmt.Sprintf("value-%d-%d", x, y)))
+			h[y].HashedValue = w.hasher.HashLeaf([]byte(fmt.Sprintf("value-%d-%d", x, y)))
 		}
 		if err := w.SetLeaves(h); err != nil {
 			t.Fatalf("Failed to batch %d: %v", x, err)

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -31,6 +31,7 @@ type TreeHasher interface {
 	HashEmpty() []byte
 	HashLeaf(leaf []byte) []byte
 	HashChildren(l, r []byte) []byte
+	// TODO(gbelvin): Replace Size() with BitLength().
 	Size() int
 }
 

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -16,60 +16,33 @@ package merkle
 
 import (
 	"crypto"
+	"fmt"
+
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
-// TODO(al): investigate whether we need configurable TreeHashers for
-// different users. Apparently E2E hashes in tree-level to the internal nodes
-// for example, and some users may want different domain separation prefixes
-// etc.
-//
-// BIG SCARY COMMENT:
-//
-// We don't want this code to have to depend on or constrain implementations for
-// specific applications but we haven't decided how we're going to split domain
-// specific stuff from the generic yet and we don't want to lose track of the fact
-// that this hashing needs to be domain aware to some extent.
-//
-// END OF BIG SCARY COMMENT
-
-// Domain separation prefixes
-// TODO(Martin2112): Move anything CT specific out of here to <handwave> look over there
 const (
-	RFC6962LeafHashPrefix = 0
-	RFC6962NodeHashPrefix = 1
+	// RFC6962SHA256Type is the string used to retrieve the RFC6962 hasher.
+	RFC6962SHA256Type = "RFC6962-SHA256"
 )
 
-// TreeHasher implements the RFC6962 tree hashing algorithm.
-type TreeHasher struct {
-	crypto.Hash
+// TreeHasher is the interface that the previous tree hasher struct implemented.
+type TreeHasher interface {
+	HashEmpty() []byte
+	HashLeaf(leaf []byte) []byte
+	HashChildren(l, r []byte) []byte
+	Size() int
 }
 
-// NewRFC6962TreeHasher creates a new TreeHasher based on the passed in hash function.
-// TODO(Martin2112): Move anything CT specific out of here to <handwave> look over there
-func NewRFC6962TreeHasher() TreeHasher {
-	return TreeHasher{Hash: crypto.SHA256}
+var hashTypes = map[string]TreeHasher{
+	RFC6962SHA256Type: rfc6962.TreeHasher{crypto.SHA256},
 }
 
-// HashEmpty returns the hash of an empty element for the tree
-func (t TreeHasher) HashEmpty() []byte {
-	return t.New().Sum(nil)
-}
-
-// HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
-// The data in leaf is prefixed by the LeafHashPrefix.
-func (t TreeHasher) HashLeaf(leaf []byte) []byte {
-	h := t.New()
-	h.Write([]byte{RFC6962LeafHashPrefix})
-	h.Write(leaf)
-	return h.Sum(nil)
-}
-
-// HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
-// The hashed structure is NodeHashPrefix||l||r.
-func (t TreeHasher) HashChildren(l, r []byte) []byte {
-	h := t.New()
-	h.Write([]byte{RFC6962NodeHashPrefix})
-	h.Write(l)
-	h.Write(r)
-	return h.Sum(nil)
+// Factory supports fetching custom hashers based on tree types.
+func Factory(hashType string) (TreeHasher, error) {
+	h, ok := hashTypes[hashType]
+	if !ok {
+		return nil, fmt.Errorf("hash type %s not found", hashType)
+	}
+	return h, nil
 }

--- a/merkle/tree_hasher_test.go
+++ b/merkle/tree_hasher_test.go
@@ -37,7 +37,7 @@ func ensureHashMatches(expected, actual []byte, testCase string, t *testing.T) {
 }
 
 func TestRfc6962Hasher(t *testing.T) {
-	hasher := NewRFC6962TreeHasher()
+	hasher := testonly.Hasher
 
 	ensureHashMatches(testonly.MustHexDecode(rfc6962EmptyHashHex), hasher.HashEmpty(), "RFC962 Empty", t)
 	ensureHashMatches(testonly.MustHexDecode(rfc6962LeafL123456HashHex), hasher.HashLeaf([]byte("L123456")), "RFC6962 Leaf", t)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -69,8 +69,8 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	}
 	leaves := depointerify(req.Leaves)
 
-	// TODO(al): TreeHasher must be selected based on log config.
-	th := merkle.NewRFC6962TreeHasher()
+	// TODO(al): Hasher must be selected based on log config.
+	th, _ := merkle.Factory("RFC6962-SHA256")
 	for i := range leaves {
 		leaves[i].MerkleLeafHash = th.HashLeaf(leaves[i].LeafValue)
 	}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -70,7 +70,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	leaves := depointerify(req.Leaves)
 
 	// TODO(al): Hasher must be selected based on log config.
-	th, _ := merkle.Factory("RFC6962-SHA256")
+	th, _ := merkle.Factory(merkle.RFC6962SHA256Type)
 	for i := range leaves {
 		leaves[i].MerkleLeafHash = th.HashLeaf(leaves[i].LeafValue)
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -23,25 +23,22 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 )
 
 var (
-	th                 = merkle.NewRFC6962TreeHasher()
+	th                 = testonly.Hasher
 	logID1             = int64(1)
 	logID2             = int64(2)
 	leaf0Request       = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0}}
 	leaf0Minus2Request = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0, -2}}
 	leaf03Request      = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0, 3}}
 	leaf0Log2Request   = trillian.GetLeavesByIndexRequest{LogId: logID2, LeafIndex: []int64{0}}
-
-	leaf1Data = []byte("value")
-	leaf3Data = []byte("value3")
-
-	leaf1 = trillian.LogLeaf{LeafIndex: 1, MerkleLeafHash: th.HashLeaf(leaf1Data), LeafValue: leaf1Data, ExtraData: []byte("extra")}
-	leaf3 = trillian.LogLeaf{LeafIndex: 3, MerkleLeafHash: th.HashLeaf(leaf3Data), LeafValue: leaf3Data, ExtraData: []byte("extra3")}
+	leaf1Data          = []byte("value")
+	leaf3Data          = []byte("value3")
+	leaf1              = trillian.LogLeaf{LeafIndex: 1, MerkleLeafHash: th.HashLeaf(leaf1Data), LeafValue: leaf1Data, ExtraData: []byte("extra")}
+	leaf3              = trillian.LogLeaf{LeafIndex: 3, MerkleLeafHash: th.HashLeaf(leaf3Data), LeafValue: leaf3Data, ExtraData: []byte("extra3")}
 
 	queueRequest0     = trillian.QueueLeavesRequest{LogId: logID1, Leaves: []*trillian.LogLeaf{&leaf1}}
 	queueRequest0Log2 = trillian.QueueLeavesRequest{LogId: logID2, Leaves: []*trillian.LogLeaf{&leaf1}}

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -54,9 +54,9 @@ type rehasher struct {
 // init must be called before the rehasher is used or reused
 func newRehasher() *rehasher {
 	// TODO(Martin2112): Hasher must be selected based on log config.
-	hasher, err := merkle.Factory("RFC6962-SHA256")
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
 	if err != nil {
-		panic("Uknown hash strategy")
+		panic("Unknown hash strategy")
 	}
 	return &rehasher{
 		th: hasher,

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -53,9 +53,13 @@ type rehasher struct {
 
 // init must be called before the rehasher is used or reused
 func newRehasher() *rehasher {
+	// TODO(Martin2112): Hasher must be selected based on log config.
+	hasher, err := merkle.Factory("RFC6962-SHA256")
+	if err != nil {
+		panic("Uknown hash strategy")
+	}
 	return &rehasher{
-		// TODO(Martin2112): TreeHasher must be selected based on log config.
-		th: merkle.NewRFC6962TreeHasher(),
+		th: hasher,
 	}
 }
 

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
+	trillian_testonly "github.com/google/trillian/testonly"
 )
 
 // rehashTest encapsulates one test case for the rehasher in isolation. Input data like the storage
@@ -311,7 +312,7 @@ func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) []byte {
 
 func treeAtSize(n int) *merkle.InMemoryMerkleTree {
 	leaves := expandLeaves(0, n-1)
-	mt := merkle.NewInMemoryMerkleTree(merkle.NewRFC6962TreeHasher())
+	mt := merkle.NewInMemoryMerkleTree(trillian_testonly.Hasher)
 	for _, leaf := range leaves {
 		mt.AddLeaf([]byte(leaf))
 	}

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -72,7 +72,7 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 		ctx := util.NewLogContext(logctx.ctx, logID)
 
 		// TODO(Martin2112): Allow for different tree hashers to be used by different logs
-		hasher, err := merkle.Factory("RFC6962-SHA256")
+		hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
 		if err != nil {
 			glog.Errorf("Unknown hash strategy for log %d: %v", logID, err)
 			continue

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -72,7 +72,12 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 		ctx := util.NewLogContext(logctx.ctx, logID)
 
 		// TODO(Martin2112): Allow for different tree hashers to be used by different logs
-		sequencer := log.NewSequencer(merkle.NewRFC6962TreeHasher(), logctx.timeSource, storage, s.keyManager)
+		hasher, err := merkle.Factory("RFC6962-SHA256")
+		if err != nil {
+			glog.Errorf("Unknown hash strategy for log %d: %v", logID, err)
+			continue
+		}
+		sequencer := log.NewSequencer(hasher, logctx.timeSource, storage, s.keyManager)
 		sequencer.SetGuardWindow(s.guardWindow)
 
 		leaves, err := sequencer.SequenceBatch(ctx, logID, logctx.batchSize)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -24,13 +24,10 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/extension"
-	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
 )
-
-var treeHasher = merkle.NewRFC6962TreeHasher()
 
 // Arbitrary time for use in tests
 var fakeTime = time.Date(2016, 6, 28, 13, 40, 12, 45, time.UTC)
@@ -38,7 +35,12 @@ var fakeTimeSource = util.FakeTimeSource{FakeTime: fakeTime}
 
 // We use a size zero tree for testing, Merkle tree state restore is tested elsewhere
 var testLogID1 = int64(1)
-var testLeaf0 = trillian.LogLeaf{MerkleLeafHash: treeHasher.HashLeaf([]byte{}), LeafValue: nil, ExtraData: nil, LeafIndex: 0}
+var testLeaf0 = trillian.LogLeaf{
+	MerkleLeafHash: testonly.Hasher.HashLeaf([]byte{}),
+	LeafValue:      nil,
+	ExtraData:      nil,
+	LeafIndex:      0,
+}
 var testLeaf0Updated = trillian.LogLeaf{MerkleLeafHash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), LeafValue: nil, ExtraData: nil, LeafIndex: 0}
 var testRoot0 = trillian.SignedLogRoot{
 	TreeSize:     0,

--- a/server/vmap/trillian_map_server.go
+++ b/server/vmap/trillian_map_server.go
@@ -41,7 +41,11 @@ func NewTrillianMapServer(registry extension.Registry) *TrillianMapServer {
 
 func (t *TrillianMapServer) getHasherForMap(mapID int64) (merkle.MapHasher, error) {
 	// TODO(al): actually return tailored hashers.
-	return merkle.NewMapHasher(merkle.NewRFC6962TreeHasher()), nil
+	h, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		return merkle.MapHasher{}, err
+	}
+	return merkle.NewMapHasher(h), nil
 }
 
 // GetLeaves implements the GetLeaves RPC method.

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -55,7 +55,7 @@ var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
 func TestSplitNodeID(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 	for i, v := range splitTestVector {
 		n := storage.NewNodeIDFromHash(v.inPath)
 		n.PrefixLenBits = v.inPathLenBits
@@ -80,7 +80,7 @@ func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 
 	nodeID := storage.NewNodeIDFromHash([]byte("1234"))
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
@@ -109,7 +109,7 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 
 	nodeIDs := []storage.NodeID{
 		storage.NewNodeIDFromHash([]byte("1234")),
@@ -162,7 +162,7 @@ func TestCacheFlush(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	m := NewMockNodeStorage(mockCtrl)
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 
 	h := "0123456789abcdef0123456789abcdef"
 	nodeID := storage.NewNodeIDFromHash([]byte(h))
@@ -247,9 +247,8 @@ func TestSuffixSerializeFormat(t *testing.T) {
 }
 
 func TestRepopulateLogSubtree(t *testing.T) {
-	hasher := merkle.NewRFC6962TreeHasher()
-	populateTheThing := PopulateLogSubtreeNodes(hasher)
-	cmt := merkle.NewCompactMerkleTree(hasher)
+	populateTheThing := PopulateLogSubtreeNodes(testonly.Hasher)
+	cmt := merkle.NewCompactMerkleTree(testonly.Hasher)
 	cmtStorage := storagepb.SubtreeProto{
 		Leaves:        make(map[string][]byte),
 		InternalNodes: make(map[string][]byte),
@@ -259,13 +258,13 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		Leaves: make(map[string][]byte),
 		Depth:  int32(defaultLogStrata[0]),
 	}
-	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareLogSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(testonly.Hasher), PrepareLogSubtreeWrite())
 	for numLeaves := int64(1); numLeaves <= 256; numLeaves++ {
 		// clear internal nodes
 		s.InternalNodes = make(map[string][]byte)
 
 		leaf := []byte(fmt.Sprintf("this is leaf %d", numLeaves))
-		leafHash := hasher.HashLeaf(leaf)
+		leafHash := testonly.Hasher.HashLeaf(leaf)
 		cmt.AddLeafHash(leafHash, func(depth int, index int64, h []byte) {
 			n, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 8)
 			if err != nil {
@@ -313,7 +312,7 @@ func TestPrefixLengths(t *testing.T) {
 	strata := []int{8, 8, 16, 32, 64, 128}
 	stratumInfo := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
-	c := NewSubtreeCache(strata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(strata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 
 	if got, want := c.stratumInfo, stratumInfo; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Got prefixLengths of %v, expected %v", got, want)
@@ -321,7 +320,7 @@ func TestPrefixLengths(t *testing.T) {
 }
 
 func TestGetStratumInfo(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(merkle.NewRFC6962TreeHasher()), PrepareMapSubtreeWrite())
+	c := NewSubtreeCache(defaultMapStrata, PopulateMapSubtreeNodes(testonly.Hasher), PrepareMapSubtreeWrite())
 	testVec := []struct {
 		depth int
 		info  stratumInfo

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -162,7 +162,7 @@ func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
 
 func (m *mySQLLogStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
 	// TODO: read hash algorithm from storage.
-	return merkle.Factory("RFC6962-SHA256")
+	return merkle.Factory(merkle.RFC6962SHA256Type)
 }
 
 func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -160,15 +160,23 @@ func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
 	return getActiveLogIDsWithPendingWork(t.tx)
 }
 
+func (m *mySQLLogStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
+	// TODO: read hash algorithm from storage.
+	return merkle.Factory("RFC6962-SHA256")
+}
+
 func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	// TODO(codingllama): Validate treeType, read hash algorithm from storage
+	// TODO(codingllama): Validate treeType
 	var allowDuplicates bool
 	if err := m.db.QueryRow(getTreePropertiesSQL, treeID).Scan(&allowDuplicates); err != nil {
 		return nil, fmt.Errorf("failed to get tree row for treeID %v: %s", treeID, err)
 	}
-	th := merkle.NewRFC6962TreeHasher()
+	hasher, err := m.hasher(treeID)
+	if err != nil {
+		return nil, err
+	}
 
-	ttx, err := m.beginTreeTx(ctx, treeID, th.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(th), cache.PrepareLogSubtreeWrite())
+	ttx, err := m.beginTreeTx(ctx, treeID, hasher.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(hasher), cache.PrepareLogSubtreeWrite())
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -64,7 +64,7 @@ func NewMapStorage(db *sql.DB) (storage.MapStorage, error) {
 
 func (m *mySQLMapStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
 	// TODO: read hash algorithm from storage.
-	return merkle.Factory("RFC6962-SHA256")
+	return merkle.Factory(merkle.RFC6962SHA256Type)
 }
 
 func (m *mySQLMapStorage) BeginForTree(ctx context.Context, treeID int64) (storage.MapTreeTX, error) {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/testonly"
 )
 
 // Parallel tests must get different log or map ids
@@ -223,7 +224,7 @@ func createSomeNodes(testName string, treeID int64) []storage.Node {
 }
 
 func createLogNodesForTreeAtSize(ts, rev int64) []storage.Node {
-	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
+	tree := merkle.NewCompactMerkleTree(testonly.Hasher)
 	nodeMap := make(map[string]storage.Node)
 	for l := 0; l < int(ts); l++ {
 		// We're only interested in the side effects of adding leaves - the node updates

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/testonly"
 )
 
 // This is a fake implementation of a NodeReader intended for use in testing Merkle path code.
@@ -126,7 +127,7 @@ func NewMultiFakeNodeReader(readers []FakeNodeReader) *MultiFakeNodeReader {
 // code. To help guard against this we check the tree root hash after each batch has been
 // processed. The supplied batches should be in ascending order of tree revision.
 func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader {
-	tree := merkle.NewCompactMerkleTree(merkle.NewRFC6962TreeHasher())
+	tree := merkle.NewCompactMerkleTree(testonly.Hasher)
 	readers := make([]FakeNodeReader, 0, len(batches))
 
 	lastBatchRevision := int64(0)

--- a/testonly/hasher.go
+++ b/testonly/hasher.go
@@ -17,7 +17,16 @@ package testonly
 // This file implements the hashing functions that are part of a Trillian
 // personality.
 
-import "crypto/sha256"
+import (
+	"crypto"
+	"crypto/sha256"
+
+	"github.com/google/trillian/merkle/rfc6962"
+)
+
+// Hasher is the default hasher for tests.
+// TODO: Make this a custom algorithm to decouple hashing from coded defaults.
+var Hasher = rfc6962.TreeHasher{crypto.SHA256}
 
 // HashKey converts a map key into a map index using SHA256.
 // This preserves tests that precomputed indexes based on SHA256.

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -49,7 +49,11 @@ func main() {
 		glog.Fatalf("Failed create MapStorage: %v", err)
 	}
 
-	hasher := merkle.NewMapHasher(merkle.NewRFC6962TreeHasher())
+	h, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		glog.Fatalf("Could not find hasher: %v", err)
+	}
+	hasher := merkle.NewMapHasher(h)
 
 	testVecs := []struct {
 		batchSize       int


### PR DESCRIPTION
- Support looking up the hasher based on the log config.
- Create a separate, test hasher for use in tests.
  This supports future decoupling of tests from hard-coded values.
- Moves RFC6962 hasher into its own module.

Partial work towards #331 