### PR TITLE
Remove unsequenced payload column from schema and log storage code

### DIFF
--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -133,7 +133,6 @@ CREATE TABLE IF NOT EXISTS Unsequenced(
   -- We want this to be unique per entry per log, but queryable by FEs so that
   -- we can try to stomp dupe submissions.
   MessageId            BINARY(32) NOT NULL,
-  Payload              BLOB NOT NULL,
   QueueTimestampNanos  BIGINT NOT NULL,
   PRIMARY KEY (TreeId, LeafIdentityHash, MessageId)
 );


### PR DESCRIPTION
Was unnecessarily writing the leaf payload into storage twice and second copy was not used by sequencing. Update tests to compare leaf hashes rather than data. Update docs for DequeueLeaves to note that leaf value is not returned but it doesn't matter because sequencing doesn't need it.