### PR TITLE
Break the dependency from storage -> grpc 

### DIFF
--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -91,10 +91,8 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 
 	err = tx.QueueLeaves(req.Leaves, t.timeSource.Now())
 	if err != nil {
-		if se, ok := err.(storage.Error); ok {
-			if se.ErrType == storage.DuplicateLeaf {
-				return nil, grpc.Errorf(codes.AlreadyExists, "Leaf hash already exists: %v", se)
-			}
+		if se, ok := err.(storage.Error); ok && se.ErrType == storage.DuplicateLeaf {
+			return nil, grpc.Errorf(codes.AlreadyExists, "Leaf hash already exists: %v", se)
 		}
 
 		return nil, err

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -91,7 +91,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 
 	err = tx.QueueLeaves(req.Leaves, t.timeSource.Now())
 	if err != nil {
-		if se, ok := err.(storage.StorageError); ok {
+		if se, ok := err.(storage.Error); ok {
 			if se.ErrType == storage.DuplicateLeaf {
 				return nil, grpc.Errorf(codes.AlreadyExists, "Leaf hash already exists: %v", se)
 			}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -91,6 +91,12 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 
 	err = tx.QueueLeaves(req.Leaves, t.timeSource.Now())
 	if err != nil {
+		if se, ok := err.(storage.StorageError); ok {
+			if se.ErrType == storage.DuplicateLeaf {
+				return nil, grpc.Errorf(codes.AlreadyExists, "Leaf hash already exists: %v", se)
+			}
+		}
+
 		return nil, err
 	}
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -283,7 +283,7 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(storage.StorageError{
+	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(storage.Error{
 		ErrType:storage.DuplicateLeaf,
 		Detail: "duplicate test"})
 	mockTx.EXPECT().Close().Return(nil)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -287,19 +287,19 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 
 	tests := []errMapTest{
 		{
-			err:   storage.Error{ErrType: storage.DuplicateLeaf, Detail: "duplicate test"},
+			err:  storage.Error{ErrType: storage.DuplicateLeaf, Detail: "duplicate test"},
 			want: codes.AlreadyExists,
 		},
 		{
-			err:   storage.Error{ErrType: -23, Detail: "negative type"},
+			err:  storage.Error{ErrType: -23, Detail: "negative type"},
 			want: codes.Unknown,
 		},
 		{
-			err:   storage.Error{ErrType: 999999999, Detail: "undefined type"},
+			err:  storage.Error{ErrType: 999999999, Detail: "undefined type"},
 			want: codes.Unknown,
 		},
 		{
-			err:   errors.New("some other kind of error"),
+			err:  errors.New("some other kind of error"),
 			want: codes.Unknown,
 		},
 	}
@@ -309,7 +309,7 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 		mockTx := storage.NewMockLogTreeTX(ctrl)
 		mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
 		mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(test.err)
-		mockTx.EXPECT().Rollback().Return(nil)
+		mockTx.EXPECT().Close().Return(nil)
 		mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 
 		mockRegistry := extension.NewMockRegistry(ctrl)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 var (
@@ -280,27 +280,51 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(storage.Error{
-		ErrType:storage.DuplicateLeaf,
-		Detail: "duplicate test"})
-	mockTx.EXPECT().Close().Return(nil)
-	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
-
-	mockRegistry := extension.NewMockRegistry(ctrl)
-	mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
-	server := NewTrillianLogRPCServer(mockRegistry, fakeTimeSource)
-
-	_, err := server.QueueLeaves(context.Background(), &queueRequest0)
-	if err == nil {
-		// The operation should not have succeeded
-		t.Fatalf("Did not propagate duplicate leaf storage error to client")
+	type errMapTest struct {
+		storageErr   error
+		expectedCode codes.Code
 	}
-	// The error should have been mapped to GRPC Already Exists
-	if got, want := grpc.Code(err), codes.AlreadyExists; got != want {
-		t.Fatalf("Got grpc code: %d for duplicate leaf, want: %d (AlreadyExists)", got, want)
+
+	tests := []errMapTest{
+		{
+			storageErr:   storage.Error{ErrType: storage.DuplicateLeaf, Detail: "duplicate test"},
+			expectedCode: codes.AlreadyExists,
+		},
+		{
+			storageErr: storage.Error{ErrType: -23, Detail: "negative type"},
+			expectedCode: codes.Unknown,
+		},
+		{
+			storageErr:   storage.Error{ErrType: 999999999, Detail: "undefined type"},
+			expectedCode: codes.Unknown,
+		},
+		{
+			storageErr:   errors.New("some other kind of error"),
+			expectedCode: codes.Unknown,
+		},
+	}
+
+	for _, test := range tests {
+		mockStorage := storage.NewMockLogStorage(ctrl)
+		mockTx := storage.NewMockLogTreeTX(ctrl)
+		mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
+		mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(test.storageErr)
+		mockTx.EXPECT().Rollback().Return(nil)
+		mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
+
+		mockRegistry := extension.NewMockRegistry(ctrl)
+		mockRegistry.EXPECT().GetLogStorage().Return(mockStorage, nil)
+		server := NewTrillianLogRPCServer(mockRegistry, fakeTimeSource)
+
+		_, err := server.QueueLeaves(context.Background(), &queueRequest0)
+		if err == nil {
+			// The operation should not have succeeded
+			t.Fatalf("Did not propagate duplicate leaf storage error to client")
+		}
+		// The error should have been mapped to the expected GRPC code
+		if got, want := grpc.Code(err), test.expectedCode; got != want {
+			t.Fatalf("Got grpc code: %d for duplicate leaf, want: %d, err=%v", got, want, err)
+		}
 	}
 }
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -300,7 +300,7 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 	}
 	// The error should have been mapped to GRPC Already Exists
 	if got, want := grpc.Code(err), codes.AlreadyExists; got != want {
-		t.Fatalf("Got grpc code: %d for duplicate leaf, want: %d (AlreadyExists)")
+		t.Fatalf("Got grpc code: %d for duplicate leaf, want: %d (AlreadyExists)", got, want)
 	}
 }
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -291,7 +291,7 @@ func TestQueueLeavesDuplicateErrorMapped(t *testing.T) {
 			expectedCode: codes.AlreadyExists,
 		},
 		{
-			storageErr: storage.Error{ErrType: -23, Detail: "negative type"},
+			storageErr:   storage.Error{ErrType: -23, Detail: "negative type"},
 			expectedCode: codes.Unknown,
 		},
 		{

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -25,9 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
@@ -331,11 +328,14 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 		_, err := t.tx.Exec(insertSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
 		if err != nil {
 			if strings.Contains(err.Error(), "Duplicate entry") {
-				return grpc.Errorf(codes.AlreadyExists, "Leaf already exists for IdentityHash: %x. err: %v",
-					leaf.LeafIdentityHash, err)
+				return storage.StorageError{
+					ErrType: storage.DuplicateLeaf,
+					Cause:   err,
+					Detail:  fmt.Sprintf("IdentityHash: %x", leaf.LeafIdentityHash),
+				}
 			}
 			glog.Warningf("Error inserting %d into LeafData: %s", i, err)
-			return grpc.Errorf(codes.Unknown, "Insert into LeafData failed for leaf %d: %v", i, err)
+			return err
 		}
 
 		// Create the work queue entry

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -328,7 +328,7 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 		_, err := t.tx.Exec(insertSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
 		if err != nil {
 			if strings.Contains(err.Error(), "Duplicate entry") {
-				return storage.StorageError{
+				return storage.Error{
 					ErrType: storage.DuplicateLeaf,
 					Cause:   err,
 					Detail:  fmt.Sprintf("IdentityHash: %x", leaf.LeafIdentityHash),

--- a/storage/types.go
+++ b/storage/types.go
@@ -26,16 +26,16 @@ const (
 	DuplicateLeaf = iota
 )
 
-// StorageError is a typed error that the storage layer can return to give callers information
+// Error is a typed error that the storage layer can return to give callers information
 // about the error to decide how to handle it.
-type StorageError struct {
+type Error struct {
 	ErrType int
 	Detail  string
 	Cause   error
 }
 
-// Error formats the internal details of a StorageError.
-func (s StorageError) Error() string {
+// Error formats the internal details of an Error including the original cause.
+func (s Error) Error() string {
 	return fmt.Sprintf("Storage: %d: %s: %v", s.ErrType, s.Detail, s.Cause)
 }
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/trillian/storage/storagepb"
 )
 
-// Integer types to distinguish storage errors that might need to be mapped at a higher level
+// Integer types to distinguish storage errors that might need to be mapped at a higher level.
 const (
 	DuplicateLeaf = iota
 )
@@ -34,7 +34,7 @@ type StorageError struct {
 	Cause   error
 }
 
-// Error formats the internal details of a StorageError
+// Error formats the internal details of a StorageError.
 func (s StorageError) Error() string {
 	return fmt.Sprintf("Storage: %d: %s: %v", s.ErrType, s.Detail, s.Cause)
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -16,14 +16,28 @@ package storage
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	"github.com/google/trillian/storage/storagepb"
 )
 
-// ErrReadOnly is returned when storage operations are not allowed because a resource is read only
-var ErrReadOnly = errors.New("storage: Operation not allowed because resource is read only")
+// Integer types to distinguish storage errors that might need to be mapped at a higher level
+const (
+	DuplicateLeaf = iota
+)
+
+// StorageError is a typed error that the storage layer can return to give callers information
+// about the error to decide how to handle it.
+type StorageError struct {
+	ErrType int
+	Detail  string
+	Cause   error
+}
+
+// Error formats the internal details of a StorageError
+func (s StorageError) Error() string {
+	return fmt.Sprintf("Storage: %d: %s: %v", s.ErrType, s.Detail, s.Cause)
+}
 
 // Node represents a single node in a Merkle tree.
 type Node struct {


### PR DESCRIPTION
Add a StorageError type that can carry details and map it in RPC server. Add test. Remove the read only error until we actually need it, when it can use StorageError.