### PR TITLE
Adding ReadOnlyMapTX and DatabaseChecker interfaces

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -57,15 +57,7 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-	tx, err := logStorage.Snapshot(context.Background())
-	if err != nil {
-		return err
-	}
-	if err := tx.IsConnected(); err != nil {
-		tx.Rollback()
-		return err
-	}
-	return tx.Commit()
+	return logStorage.CheckDatabaseAccessible(context.Background())
 }
 
 func startRPCServer(registry extension.Registry) *grpc.Server {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -57,18 +57,14 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-
 	tx, err := logStorage.Snapshot(context.Background())
 	if err != nil {
 		return err
 	}
-
-	// Pull the log ids, we don't care about the result, we just want to know that it works
-	if _, err := tx.GetActiveLogIDs(); err != nil {
+	if err := tx.CheckDatabaseAccessible(); err != nil {
 		tx.Rollback()
 		return err
 	}
-
 	return tx.Commit()
 }
 

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -61,7 +61,7 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-	if err := tx.CheckDatabaseAccessible(); err != nil {
+	if err := tx.IsConnected(); err != nil {
 		tx.Rollback()
 		return err
 	}

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -54,7 +54,7 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-	if err := tx.CheckDatabaseAccessible(); err != nil {
+	if err := tx.IsConnected(); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -50,14 +50,7 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-	tx, err := mapStorage.Snapshot(context.Background())
-	if err != nil {
-		return err
-	}
-	if err := tx.IsConnected(); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return mapStorage.CheckDatabaseAccessible(context.Background())
 }
 
 func startRPCServer(registry extension.Registry) *grpc.Server {

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -50,14 +50,13 @@ func checkDatabaseAccessible(registry extension.Registry) error {
 	if err != nil {
 		return err
 	}
-
-	// TODO(codingllama): We shouldn't use a mapID here
-	tx, err := mapStorage.BeginForTree(context.Background(), 0)
+	tx, err := mapStorage.Snapshot(context.Background())
 	if err != nil {
 		return err
 	}
-
-	// TODO(codingllama): Add some sort of liveness ping here
+	if err := tx.CheckDatabaseAccessible(); err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -24,7 +24,6 @@ import (
 // ReadOnlyLogTX provides a read-only view into log data.
 // A ReadOnlyLogTX, unlike ReadOnlyLogTreeTX, is not tied to a particular tree.
 type ReadOnlyLogTX interface {
-	DatabaseChecker
 	LogMetadata
 
 	// Commit ensures the data read by the TX is consistent in the database. Only after Commit the
@@ -60,6 +59,8 @@ type LogTreeTX interface {
 
 // ReadOnlyLogStorage represents a narrowed read-only view into a LogStorage.
 type ReadOnlyLogStorage interface {
+	DatabaseChecker
+
 	// Snapshot starts a read-only transaction not tied to any particular tree.
 	Snapshot(ctx context.Context) (ReadOnlyLogTX, error)
 

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -24,6 +24,7 @@ import (
 // ReadOnlyLogTX provides a read-only view into log data.
 // A ReadOnlyLogTX, unlike ReadOnlyLogTreeTX, is not tied to a particular tree.
 type ReadOnlyLogTX interface {
+	DatabaseChecker
 	LogMetadata
 
 	// Commit ensures the data read by the TX is consistent in the database. Only after Commit the

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -20,6 +20,19 @@ import (
 	"github.com/google/trillian"
 )
 
+// ReadOnlyMapTX provides a read-only view into log data.
+// A ReadOnlyMapTX, unlike ReadOnlyMapTreeTX, is not tied to a particular tree.
+type ReadOnlyMapTX interface {
+	DatabaseChecker
+
+	// Commit ensures the data read by the TX is consistent in the database. Only after Commit the
+	// data read should be regarded as valid.
+	Commit() error
+
+	// Rollback discards the read-only TX.
+	Rollback() error
+}
+
 // ReadOnlyMapTreeTX provides a read-only view into the Map data.
 // A ReadOnlyMapTreeTX can only read from the tree specified in its creation.
 type ReadOnlyMapTreeTX interface {
@@ -43,6 +56,9 @@ type MapTreeTX interface {
 
 // ReadOnlyMapStorage provides a narrow read-only view into a MapStorage.
 type ReadOnlyMapStorage interface {
+	// Snapshot starts a read-only transaction not tied to any particular tree.
+	Snapshot(ctx context.Context) (ReadOnlyMapTX, error)
+
 	// SnapshotForTree starts a new read-only transaction.
 	// Commit must be called when the caller is finished with the returned object,
 	// and values read through it should only be propagated if Commit returns

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -23,8 +23,6 @@ import (
 // ReadOnlyMapTX provides a read-only view into log data.
 // A ReadOnlyMapTX, unlike ReadOnlyMapTreeTX, is not tied to a particular tree.
 type ReadOnlyMapTX interface {
-	DatabaseChecker
-
 	// Commit ensures the data read by the TX is consistent in the database. Only after Commit the
 	// data read should be regarded as valid.
 	Commit() error
@@ -56,6 +54,8 @@ type MapTreeTX interface {
 
 // ReadOnlyMapStorage provides a narrow read-only view into a MapStorage.
 type ReadOnlyMapStorage interface {
+	DatabaseChecker
+
 	// Snapshot starts a read-only transaction not tied to any particular tree.
 	Snapshot(ctx context.Context) (ReadOnlyMapTX, error)
 

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -42,6 +42,16 @@ func (_mr *_MockLogStorageRecorder) BeginForTree(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BeginForTree", arg0, arg1)
 }
 
+func (_m *MockLogStorage) CheckDatabaseAccessible(_param0 context.Context) error {
+	ret := _m.ctrl.Call(_m, "CheckDatabaseAccessible", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockLogStorageRecorder) CheckDatabaseAccessible(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckDatabaseAccessible", arg0)
+}
+
 func (_m *MockLogStorage) Snapshot(_param0 context.Context) (ReadOnlyLogTX, error) {
 	ret := _m.ctrl.Call(_m, "Snapshot", _param0)
 	ret0, _ := ret[0].(ReadOnlyLogTX)
@@ -295,6 +305,16 @@ func (_mr *_MockMapStorageRecorder) BeginForTree(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BeginForTree", arg0, arg1)
 }
 
+func (_m *MockMapStorage) CheckDatabaseAccessible(_param0 context.Context) error {
+	ret := _m.ctrl.Call(_m, "CheckDatabaseAccessible", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMapStorageRecorder) CheckDatabaseAccessible(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckDatabaseAccessible", arg0)
+}
+
 func (_m *MockMapStorage) Snapshot(_param0 context.Context) (ReadOnlyMapTX, error) {
 	ret := _m.ctrl.Call(_m, "Snapshot", _param0)
 	ret0, _ := ret[0].(ReadOnlyMapTX)
@@ -502,16 +522,6 @@ func (_m *MockReadOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
 
 func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
-}
-
-func (_m *MockReadOnlyLogTX) IsConnected() error {
-	ret := _m.ctrl.Call(_m, "IsConnected")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockReadOnlyLogTXRecorder) IsConnected() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsConnected")
 }
 
 func (_m *MockReadOnlyLogTX) Rollback() error {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -472,16 +472,6 @@ func (_m *MockReadOnlyLogTX) EXPECT() *_MockReadOnlyLogTXRecorder {
 	return _m.recorder
 }
 
-func (_m *MockReadOnlyLogTX) CheckDatabaseAccessible() error {
-	ret := _m.ctrl.Call(_m, "CheckDatabaseAccessible")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockReadOnlyLogTXRecorder) CheckDatabaseAccessible() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckDatabaseAccessible")
-}
-
 func (_m *MockReadOnlyLogTX) Commit() error {
 	ret := _m.ctrl.Call(_m, "Commit")
 	ret0, _ := ret[0].(error)
@@ -512,6 +502,16 @@ func (_m *MockReadOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
 
 func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
+}
+
+func (_m *MockReadOnlyLogTX) IsConnected() error {
+	ret := _m.ctrl.Call(_m, "IsConnected")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReadOnlyLogTXRecorder) IsConnected() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsConnected")
 }
 
 func (_m *MockReadOnlyLogTX) Rollback() error {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -295,6 +295,17 @@ func (_mr *_MockMapStorageRecorder) BeginForTree(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BeginForTree", arg0, arg1)
 }
 
+func (_m *MockMapStorage) Snapshot(_param0 context.Context) (ReadOnlyMapTX, error) {
+	ret := _m.ctrl.Call(_m, "Snapshot", _param0)
+	ret0, _ := ret[0].(ReadOnlyMapTX)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMapStorageRecorder) Snapshot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Snapshot", arg0)
+}
+
 func (_m *MockMapStorage) SnapshotForTree(_param0 context.Context, _param1 int64) (ReadOnlyMapTreeTX, error) {
 	ret := _m.ctrl.Call(_m, "SnapshotForTree", _param0, _param1)
 	ret0, _ := ret[0].(ReadOnlyMapTreeTX)
@@ -459,6 +470,16 @@ func NewMockReadOnlyLogTX(ctrl *gomock.Controller) *MockReadOnlyLogTX {
 
 func (_m *MockReadOnlyLogTX) EXPECT() *_MockReadOnlyLogTXRecorder {
 	return _m.recorder
+}
+
+func (_m *MockReadOnlyLogTX) CheckDatabaseAccessible() error {
+	ret := _m.ctrl.Call(_m, "CheckDatabaseAccessible")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReadOnlyLogTXRecorder) CheckDatabaseAccessible() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckDatabaseAccessible")
 }
 
 func (_m *MockReadOnlyLogTX) Commit() error {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -81,6 +81,10 @@ func NewLogStorage(db *sql.DB) (storage.LogStorage, error) {
 	}, nil
 }
 
+func (m *mySQLLogStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return checkDatabaseAccessible(ctx, m.db)
+}
+
 func (m *mySQLLogStorage) getLeavesByIndexStmt(num int) (*sql.Stmt, error) {
 	return m.getStmt(selectLeavesByIndexSQL, num, "?", "?")
 }
@@ -149,10 +153,6 @@ func (t *readOnlyLogTX) Commit() error {
 
 func (t *readOnlyLogTX) Rollback() error {
 	return t.tx.Rollback()
-}
-
-func (t *readOnlyLogTX) IsConnected() error {
-	return isConnected(t.tx)
 }
 
 func (t *readOnlyLogTX) GetActiveLogIDs() ([]int64, error) {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -152,7 +152,7 @@ func (t *readOnlyLogTX) Rollback() error {
 }
 
 func (t *readOnlyLogTX) IsConnected() error {
-	return checkDatabaseAccessible(t.tx)
+	return isConnected(t.tx)
 }
 
 func (t *readOnlyLogTX) GetActiveLogIDs() ([]int64, error) {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	getTreePropertiesSQL  = "SELECT AllowsDuplicateLeaves FROM Trees WHERE TreeId=?"
-	getTreeParametersSQL  = "SELECT ReadOnlyRequests From TreeControl WHERE TreeID=?"
 	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,Payload
 			FROM Unsequenced
 			WHERE TreeID=?
@@ -150,6 +149,10 @@ func (t *readOnlyLogTX) Commit() error {
 
 func (t *readOnlyLogTX) Rollback() error {
 	return t.tx.Rollback()
+}
+
+func (t *readOnlyLogTX) CheckDatabaseAccessible() error {
+	return checkDatabaseAccessible(t.tx)
 }
 
 func (t *readOnlyLogTX) GetActiveLogIDs() ([]int64, error) {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -151,7 +151,7 @@ func (t *readOnlyLogTX) Rollback() error {
 	return t.tx.Rollback()
 }
 
-func (t *readOnlyLogTX) CheckDatabaseAccessible() error {
+func (t *readOnlyLogTX) IsConnected() error {
 	return checkDatabaseAccessible(t.tx)
 }
 

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -156,7 +156,6 @@ func TestBegin(t *testing.T) {
 		}
 
 	}
-
 }
 
 func TestSnapshot(t *testing.T) {
@@ -198,7 +197,6 @@ func TestSnapshot(t *testing.T) {
 		}
 
 	}
-
 }
 
 func TestOpenStateCommit(t *testing.T) {
@@ -973,6 +971,28 @@ func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
 	}
 	for _, test := range tests {
 		runTestGetActiveLogIDsWithPendingWork(t, test)
+	}
+}
+
+func TestReadOnlyLogTX_CheckDatabaseAccessible(t *testing.T) {
+	cleanTestDB(DB)
+
+	s, err := NewLogStorage(DB)
+	if err != nil {
+		t.Fatalf("NewLogStorage() = (_, %v), want = (_, nil)", err)
+	}
+
+	tx, err := s.Snapshot(context.TODO())
+	if err != nil {
+		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
+	}
+
+	if err := tx.CheckDatabaseAccessible(); err != nil {
+		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Errorf("Commit() = (_, %v), want = (_, nil)", err)
 	}
 }
 

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -98,6 +98,17 @@ func setAllowsDuplicates(db *sql.DB, treeID int64, allowDuplicates bool) error {
 	return err
 }
 
+func TestMySQLLogStorage_CheckDatabaseAccessible(t *testing.T) {
+	cleanTestDB(DB)
+	s, err := NewLogStorage(DB)
+	if err != nil {
+		t.Fatalf("NewLogStorage() = (_, %v), want = (_, nil)", err)
+	}
+	if err := s.CheckDatabaseAccessible(context.Background()); err != nil {
+		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+}
+
 func TestBegin(t *testing.T) {
 	logID1 := createLogID("TestBegin1")
 	logID2 := createLogID("TestBegin2")
@@ -971,28 +982,6 @@ func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
 	}
 	for _, test := range tests {
 		runTestGetActiveLogIDsWithPendingWork(t, test)
-	}
-}
-
-func TestReadOnlyLogTX_IsConnected(t *testing.T) {
-	cleanTestDB(DB)
-
-	s, err := NewLogStorage(DB)
-	if err != nil {
-		t.Fatalf("NewLogStorage() = (_, %v), want = (_, nil)", err)
-	}
-
-	tx, err := s.Snapshot(context.TODO())
-	if err != nil {
-		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
-	}
-
-	if err := tx.IsConnected(); err != nil {
-		t.Errorf("IsConnected() = %v, want = nil", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		t.Errorf("Commit() = (_, %v), want = (_, nil)", err)
 	}
 }
 

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -974,7 +974,7 @@ func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
 	}
 }
 
-func TestReadOnlyLogTX_CheckDatabaseAccessible(t *testing.T) {
+func TestReadOnlyLogTX_IsConnected(t *testing.T) {
 	cleanTestDB(DB)
 
 	s, err := NewLogStorage(DB)
@@ -987,8 +987,8 @@ func TestReadOnlyLogTX_CheckDatabaseAccessible(t *testing.T) {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
 	}
 
-	if err := tx.CheckDatabaseAccessible(); err != nil {
-		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	if err := tx.IsConnected(); err != nil {
+		t.Errorf("IsConnected() = %v, want = nil", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -82,7 +82,7 @@ func (t *readOnlyMapTX) Rollback() error {
 	return t.tx.Rollback()
 }
 
-func (t *readOnlyMapTX) CheckDatabaseAccessible() error {
+func (t *readOnlyMapTX) IsConnected() error {
 	return checkDatabaseAccessible(t.tx)
 }
 

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -62,6 +62,10 @@ func NewMapStorage(db *sql.DB) (storage.MapStorage, error) {
 	}, nil
 }
 
+func (m *mySQLMapStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return checkDatabaseAccessible(ctx, m.db)
+}
+
 type readOnlyMapTX struct {
 	tx *sql.Tx
 }
@@ -80,10 +84,6 @@ func (t *readOnlyMapTX) Commit() error {
 
 func (t *readOnlyMapTX) Rollback() error {
 	return t.tx.Rollback()
-}
-
-func (t *readOnlyMapTX) IsConnected() error {
-	return isConnected(t.tx)
 }
 
 func (m *mySQLMapStorage) hasher(treeID int64) (merkle.TreeHasher, error) {

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -83,7 +83,7 @@ func (t *readOnlyMapTX) Rollback() error {
 }
 
 func (t *readOnlyMapTX) IsConnected() error {
-	return checkDatabaseAccessible(t.tx)
+	return isConnected(t.tx)
 }
 
 func (m *mySQLMapStorage) hasher(treeID int64) (merkle.TreeHasher, error) {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -24,6 +24,17 @@ import (
 	"github.com/google/trillian/storage"
 )
 
+func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
+	cleanTestDB(DB)
+	s, err := NewMapStorage(DB)
+	if err != nil {
+		t.Fatalf("NewMapStorage() = (_, %v), want = (_, nil)", err)
+	}
+	if err := s.CheckDatabaseAccessible(context.Background()); err != nil {
+		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+}
+
 func TestMapBegin(t *testing.T) {
 	mapID := createMapID("TestBegin")
 	cleanTestDB(DB)
@@ -383,28 +394,6 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 	}
 }
 
-func TestReadOnlyMapTX_IsConnected(t *testing.T) {
-	cleanTestDB(DB)
-
-	s, err := NewMapStorage(DB)
-	if err != nil {
-		t.Fatalf("NewMapStorage() = (_, %v), want = (_, nil)", err)
-	}
-
-	tx, err := s.Snapshot(context.TODO())
-	if err != nil {
-		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
-	}
-
-	if err := tx.IsConnected(); err != nil {
-		t.Errorf("IsConnected() = %v, want = nil", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		t.Errorf("Commit() = (_, %v), want = (_, nil)", err)
-	}
-}
-
 func TestReadOnlyMapTX_Rollback(t *testing.T) {
 	cleanTestDB(DB)
 
@@ -416,11 +405,6 @@ func TestReadOnlyMapTX_Rollback(t *testing.T) {
 	tx, err := s.Snapshot(context.TODO())
 	if err != nil {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
-	}
-
-	// Do *something* before rolling back
-	if err := tx.IsConnected(); err != nil {
-		t.Fatalf("IsConnected() = %v, want = nil", err)
 	}
 
 	// It's a bit hard to have a more meaningful test. This should suffice.

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -383,7 +383,7 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 	}
 }
 
-func TestReadOnlyMapTX_CheckDatabaseAccessible(t *testing.T) {
+func TestReadOnlyMapTX_IsConnected(t *testing.T) {
 	cleanTestDB(DB)
 
 	s, err := NewMapStorage(DB)
@@ -396,8 +396,8 @@ func TestReadOnlyMapTX_CheckDatabaseAccessible(t *testing.T) {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
 	}
 
-	if err := tx.CheckDatabaseAccessible(); err != nil {
-		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	if err := tx.IsConnected(); err != nil {
+		t.Errorf("IsConnected() = %v, want = nil", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -419,8 +419,8 @@ func TestReadOnlyMapTX_Rollback(t *testing.T) {
 	}
 
 	// Do *something* before rolling back
-	if err := tx.CheckDatabaseAccessible(); err != nil {
-		t.Fatalf("CheckDatabaseAccessible() = %v, want = nil", err)
+	if err := tx.IsConnected(); err != nil {
+		t.Fatalf("IsConnected() = %v, want = nil", err)
 	}
 
 	// It's a bit hard to have a more meaningful test. This should suffice.

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -104,7 +104,7 @@ func TestMapRootUpdate(t *testing.T) {
 	mapID := createMapID("TestLatestSignedMapRoot")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Commit()
@@ -163,7 +163,7 @@ func TestMapSetGetRoundTrip(t *testing.T) {
 	mapID := createMapID("TestMapSetGetRoundTrip")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 
 	readRev := int64(1)
 
@@ -202,7 +202,7 @@ func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
 	mapID := createMapID("TestMapSetSameKeyInSameRevisionFails")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 
 	{
@@ -232,7 +232,7 @@ func TestMapGetUnknownKey(t *testing.T) {
 	mapID := createMapID("TestMapGetUnknownKey")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 
 	{
@@ -256,7 +256,7 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 	mapID := createMapID("TestMapSetGetMultipleRevisions")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 
 	tests := []struct {
 		rev  int64
@@ -310,7 +310,7 @@ func TestLatestSignedMapRootNoneWritten(t *testing.T) {
 	mapID := createMapID("TestLatestSignedMapRootNoneWritten")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Rollback()
@@ -330,7 +330,7 @@ func TestLatestSignedMapRoot(t *testing.T) {
 	mapID := createMapID("TestLatestSignedMapRoot")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Rollback()
@@ -365,7 +365,7 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 	mapID := createMapID("TestDuplicateSignedMapRoot")
 	cleanTestDB(DB)
 	prepareTestMapDB(DB, mapID, t)
-	s := prepareTestMapStorage(DB, mapID, t)
+	s := prepareTestMapStorage(DB, t)
 	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Commit()
@@ -383,7 +383,53 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 	}
 }
 
-func prepareTestMapStorage(db *sql.DB, mapID mapIDAndTest, t *testing.T) storage.MapStorage {
+func TestReadOnlyMapTX_CheckDatabaseAccessible(t *testing.T) {
+	cleanTestDB(DB)
+
+	s, err := NewMapStorage(DB)
+	if err != nil {
+		t.Fatalf("NewMapStorage() = (_, %v), want = (_, nil)", err)
+	}
+
+	tx, err := s.Snapshot(context.TODO())
+	if err != nil {
+		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
+	}
+
+	if err := tx.CheckDatabaseAccessible(); err != nil {
+		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Errorf("Commit() = (_, %v), want = (_, nil)", err)
+	}
+}
+
+func TestReadOnlyMapTX_Rollback(t *testing.T) {
+	cleanTestDB(DB)
+
+	s, err := NewMapStorage(DB)
+	if err != nil {
+		t.Fatalf("NewMapStorage() = (_, %v), want = (_, nil)", err)
+	}
+
+	tx, err := s.Snapshot(context.TODO())
+	if err != nil {
+		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
+	}
+
+	// Do *something* before rolling back
+	if err := tx.CheckDatabaseAccessible(); err != nil {
+		t.Fatalf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+
+	// It's a bit hard to have a more meaningful test. This should suffice.
+	if err := tx.Rollback(); err != nil {
+		t.Errorf("Rollback() = (_, %v), want = (_, nil)", err)
+	}
+}
+
+func prepareTestMapStorage(db *sql.DB, t *testing.T) storage.MapStorage {
 	s, err := NewMapStorage(db)
 	if err != nil {
 		t.Fatalf("Failed to open map storage: %s", err)

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -70,7 +70,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	const writeRevision = int64(100)
 
-	nodesToStore := createSomeNodes("TestNodeRoundTrip", logID.logID)
+	nodesToStore := createSomeNodes()
 	nodeIDsToRead := make([]storage.NodeID, len(nodesToStore))
 	for i := range nodesToStore {
 		nodeIDsToRead[i] = nodesToStore[i].NodeID
@@ -212,7 +212,7 @@ func createMapID(testName string) mapIDAndTest {
 	}
 }
 
-func createSomeNodes(testName string, treeID int64) []storage.Node {
+func createSomeNodes() []storage.Node {
 	r := make([]storage.Node, 4)
 	for i := range r {
 		r[i].NodeID = storage.NewNodeIDWithPrefix(uint64(i), 8, 8, 8)

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -407,3 +407,14 @@ func (t *treeTX) Rollback() error {
 func (t *treeTX) IsOpen() bool {
 	return !t.closed
 }
+
+func checkDatabaseAccessible(tx *sql.Tx) error {
+	stmt, err := tx.Prepare("SELECT TreeId FROM Trees LIMIT 1")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec()
+	return err
+}

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -408,7 +408,7 @@ func (t *treeTX) IsOpen() bool {
 	return !t.closed
 }
 
-func checkDatabaseAccessible(tx *sql.Tx) error {
+func isConnected(tx *sql.Tx) error {
 	stmt, err := tx.Prepare("SELECT TreeId FROM Trees LIMIT 1")
 	if err != nil {
 		return err

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -408,8 +408,10 @@ func (t *treeTX) IsOpen() bool {
 	return !t.closed
 }
 
-func isConnected(tx *sql.Tx) error {
-	stmt, err := tx.Prepare("SELECT TreeId FROM Trees LIMIT 1")
+func checkDatabaseAccessible(ctx context.Context, db *sql.DB) error {
+	_ = ctx
+
+	stmt, err := db.Prepare("SELECT TreeId FROM Trees LIMIT 1")
 	if err != nil {
 		return err
 	}

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -49,6 +49,12 @@ type TreeTX interface {
 	WriteRevision() int64
 }
 
+// DatabaseChecker performs connectivity checks on the database.
+type DatabaseChecker interface {
+	// CheckDatabaseAccessible returns nil if the database is accessible, error otherwise.
+	CheckDatabaseAccessible() error
+}
+
 // NodeReader provides a read-only interface into the stored tree nodes.
 type NodeReader interface {
 	// GetMerkleNodes looks up the set of nodes identified by ids, at treeRevision, and returns them.

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -14,6 +14,10 @@
 
 package storage
 
+import (
+	"context"
+)
+
 // ReadOnlyTreeTX represents a read-only transaction on a TreeStorage.
 // A ReadOnlyTreeTX can only modify the tree specified in its creation.
 type ReadOnlyTreeTX interface {
@@ -51,8 +55,8 @@ type TreeTX interface {
 
 // DatabaseChecker performs connectivity checks on the database.
 type DatabaseChecker interface {
-	// IsConnected returns nil if connected to the database, error otherwise.
-	IsConnected() error
+	// CheckDatabaseAccessible returns nil if the database is accessible, error otherwise.
+	CheckDatabaseAccessible(ctx context.Context) error
 }
 
 // NodeReader provides a read-only interface into the stored tree nodes.

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -51,8 +51,8 @@ type TreeTX interface {
 
 // DatabaseChecker performs connectivity checks on the database.
 type DatabaseChecker interface {
-	// CheckDatabaseAccessible returns nil if the database is accessible, error otherwise.
-	CheckDatabaseAccessible() error
+	// IsConnected returns nil if connected to the database, error otherwise.
+	IsConnected() error
 }
 
 // NodeReader provides a read-only interface into the stored tree nodes.


### PR DESCRIPTION
ReadOnlyMapTX allows us to create map snapshot transactions without a treeID.
DatabaseChecker allows us to check connectivity in more optimal manner (ie,
without listing all tree IDs, which is likelyt to become expensive at some point).

ReadOnlyMapTX and ReadOnlyLogTX both implement DatabaseChecker. Connectivity
checks have been modified to use the new method.