### PR TITLE
Delete some obsolete documentation

### DIFF
--- a/extension/builtin/default_registry.go
+++ b/extension/builtin/default_registry.go
@@ -44,7 +44,6 @@ func (r *defaultRegistry) GetMapStorage() (storage.MapStorage, error) {
 
 // NewDefaultExtensionRegistry returns the default extension.Registry implementation, which is
 // backed by a MySQL database and configured via flags.
-// The returned registry is wraped in a cached registry.
 func NewDefaultExtensionRegistry() (extension.Registry, error) {
 	db, err := mysql.OpenDB(*MySQLURIFlag)
 	if err != nil {

--- a/extension/registry.go
+++ b/extension/registry.go
@@ -23,11 +23,9 @@ import (
 // implementation.
 type Registry interface {
 
-	// GetLogStorage returns a configured storage.LogStorage instance for the specified tree ID or an
-	// error if the storage cannot be set up.
+	// GetLogStorage returns a configured storage.LogStorage instance or an error if the storage cannot be set up.
 	GetLogStorage() (storage.LogStorage, error)
 
-	// GetMapStorage returns a configured storage.MapStorage instance for the specified tree ID or an
-	// error if the storage cannot be set up.
+	// GetMapStorage returns a configured storage.MapStorage instance or an error if the storage cannot be set up.
 	GetMapStorage() (storage.MapStorage, error)
 }


### PR DESCRIPTION
While addressing issue #324, the treeID parameter in the extension.Registry interface and the cachedRegistry were removed. However, not all of the documentation referred to them was.