### PR TITLE
Pass PrivateKeyManager when creating a new Signer

### DIFF
--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -37,7 +37,16 @@ type Signer struct {
 // NewSigner creates a new Signer wrapping up a hasher and a signer. For the moment
 // we only support SHA256 hashing and either ECDSA or RSA signing but this is not enforced
 // here.
-func NewSigner(key PrivateKeyManager) *Signer {
+func NewSigner(sigAlgo sigpb.DigitallySigned_SignatureAlgorithm, signer crypto.Signer) *Signer {
+	return NewSignerFromPrivateKeyManager(localSigner{
+		Signer:             signer,
+		signatureAlgorithm: sigAlgo,
+	})
+}
+
+// NewSignerFromPrivateKeyManager creates a new Signer wrapping up a hasher and a signer.
+// For the moment, we only support SHA256 hashing and either ECDSA or RSA signing but this is not enforced here.
+func NewSignerFromPrivateKeyManager(key PrivateKeyManager) *Signer {
 	return &Signer{
 		hash: crypto.SHA256,
 		key:  key,

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -94,7 +94,7 @@ func TestSignerFails(t *testing.T) {
 	digest := messageHash()
 	mockKey.EXPECT().Sign(gomock.Any(), digest[:], usesSHA256Hasher{}).Return(digest, errors.New("sign"))
 
-	logSigner := NewSignerFromPrivateKeyManager(mockKey)
+	logSigner := NewSigner(sigpb.DigitallySigned_ECDSA, mockKey)
 
 	_, err := logSigner.Sign([]byte(message))
 
@@ -114,7 +114,7 @@ func TestSignLogRootSignerFails(t *testing.T) {
 		[]byte{0xe5, 0xb3, 0x18, 0x1a, 0xec, 0xc8, 0x64, 0xc6, 0x39, 0x6d, 0x83, 0x21, 0x7a, 0x18, 0x3, 0x9, 0xf5, 0xa0, 0x25, 0xde, 0xf7, 0x1b, 0xdb, 0x2d, 0xbe, 0x42, 0x8a, 0x4a, 0xab, 0xc1, 0xcd, 0x49},
 		usesSHA256Hasher{}).Return([]byte{}, errors.New("signfail"))
 
-	logSigner := NewSignerFromPrivateKeyManager(mockKey)
+	logSigner := NewSigner(sigpb.DigitallySigned_ECDSA, mockKey)
 
 	root := trillian.SignedLogRoot{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}
 	_, err := logSigner.Sign(HashLogRoot(root))

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -54,7 +54,7 @@ func TestSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open test key")
 	}
-	signer := NewSigner(km)
+	signer := NewSignerFromPrivateKeyManager(km)
 
 	pk, err := PublicKeyFromPEM(testonly.DemoPublicKey)
 	if err != nil {
@@ -94,7 +94,7 @@ func TestSignerFails(t *testing.T) {
 	digest := messageHash()
 	mockKey.EXPECT().Sign(gomock.Any(), digest[:], usesSHA256Hasher{}).Return(digest, errors.New("sign"))
 
-	logSigner := NewSigner(mockKey)
+	logSigner := NewSignerFromPrivateKeyManager(mockKey)
 
 	_, err := logSigner.Sign([]byte(message))
 
@@ -114,7 +114,7 @@ func TestSignLogRootSignerFails(t *testing.T) {
 		[]byte{0xe5, 0xb3, 0x18, 0x1a, 0xec, 0xc8, 0x64, 0xc6, 0x39, 0x6d, 0x83, 0x21, 0x7a, 0x18, 0x3, 0x9, 0xf5, 0xa0, 0x25, 0xde, 0xf7, 0x1b, 0xdb, 0x2d, 0xbe, 0x42, 0x8a, 0x4a, 0xab, 0xc1, 0xcd, 0x49},
 		usesSHA256Hasher{}).Return([]byte{}, errors.New("signfail"))
 
-	logSigner := NewSigner(mockKey)
+	logSigner := NewSignerFromPrivateKeyManager(mockKey)
 
 	root := trillian.SignedLogRoot{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}
 	_, err := logSigner.Sign(HashLogRoot(root))

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -54,7 +54,7 @@ func TestSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open test key")
 	}
-	signer := NewSigner(km.SignatureAlgorithm(), km)
+	signer := NewSigner(km)
 
 	pk, err := PublicKeyFromPEM(testonly.DemoPublicKey)
 	if err != nil {
@@ -90,12 +90,11 @@ func TestSignerFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockSigner := NewMockSigner(ctrl)
+	mockKey := NewMockPrivateKeyManager(ctrl)
 	digest := messageHash()
+	mockKey.EXPECT().Sign(gomock.Any(), digest[:], usesSHA256Hasher{}).Return(digest, errors.New("sign"))
 
-	mockSigner.EXPECT().Sign(gomock.Any(), digest[:], usesSHA256Hasher{}).Return(digest, errors.New("sign"))
-
-	logSigner := createTestSigner(mockSigner)
+	logSigner := NewSigner(mockKey)
 
 	_, err := logSigner.Sign([]byte(message))
 
@@ -110,20 +109,15 @@ func TestSignLogRootSignerFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockSigner := NewMockSigner(ctrl)
-
-	mockSigner.EXPECT().Sign(gomock.Any(),
+	mockKey := NewMockPrivateKeyManager(ctrl)
+	mockKey.EXPECT().Sign(gomock.Any(),
 		[]byte{0xe5, 0xb3, 0x18, 0x1a, 0xec, 0xc8, 0x64, 0xc6, 0x39, 0x6d, 0x83, 0x21, 0x7a, 0x18, 0x3, 0x9, 0xf5, 0xa0, 0x25, 0xde, 0xf7, 0x1b, 0xdb, 0x2d, 0xbe, 0x42, 0x8a, 0x4a, 0xab, 0xc1, 0xcd, 0x49},
 		usesSHA256Hasher{}).Return([]byte{}, errors.New("signfail"))
 
-	logSigner := createTestSigner(mockSigner)
+	logSigner := NewSigner(mockKey)
 
 	root := trillian.SignedLogRoot{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}
 	_, err := logSigner.Sign(HashLogRoot(root))
 
 	testonly.EnsureErrorContains(t, err, "signfail")
-}
-
-func createTestSigner(mock *MockSigner) *Signer {
-	return NewSigner(sigpb.DigitallySigned_RSA, mock)
 }

--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -31,8 +31,13 @@ import (
 	"github.com/google/trillian/crypto/sigpb"
 )
 
-// ErrVerify occurs whenever signature verification fails.
-var ErrVerify = errors.New("signature verification failed")
+var (
+	ErrVerify = errors.New("signature verification failed")
+
+	cryptoHashLookup = map[sigpb.DigitallySigned_HashAlgorithm]crypto.Hash{
+		sigpb.DigitallySigned_SHA256: crypto.SHA256,
+	}
+)
 
 // PublicKeyFromFile returns the public key contained in the keyFile in PEM format.
 func PublicKeyFromFile(keyFile string) (crypto.PublicKey, error) {
@@ -77,7 +82,7 @@ func Verify(pub crypto.PublicKey, data []byte, sig *sigpb.DigitallySigned) error
 	sigAlgo := sig.SignatureAlgorithm
 
 	// Recompute digest
-	hasher, ok := signerHashLookup[sig.HashAlgorithm]
+	hasher, ok := cryptoHashLookup[sig.HashAlgorithm]
 	if !ok {
 		return fmt.Errorf("unsupported hash algorithm %v", hasher)
 	}

--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	ErrVerify = errors.New("signature verification failed")
+	errVerify = errors.New("signature verification failed")
 
 	cryptoHashLookup = map[sigpb.DigitallySigned_HashAlgorithm]crypto.Hash{
 		sigpb.DigitallySigned_SHA256: crypto.SHA256,
@@ -120,14 +120,14 @@ func verifyECDSA(pub *ecdsa.PublicKey, hashed, sig []byte) error {
 	}
 	rest, err := asn1.Unmarshal(sig, &ecdsaSig)
 	if err != nil {
-		return ErrVerify
+		return errVerify
 	}
 	if len(rest) != 0 {
-		return ErrVerify
+		return errVerify
 	}
 
 	if !ecdsa.Verify(pub, hashed, ecdsaSig.R, ecdsaSig.S) {
-		return ErrVerify
+		return errVerify
 	}
 	return nil
 

--- a/crypto/verifier_test.go
+++ b/crypto/verifier_test.go
@@ -18,7 +18,6 @@ import (
 	"crypto"
 	"testing"
 
-	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/testonly"
 )
 
@@ -36,11 +35,9 @@ func TestSignVerify(t *testing.T) {
 		PEM      string
 		password string
 		HashAlgo crypto.Hash
-		SigAlgo  sigpb.DigitallySigned_SignatureAlgorithm
 	}{
-		{privPEM, "", crypto.SHA256, sigpb.DigitallySigned_ECDSA},
-		{testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass,
-			crypto.SHA256, sigpb.DigitallySigned_ECDSA},
+		{privPEM, "", crypto.SHA256},
+		{testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass, crypto.SHA256},
 	} {
 
 		km, err := NewFromPrivatePEM(test.PEM, test.password)
@@ -48,7 +45,7 @@ func TestSignVerify(t *testing.T) {
 			t.Errorf("LoadPrivateKey(_, %v)=%v, want nil", test.password, err)
 			continue
 		}
-		signer := NewSigner(test.SigAlgo, km)
+		signer := NewSigner(km)
 
 		// Sign and Verify.
 		msg := []byte("foo")

--- a/crypto/verifier_test.go
+++ b/crypto/verifier_test.go
@@ -45,7 +45,7 @@ func TestSignVerify(t *testing.T) {
 			t.Errorf("LoadPrivateKey(_, %v)=%v, want nil", test.password, err)
 			continue
 		}
-		signer := NewSigner(km)
+		signer := NewSignerFromPrivateKeyManager(km)
 
 		// Sign and Verify.
 		msg := []byte("foo")

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -34,7 +34,7 @@ func signV1TreeHead(km crypto.PrivateKeyManager, sth *ct.SignedTreeHead) error {
 		return err
 	}
 
-	trillianSigner := crypto.NewSigner(km)
+	trillianSigner := crypto.NewSignerFromPrivateKeyManager(km)
 
 	signature, err := trillianSigner.Sign(sthBytes)
 	if err != nil {
@@ -127,7 +127,7 @@ func serializeAndSignSCT(km crypto.PrivateKeyManager, leaf ct.MerkleTreeLeaf, sc
 }
 
 func signSCT(km crypto.PrivateKeyManager, t time.Time, sctData []byte) (*ct.SignedCertificateTimestamp, error) {
-	trillianSigner := crypto.NewSigner(km)
+	trillianSigner := crypto.NewSignerFromPrivateKeyManager(km)
 	signature, err := trillianSigner.Sign(sctData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign data: %v", err)

--- a/examples/ct/serialize.go
+++ b/examples/ct/serialize.go
@@ -34,7 +34,7 @@ func signV1TreeHead(km crypto.PrivateKeyManager, sth *ct.SignedTreeHead) error {
 		return err
 	}
 
-	trillianSigner := crypto.NewSigner(km.SignatureAlgorithm(), km)
+	trillianSigner := crypto.NewSigner(km)
 
 	signature, err := trillianSigner.Sign(sthBytes)
 	if err != nil {
@@ -127,7 +127,7 @@ func serializeAndSignSCT(km crypto.PrivateKeyManager, leaf ct.MerkleTreeLeaf, sc
 }
 
 func signSCT(km crypto.PrivateKeyManager, t time.Time, sctData []byte) (*ct.SignedCertificateTimestamp, error) {
-	trillianSigner := crypto.NewSigner(km.SignatureAlgorithm(), km)
+	trillianSigner := crypto.NewSigner(km)
 	signature, err := trillianSigner.Sign(sctData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign data: %v", err)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -149,7 +149,7 @@ func (s Sequencer) initMerkleTreeFromStorage(ctx context.Context, currentRoot tr
 }
 
 func (s Sequencer) createRootSignature(ctx context.Context, root trillian.SignedLogRoot) (*sigpb.DigitallySigned, error) {
-	trillianSigner := crypto.NewSigner(s.keyManager.SignatureAlgorithm(), s.keyManager)
+	trillianSigner := crypto.NewSigner(s.keyManager)
 	signature, err := trillianSigner.Sign(crypto.HashLogRoot(root))
 	if err != nil {
 		glog.Warningf("%s: signer failed to sign root: %v", util.LogIDPrefix(ctx), err)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -149,7 +149,7 @@ func (s Sequencer) initMerkleTreeFromStorage(ctx context.Context, currentRoot tr
 }
 
 func (s Sequencer) createRootSignature(ctx context.Context, root trillian.SignedLogRoot) (*sigpb.DigitallySigned, error) {
-	trillianSigner := crypto.NewSigner(s.keyManager)
+	trillianSigner := crypto.NewSignerFromPrivateKeyManager(s.keyManager)
 	signature, err := trillianSigner.Sign(crypto.HashLogRoot(root))
 	if err != nil {
 		glog.Warningf("%s: signer failed to sign root: %v", util.LogIDPrefix(ctx), err)


### PR DESCRIPTION
Simplifies the code a bit by removing a superfluous parameter.