### PR TITLE
Create Client Interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -134,7 +134,6 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 
 	// Verify Consistency proof.
 	if str.TreeSize == c.root.TreeSize &&
-		str.TreeSize == c.root.TreeSize &&
 		bytes.Equal(str.RootHash, c.root.RootHash) {
 		// Tree has not been updated.
 		return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -68,7 +68,7 @@ func TestAddLeaf(t *testing.T) {
 		},
 	} {
 		client := New(logID, test.client, testonly.Hasher, env.PublicKey)
-		client.MaxTries = 1
+		client.SetMaxTries(1)
 
 		if err, want := client.AddLeaf(ctx, []byte(test.desc)), codes.DeadlineExceeded; grpc.Code(err) != want {
 			t.Errorf("AddLeaf(%v): %v, want, %v", test.desc, err, want)
@@ -96,7 +96,7 @@ func TestUpdateSTR(t *testing.T) {
 	cli := trillian.NewTrillianLogClient(env.ClientConn)
 	client := New(logID, cli, testonly.Hasher, env.PublicKey)
 
-	before := client.STR.TreeSize
+	before := client.STR().TreeSize
 	if err, want := client.AddLeaf(ctx, []byte("foo")), codes.DeadlineExceeded; grpc.Code(err) != want {
 		t.Errorf("AddLeaf(): %v, want, %v", err, want)
 	}
@@ -104,7 +104,7 @@ func TestUpdateSTR(t *testing.T) {
 	if err := client.UpdateSTR(ctx); err != nil {
 		t.Error(err)
 	}
-	if got, want := client.STR.TreeSize, before; got <= want {
+	if got, want := client.STR().TreeSize, before; got <= want {
 		t.Errorf("Tree size after add Leaf: %v, want > %v", got, want)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -26,13 +27,14 @@ import (
 	"github.com/google/trillian/testonly/integration"
 )
 
+const timeout = 100 * time.Millisecond
+
 func TestAddGetLeaf(t *testing.T) {
 	// TODO: Build a GetLeaf method and test a full get/set cycle.
 }
 
 func TestAddLeaf(t *testing.T) {
-	ctx := context.Background()
-	env, err := integration.NewLogEnv(ctx, 0, "TestAddLeaf")
+	env, err := integration.NewLogEnv(context.Background(), 0, "TestAddLeaf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,23 +70,24 @@ func TestAddLeaf(t *testing.T) {
 		},
 	} {
 		client := New(logID, test.client, testonly.Hasher, env.PublicKey)
-		client.SetMaxTries(1)
-
-		if err, want := client.AddLeaf(ctx, []byte(test.desc)), codes.DeadlineExceeded; grpc.Code(err) != want {
-			t.Errorf("AddLeaf(%v): %v, want, %v", test.desc, err, want)
-			continue
+		{
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+			defer cancel()
+			if err, want := client.AddLeaf(ctx, []byte(test.desc)), codes.DeadlineExceeded; grpc.Code(err) != want {
+				t.Errorf("AddLeaf(%v): %v, want, %v", test.desc, err, want)
+				continue
+			}
 		}
 		env.Sequencer.OperationLoop() // Sequence the new node.
-		err := client.AddLeaf(ctx, []byte(test.desc))
+		err := client.AddLeaf(context.Background(), []byte(test.desc))
 		if got := err != nil; got != test.wantErr {
 			t.Errorf("AddLeaf(%v): %v, want error: %v", test.desc, err, test.wantErr)
 		}
 	}
 }
 
-func TestUpdateSTR(t *testing.T) {
-	ctx := context.Background()
-	env, err := integration.NewLogEnv(ctx, 0, "TestUpdateSTR")
+func TestUpdateRoot(t *testing.T) {
+	env, err := integration.NewLogEnv(context.Background(), 0, "TestUpdateRoot")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,15 +99,21 @@ func TestUpdateSTR(t *testing.T) {
 	cli := trillian.NewTrillianLogClient(env.ClientConn)
 	client := New(logID, cli, testonly.Hasher, env.PublicKey)
 
-	before := client.STR().TreeSize
-	if err, want := client.AddLeaf(ctx, []byte("foo")), codes.DeadlineExceeded; grpc.Code(err) != want {
-		t.Errorf("AddLeaf(): %v, want, %v", err, want)
+	before := client.Root().TreeSize
+
+	{
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+		defer cancel()
+		if err, want := client.AddLeaf(ctx, []byte("foo")), codes.DeadlineExceeded; grpc.Code(err) != want {
+			t.Errorf("AddLeaf(): %v, want, %v", err, want)
+		}
 	}
+
 	env.Sequencer.OperationLoop() // Sequence the new node.
-	if err := client.UpdateSTR(ctx); err != nil {
+	if err := client.UpdateRoot(context.Background()); err != nil {
 		t.Error(err)
 	}
-	if got, want := client.STR().TreeSize, before; got <= want {
+	if got, want := client.Root().TreeSize, before; got <= want {
 		t.Errorf("Tree size after add Leaf: %v, want > %v", got, want)
 	}
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/google/trillian"
+)
+
+// LogVerifier is a client that verifies output from Trillian.
+type LogVerifier interface {
+	AddLeaf(ctx context.Context, data []byte) error
+	UpdateSTR(ctx context.Context) error
+	STR() trillian.SignedLogRoot
+	SetMaxTries(int)
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -20,10 +20,15 @@ import (
 	"github.com/google/trillian"
 )
 
-// LogVerifier is a client that verifies output from Trillian.
-type LogVerifier interface {
+// VerifyingLogClient is a client that verifies output from Trillian.
+type VerifyingLogClient interface {
+	// AddLeaf adds data to the Trillian Log and blocks until an inclusion proof
+	// is available. If no proof is available within the ctx deadline, DeadlineExceeded
+	// is returned.
 	AddLeaf(ctx context.Context, data []byte) error
-	UpdateSTR(ctx context.Context) error
-	STR() trillian.SignedLogRoot
-	SetMaxTries(int)
+	// UpdateRoot fetches and verifies the current SignedTreeRoot.
+	// It checks signatures as well as consistency proofs from the last-seen root.
+	UpdateRoot(ctx context.Context) error
+	// Root provides the last root obtained by UpdateRoot.
+	Root() trillian.SignedLogRoot
 }


### PR DESCRIPTION
Creating an interface for the client allows other clients to be
created (eg. a non-verifying client).
It also enables unit testing with mock clients.