### PR TITLE
Remove pointless index from LeafData

### DIFF
--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -84,7 +84,6 @@ CREATE TABLE IF NOT EXISTS LeafData(
   -- This data is not included in signing and hashing.
   ExtraData            BLOB,
   PRIMARY KEY(TreeId, LeafIdentityHash),
-  INDEX LeafHashIdx(LeafIdentityHash),
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
Secondary indexes are prefixed with the primary clustered index key so this is probably doing nothing except take up disk space / RAM.