### PR TITLE
Use pointers to return empty values on err

### DIFF
--- a/examples/ct/handlers.go
+++ b/examples/ct/handlers.go
@@ -310,7 +310,7 @@ func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, 
 
 	// As the Log server has successfully queued up the Merkle tree leaf, we can
 	// respond with an SCT.
-	err = marshalAndWriteAddChainResponse(*sct, c.logKeyManager, w)
+	err = marshalAndWriteAddChainResponse(sct, c.logKeyManager, w)
 	if err != nil {
 		// reason is logged and http status is already set
 		// TODO(Martin2112): Record failure for monitoring when it's implemented
@@ -717,7 +717,7 @@ func extraDataForChain(chain []*x509.Certificate, isPrecert bool) ([]byte, error
 
 // marshalAndWriteAddChainResponse is used by add-chain and add-pre-chain to create and write
 // the JSON response to the client
-func marshalAndWriteAddChainResponse(sct ct.SignedCertificateTimestamp, km crypto.KeyManager, w http.ResponseWriter) error {
+func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, km crypto.KeyManager, w http.ResponseWriter) error {
 	logID, err := GetCTLogID(km)
 	if err != nil {
 		return fmt.Errorf("failed to marshal logID: %v", err)

--- a/examples/ct/handlers.go
+++ b/examples/ct/handlers.go
@@ -263,7 +263,7 @@ func parseBodyAsJSONChain(c LogContext, r *http.Request) (ct.AddChainRequest, er
 // TODO(Martin2112): Doesn't properly handle duplicate submissions yet but the backend
 // needs this to be implemented before we can do it here
 func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, r *http.Request, isPrecert bool) (int, error) {
-	var signerFn func(crypto.KeyManager, *x509.Certificate, *x509.Certificate, time.Time) (ct.MerkleTreeLeaf, ct.SignedCertificateTimestamp, error)
+	var signerFn func(crypto.KeyManager, *x509.Certificate, *x509.Certificate, time.Time) (*ct.MerkleTreeLeaf, *ct.SignedCertificateTimestamp, error)
 	var method EntrypointName
 	if isPrecert {
 		method = AddPreChainName
@@ -295,7 +295,7 @@ func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, 
 	}
 
 	// Send the Merkle tree leaf on to the Log server.
-	leaf, err := buildLogLeafForAddChain(c, merkleLeaf, chain)
+	leaf, err := buildLogLeafForAddChain(c, *merkleLeaf, chain)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to build LogLeaf: %v", err)
 	}
@@ -310,7 +310,7 @@ func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, 
 
 	// As the Log server has successfully queued up the Merkle tree leaf, we can
 	// respond with an SCT.
-	err = marshalAndWriteAddChainResponse(sct, c.logKeyManager, w)
+	err = marshalAndWriteAddChainResponse(*sct, c.logKeyManager, w)
 	if err != nil {
 		// reason is logged and http status is already set
 		// TODO(Martin2112): Record failure for monitoring when it's implemented

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -1221,8 +1221,8 @@ func createJSONChain(t *testing.T, p PEMCertPool) io.Reader {
 	return bufio.NewReader(&buffer)
 }
 
-func logLeavesForCert(t *testing.T, km crypto.KeyManager, certs []*x509.Certificate, merkleLeaf ct.MerkleTreeLeaf, isPrecert bool) []*trillian.LogLeaf {
-	leafData, err := tls.Marshal(merkleLeaf)
+func logLeavesForCert(t *testing.T, km crypto.KeyManager, certs []*x509.Certificate, merkleLeaf *ct.MerkleTreeLeaf, isPrecert bool) []*trillian.LogLeaf {
+	leafData, err := tls.Marshal(*merkleLeaf)
 	if err != nil {
 		t.Fatalf("failed to serialize leaf: %v", err)
 	}

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -1221,8 +1221,8 @@ func createJSONChain(t *testing.T, p PEMCertPool) io.Reader {
 	return bufio.NewReader(&buffer)
 }
 
-func logLeavesForCert(t *testing.T, km crypto.KeyManager, certs []*x509.Certificate, merkleLeaf *ct.MerkleTreeLeaf, isPrecert bool) []*trillian.LogLeaf {
-	leafData, err := tls.Marshal(*merkleLeaf)
+func logLeavesForCert(t *testing.T, km crypto.KeyManager, certs []*x509.Certificate, merkleLeaf ct.MerkleTreeLeaf, isPrecert bool) []*trillian.LogLeaf {
+	leafData, err := tls.Marshal(merkleLeaf)
 	if err != nil {
 		t.Fatalf("failed to serialize leaf: %v", err)
 	}

--- a/examples/ct/serialize_test.go
+++ b/examples/ct/serialize_test.go
@@ -67,8 +67,8 @@ func TestSignV1SCTForCertificate(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("Mismatched SCT (cert), got %v, expected %v", got, expected)
+	if !reflect.DeepEqual(*got, expected) {
+		t.Fatalf("Mismatched SCT (cert), got \n%v, expected \n%v", got, expected)
 	}
 
 	// Additional checks that the MerkleTreeLeaf we built is correct
@@ -127,8 +127,8 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 				Signature: tls.ECDSA},
 			Signature: []byte("signed")}}
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("Mismatched SCT (precert), got %v, expected %v", got, expected)
+	if !reflect.DeepEqual(*got, expected) {
+		t.Fatalf("Mismatched SCT (precert), got \n%v, expected \n%v", got, expected)
 	}
 
 	// Additional checks that the MerkleTreeLeaf we built is correct


### PR DESCRIPTION
I believe it is canonical Go to return pointers to objects, especially when a function can error. 