### PR TITLE
Add googleapis path to protoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,8 @@ install:
       cd ../protoc
       wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
       unzip protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
-      git clone https://github.com/googleapis/googleapis.git
-      cd include/google
-      ln -s ../../googleapis/google/rpc
     )
+  - git clone https://github.com/googleapis/googleapis.git $GOPATH/src/github.com/googleapis/googleapis
   - export PATH=$(pwd)/../protoc/bin:$PATH
   - go get -d ./...
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update > /dev/null && brew install mariadb && mysql.server start; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ install:
       wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
       unzip protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
     )
-  - git clone https://github.com/googleapis/googleapis.git $GOPATH/src/github.com/googleapis/googleapis
   - export PATH=$(pwd)/../protoc/bin:$PATH
+  # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
+  - git clone https://github.com/googleapis/googleapis.git $GOPATH/src/github.com/googleapis/googleapis
   - go get -d ./...
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update > /dev/null && brew install mariadb && mysql.server start; fi
   - go get -u github.com/client9/misspell/cmd/misspell

--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ get -d -v -t ./...`).
 ### Building
 
 ```console
-% go get github.com/google/trillian
+% go get -u -v -t github.com/google/trillian
 % cd $GOPATH/src/github.com/google/trillian
-% go get -t -u -v ./...
-% go test ./... && go install ./...
+% go test ./...
 ```
 
 ### Rebuilding Generated Code
@@ -89,8 +88,6 @@ Re-generating mock or protobuffer files is only needed if you're changing
 the original files; if you do, run the following command:
 
 ```console
-% git clone https://github.com/googleapis/googleapis.git \
-    $GOPATH/src/github.com/googleapis/googleapis
 % go generate -x ./...  # hunts for //go:generate comments and runs them
 ```
 
@@ -99,6 +96,10 @@ You'll need to have the following tools installed to do this:
   - `mockgen` tool from https://github.com/golang/mock
   - `protoc` and the Go protoc extension (see documentation linked from the
     [protobuf site](https://github.com/google/protobuf))
+       - You also need the `.proto` files from the
+         [google/rpc](https://github.com/googleapis/googleapis/tree/master/google/rpc)
+         directory of the [googleapis](https://github.com/googleapis/googleapis)
+         project to be installed somewhere in `protoc`'s search path.
 
 ### MySQL Setup
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ get -d -v -t ./...`).
 ### Building
 
 ```console
-% go get -u -v -t github.com/google/trillian
+% go get github.com/google/trillian
 % cd $GOPATH/src/github.com/google/trillian
-% go test ./...
+% go get -t -u -v ./...
+% go test ./... && go install ./...
 ```
 
 ### Rebuilding Generated Code
@@ -88,6 +89,8 @@ Re-generating mock or protobuffer files is only needed if you're changing
 the original files; if you do, run the following command:
 
 ```console
+% git clone https://github.com/googleapis/googleapis.git \
+    $GOPATH/src/github.com/googleapis/googleapis
 % go generate -x ./...  # hunts for //go:generate comments and runs them
 ```
 
@@ -96,10 +99,6 @@ You'll need to have the following tools installed to do this:
   - `mockgen` tool from https://github.com/golang/mock
   - `protoc` and the Go protoc extension (see documentation linked from the
     [protobuf site](https://github.com/google/protobuf))
-       - You also need the `.proto` files from the
-         [google/rpc](https://github.com/googleapis/googleapis/tree/master/google/rpc)
-         directory of the [googleapis](https://github.com/googleapis/googleapis)
-         project to be installed somewhere in `protoc`'s search path.
 
 ### MySQL Setup
 

--- a/gen.go
+++ b/gen.go
@@ -14,4 +14,4 @@
 
 package trillian
 
-//go:generate protoc -I=. -I=$GOPATH/src/ --go_out=plugins=grpc:. trillian_api.proto trillian.proto
+//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis --go_out=plugins=grpc:. trillian_api.proto trillian.proto


### PR DESCRIPTION
Added -I=$GOPATH/src/github.com/googleapis/googleapis to protoc instructions and
updated README accordingly. This avoids the need to link googleapis inside the
protoc directory on Travis, for example.