### PR TITLE
Add a custom leaf data prefix to the log integration test

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -44,6 +44,7 @@ type TestParameters struct {
 	sequencingWaitTotal time.Duration
 	sequencingPollWait  time.Duration
 	rpcRequestDeadline  time.Duration
+	customLeafPrefix    string
 }
 
 // DefaultTestParameters builds a TestParameters object for a normal
@@ -62,6 +63,7 @@ func DefaultTestParameters(treeID int64) TestParameters {
 		sequencingWaitTotal: 10 * time.Second * 60,
 		sequencingPollWait:  time.Second * 5,
 		rpcRequestDeadline:  time.Second * 10,
+		customLeafPrefix:    "",
 	}
 }
 
@@ -186,14 +188,14 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 		// Leaf data based on the sequence number so we can check the hashes
 		leafNumber := params.startLeaf + l
 
-		data := []byte(fmt.Sprintf("Leaf %d", leafNumber))
+		data := []byte(fmt.Sprintf("%sLeaf %d", params.customLeafPrefix, leafNumber))
 		idHash := sha256.Sum256(data)
 
 		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: idHash[:],
 			MerkleLeafHash:   testonly.Hasher.HashLeaf(data),
 			LeafValue:        data,
-			ExtraData:        []byte(fmt.Sprintf("Extra %d", leafNumber)),
+			ExtraData:        []byte(fmt.Sprintf("%sExtra %d", params.customLeafPrefix, leafNumber)),
 		}
 		leaves = append(leaves, leaf)
 

--- a/integration/log.go
+++ b/integration/log.go
@@ -257,7 +257,7 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params T
 	leafDataPresenceMap := make(map[string]bool)
 
 	for l := int64(0); l < params.leafCount; l++ {
-		leafDataPresenceMap[fmt.Sprintf("Leaf %d", l+params.startLeaf)] = true
+		leafDataPresenceMap[fmt.Sprintf("%sLeaf %d", params.customLeafPrefix, l+params.startLeaf)] = true
 	}
 
 	for currentLeaf < params.leafCount {

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -38,6 +38,7 @@ var readBatchSizeFlag = flag.Int64("read_batch_size", 50, "Batch size when getti
 var waitForSequencingFlag = flag.Duration("wait_for_sequencing", time.Second*60, "How long to wait for leaves to be sequenced")
 var waitBetweenQueueChecksFlag = flag.Duration("queue_poll_wait", time.Second*5, "How frequently to check the queue while waiting")
 var rpcRequestDeadlineFlag = flag.Duration("rpc_deadline", time.Second*10, "Deadline to use for all RPC requests")
+var customLeafPrefixFlag = flag.String("custom_leaf_prefix", "", "Prefix string added to all queued leaves")
 
 func TestLiveLogIntegration(t *testing.T) {
 	flag.Parse()
@@ -59,6 +60,7 @@ func TestLiveLogIntegration(t *testing.T) {
 		sequencingWaitTotal: *waitForSequencingFlag,
 		sequencingPollWait:  *waitBetweenQueueChecksFlag,
 		rpcRequestDeadline:  *rpcRequestDeadlineFlag,
+		customLeafPrefix:    *customLeafPrefixFlag,
 	}
 	if params.startLeaf < 0 || params.leafCount <= 0 {
 		t.Fatalf("Start leaf index must be >= 0 (%d) and number of leaves must be > 0 (%d)", params.startLeaf, params.leafCount)


### PR DESCRIPTION
This allows multiple test clients to be run against the same log tree or fast restart of tests with a different prefix without having to clear the log.