### PR TITLE
Add an ObjectHasher to the Merkle Tree Hashers

### DIFF
--- a/merkle/objhasher/objhasher.go
+++ b/merkle/objhasher/objhasher.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/merkle/objhasher/objhasher.go
+++ b/merkle/objhasher/objhasher.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objhasher
+
+import (
+	"crypto/sha256" // Use SHA256 to match ObjectHash.
+
+	"github.com/benlaurie/objecthash/go/objecthash"
+)
+
+// ObjectHasher uses ObjectHash to compute leaf hashes.
+var ObjectHasher = objhasher{}
+
+// ObjectHash does not use `1` as any of its type prefixes,
+// preserving domain separation.
+const nodeHashPrefix = 1
+
+type objhasher struct{}
+
+// HashEmpty returns the hash of an empty element for the tree
+func (t objhasher) HashEmpty() []byte {
+	return sha256.New().Sum(nil)
+}
+
+// HashLeaf returns the object hash of leaf, which must be a JSON object.
+func (t objhasher) HashLeaf(leaf []byte) []byte {
+	hash := objecthash.CommonJSONHash(string(leaf))
+	return hash[:]
+}
+
+// HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+func (t objhasher) HashChildren(l, r []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte{nodeHashPrefix})
+	h.Write(l)
+	h.Write(r)
+	return h.Sum(nil)
+}

--- a/merkle/objhasher/objhasher_test.go
+++ b/merkle/objhasher/objhasher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,15 @@
 package objhasher
 
 import (
+	"bytes"
+	"crypto"
 	"encoding/hex"
 	"testing"
+
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
-func TestObjectHasher(t *testing.T) {
+func TestLeafHash(t *testing.T) {
 	h := ObjectHasher
 
 	for _, tc := range []struct {
@@ -40,6 +44,32 @@ func TestObjectHasher(t *testing.T) {
 		leaf := h.HashLeaf(tc.json)
 		if got := hex.EncodeToString(leaf); got != tc.want {
 			t.Errorf("HashLeaf(%v): \n%v, want \n%v", tc.json, got, tc.want)
+		}
+	}
+}
+
+func TestHashEmpty(t *testing.T) {
+	h := ObjectHasher
+	rfc := rfc6962.TreeHasher{crypto.SHA256}
+
+	if got, want := h.HashEmpty(), rfc.HashEmpty(); !bytes.Equal(got, want) {
+		t.Errorf("HashEmpty():\n%x, want\n%x", got, want)
+	}
+}
+
+func TestHashChildren(t *testing.T) {
+	h := ObjectHasher
+	rfc := rfc6962.TreeHasher{crypto.SHA256}
+
+	for _, tc := range []struct {
+		r, l []byte
+	}{
+		{
+			r: []byte("a"), l: []byte("b"),
+		},
+	} {
+		if got, want := h.HashChildren(tc.r, tc.l), rfc.HashChildren(tc.r, tc.l); !bytes.Equal(got, want) {
+			t.Errorf("HashChildren(%x, %x):\n%x, want\n%x", tc.r, tc.l, got, want)
 		}
 	}
 }

--- a/merkle/objhasher/objhasher_test.go
+++ b/merkle/objhasher/objhasher_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objhasher
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestObjectHasher(t *testing.T) {
+	h := ObjectHasher
+
+	for _, tc := range []struct {
+		json []byte
+		want string
+	}{
+		{
+			// Verify that ordering does not affect output hash.
+			json: []byte(`{"k1":"v1","k2":"v2","k3":"v3"}`),
+			want: "ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057",
+		},
+		{
+			// Same values, different order.
+			json: []byte(`{"k2":"v2","k1":"v1","k3":"v3"}`),
+			want: "ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057",
+		},
+	} {
+		leaf := h.HashLeaf(tc.json)
+		if got := hex.EncodeToString(leaf); got != tc.want {
+			t.Errorf("HashLeaf(%v): \n%v, want \n%v", tc.json, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Support storing generic objects in Trillian by using ObjectHash to hash generic JSON leaf nodes.

This support Key Transparency's migration onto the Trillian 

Genuine Question: 
Should I add a JSON-ObjectHash tree type?  A related [PR](#398) moves computing the Merkle Leaf hash to the client, which would remove the need to add a new tree type for each kind of leaf hash. 