### PR TITLE
Adding AdminStorage.UpdateTree method

### DIFF
--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -94,7 +94,9 @@ type AdminWriter interface {
 
 	// UpdateTree updates the specified tree in storage, returning a tree
 	// with all storage-generated fields set.
-	// updateFunc is called to perform the desired tree modifications.
+	// updateFunc is called to perform the desired tree modifications. Refer
+	// to trillian.Tree for details on which fields are mutable and what is
+	// considered valid.
 	// Returns an error if the tree is invalid or the update cannot be
 	// performed.
 	UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error)

--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -91,4 +91,11 @@ type AdminWriter interface {
 	// Remaining fields must be set to valid values.
 	// Returns an error if the tree is invalid or creation fails.
 	CreateTree(ctx context.Context, tree *trillian.Tree) (*trillian.Tree, error)
+
+	// UpdateTree updates the specified tree in storage, returning a tree
+	// with all storage-generated fields set.
+	// updateFunc is called to perform the desired tree modifications.
+	// Returns an error if the tree is invalid or the update cannot be
+	// performed.
+	UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error)
 }

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -220,7 +220,6 @@ func openTestDBOrDie() *sql.DB {
 
 // cleanTestDB deletes all the entries in the database.
 func cleanTestDB(db *sql.DB) {
-	// Wipe out anything that was there for this log id
 	for _, table := range allTables {
 		if _, err := db.Exec(fmt.Sprintf("DELETE FROM %s", table)); err != nil {
 			panic(fmt.Errorf("Failed to delete rows in %s: %s", table, err))

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -149,7 +149,6 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 	}
 
 	referenceLog := *LogTree
-
 	validLog := referenceLog
 	validLog.TreeState = trillian.TreeState_FROZEN
 	validLog.DisplayName = "Frozen Tree"
@@ -177,42 +176,42 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 
 	// Test for an unknown tree outside the loop: it makes the test logic simpler
 	if _, errOnUpdate, err := updateTree(s, -1, func(t *trillian.Tree) {}); err == nil || !errOnUpdate {
-		t.Errorf("updateTree() = (_, %v, %v), wanted lookup error (ie, error on update)", errOnUpdate, err)
+		t.Errorf("updateTree(_, -1, _) = (_, %v, %v), want = (_, true, lookup error)", errOnUpdate, err)
 	}
 
 	tests := []struct {
-		desc                 string
-		createTree, wantTree *trillian.Tree
-		updateFunc           func(*trillian.Tree)
-		wantErr              bool
+		desc         string
+		create, want *trillian.Tree
+		updateFunc   func(*trillian.Tree)
+		wantErr      bool
 	}{
 		{
 			desc:       "validLog",
-			createTree: &referenceLog,
+			create:     &referenceLog,
 			updateFunc: validLogFunc,
-			wantTree:   &validLog,
+			want:       &validLog,
 		},
 		{
 			desc:       "invalidLog",
-			createTree: &referenceLog,
+			create:     &referenceLog,
 			updateFunc: invalidLogFunc,
 			wantErr:    true,
 		},
 		{
 			desc:       "readonlyChanged",
-			createTree: &referenceLog,
+			create:     &referenceLog,
 			updateFunc: readonlyChangedFunc,
 			wantErr:    true,
 		},
 		{
 			desc:       "validMap",
-			createTree: &referenceMap,
+			create:     &referenceMap,
 			updateFunc: validMapFunc,
-			wantTree:   &validMap,
+			want:       &validMap,
 		},
 	}
 	for _, test := range tests {
-		createdTree, err := createTree(s, test.createTree)
+		createdTree, err := createTree(s, test.create)
 		if err != nil {
 			t.Errorf("createTree() = (_, %v), want = (_, nil)", err)
 			continue
@@ -240,8 +239,8 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 		if createdTree.UpdateTimeMillisSinceEpoch > updatedTree.UpdateTimeMillisSinceEpoch {
 			t.Errorf("%v: UpdateTime = %v, want >= %v", test.desc, updatedTree.UpdateTimeMillisSinceEpoch, createdTree.UpdateTimeMillisSinceEpoch)
 		}
-		// Copy storage-generated values to wantTree before comparing
-		wantTree := *test.wantTree
+		// Copy storage-generated values to want before comparing
+		wantTree := *test.want
 		wantTree.TreeId = updatedTree.TreeId
 		wantTree.CreateTimeMillisSinceEpoch = updatedTree.CreateTimeMillisSinceEpoch
 		wantTree.UpdateTimeMillisSinceEpoch = updatedTree.UpdateTimeMillisSinceEpoch


### PR DESCRIPTION
UpdateTree is meant to back both Tree Update and (soft) Delete RPCs, as well as
state transitions to HARD_DELETED.