### PR TITLE
Add a default way to acquire a Registry for tests

### DIFF
--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -20,13 +20,10 @@ import (
 	"reflect"
 	"testing"
 
-	_ "github.com/go-sql-driver/mysql" // Load MySQL driver
-
 	"github.com/google/trillian"
-	"github.com/google/trillian/extension/builtin"
 	sa "github.com/google/trillian/server/admin"
-	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/testonly/integration"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -176,14 +173,7 @@ func setupAdminServer() (trillian.TrillianAdminClient, func(), error) {
 	}
 	// lis is closed via returned func
 
-	// TODO(alanparra): Have a standard way to get a registry for tests. With a few changes
-	// we could leverage the utilities under testonly/integration.
-	db, err := mysql.OpenDB(*builtin.MySQLURIFlag)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	registry, err := builtin.NewExtensionRegistry(db, nil /* signer */)
+	registry, err := integration.NewRegistryForTests("AdminIntegrationTest")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/testonly/integration/db.go
+++ b/testonly/integration/db.go
@@ -78,6 +78,11 @@ func GetTestDB(testID string) (*sql.DB, error) {
 	return dbTest, nil
 }
 
+// relativeToPackage returns the input path p as an absolute path, resolved relative to this
+// package.
+// The working directory for Go tests is the dir of test file. Using "plain" relative paths in test
+// utilities is, therefore, brittle, as the directory structure may change depending on where the
+// tests are placed.
 func relativeToPackage(p string) (string, error) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {

--- a/testonly/integration/db.go
+++ b/testonly/integration/db.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	// createSQLFile is a relative path from the current package.
+	createSQLFile = "../../storage/mysql/storage.sql"
+	mysqlRootURI  = "root@tcp(127.0.0.1:3306)/"
+)
+
+// GetTestDB drops and recreates the test database.
+// Returns a database connection to the test database.
+func GetTestDB(testID string) (*sql.DB, error) {
+	dbName := fmt.Sprintf("test_%v", testID)
+	testDBURI := fmt.Sprintf("root@tcp(127.0.0.1:3306)/%v", dbName)
+
+	// Drop existing database.
+	dbRoot, err := sql.Open("mysql", mysqlRootURI)
+	if err != nil {
+		return nil, err
+	}
+	defer dbRoot.Close()
+	resetSQL := []string{
+		fmt.Sprintf("DROP DATABASE IF EXISTS %v;", dbName),
+		fmt.Sprintf("CREATE DATABASE %v;", dbName),
+	}
+	for _, sql := range resetSQL {
+		if _, err := dbRoot.Exec(sql); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create new database.
+	dbTest, err := sql.Open("mysql", testDBURI)
+	if err != nil {
+		return nil, err
+	}
+
+	createSQLPath, err := relativeToPackage(createSQLFile)
+	if err != nil {
+		return nil, err
+	}
+	createSQL, err := ioutil.ReadFile(createSQLPath)
+	if err != nil {
+		return nil, err
+	}
+	sqlSlice := strings.Split(string(createSQL), ";\n")
+	// Omit the last element of the slice, since it will be "".
+	for _, sql := range sqlSlice[:len(sqlSlice)-1] {
+		if _, err := dbTest.Exec(sql); err != nil {
+			return nil, err
+		}
+	}
+
+	return dbTest, nil
+}
+
+func relativeToPackage(p string) (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("cannot get caller information")
+	}
+	return filepath.Abs(filepath.Join(path.Dir(file), p))
+}

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"github.com/google/trillian/extension"
+	"github.com/google/trillian/extension/builtin"
+)
+
+// NewRegistryForTests returns an extension.Registry for integration tests.
+// A new database will be recreated, as per GetTestDB.
+func NewRegistryForTests(testID string) (extension.Registry, error) {
+	db, err := GetTestDB(testID)
+	if err != nil {
+		return nil, err
+	}
+	return builtin.NewExtensionRegistry(db, nil /* signer */)
+}


### PR DESCRIPTION
This addresses a TODO from a previous review.

* GetTestDB made public, moved to db.go and fixed to not make assumptions about
  the path of storage.sql
* Added NewRegistryForTests and registry.go