### PR TITLE
Remove (de)pointerify

### DIFF
--- a/client/client_proxy.go
+++ b/client/client_proxy.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"log"
+
+	context "golang.org/x/net/context"
+
+	google_protobuf "github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/trillian"
+	"google.golang.org/grpc"
+)
+
+// MockLogClient supports applying mutations to the return values of the TrillianLogClient
+type MockLogClient struct {
+	c                    trillian.TrillianLogClient
+	mGetInclusionProof   bool
+	mGetConsistencyProof bool
+}
+
+// QueueLeaf forwards requests.
+func (c *MockLogClient) QueueLeaf(ctx context.Context, in *trillian.QueueLeafRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	return c.c.QueueLeaf(ctx, in)
+}
+
+// QueueLeaves forwards requests.
+func (c *MockLogClient) QueueLeaves(ctx context.Context, in *trillian.QueueLeavesRequest, opts ...grpc.CallOption) (*trillian.QueueLeavesResponse, error) {
+	return c.c.QueueLeaves(ctx, in)
+}
+
+// GetInclusionProof forwards requests and modifies the response.
+func (c *MockLogClient) GetInclusionProof(ctx context.Context, in *trillian.GetInclusionProofRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofResponse, error) {
+	resp, err := c.c.GetInclusionProof(ctx, in)
+	if c.mGetInclusionProof {
+		resp.Proof.ProofNode[3].NodeHash[4] ^= 3
+	}
+	return resp, err
+}
+
+// GetInclusionProofByHash forwards requests.
+func (c *MockLogClient) GetInclusionProofByHash(ctx context.Context, in *trillian.GetInclusionProofByHashRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofByHashResponse, error) {
+	resp, err := c.c.GetInclusionProofByHash(ctx, in)
+	if c.mGetInclusionProof {
+		log.Print(resp)
+		resp.Proof[0].ProofNode[0].NodeHash[4] ^= 3
+	}
+	return resp, err
+}
+
+// GetConsistencyProof forwards requests and modifies responses.
+func (c *MockLogClient) GetConsistencyProof(ctx context.Context, in *trillian.GetConsistencyProofRequest, opts ...grpc.CallOption) (*trillian.GetConsistencyProofResponse, error) {
+	resp, err := c.c.GetConsistencyProof(ctx, in)
+	if c.mGetConsistencyProof {
+		log.Print(resp)
+		resp.Proof.ProofNode[0].NodeHash[3] ^= 3
+	}
+	return resp, err
+}
+
+// GetLatestSignedLogRoot forwards requests.
+func (c *MockLogClient) GetLatestSignedLogRoot(ctx context.Context, in *trillian.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*trillian.GetLatestSignedLogRootResponse, error) {
+	return c.c.GetLatestSignedLogRoot(ctx, in)
+}
+
+// GetSequencedLeafCount forwards requests.
+func (c *MockLogClient) GetSequencedLeafCount(ctx context.Context, in *trillian.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*trillian.GetSequencedLeafCountResponse, error) {
+	return c.c.GetSequencedLeafCount(ctx, in)
+}
+
+// GetLeavesByIndex forwards requests.
+func (c *MockLogClient) GetLeavesByIndex(ctx context.Context, in *trillian.GetLeavesByIndexRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByIndexResponse, error) {
+	return c.c.GetLeavesByIndex(ctx, in)
+}
+
+// GetLeavesByHash forwards requests.
+func (c *MockLogClient) GetLeavesByHash(ctx context.Context, in *trillian.GetLeavesByHashRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByHashResponse, error) {
+	return c.c.GetLeavesByHash(ctx, in)
+}
+
+// GetEntryAndProof forwards requests.
+func (c *MockLogClient) GetEntryAndProof(ctx context.Context, in *trillian.GetEntryAndProofRequest, opts ...grpc.CallOption) (*trillian.GetEntryAndProofResponse, error) {
+	return c.c.GetEntryAndProof(ctx, in)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/golang/glog"
+	"github.com/google/trillian"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/testonly/integration"
 )
@@ -43,16 +43,42 @@ func TestAddLeaf(t *testing.T) {
 		t.Errorf("Failed to create log: %v", err)
 	}
 
-	client := New(logID, env.ClientConn, testonly.Hasher)
-	client.MaxTries = 1
+	cli := trillian.NewTrillianLogClient(env.ClientConn)
+	for _, test := range []struct {
+		desc    string
+		client  trillian.TrillianLogClient
+		wantErr bool
+	}{
+		{
+			desc:   "success 1",
+			client: &MockLogClient{c: cli},
+		},
+		{
+			desc:   "success 2",
+			client: &MockLogClient{c: cli},
+		},
+		{
+			desc:    "invalid inclusion proof",
+			client:  &MockLogClient{c: cli, mGetInclusionProof: true},
+			wantErr: true,
+		},
+		{
+			desc:    "invalid consistency proof",
+			client:  &MockLogClient{c: cli, mGetConsistencyProof: true},
+			wantErr: true,
+		},
+	} {
+		client := New(logID, test.client, testonly.Hasher)
+		client.MaxTries = 1
 
-	if err, want := client.AddLeaf(ctx, []byte("foo")), codes.DeadlineExceeded; grpc.Code(err) != want {
-		t.Errorf("AddLeaf(): %v, want, %v", err, want)
-	}
-	env.Sequencer.OperationLoop() // Sequence the new node.
-	glog.Infof("try AddLeaf again")
-	if err := client.AddLeaf(ctx, []byte("foo")); err != nil {
-		t.Errorf("Failed to add Leaf: %v", err)
+		if err, want := client.AddLeaf(ctx, []byte(test.desc)), codes.DeadlineExceeded; grpc.Code(err) != want {
+			t.Errorf("AddLeaf(%v): %v, want, %v", test.desc, err, want)
+		}
+		env.Sequencer.OperationLoop() // Sequence the new node.
+		err := client.AddLeaf(ctx, []byte(test.desc))
+		if got := err != nil; got != test.wantErr {
+			t.Errorf("AddLeaf(%v): %v, want error: %v", test.desc, err, test.wantErr)
+		}
 	}
 }
 
@@ -66,7 +92,8 @@ func TestUpdateSTR(t *testing.T) {
 	if err := env.CreateLog(logID); err != nil {
 		t.Errorf("Failed to create log: %v", err)
 	}
-	client := New(logID, env.ClientConn, testonly.Hasher)
+	cli := trillian.NewTrillianLogClient(env.ClientConn)
+	client := New(logID, cli, testonly.Hasher)
 
 	before := client.STR.TreeSize
 	if err, want := client.AddLeaf(ctx, []byte("foo")), codes.DeadlineExceeded; grpc.Code(err) != want {

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -1239,7 +1239,14 @@ func logLeavesForCert(t *testing.T, km crypto.PrivateKeyManager, certs []*x509.C
 		t.Fatalf("failed to serialize extra data: %v", err)
 	}
 
-	return []*trillian.LogLeaf{{LeafIdentityHash: leafIDHash[:], LeafValue: leafData, ExtraData: extraData}}
+	return []*trillian.LogLeaf{
+		{
+			LeafIdentityHash: leafIDHash[:],
+			MerkleLeafHash:   treeHasher.HashLeaf(leafData),
+			LeafValue:        leafData,
+			ExtraData:        extraData,
+		},
+	}
 }
 
 type dlMatcher struct {

--- a/integration/log.go
+++ b/integration/log.go
@@ -180,7 +180,7 @@ func RunLogIntegration(client trillian.TrillianLogClient, params TestParameters)
 }
 
 func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error {
-	leaves := []trillian.LogLeaf{}
+	leaves := []*trillian.LogLeaf{}
 
 	for l := int64(0); l < params.leafCount; l++ {
 		// Leaf data based on the sequence number so we can check the hashes
@@ -189,8 +189,9 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 		data := []byte(fmt.Sprintf("Leaf %d", leafNumber))
 		idHash := sha256.Sum256(data)
 
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: idHash[:],
+			MerkleLeafHash:   testonly.Hasher.HashLeaf(data),
 			LeafValue:        data,
 			ExtraData:        []byte(fmt.Sprintf("Extra %d", leafNumber)),
 		}
@@ -199,9 +200,11 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 		if len(leaves) >= params.queueBatchSize || (l+1) == params.leafCount {
 			glog.Infof("Queueing %d leaves ...", len(leaves))
 
-			req := makeQueueLeavesRequest(params.treeID, leaves)
 			ctx, cancel := getRPCDeadlineContext(params)
-			_, err := client.QueueLeaves(ctx, &req)
+			_, err := client.QueueLeaves(ctx, &trillian.QueueLeavesRequest{
+				LogId:  params.treeID,
+				Leaves: leaves,
+			})
 			cancel()
 
 			if err != nil {
@@ -376,7 +379,11 @@ func checkInclusionProofTreeSizeOutOfRange(logID int64, client trillian.Trillian
 func checkInclusionProofsAtIndex(index int64, logID int64, tree *merkle.InMemoryMerkleTree, client trillian.TrillianLogClient, params TestParameters) error {
 	for treeSize := int64(0); treeSize < min(params.leafCount, int64(2*params.sequencerBatchSize)); treeSize++ {
 		ctx, cancel := getRPCDeadlineContext(params)
-		resp, err := client.GetInclusionProof(ctx, &trillian.GetInclusionProofRequest{LogId: logID, LeafIndex: index, TreeSize: int64(treeSize)})
+		resp, err := client.GetInclusionProof(ctx, &trillian.GetInclusionProofRequest{
+			LogId:     logID,
+			LeafIndex: index,
+			TreeSize:  int64(treeSize),
+		})
 		cancel()
 
 		// If the index is larger than the tree size we cannot have a valid proof
@@ -427,17 +434,6 @@ func checkConsistencyProof(consistParams consistencyProofParams, treeID int64, t
 
 	// Compare the proofs, they should be identical
 	return compareLogAndTreeProof(resp.Proof, proof)
-}
-
-func makeQueueLeavesRequest(logID int64, leaves []trillian.LogLeaf) trillian.QueueLeavesRequest {
-	leafProtos := make([]*trillian.LogLeaf, 0, len(leaves))
-
-	for _, leaf := range leaves {
-		leaf := leaf
-		leafProtos = append(leafProtos, &leaf)
-	}
-
-	return trillian.QueueLeavesRequest{LogId: logID, Leaves: leafProtos}
 }
 
 func makeGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *trillian.GetLeavesByIndexRequest {

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -109,7 +109,7 @@ func (s Sequencer) buildNodesFromNodeMap(nodeMap map[string]storage.Node, newVer
 	return targetNodes, nil
 }
 
-func (s Sequencer) sequenceLeaves(mt *merkle.CompactMerkleTree, leaves []trillian.LogLeaf) (map[string]storage.Node, []trillian.LogLeaf, error) {
+func (s Sequencer) sequenceLeaves(mt *merkle.CompactMerkleTree, leaves []*trillian.LogLeaf) (map[string]storage.Node, []*trillian.LogLeaf, error) {
 	nodeMap := make(map[string]storage.Node)
 	// Update the tree state and sequence the leaves and assign sequence numbers to the new leaves
 	for i, leaf := range leaves {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -76,14 +76,13 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	if err := validateQueueLeavesRequest(req); err != nil {
 		return nil, err
 	}
-	leaves := depointerify(req.Leaves)
 
 	tx, err := t.prepareStorageTx(ctx, req.LogId)
 	if err != nil {
 		return nil, err
 	}
 
-	err = tx.QueueLeaves(leaves, t.timeSource.Now())
+	err = tx.QueueLeaves(req.Leaves, t.timeSource.Now())
 	if err != nil {
 		tx.Rollback()
 		return nil, err
@@ -295,14 +294,16 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 		return nil, err
 	}
 
-	return &trillian.GetLeavesByIndexResponse{Leaves: pointerify(leaves)}, nil
+	return &trillian.GetLeavesByIndexResponse{
+		Leaves: leaves,
+	}, nil
 }
 
 // GetLeavesByHash obtains one or more leaves based on their tree hash. It is not possible
 // to fetch leaves that have been queued but not yet integrated. Logs may accept duplicate
 // entries so this may return more results than the number of hashes in the request.
 func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillian.GetLeavesByHashRequest) (*trillian.GetLeavesByHashResponse, error) {
-	return t.getLeavesByHashInternal(ctx, "GetLeavesByHash", req, func(tx storage.ReadOnlyLogTreeTX, hashes [][]byte, sequenceOrder bool) ([]trillian.LogLeaf, error) {
+	return t.getLeavesByHashInternal(ctx, "GetLeavesByHash", req, func(tx storage.ReadOnlyLogTreeTX, hashes [][]byte, sequenceOrder bool) ([]*trillian.LogLeaf, error) {
 		return tx.GetLeavesByHash(hashes, sequenceOrder)
 	})
 }
@@ -345,15 +346,15 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 		return nil, grpc.Errorf(codes.Internal, "expected one leaf from storage but got: %d", len(leaves))
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
 	// Work is complete, we have everything we need for the response
 	return &trillian.GetEntryAndProofResponse{
 		Proof: &proof,
-		Leaf:  &leaves[0]}, nil
+		Leaf:  leaves[0],
+	}, nil
 }
 
 func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
@@ -392,23 +393,6 @@ func (t *TrillianLogRPCServer) commitAndLog(ctx context.Context, tx storage.Read
 	return err
 }
 
-func depointerify(protos []*trillian.LogLeaf) []trillian.LogLeaf {
-	leaves := make([]trillian.LogLeaf, 0, len(protos))
-	for _, leafProto := range protos {
-		leaves = append(leaves, *leafProto)
-	}
-	return leaves
-}
-
-func pointerify(leaves []trillian.LogLeaf) []*trillian.LogLeaf {
-	protos := make([]*trillian.LogLeaf, 0, len(leaves))
-	for _, leaf := range leaves {
-		leaf := leaf
-		protos = append(protos, &leaf)
-	}
-	return protos
-}
-
 func validateLeafIndices(leafIndices []int64) bool {
 	for _, index := range leafIndices {
 		if index < 0 {
@@ -445,7 +429,7 @@ func getInclusionProofForLeafIndex(tx storage.ReadOnlyLogTreeTX, snapshot, leafI
 
 // getLeavesByHashInternal does the work of fetching leaves by either their raw data or merkle
 // tree hash depending on the supplied fetch function
-func (t *TrillianLogRPCServer) getLeavesByHashInternal(ctx context.Context, desc string, req *trillian.GetLeavesByHashRequest, fetchFunc func(storage.ReadOnlyLogTreeTX, [][]byte, bool) ([]trillian.LogLeaf, error)) (*trillian.GetLeavesByHashResponse, error) {
+func (t *TrillianLogRPCServer) getLeavesByHashInternal(ctx context.Context, desc string, req *trillian.GetLeavesByHashRequest, fetchFunc func(storage.ReadOnlyLogTreeTX, [][]byte, bool) ([]*trillian.LogLeaf, error)) (*trillian.GetLeavesByHashResponse, error) {
 	ctx = util.NewLogContext(ctx, req.LogId)
 	if len(req.LeafHash) == 0 || !validateLeafHashes(req.LeafHash) {
 		return nil, grpc.Errorf(codes.FailedPrecondition, "Invalid leaf hash")
@@ -467,6 +451,6 @@ func (t *TrillianLogRPCServer) getLeavesByHashInternal(ctx context.Context, desc
 	}
 
 	return &trillian.GetLeavesByHashResponse{
-		Leaves: pointerify(leaves),
+		Leaves: leaves,
 	}, nil
 }

--- a/server/validate.go
+++ b/server/validate.go
@@ -74,5 +74,11 @@ func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
 	if len(req.Leaves) == 0 {
 		return grpc.Errorf(codes.InvalidArgument, "len(leaves)=0, want > 0")
 	}
+	for _, leaf := range req.Leaves {
+		if len(leaf.MerkleLeafHash) == 0 {
+			return grpc.Errorf(codes.InvalidArgument, "Missing MerkleLeafHash")
+		}
+
+	}
 	return nil
 }

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -85,7 +85,7 @@ type LogStorage interface {
 // LeafQueuer provides a write-only interface for the queueing (but not necessarily integration) of leaves.
 type LeafQueuer interface {
 	// QueueLeaves enqueues leaves for later integration into the tree.
-	QueueLeaves(leaves []trillian.LogLeaf, queueTimestamp time.Time) error
+	QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.Time) error
 }
 
 // LeafDequeuer provides an interface for reading previously queued leaves for integration into the tree.
@@ -94,8 +94,8 @@ type LeafDequeuer interface {
 	// Leaves which have been dequeued within a Rolled-back Tx will become available for dequeing again.
 	// Leaves queued more recently than the cutoff time will not be returned. This allows for
 	// guard intervals to be configured.
-	DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLeaf, error)
-	UpdateSequencedLeaves(leaves []trillian.LogLeaf) error
+	DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error)
+	UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error
 }
 
 // LeafReader provides a read only interface to stored tree leaves
@@ -104,12 +104,12 @@ type LeafReader interface {
 	// tree via sequencing.
 	GetSequencedLeafCount() (int64, error)
 	// GetLeavesByIndex returns leaf metadata and data for a set of specified sequenced leaf indexes.
-	GetLeavesByIndex(leaves []int64) ([]trillian.LogLeaf, error)
+	GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error)
 	// GetLeavesByHash looks up sequenced leaf metadata and data by their Merkle leaf hash. If the
 	// tree permits duplicate leaves callers must be prepared to handle multiple results with the
 	// same hash but different sequence numbers. If orderBySequence is true then the returned data
 	// will be in ascending sequence number order.
-	GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]trillian.LogLeaf, error)
+	GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error)
 }
 
 // LogRootReader provides an interface for reading SignedLogRoots.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -105,9 +105,9 @@ func (_mr *_MockLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockLogTreeTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -138,9 +138,9 @@ func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
 }
 
-func (_m *MockLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,9 +149,9 @@ func (_mr *_MockLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
 }
 
-func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]trillian.LogLeaf, error) {
+func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -203,7 +203,7 @@ func (_mr *_MockLogTreeTXRecorder) LatestSignedLogRoot() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot")
 }
 
-func (_m *MockLogTreeTX) QueueLeaves(_param0 []trillian.LogLeaf, _param1 time.Time) error {
+func (_m *MockLogTreeTX) QueueLeaves(_param0 []*trillian.LogLeaf, _param1 time.Time) error {
 	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -253,7 +253,7 @@ func (_mr *_MockLogTreeTXRecorder) StoreSignedLogRoot(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedLogRoot", arg0)
 }
 
-func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 []trillian.LogLeaf) error {
+func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 []*trillian.LogLeaf) error {
 	ret := _m.ctrl.Call(_m, "UpdateSequencedLeaves", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -565,9 +565,9 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]trillian.LogLeaf, error) {
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -576,9 +576,9 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]trillian.LogLeaf, error) {
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
-	ret0, _ := ret[0].([]trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -417,7 +417,6 @@ func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]trillian.LogLeaf, error)
 
 func (t *logTreeTX) GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByMerkleHashStmt(len(leafHashes), orderBySequence)
-
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -232,7 +232,7 @@ func (t *logTreeTX) WriteRevision() int64 {
 	return t.treeTX.writeRevision
 }
 
-func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.LogLeaf, error) {
+func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {
 	stx, err := t.tx.Prepare(selectQueuedLeavesSQL)
 
 	if err != nil {
@@ -240,7 +240,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.L
 		return nil, err
 	}
 
-	leaves := make([]trillian.LogLeaf, 0, limit)
+	leaves := make([]*trillian.LogLeaf, 0, limit)
 	rows, err := stx.Query(t.treeID, cutoffTime.UnixNano(), limit)
 
 	if err != nil {
@@ -268,7 +268,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.L
 		// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
 		// sequencer. The sequencer only writes to the SequencedLeafData table and the client
 		// supplied data was already written to LeafData as part of queueing the leaf.
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: leafIDHash,
 			MerkleLeafHash:   merkleHash,
 		}
@@ -292,7 +292,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]trillian.L
 	return leaves, nil
 }
 
-func (t *logTreeTX) QueueLeaves(leaves []trillian.LogLeaf, queueTimestamp time.Time) error {
+func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.Time) error {
 	// Don't accept batches if any of the leaves are invalid.
 	for _, leaf := range leaves {
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
@@ -375,7 +375,7 @@ func (t *logTreeTX) GetSequencedLeafCount() (int64, error) {
 	return sequencedLeafCount, err
 }
 
-func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]trillian.LogLeaf, error) {
+func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByIndexStmt(len(leaves))
 	if err != nil {
 		return nil, err
@@ -392,30 +392,29 @@ func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]trillian.LogLeaf, error)
 		return nil, err
 	}
 
-	ret := make([]trillian.LogLeaf, len(leaves))
-	num := 0
-
+	ret := make([]*trillian.LogLeaf, 0, len(leaves))
 	defer rows.Close()
 	for rows.Next() {
-		if err := rows.Scan(&ret[num].MerkleLeafHash, &ret[num].LeafIdentityHash, &ret[num].LeafValue, &ret[num].LeafIndex, &ret[num].ExtraData); err != nil {
+		leaf := &trillian.LogLeaf{}
+		if err := rows.Scan(
+			&leaf.MerkleLeafHash,
+			&leaf.LeafIdentityHash,
+			&leaf.LeafValue,
+			&leaf.LeafIndex,
+			&leaf.ExtraData); err != nil {
 			glog.Warningf("Failed to scan merkle leaves: %s", err)
 			return nil, err
 		}
-
-		if got, want := len(ret[num].MerkleLeafHash), t.hashSizeBytes; got != want {
-			return nil, fmt.Errorf("scanned leaf does not have hash length %d, got %d", want, got)
-		}
-
-		num++
+		ret = append(ret, leaf)
 	}
 
-	if num != len(leaves) {
-		return nil, fmt.Errorf("expected %d leaves, but saw %d", len(leaves), num)
+	if got, want := len(ret), len(leaves); got != want {
+		return nil, fmt.Errorf("len(ret): %d, want %d", got, want)
 	}
 	return ret, nil
 }
 
-func (t *logTreeTX) GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]trillian.LogLeaf, error) {
+func (t *logTreeTX) GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByMerkleHashStmt(len(leafHashes), orderBySequence)
 	if err != nil {
 		return nil, err
@@ -478,7 +477,7 @@ func (t *logTreeTX) StoreSignedLogRoot(root trillian.SignedLogRoot) error {
 	return checkResultOkAndRowCountIs(res, err, 1)
 }
 
-func (t *logTreeTX) UpdateSequencedLeaves(leaves []trillian.LogLeaf) error {
+func (t *logTreeTX) UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error {
 	// TODO: In theory we can do this with CASE / WHEN in one SQL statement but it's more fiddly
 	// and can be implemented later if necessary
 	for _, leaf := range leaves {
@@ -499,7 +498,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(leaves []trillian.LogLeaf) error {
 	return nil
 }
 
-func (t *logTreeTX) removeSequencedLeaves(leaves []trillian.LogLeaf) error {
+func (t *logTreeTX) removeSequencedLeaves(leaves []*trillian.LogLeaf) error {
 	tmpl, err := t.ls.getDeleteUnsequencedStmt(len(leaves))
 	if err != nil {
 		glog.Warningf("Failed to get delete statement for sequenced work: %s", err)
@@ -527,7 +526,7 @@ func (t *logTreeTX) removeSequencedLeaves(leaves []trillian.LogLeaf) error {
 	return nil
 }
 
-func (t *logTreeTX) getLeavesByHashInternal(leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]trillian.LogLeaf, error) {
+func (t *logTreeTX) getLeavesByHashInternal(leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]*trillian.LogLeaf, error) {
 	stx := t.tx.Stmt(tmpl)
 	var args []interface{}
 	for _, hash := range leafHashes {
@@ -541,11 +540,11 @@ func (t *logTreeTX) getLeavesByHashInternal(leafHashes [][]byte, tmpl *sql.Stmt,
 	}
 
 	// The tree could include duplicates so we don't know how many results will be returned
-	var ret []trillian.LogLeaf
+	var ret []*trillian.LogLeaf
 
 	defer rows.Close()
 	for rows.Next() {
-		leaf := trillian.LogLeaf{}
+		leaf := &trillian.LogLeaf{}
 
 		if err := rows.Scan(&leaf.MerkleLeafHash, &leaf.LeafIdentityHash, &leaf.LeafValue, &leaf.LeafIndex, &leaf.ExtraData); err != nil {
 			glog.Warningf("LogID: %d Scan() %s = %s", t.treeID, desc, err)

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -66,7 +66,7 @@ func createFakeLeaf(db *sql.DB, logID int64, rawHash, hash, data, extraData []by
 	}
 }
 
-func checkLeafContents(leaf trillian.LogLeaf, seq int64, rawHash, hash, data, extraData []byte, t *testing.T) {
+func checkLeafContents(leaf *trillian.LogLeaf, seq int64, rawHash, hash, data, extraData []byte, t *testing.T) {
 	if got, want := leaf.MerkleLeafHash, hash; !bytes.Equal(got, want) {
 		t.Fatalf("Wrong leaf hash in returned leaf got\n%v\nwant:\n%v", got, want)
 	}
@@ -1056,7 +1056,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	}
 }
 
-func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
+func ensureAllLeavesDistinct(leaves []*trillian.LogLeaf, t *testing.T) {
 	// All the leaf value hashes should be distinct because the leaves were created with distinct
 	// leaf data. If only we had maps with slices as keys or sets or pretty much any kind of usable
 	// data structures we could do this properly.
@@ -1071,14 +1071,14 @@ func ensureAllLeavesDistinct(leaves []trillian.LogLeaf, t *testing.T) {
 }
 
 // Creates some test leaves with predictable data
-func createTestLeaves(n, startSeq int64) []trillian.LogLeaf {
-	var leaves []trillian.LogLeaf
+func createTestLeaves(n, startSeq int64) []*trillian.LogLeaf {
+	var leaves []*trillian.LogLeaf
 	for l := int64(0); l < n; l++ {
 		lv := fmt.Sprintf("Leaf %d", l+startSeq)
 		h := sha256.New()
 		h.Write([]byte(lv))
 		leafHash := h.Sum(nil)
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: leafHash,
 			MerkleLeafHash:   leafHash,
 			LeafValue:        []byte(lv),
@@ -1120,7 +1120,7 @@ func failIfTXStillOpen(t *testing.T, op string, tx storage.LogTreeTX) {
 	}
 }
 
-func leafInBatch(leaf trillian.LogLeaf, batch []trillian.LogLeaf) bool {
+func leafInBatch(leaf *trillian.LogLeaf, batch []*trillian.LogLeaf) bool {
 	for _, bl := range batch {
 		if bytes.Equal(bl.LeafIdentityHash, leaf.LeafIdentityHash) {
 			return true

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -66,7 +66,7 @@ func main() {
 		panic(err)
 	}
 
-	leaves := []trillian.LogLeaf{}
+	leaves := []*trillian.LogLeaf{}
 	for l := 0; l < *numInsertionsFlag; l++ {
 		// Leaf data based in the sequence number so we can check the hashes
 		leafNumber := *startInsertFromFlag + l
@@ -76,7 +76,7 @@ func main() {
 
 		log.Infof("Preparing leaf %d\n", leafNumber)
 
-		leaf := trillian.LogLeaf{
+		leaf := &trillian.LogLeaf{
 			MerkleLeafHash: []byte(hash[:]),
 			LeafValue:      data,
 			ExtraData:      nil,


### PR DESCRIPTION
This PR has been rebased on #386

Standardize on using `*trillian.LogLeaf` throughout the code.
This better matches the generated pb.go APIs, and should speed
up the code be eliminating extra memcopys.