### PR TITLE
Get private key from admin storage instead of command-line flag

### DIFF
--- a/crypto/keys/private.go
+++ b/crypto/keys/private.go
@@ -15,6 +15,7 @@
 package keys
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
@@ -23,7 +24,15 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/google/trillian"
 )
+
+// Provider handles acquisition of signers for trees.
+type Provider interface {
+	// Signer returns a signer for the given tree.
+	Signer(context.Context, *trillian.Tree) (crypto.Signer, error)
+}
 
 // NewFromPrivatePEMFile reads a PEM-encoded private key from a file.
 // The key may be protected by a password.

--- a/crypto/keys/private.go
+++ b/crypto/keys/private.go
@@ -28,10 +28,13 @@ import (
 	"github.com/google/trillian"
 )
 
-// Provider handles acquisition of signers for trees.
-type Provider interface {
-	// Signer returns a signer for the given tree.
-	Signer(context.Context, *trillian.Tree) (crypto.Signer, error)
+// SignerFactory creates signers for Trillian trees.
+// A signers may be created by loading a private key, interfacing with a HSM,
+// or sending network requests to a remote key management service, to give a few
+// examples.
+type SignerFactory interface {
+	// NewSigner returns a signer for the given tree.
+	NewSigner(context.Context, *trillian.Tree) (crypto.Signer, error)
 }
 
 // NewFromPrivatePEMFile reads a PEM-encoded private key from a file.

--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -19,7 +19,7 @@ go build ./examples/ct/ctmapper/mapper
 go build ./examples/ct/ctmapper/lookup
 
 # in one terminal:
-./trillian_map_server --logtostderr --private_key_password=towel --private_key_file=testdata/trillian-map-server-key.pem
+./trillian_map_server --logtostderr
 
 # in another (leaving the trillian_map_server running):
 ./mapper -source http://ct.googleapis.com/pilot -map_id=1 -map_server=localhost:8091 --logtostderr

--- a/extension/builtin/default_registry.go
+++ b/extension/builtin/default_registry.go
@@ -53,8 +53,8 @@ func (r *defaultRegistry) GetMapStorage() (storage.MapStorage, error) {
 	return mysql.NewMapStorage(r.db), nil
 }
 
-func (r *defaultRegistry) GetKeyProvider() (keys.Provider, error) {
-	return keyProvider{}, nil
+func (r *defaultRegistry) GetSignerFactory() (keys.SignerFactory, error) {
+	return signerFactory{}, nil
 }
 
 // NewExtensionRegistry returns an extension.Registry implementation backed by a given
@@ -74,11 +74,11 @@ func NewDefaultExtensionRegistry() (extension.Registry, error) {
 	return NewExtensionRegistry(db)
 }
 
-// keyProvider implements keys.Provider.
-type keyProvider struct{}
+// signerFactory implements keys.SignerFactory.
+type signerFactory struct{}
 
-// Signer returns a crypto.Signer for the given tree.
-func (p keyProvider) Signer(ctx context.Context, tree *trillian.Tree) (crypto.Signer, error) {
+// NewSigner returns a crypto.Signer for the given tree.
+func (f signerFactory) NewSigner(ctx context.Context, tree *trillian.Tree) (crypto.Signer, error) {
 	if tree.PrivateKey == nil {
 		return nil, fmt.Errorf("tree %d has no PrivateKey", tree.GetTreeId())
 	}

--- a/extension/mock_registry.go
+++ b/extension/mock_registry.go
@@ -40,17 +40,6 @@ func (_mr *_MockRegistryRecorder) GetAdminStorage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAdminStorage")
 }
 
-func (_m *MockRegistry) GetKeyProvider() (keys.Provider, error) {
-	ret := _m.ctrl.Call(_m, "GetKeyProvider")
-	ret0, _ := ret[0].(keys.Provider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockRegistryRecorder) GetKeyProvider() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyProvider")
-}
-
 func (_m *MockRegistry) GetLogStorage() (storage.LogStorage, error) {
 	ret := _m.ctrl.Call(_m, "GetLogStorage")
 	ret0, _ := ret[0].(storage.LogStorage)
@@ -71,4 +60,15 @@ func (_m *MockRegistry) GetMapStorage() (storage.MapStorage, error) {
 
 func (_mr *_MockRegistryRecorder) GetMapStorage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMapStorage")
+}
+
+func (_m *MockRegistry) GetSignerFactory() (keys.SignerFactory, error) {
+	ret := _m.ctrl.Call(_m, "GetSignerFactory")
+	ret0, _ := ret[0].(keys.SignerFactory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRegistryRecorder) GetSignerFactory() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSignerFactory")
 }

--- a/extension/mock_registry.go
+++ b/extension/mock_registry.go
@@ -5,7 +5,7 @@ package extension
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	crypto "github.com/google/trillian/crypto"
+	keys "github.com/google/trillian/crypto/keys"
 	storage "github.com/google/trillian/storage"
 )
 
@@ -40,6 +40,17 @@ func (_mr *_MockRegistryRecorder) GetAdminStorage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAdminStorage")
 }
 
+func (_m *MockRegistry) GetKeyProvider() (keys.Provider, error) {
+	ret := _m.ctrl.Call(_m, "GetKeyProvider")
+	ret0, _ := ret[0].(keys.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRegistryRecorder) GetKeyProvider() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyProvider")
+}
+
 func (_m *MockRegistry) GetLogStorage() (storage.LogStorage, error) {
 	ret := _m.ctrl.Call(_m, "GetLogStorage")
 	ret0, _ := ret[0].(storage.LogStorage)
@@ -60,15 +71,4 @@ func (_m *MockRegistry) GetMapStorage() (storage.MapStorage, error) {
 
 func (_mr *_MockRegistryRecorder) GetMapStorage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMapStorage")
-}
-
-func (_m *MockRegistry) GetSigner(_param0 int64) (*crypto.Signer, error) {
-	ret := _m.ctrl.Call(_m, "GetSigner", _param0)
-	ret0, _ := ret[0].(*crypto.Signer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockRegistryRecorder) GetSigner(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSigner", arg0)
 }

--- a/extension/registry.go
+++ b/extension/registry.go
@@ -33,6 +33,6 @@ type Registry interface {
 	// GetMapStorage returns a configured storage.MapStorage instance or an error if the storage cannot be set up.
 	GetMapStorage() (storage.MapStorage, error)
 
-	// GetKeyProvider returns a keys.Provider that allows access to the private keys belonging to all trees.
-	GetKeyProvider() (keys.Provider, error)
+	// GetSignerFactory returns a keys.SignerFactory that allows access to the private keys belonging to all trees.
+	GetSignerFactory() (keys.SignerFactory, error)
 }

--- a/extension/registry.go
+++ b/extension/registry.go
@@ -15,7 +15,7 @@
 package extension
 
 import (
-	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/storage"
 )
 
@@ -33,6 +33,6 @@ type Registry interface {
 	// GetMapStorage returns a configured storage.MapStorage instance or an error if the storage cannot be set up.
 	GetMapStorage() (storage.MapStorage, error)
 
-	// GetSigner returns a configured crypto.Signer instance for the specified tree ID or an error if the signer cannot be set up.
-	GetSigner(treeID int64) (*crypto.Signer, error)
+	// GetKeyProvider returns a keys.Provider that allows access to the private keys belonging to all trees.
+	GetKeyProvider() (keys.Provider, error)
 }

--- a/integration/ct_prep_test.sh
+++ b/integration/ct_prep_test.sh
@@ -40,7 +40,7 @@ for ((i=0; i < RPC_SERVER_COUNT; i++)); do
   RPC_SERVERS="${RPC_SERVERS},localhost:${port}"
 
   echo "Starting Log RPC server on port ${port}"
-  ./trillian_log_server --private_key_password=towel --private_key_file=${TESTDATA}/log-rpc-server.privkey.pem --port ${port} --export_metrics=false &
+  ./trillian_log_server --port ${port} --export_metrics=false &
   pid=$!
   RPC_SERVER_PIDS+=(${pid})
   waitForServerStartup ${port}
@@ -64,7 +64,7 @@ waitForServerStartup ${LB_PORT}
 declare -a LOG_SIGNER_PIDS
 for ((i=0; i < LOG_SIGNER_COUNT; i++)); do
   echo "Starting Log signer"
-  ./trillian_log_signer --private_key_password=towel --private_key_file=${TESTDATA}/log-rpc-server.privkey.pem --sequencer_sleep_between_runs="1s" --batch_size=500 --export_metrics=false --num_sequencers 2 &
+  ./trillian_log_signer --sequencer_sleep_between_runs="1s" --batch_size=500 --export_metrics=false --num_sequencers 2 &
   pid=$!
   LOG_SIGNER_PIDS+=(${pid})
 done

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -18,7 +18,7 @@ done
 
 echo "Starting Log RPC server on port ${RPC_PORT}"
 pushd "${TRILLIAN_ROOT}" > /dev/null
-./trillian_log_server --private_key_password=towel --private_key_file=${TESTDATA}/log-rpc-server.privkey.pem --port ${RPC_PORT} &
+./trillian_log_server --port ${RPC_PORT} &
 RPC_SERVER_PID=$!
 popd > /dev/null
 
@@ -28,7 +28,7 @@ waitForServerStartup ${RPC_PORT}
 
 echo "Starting Log signer"
 pushd "${TRILLIAN_ROOT}" > /dev/null
-./trillian_log_signer --private_key_password=towel --private_key_file=${TESTDATA}/log-rpc-server.privkey.pem --sequencer_sleep_between_runs="1s" --batch_size=100 --export_metrics=false &
+./trillian_log_signer --sequencer_sleep_between_runs="1s" --batch_size=100 --export_metrics=false &
 LOG_SIGNER_PID=$!
 TO_KILL+=(${LOG_SIGNER_PID})
 popd > /dev/null

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -15,7 +15,7 @@ yes | "${SCRIPTS_DIR}"/resetdb.sh
 
 echo "Starting Map RPC server on port ${RPC_PORT}"
 pushd "${TRILLIAN_ROOT}" > /dev/null
-./trillian_map_server --private_key_password=towel --private_key_file=${TESTDATA}/map-rpc-server.privkey.pem --port ${RPC_PORT} &
+./trillian_map_server --port ${RPC_PORT} &
 RPC_SERVER_PID=$!
 popd > /dev/null
 

--- a/scripts/createtree.sh
+++ b/scripts/createtree.sh
@@ -12,7 +12,7 @@ tree_type=$2
 
 mysql ${testdbopts} -e "
     INSERT INTO Trees(TreeId, TreeState, TreeType, HashStrategy, HashAlgorithm, SignatureAlgorithm, DuplicatePolicy, CreateTime, UpdateTime, PrivateKey)
-    VALUES (${tree_id}, 'ACTIVE', '${tree_type}', 'RFC_6962', 'SHA256', 'RSA', 'NOT_ALLOWED', NOW(), NOW(), '\x0a\x27\x74\x79\x70\x65\x2e\x67\x6f\x6f\x67\x6c\x65\x61\x70\x69\x73\x2e\x63\x6f\x6d\x2f\x74\x72\x69\x6c\x6c\x69\x61\x6e\x2e\x50\x45\x4d\x4b\x65\x79\x46\x69\x6c\x65\x12\x2c\x0a\x23\x74\x65\x73\x74\x64\x61\x74\x61\x2f\x6c\x6f\x67\x2d\x72\x70\x63\x2d\x73\x65\x72\x76\x65\x72\x2e\x70\x72\x69\x76\x6b\x65\x79\x2e\x70\x65\x6d\x12\x05\x74\x6f\x77\x65\x6c')"
+    VALUES (${tree_id}, 'ACTIVE', '${tree_type}', 'RFC_6962', 'SHA256', 'RSA', 'NOT_ALLOWED', NOW(), NOW(), X'0a27747970652e676f6f676c65617069732e636f6d2f7472696c6c69616e2e50454d4b657946696c65122c0a2374657374646174612f6c6f672d7270632d7365727665722e707269766b65792e70656d1205746f77656c')"
 mysql ${testdbopts} -e "
     INSERT INTO TreeControl(TreeId, SigningEnabled, SequencingEnabled, SequenceIntervalSeconds)
     VALUES(${tree_id}, true, true, 1)"

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -147,12 +147,12 @@ func newSigner(ctx context.Context, registry extension.Registry, logID int64) (*
 		return nil, err
 	}
 
-	keyProvider, err := registry.GetKeyProvider()
+	keyProvider, err := registry.GetSignerFactory()
 	if err != nil {
 		return nil, err
 	}
 
-	signer, err := keyProvider.Signer(ctx, tree)
+	signer, err := keyProvider.NewSigner(ctx, tree)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -78,12 +78,12 @@ var zeroDuration = 0 * time.Second
 
 const writeRev = int64(24)
 
-type keyProvider struct {
+type signerFactory struct {
 	signers map[int64]crypto.Signer
 }
 
-func (p *keyProvider) Signer(ctx context.Context, tree *trillian.Tree) (crypto.Signer, error) {
-	signer := p.signers[tree.GetTreeId()]
+func (f *signerFactory) NewSigner(ctx context.Context, tree *trillian.Tree) (crypto.Signer, error) {
+	signer := f.signers[tree.GetTreeId()]
 	if signer == nil {
 		return nil, fmt.Errorf("no signer for tree %v", tree.GetTreeId())
 	}
@@ -147,7 +147,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	registry := extension.NewMockRegistry(mockCtrl)
 	registry.EXPECT().GetAdminStorage().Return(mockAdmin)
 	registry.EXPECT().GetLogStorage().Return(mockStorage, nil)
-	registry.EXPECT().GetKeyProvider().Return(&keyProvider{
+	registry.EXPECT().GetSignerFactory().Return(&signerFactory{
 		signers: map[int64]crypto.Signer{logID: signer},
 	}, nil)
 	sm := NewSequencerManager(registry, zeroDuration)
@@ -190,7 +190,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	registry := extension.NewMockRegistry(mockCtrl)
 	registry.EXPECT().GetAdminStorage().Return(mockAdmin)
 	registry.EXPECT().GetLogStorage().Return(mockStorage, nil)
-	registry.EXPECT().GetKeyProvider().Return(&keyProvider{
+	registry.EXPECT().GetSignerFactory().Return(&signerFactory{
 		signers: map[int64]crypto.Signer{logID: signer},
 	}, nil)
 
@@ -230,7 +230,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	registry := extension.NewMockRegistry(mockCtrl)
 	registry.EXPECT().GetAdminStorage().Return(mockAdmin)
 	registry.EXPECT().GetLogStorage().Return(mockStorage, nil)
-	registry.EXPECT().GetKeyProvider().Return(&keyProvider{
+	registry.EXPECT().GetSignerFactory().Return(&signerFactory{
 		signers: map[int64]crypto.Signer{logID: signer},
 	}, nil)
 

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -108,13 +108,10 @@ func TestSequencerManagerNothingToDo(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockStorage := storage.NewMockLogStorage(mockCtrl)
 
 	registry := extension.NewMockRegistry(mockCtrl)
-	registry.EXPECT().GetAdminStorage().Return(mockAdmin)
 	registry.EXPECT().GetLogStorage().Return(mockStorage, nil)
-	registry.EXPECT().GetKeyProvider().Return(&keyProvider{}, nil)
 	sm := NewSequencerManager(registry, zeroDuration)
 
 	sm.ExecutePass([]int64{}, createTestContext(registry))
@@ -144,6 +141,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
+	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)
 
 	registry := extension.NewMockRegistry(mockCtrl)
@@ -186,6 +184,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
+	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)
 
 	registry := extension.NewMockRegistry(mockCtrl)
@@ -225,6 +224,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
+	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)
 
 	registry := extension.NewMockRegistry(mockCtrl)

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -21,14 +21,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension/builtin"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/storage/testonly"
-	to "github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
 )
@@ -39,7 +38,11 @@ var (
 	sleepBetweenRuns = 100 * time.Millisecond
 	timeSource       = util.SystemTimeSource{}
 	// PublicKey returns the public key that verifies responses from this server.
-	PublicKey, _ = keys.NewFromPublicPEM(to.DemoPublicKey)
+	PublicKey, _ = keys.NewFromPublicPEMFile("../testdata/log-rpc-server.pubkey.pem")
+	privateKey   = &trillian.PEMKeyFile{
+		Path:     "../testdata/log-rpc-server.privkey.pem",
+		Password: "towel",
+	}
 )
 
 // LogEnv is a test environment that contains both a log server and a connection to it.
@@ -78,12 +81,7 @@ func NewLogEnv(ctx context.Context, numSequencers int, testID string) (*LogEnv, 
 		return nil, err
 	}
 
-	key, err := keys.NewFromPrivatePEM(to.DemoPrivateKey, to.DemoPrivateKeyPass)
-	if err != nil {
-		return nil, err
-	}
-
-	registry, err := builtin.NewExtensionRegistry(db, crypto.NewSigner(key))
+	registry, err := builtin.NewExtensionRegistry(db)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +166,15 @@ func (env *LogEnv) CreateLog() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	tree, err := tx.CreateTree(ctx, testonly.LogTree)
+
+	tree := testonly.LogTree
+
+	tree.PrivateKey, err = ptypes.MarshalAny(privateKey)
+	if err != nil {
+		return 0, err
+	}
+
+	tree, err = tx.CreateTree(ctx, tree)
 	if err != nil {
 		return 0, err
 	}

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"context"
+	"crypto"
 	"database/sql"
 	"net"
 	"sync"
@@ -38,12 +39,20 @@ var (
 	sleepBetweenRuns = 100 * time.Millisecond
 	timeSource       = util.SystemTimeSource{}
 	// PublicKey returns the public key that verifies responses from this server.
-	PublicKey, _ = keys.NewFromPublicPEMFile("../testdata/log-rpc-server.pubkey.pem")
-	privateKey   = &trillian.PEMKeyFile{
-		Path:     "../testdata/log-rpc-server.privkey.pem",
+	PublicKey  = keyFromPublicPEMFile(relativeToPackage("../../testdata/log-rpc-server.pubkey.pem"))
+	privateKey = &trillian.PEMKeyFile{
+		Path:     relativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
 		Password: "towel",
 	}
 )
+
+func keyFromPublicPEMFile(path string) crypto.PublicKey {
+	key, err := keys.NewFromPublicPEMFile(path)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
 
 // LogEnv is a test environment that contains both a log server and a connection to it.
 type LogEnv struct {

--- a/testonly/integration/db.go
+++ b/testonly/integration/db.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -59,11 +58,7 @@ func GetTestDB(testID string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	createSQLPath, err := relativeToPackage(createSQLFile)
-	if err != nil {
-		return nil, err
-	}
-	createSQL, err := ioutil.ReadFile(createSQLPath)
+	createSQL, err := ioutil.ReadFile(relativeToPackage(createSQLFile))
 	if err != nil {
 		return nil, err
 	}
@@ -83,10 +78,15 @@ func GetTestDB(testID string) (*sql.DB, error) {
 // The working directory for Go tests is the dir of test file. Using "plain" relative paths in test
 // utilities is, therefore, brittle, as the directory structure may change depending on where the
 // tests are placed.
-func relativeToPackage(p string) (string, error) {
+func relativeToPackage(p string) string {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", errors.New("cannot get caller information")
+		panic("cannot get caller information")
 	}
-	return filepath.Abs(filepath.Join(path.Dir(file), p))
+
+	absPath, err := filepath.Abs(filepath.Join(path.Dir(file), p))
+	if err != nil {
+		panic(err)
+	}
+	return absPath
 }

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -26,5 +26,5 @@ func NewRegistryForTests(testID string) (extension.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return builtin.NewExtensionRegistry(db, nil /* signer */)
+	return builtin.NewExtensionRegistry(db)
 }


### PR DESCRIPTION
The private key of a tree is now discovered via the admin storage interface. This allows different trees to use different keys.

The --private_key_file and --private_key_password flags have been removed.

A new keys.Provider interface abstracts away how a private key / signer is acquired for a tree. The default implementation supports only loading PEM-encoded keys from disk.