### PR TITLE
Remove (de)pointerify

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -109,7 +109,7 @@ func (s Sequencer) buildNodesFromNodeMap(nodeMap map[string]storage.Node, newVer
 	return targetNodes, nil
 }
 
-func (s Sequencer) sequenceLeaves(mt *merkle.CompactMerkleTree, leaves []trillian.LogLeaf) (map[string]storage.Node, []trillian.LogLeaf, error) {
+func (s Sequencer) sequenceLeaves(mt *merkle.CompactMerkleTree, leaves []*trillian.LogLeaf) (map[string]storage.Node, []*trillian.LogLeaf, error) {
 	nodeMap := make(map[string]storage.Node)
 	// Update the tree state and sequence the leaves and assign sequence numbers to the new leaves
 	for i, leaf := range leaves {

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -85,7 +85,7 @@ type LogStorage interface {
 // LeafQueuer provides a write-only interface for the queueing (but not necessarily integration) of leaves.
 type LeafQueuer interface {
 	// QueueLeaves enqueues leaves for later integration into the tree.
-	QueueLeaves(leaves []trillian.LogLeaf, queueTimestamp time.Time) error
+	QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.Time) error
 }
 
 // LeafDequeuer provides an interface for reading previously queued leaves for integration into the tree.
@@ -94,8 +94,8 @@ type LeafDequeuer interface {
 	// Leaves which have been dequeued within a Rolled-back Tx will become available for dequeing again.
 	// Leaves queued more recently than the cutoff time will not be returned. This allows for
 	// guard intervals to be configured.
-	DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLeaf, error)
-	UpdateSequencedLeaves(leaves []trillian.LogLeaf) error
+	DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error)
+	UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error
 }
 
 // LeafReader provides a read only interface to stored tree leaves
@@ -104,12 +104,12 @@ type LeafReader interface {
 	// tree via sequencing.
 	GetSequencedLeafCount() (int64, error)
 	// GetLeavesByIndex returns leaf metadata and data for a set of specified sequenced leaf indexes.
-	GetLeavesByIndex(leaves []int64) ([]trillian.LogLeaf, error)
+	GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error)
 	// GetLeavesByHash looks up sequenced leaf metadata and data by their Merkle leaf hash. If the
 	// tree permits duplicate leaves callers must be prepared to handle multiple results with the
 	// same hash but different sequence numbers. If orderBySequence is true then the returned data
 	// will be in ascending sequence number order.
-	GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]trillian.LogLeaf, error)
+	GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error)
 }
 
 // LogRootReader provides an interface for reading SignedLogRoots.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -105,9 +105,9 @@ func (_mr *_MockLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockLogTreeTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -138,9 +138,9 @@ func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
 }
 
-func (_m *MockLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,9 +149,9 @@ func (_mr *_MockLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
 }
 
-func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -203,7 +203,7 @@ func (_mr *_MockLogTreeTXRecorder) LatestSignedLogRoot() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot")
 }
 
-func (_m *MockLogTreeTX) QueueLeaves(_param0 []trillian.LogLeaf, _param1 time.Time) error {
+func (_m *MockLogTreeTX) QueueLeaves(_param0 []*trillian.LogLeaf, _param1 time.Time) error {
 	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -253,7 +253,7 @@ func (_mr *_MockLogTreeTXRecorder) StoreSignedLogRoot(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedLogRoot", arg0)
 }
 
-func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 []trillian.LogLeaf) error {
+func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 []*trillian.LogLeaf) error {
 	ret := _m.ctrl.Call(_m, "UpdateSequencedLeaves", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -565,9 +565,9 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]trillian.LogLeaf, error) {
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -576,9 +576,9 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]trillian.LogLeaf, error) {
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -65,7 +65,7 @@ func createFakeLeaf(db *sql.DB, logID int64, rawHash, hash, data, extraData []by
 	}
 }
 
-func checkLeafContents(leaf trillian.LogLeaf, seq int64, rawHash, hash, data, extraData []byte, t *testing.T) {
+func checkLeafContents(leaf *trillian.LogLeaf, seq int64, rawHash, hash, data, extraData []byte, t *testing.T) {
 	if got, want := leaf.MerkleLeafHash, hash; !bytes.Equal(got, want) {
 		t.Fatalf("Wrong leaf hash in returned leaf got\n%v\nwant:\n%v", got, want)
 	}
@@ -950,7 +950,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	commit(tx, t)
 }
 
-func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
+func ensureAllLeavesDistinct(leaves []*trillian.LogLeaf, t *testing.T) {
 	// All the leaf value hashes should be distinct because the leaves were created with distinct
 	// leaf data. If only we had maps with slices as keys or sets or pretty much any kind of usable
 	// data structures we could do this properly.
@@ -965,14 +965,14 @@ func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
 }
 
 // Creates some test leaves with predictable data
-func createTestLeaves(n, startSeq int64) []trillian.LogLeaf {
-	var leaves []trillian.LogLeaf
+func createTestLeaves(n, startSeq int64) []*trillian.LogLeaf {
+	var leaves []*trillian.LogLeaf
 	for l := int64(0); l < n; l++ {
 		lv := fmt.Sprintf("Leaf %d", l+startSeq)
 		h := sha256.New()
 		h.Write([]byte(lv))
 		leafHash := h.Sum(nil)
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: leafHash,
 			MerkleLeafHash:   leafHash,
 			LeafValue:        []byte(lv),
@@ -1028,7 +1028,7 @@ func closeSnapshot(tx closeableSnapshot) error {
 	return tx.Rollback()
 }
 
-func leafInBatch(leaf trillian.LogLeaf, batch []trillian.LogLeaf) bool {
+func leafInBatch(leaf *trillian.LogLeaf, batch []*trillian.LogLeaf) bool {
 	for _, bl := range batch {
 		if bytes.Equal(bl.LeafIdentityHash, leaf.LeafIdentityHash) {
 			return true

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -66,7 +66,7 @@ func main() {
 		panic(err)
 	}
 
-	leaves := []trillian.LogLeaf{}
+	leaves := []*trillian.LogLeaf{}
 	for l := 0; l < *numInsertionsFlag; l++ {
 		// Leaf data based in the sequence number so we can check the hashes
 		leafNumber := *startInsertFromFlag + l
@@ -76,7 +76,7 @@ func main() {
 
 		log.Infof("Preparing leaf %d\n", leafNumber)
 
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			MerkleLeafHash: []byte(hash[:]),
 			LeafValue:      data,
 			ExtraData:      nil,


### PR DESCRIPTION
This PR has been rebased on #386

Standardize on using `*trillian.LogLeaf` throughout the code.
This better matches the generated pb.go APIs, and should speed
up the code be eliminating extra memcopys.