### PR TITLE
Make personality compute MerkleLeafHash

### DIFF
--- a/examples/ct/handlers.go
+++ b/examples/ct/handlers.go
@@ -16,6 +16,7 @@ package ct
 
 import (
 	"context"
+	gocrypto "crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -36,6 +37,7 @@ import (
 	"github.com/google/certificate-transparency/go/x509"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/util"
 )
 
@@ -81,8 +83,11 @@ const (
 	GetEntryAndProofName  = EntrypointName("GetEntryAndProof")
 )
 
-// Entrypoints is a list of entrypoint names as exposed in statistics/logging.
-var Entrypoints = []EntrypointName{AddChainName, AddPreChainName, GetSTHName, GetSTHConsistencyName, GetProofByHashName, GetEntriesName, GetRootsName, GetEntryAndProofName}
+var (
+	// Entrypoints is a list of entrypoint names as exposed in statistics/logging.
+	Entrypoints = []EntrypointName{AddChainName, AddPreChainName, GetSTHName, GetSTHConsistencyName, GetProofByHashName, GetEntriesName, GetRootsName, GetEntryAndProofName}
+	treeHasher  = rfc6962.TreeHasher{Hash: gocrypto.SHA256}
+)
 
 // PathHandlers maps from a path to the relevant AppHandler instance.
 type PathHandlers map[string]AppHandler
@@ -299,7 +304,10 @@ func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to build LogLeaf: %v", err)
 	}
-	req := trillian.QueueLeavesRequest{LogId: c.logID, Leaves: []*trillian.LogLeaf{&leaf}}
+	req := trillian.QueueLeavesRequest{
+		LogId:  c.logID,
+		Leaves: []*trillian.LogLeaf{leaf},
+	}
 
 	glog.V(2).Infof("%s: %s => grpc.QueueLeaves", c.LogPrefix, method)
 	_, err = c.rpcClient.QueueLeaves(ctx, &req)
@@ -649,31 +657,32 @@ func verifyAddChain(c LogContext, req ct.AddChainRequest, w http.ResponseWriter,
 
 // buildLogLeafForAddChain is also used by add-pre-chain and does the hashing to build a
 // LogLeaf that will be sent to the backend
-func buildLogLeafForAddChain(c LogContext, merkleLeaf ct.MerkleTreeLeaf, chain []*x509.Certificate) (trillian.LogLeaf, error) {
+func buildLogLeafForAddChain(c LogContext, merkleLeaf ct.MerkleTreeLeaf, chain []*x509.Certificate) (*trillian.LogLeaf, error) {
 	leafData, err := tls.Marshal(merkleLeaf)
 	if err != nil {
 		glog.Warningf("%s: Failed to serialize Merkle leaf: %v", c.LogPrefix, err)
-		return trillian.LogLeaf{}, err
+		return nil, err
 	}
 
 	isPrecert, err := IsPrecertificate(chain[0])
 	if err != nil {
 		glog.Warningf("%s: Failed to determine if cert or pre-cert: %v", c.LogPrefix, err)
-		return trillian.LogLeaf{}, err
+		return nil, err
 	}
 
 	extraData, err := extraDataForChain(chain, isPrecert)
 	if err != nil {
 		glog.Warningf("%s: Failed to serialize chain for ExtraData: %v", c.LogPrefix, err)
-		return trillian.LogLeaf{}, err
+		return nil, err
 	}
 
 	// leafIDHash allows Trillian to detect duplicate entries, so this should be
 	// a hash over the cert data.
 	leafIDHash := sha256.Sum256(chain[0].Raw)
 
-	return trillian.LogLeaf{
+	return &trillian.LogLeaf{
 		LeafIdentityHash: leafIDHash[:],
+		MerkleLeafHash:   treeHasher.HashLeaf(leafData),
 		LeafValue:        leafData,
 		ExtraData:        extraData,
 	}, nil

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -1239,7 +1239,14 @@ func logLeavesForCert(t *testing.T, km crypto.PrivateKeyManager, certs []*x509.C
 		t.Fatalf("failed to serialize extra data: %v", err)
 	}
 
-	return []*trillian.LogLeaf{{LeafIdentityHash: leafIDHash[:], LeafValue: leafData, ExtraData: extraData}}
+	return []*trillian.LogLeaf{
+		{
+			LeafIdentityHash: leafIDHash[:],
+			MerkleLeafHash:   treeHasher.HashLeaf(leafData),
+			LeafValue:        leafData,
+			ExtraData:        extraData,
+		},
+	}
 }
 
 type dlMatcher struct {

--- a/integration/log.go
+++ b/integration/log.go
@@ -191,6 +191,7 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 
 		leaf := trillian.LogLeaf{
 			LeafIdentityHash: idHash[:],
+			MerkleLeafHash:   testonly.Hasher.HashLeaf(data),
 			LeafValue:        data,
 			ExtraData:        []byte(fmt.Sprintf("Extra %d", leafNumber)),
 		}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -78,12 +78,6 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	}
 	leaves := depointerify(req.Leaves)
 
-	// TODO(al): Hasher must be selected based on log config.
-	th, _ := merkle.Factory(merkle.RFC6962SHA256Type)
-	for i := range leaves {
-		leaves[i].MerkleLeafHash = th.HashLeaf(leaves[i].LeafValue)
-	}
-
 	tx, err := t.prepareStorageTx(ctx, req.LogId)
 	if err != nil {
 		return nil, err

--- a/server/validate.go
+++ b/server/validate.go
@@ -74,5 +74,11 @@ func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
 	if len(req.Leaves) == 0 {
 		return grpc.Errorf(codes.InvalidArgument, "len(leaves)=0, want > 0")
 	}
+	for _, leaf := range req.Leaves {
+		if len(leaf.MerkleLeafHash) == 0 {
+			return grpc.Errorf(codes.InvalidArgument, "Missing MerkleLeafHash")
+		}
+
+	}
 	return nil
 }


### PR DESCRIPTION
This
- Improves API readability. All fields of LogLeaf are provided by client.
- Improves API usability. Client's don't have to guess what hash algorithm was used to compute the MerkleTreeHash.
- Improves future flexibility. Server won't need to be modified to support new MerkleLeafHash algos.
- Improves server speed. Saves a DB lookup of the hash algo.