### PR TITLE
Run integration tests in-process

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,7 +34,7 @@ func TestAddGetLeaf(t *testing.T) {
 
 func TestAddLeaf(t *testing.T) {
 	ctx := context.Background()
-	env, err := integration.NewLogEnv(ctx, "TestAddLeaf")
+	env, err := integration.NewLogEnv(ctx, 0, "TestAddLeaf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestAddLeaf(t *testing.T) {
 
 func TestUpdateSTR(t *testing.T) {
 	ctx := context.Background()
-	env, err := integration.NewLogEnv(ctx, "TestUpdateSTR")
+	env, err := integration.NewLogEnv(ctx, 0, "TestUpdateSTR")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,7 +34,7 @@ func TestAddGetLeaf(t *testing.T) {
 
 func TestAddLeaf(t *testing.T) {
 	ctx := context.Background()
-	env, err := integration.NewLogEnv("TestAddLeaf")
+	env, err := integration.NewLogEnv(ctx, "TestAddLeaf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestAddLeaf(t *testing.T) {
 
 func TestUpdateSTR(t *testing.T) {
 	ctx := context.Background()
-	env, err := integration.NewLogEnv("TestUpdateSTR")
+	env, err := integration.NewLogEnv(ctx, "TestUpdateSTR")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/extension/builtin/default_registry.go
+++ b/extension/builtin/default_registry.go
@@ -53,6 +53,13 @@ func (r *defaultRegistry) GetKeyManager(treeID int64) (crypto.KeyManager, error)
 	return r.km, nil
 }
 
+// NewExtensionRegistry returns an extension.Registry implementation backed by a given
+// MySQL database and a KeyManager instance.
+func NewExtensionRegistry(db *sql.DB, km crypto.KeyManager) (extension.Registry, error) {
+	return &defaultRegistry{db: db, km: km}, nil
+
+}
+
 // NewDefaultExtensionRegistry returns the default extension.Registry implementation, which is
 // backed by a MySQL database and configured via flags.
 func NewDefaultExtensionRegistry() (extension.Registry, error) {
@@ -64,8 +71,5 @@ func NewDefaultExtensionRegistry() (extension.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &defaultRegistry{
-		db: db,
-		km: km,
-	}, nil
+	return NewExtensionRegistry(db, km)
 }

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -130,6 +130,11 @@ func (l LogOperationManager) getLogsAndExecutePass(ctx context.Context) bool {
 	return false
 }
 
+// OperationSingle performs a single pass of the manager.
+func (l LogOperationManager) OperationSingle() {
+	l.getLogsAndExecutePass(l.context.ctx)
+}
+
 // OperationLoop starts the manager working. It continues until told to exit.
 // TODO(Martin2112): No mechanism for error reporting etc., this is OK for v1 but needs work
 func (l LogOperationManager) OperationLoop() {

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -45,7 +45,6 @@ var (
 	sleep              = time.Duration(0)
 	signInterval       = time.Duration(0)
 	timeSource         = util.SystemTimeSource{}
-	ctx                = context.Background()
 )
 
 // LogEnv is a test environment that contains both a log server and a connection to it.
@@ -117,7 +116,7 @@ func getTestDB(testID string) (*sql.DB, error) {
 
 // NewLogEnv creates a fresh DB, log server, and client.
 // testID should be unique to each unittest package so as to allow parallel tests.
-func NewLogEnv(testID string) (*LogEnv, error) {
+func NewLogEnv(ctx context.Context, testID string) (*LogEnv, error) {
 	db, err := getTestDB(testID)
 	if err != nil {
 		return nil, err

--- a/testonly/integration/ct.go
+++ b/testonly/integration/ct.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/google/trillian/examples/ct"
+)
+
+// CTLogEnv is a test environment that contains both a log server and a CT personality
+// connected to it.
+type CTLogEnv struct {
+	logEnv       *LogEnv
+	ctListener   net.Listener
+	ctHTTPServer *http.Server
+	CTAddr       string
+}
+
+// NewCTLogEnv creates a fresh DB, log server, and CT personality.
+// testID should be unique to each unittest package so as to allow parallel tests.
+func NewCTLogEnv(ctx context.Context, cfgs []ct.LogConfig, numSequencers int, testID string) (*CTLogEnv, error) {
+	// Start log server and signer.
+	logEnv, err := NewLogEnv(ctx, numSequencers, testID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LogEnv: %v", err)
+	}
+
+	// Provision the logs.
+	for _, cfg := range cfgs {
+		if err := logEnv.CreateLog(cfg.LogID); err != nil {
+			return nil, fmt.Errorf("failed to provision log %d: %v", cfg.LogID, err)
+		}
+	}
+
+	// Start the CT personality.
+	addr, listener, err := listen()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find an unused port for CT personality: %v", err)
+	}
+	server := http.Server{Addr: addr, Handler: nil}
+	logEnv.pendingTasks.Add(1)
+	go func(env *LogEnv, server *http.Server, listener net.Listener, cfgs []ct.LogConfig) {
+		defer env.pendingTasks.Done()
+		client := trillian.NewTrillianLogClient(env.ClientConn)
+		for _, cfg := range cfgs {
+			handlers, err := cfg.SetUpInstance(client, 10*time.Second)
+			if err != nil {
+				glog.Fatalf("Failed to set up log instance for %+v: %v", cfg, err)
+			}
+			for path, handler := range *handlers {
+				http.Handle(path, handler)
+			}
+		}
+		server.Serve(listener)
+	}(logEnv, &server, listener, cfgs)
+	return &CTLogEnv{
+		logEnv:       logEnv,
+		ctListener:   listener,
+		ctHTTPServer: &server,
+		CTAddr:       addr,
+	}, nil
+}
+
+// Close shuts down the servers.
+func (env *CTLogEnv) Close() {
+	env.ctListener.Close()
+	env.logEnv.Close()
+}


### PR DESCRIPTION
Should be rather faster (e.g. 1.5s for CT test, 9s for log test)