### PR TITLE
Add Close() method to TX types, defer call it in all occurrences

### DIFF
--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -211,6 +211,7 @@ func nodeIDFromAddress(size int, prefix []byte, index *big.Int, depth int) stora
 // subsequently closed when this method exits.
 func (s *subtreeWriter) buildSubtree() {
 	defer close(s.root)
+	defer s.tx.Close()
 
 	leaves := make([]HStar2LeafHash, 0, len(s.leafQueue))
 	nodesToStore := make([]storage.Node, 0, len(s.leafQueue)*2)

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -334,6 +334,7 @@ func testSparseTreeCalculatedRoot(t *testing.T, vec sparseTestVector) {
 	w, tx := getSparseMerkleTreeWriterWithMockTX(mockCtrl, rev)
 
 	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Close().AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(int64(rev), gomock.Any()).AnyTimes().Return([]storage.Node{}, nil)
 	tx.EXPECT().SetMerkleNodes(gomock.Any()).AnyTimes().Return(nil)
 
@@ -393,6 +394,7 @@ func testSparseTreeFetches(t *testing.T, vec sparseTestVector) {
 	const rev = 100
 	w, tx := getSparseMerkleTreeWriterWithMockTX(mockCtrl, rev)
 	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Close().AnyTimes().Return(nil)
 
 	reads := make(map[string]string)
 	readMutex := sync.Mutex{}

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -104,12 +104,12 @@ func (l LogOperationManager) getLogsAndExecutePass(ctx context.Context) bool {
 		glog.Warningf("Failed to get tx for run: %v", err)
 		return false
 	}
+	defer tx.Close()
 
 	// Inner loop is across all active logs, currently one at a time
 	logIDs, err := tx.GetActiveLogIDs()
 	if err != nil {
 		glog.Warningf("Failed to get log list for run: %v", err)
-		tx.Rollback()
 		return false
 	}
 

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -51,7 +51,7 @@ func TestLogOperationManagerGetLogsFails(t *testing.T) {
 
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs().Return(nil, errors.New("getactivelogs"))
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
@@ -73,6 +73,7 @@ func TestLogOperationManagerCommitFails(t *testing.T) {
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("commit"))
+	mockTx.EXPECT().Close().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
@@ -113,6 +114,7 @@ func TestLogOperationManagerPassesIDs(t *testing.T) {
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{logID1, logID2}, nil)
 	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
+	mockTx.EXPECT().Close().AnyTimes().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -156,6 +156,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByIndex([]int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
@@ -181,6 +182,7 @@ func TestGetLeavesByIndexMultiple(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf03Request.LogId).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByIndex([]int64{0, 3}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
@@ -260,6 +262,7 @@ func TestQueueLeaves(t *testing.T) {
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
 	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
@@ -369,6 +372,7 @@ func TestGetLatestSignedLogRoot(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getLogRootRequest1.LogId).Return(mockTx, nil)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -482,6 +486,7 @@ func TestGetLeavesByHash(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("test"), []byte("data")}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -559,7 +564,7 @@ func TestGetProofByHashWrongNodeCountFetched(t *testing.T) {
 	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 	// The server expects three nodes from storage but we return only two
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -584,7 +589,7 @@ func TestGetProofByHashWrongNodeReturned(t *testing.T) {
 	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 	// We set this up so one of the returned nodes has the wrong ID
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: testonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -631,6 +636,7 @@ func TestGetProofByHash(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -706,7 +712,7 @@ func TestGetProofByIndexWrongNodeCountFetched(t *testing.T) {
 	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -730,7 +736,7 @@ func TestGetProofByIndexWrongNodeReturned(t *testing.T) {
 	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: testonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -775,6 +781,7 @@ func TestGetProofByIndex(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -833,7 +840,7 @@ func TestGetEntryAndProofGetMerkleNodesFails(t *testing.T) {
 	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("GetNodes"))
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -860,7 +867,7 @@ func TestGetEntryAndProofGetLeavesFails(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return(nil, errors.New("GetLeaves"))
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -888,7 +895,7 @@ func TestGetEntryAndProofGetLeavesReturnsMultiple(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	// Code passed one leaf index so expects one result, but we return more
 	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -916,6 +923,7 @@ func TestGetEntryAndProofCommitFails(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("COMMIT"))
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -943,6 +951,7 @@ func TestGetEntryAndProof(t *testing.T) {
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -1032,6 +1041,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 
 	mockTx.EXPECT().GetSequencedLeafCount().Return(int64(268), nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -1091,7 +1101,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongCount(t *testing.T) {
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	// The server expects one node from storage but we return two
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -1115,7 +1125,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongNode(t *testing.T) {
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	// Return an unexpected node that wasn't requested
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(1, 2, 64), NodeRevision: 3}}, nil)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -1157,6 +1167,7 @@ func TestGetConsistencyProof(t *testing.T) {
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
@@ -1218,6 +1229,7 @@ func (p *parameterizedTest) executeCommitFailsTest(t *testing.T, logID int64) {
 	}
 	p.prepareTx(mockTx)
 	mockTx.EXPECT().Commit().Return(errors.New("bang"))
+	mockTx.EXPECT().Close().Return(errors.New("bang"))
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 
 	mockRegistry := extension.NewMockRegistry(p.ctrl)
@@ -1258,7 +1270,7 @@ func (p *parameterizedTest) executeStorageFailureTest(t *testing.T, logID int64)
 		mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	}
 	p.prepareTx(mockTx)
-	mockTx.EXPECT().Rollback().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 
 	mockRegistry := extension.NewMockRegistry(p.ctrl)
 	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -99,6 +99,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
 	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]*trillian.LogLeaf{}, nil)
@@ -126,7 +127,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	// Set up enough mockery to be able to sequence. We don't test all the error paths
 	// through sequencer as other tests cover this
 	mockTx.EXPECT().Commit().Return(nil)
-	mockTx.EXPECT().Rollback().AnyTimes().Do(func() { panic(nil) })
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(testRoot0.TreeRevision + 1)
 	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]*trillian.LogLeaf{testLeaf0}, nil)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
@@ -155,6 +156,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
 	// Expect a 5 second guard window to be passed from manager -> sequencer -> storage

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -32,6 +32,9 @@ type ReadOnlyLogTX interface {
 
 	// Rollback discards the read-only TX.
 	Rollback() error
+
+	// Close attempts to Rollback the TX if it's open, it's a noop otherwise.
+	Close() error
 }
 
 // ReadOnlyLogTreeTX provides a read-only view into the Log data.

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -29,6 +29,9 @@ type ReadOnlyMapTX interface {
 
 	// Rollback discards the read-only TX.
 	Rollback() error
+
+	// Close attempts to Rollback the TX if it's open, it's a noop otherwise.
+	Close() error
 }
 
 // ReadOnlyMapTreeTX provides a read-only view into the Map data.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -95,6 +95,16 @@ func (_m *MockLogTreeTX) EXPECT() *_MockLogTreeTXRecorder {
 	return _m.recorder
 }
 
+func (_m *MockLogTreeTX) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockLogTreeTXRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
 func (_m *MockLogTreeTX) Commit() error {
 	ret := _m.ctrl.Call(_m, "Commit")
 	ret0, _ := ret[0].(error)
@@ -358,6 +368,16 @@ func (_m *MockMapTreeTX) EXPECT() *_MockMapTreeTXRecorder {
 	return _m.recorder
 }
 
+func (_m *MockMapTreeTX) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMapTreeTXRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
 func (_m *MockMapTreeTX) Commit() error {
 	ret := _m.ctrl.Call(_m, "Commit")
 	ret0, _ := ret[0].(error)
@@ -492,6 +512,16 @@ func (_m *MockReadOnlyLogTX) EXPECT() *_MockReadOnlyLogTXRecorder {
 	return _m.recorder
 }
 
+func (_m *MockReadOnlyLogTX) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReadOnlyLogTXRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
 func (_m *MockReadOnlyLogTX) Commit() error {
 	ret := _m.ctrl.Call(_m, "Commit")
 	ret0, _ := ret[0].(error)
@@ -553,6 +583,16 @@ func NewMockReadOnlyLogTreeTX(ctrl *gomock.Controller) *MockReadOnlyLogTreeTX {
 
 func (_m *MockReadOnlyLogTreeTX) EXPECT() *_MockReadOnlyLogTreeTXRecorder {
 	return _m.recorder
+}
+
+func (_m *MockReadOnlyLogTreeTX) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReadOnlyLogTreeTXRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
 func (_m *MockReadOnlyLogTreeTX) Commit() error {
@@ -669,6 +709,16 @@ func NewMockReadOnlyMapTreeTX(ctrl *gomock.Controller) *MockReadOnlyMapTreeTX {
 
 func (_m *MockReadOnlyMapTreeTX) EXPECT() *_MockReadOnlyMapTreeTXRecorder {
 	return _m.recorder
+}
+
+func (_m *MockReadOnlyMapTreeTX) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReadOnlyMapTreeTXRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
 func (_m *MockReadOnlyMapTreeTX) Commit() error {

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian"
 	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
@@ -113,7 +114,11 @@ func (t *adminTX) Close() error {
 	closed := t.closed
 	t.mu.RUnlock()
 	if !closed {
-		return t.Rollback()
+		err := t.Rollback()
+		if err != nil {
+			glog.Warningf("Rollback error on Close(): %v", err)
+		}
+		return err
 	}
 	return nil
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -159,6 +159,13 @@ func (t *readOnlyLogTX) Rollback() error {
 	return t.tx.Rollback()
 }
 
+func (t *readOnlyLogTX) Close() error {
+	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
+		return err
+	}
+	return nil
+}
+
 func (t *readOnlyLogTX) GetActiveLogIDs() ([]int64, error) {
 	return getActiveLogIDs(t.tx)
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -161,6 +161,7 @@ func (t *readOnlyLogTX) Rollback() error {
 
 func (t *readOnlyLogTX) Close() error {
 	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
+		glog.Warningf("Rollback error on Close(): %v", err)
 		return err
 	}
 	return nil

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -87,6 +87,13 @@ func (t *readOnlyMapTX) Rollback() error {
 	return t.tx.Rollback()
 }
 
+func (t *readOnlyMapTX) Close() error {
+	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
+		return err
+	}
+	return nil
+}
+
 func (m *mySQLMapStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
 	// TODO: read hash algorithm from storage.
 	return merkle.Factory(merkle.RFC6962SHA256Type)

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -89,6 +89,7 @@ func (t *readOnlyMapTX) Rollback() error {
 
 func (t *readOnlyMapTX) Close() error {
 	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
+		glog.Warningf("Rollback error on Close(): %v", err)
 		return err
 	}
 	return nil

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -64,7 +64,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	{
 		tx := beginLogTx(s, logID, t)
-		defer closeTX(tx)
+		defer tx.Close()
 		forceWriteRevision(writeRevision, tx)
 
 		// Need to read nodes before attempting to write
@@ -81,7 +81,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	{
 		tx := beginLogTx(s, logID, t)
-		defer closeTX(tx)
+		defer tx.Close()
 
 		readNodes, err := tx.GetMerkleNodes(100, nodeIDsToRead)
 		if err != nil {
@@ -110,7 +110,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 
 	{
 		tx := beginLogTx(s, logID, t)
-		defer closeTX(tx)
+		defer tx.Close()
 		forceWriteRevision(writeRevision, tx)
 
 		// Need to read nodes before attempting to write
@@ -127,7 +127,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 
 	{
 		tx := beginLogTx(s, logID, t)
-		defer closeTX(tx)
+		defer tx.Close()
 
 		readNodes, err := tx.GetMerkleNodes(100, nodeIDsToRead)
 		if err != nil {

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -404,6 +404,13 @@ func (t *treeTX) Rollback() error {
 	return nil
 }
 
+func (t *treeTX) Close() error {
+	if !t.closed {
+		return t.Rollback()
+	}
+	return nil
+}
+
 func (t *treeTX) IsOpen() bool {
 	return !t.closed
 }

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -406,7 +406,11 @@ func (t *treeTX) Rollback() error {
 
 func (t *treeTX) Close() error {
 	if !t.closed {
-		return t.Rollback()
+		err := t.Rollback()
+		if err != nil {
+			glog.Warningf("Rollback error on Close(): %v", err)
+		}
+		return err
 	}
 	return nil
 }

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -190,6 +190,7 @@ func (tester *AdminStorageTester) TestListTrees(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v: Snapshot() = %v, want = nil", i, err)
 		}
+		defer tx.Close()
 		runListTreeIDsTest(ctx, t, i, tx, wantTrees)
 		runListTreesTest(ctx, t, i, tx, wantTrees)
 		if err := tx.Commit(); err != nil {
@@ -269,6 +270,7 @@ func (tester *AdminStorageTester) TestAdminTXClose(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v: Begin() = (_, %v), want = (_, nil)", i, err)
 		}
+		defer tx.Close()
 
 		tree, err := tx.CreateTree(ctx, LogTree)
 		if err != nil {

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -33,6 +33,9 @@ type ReadOnlyTreeTX interface {
 	// Rollback aborts this transaction.
 	Rollback() error
 
+	// Close attempts to Rollback the TX if it's open, it's a noop otherwise.
+	Close() error
+
 	// Open indicates if this transaction is open. An open transaction is one for which
 	// Commit() or Rollback() has never been called. Implementations must do all clean up
 	// in these methods so transactions are assumed closed regardless of the reported success.

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -87,6 +87,7 @@ func main() {
 		if err != nil {
 			glog.Exitf("Failed to Begin() a new tx: %v", err)
 		}
+		defer tx.Close()
 		w, err := merkle.NewSparseMerkleTreeWriter(tx.WriteRevision(), hasher,
 			func() (storage.TreeTX, error) {
 				return ms.BeginForTree(ctx, mapID)
@@ -126,8 +127,7 @@ func main() {
 			glog.Exitf("Failed to store SMH: %v", err)
 		}
 
-		err = tx.Commit()
-		if err != nil {
+		if err := tx.Commit(); err != nil {
 			glog.Exitf("Failed to Commit() tx: %v", err)
 		}
 	}


### PR DESCRIPTION
I've tracked all TXs being opened and made sure they're being defer-closed after
creation. There's no more need to tx.Rollback() at every exit point.

A few deferred commits have been removed and made explicit as well (mostly on
the Map server implementation).