### PR TITLE
admin.Server returns the correct error codes

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -164,6 +164,16 @@ func (e *trillianError) Code() Code {
 	return e.code
 }
 
+// ErrorCode returns the assigned Code if err is a TrillianError, Unknown
+// otherwise.
+func ErrorCode(err error) Code {
+	terr, ok := err.(TrillianError)
+	if ok {
+		return terr.Code()
+	}
+	return Unknown
+}
+
 // Errorf creates a TrillianError from the specified code and message.
 func Errorf(code Code, format string, a ...interface{}) error {
 	return &trillianError{code, fmt.Sprintf(format, a...)}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -15,6 +15,7 @@
 package errors
 
 import (
+	"errors"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -45,6 +46,22 @@ func TestCodes(t *testing.T) {
 	for _, test := range tests {
 		if uint64(test.got) != uint64(test.want) {
 			t.Errorf("got = %v, want = %v", test.got, test.want)
+		}
+	}
+}
+
+func TestErrorCode(t *testing.T) {
+	tests := []struct {
+		err      error
+		wantCode Code
+	}{
+		{err: Errorf(InvalidArgument, "invalid argument error"), wantCode: InvalidArgument},
+		{err: Errorf(NotFound, "not found error"), wantCode: NotFound},
+		{err: errors.New("generic error"), wantCode: Unknown},
+	}
+	for _, test := range tests {
+		if got := ErrorCode(test.err); got != test.wantCode {
+			t.Errorf("err = %v, wantCode = %v", test.err, test.wantCode)
 		}
 	}
 }

--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/server/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -42,6 +43,14 @@ func (s *Server) ListTrees(context.Context, *trillian.ListTreesRequest) (*trilli
 
 // GetTree implements trillian.TrillianAdminServer.GetTree.
 func (s *Server) GetTree(ctx context.Context, request *trillian.GetTreeRequest) (*trillian.Tree, error) {
+	tree, err := s.getTreeImpl(ctx, request)
+	if err != nil {
+		return nil, errors.WrapError(err)
+	}
+	return tree, nil
+}
+
+func (s *Server) getTreeImpl(ctx context.Context, request *trillian.GetTreeRequest) (*trillian.Tree, error) {
 	tx, err := s.registry.AdminStorage.Snapshot(ctx)
 	if err != nil {
 		return nil, err
@@ -60,6 +69,14 @@ func (s *Server) GetTree(ctx context.Context, request *trillian.GetTreeRequest) 
 
 // CreateTree implements trillian.TrillianAdminServer.CreateTree.
 func (s *Server) CreateTree(ctx context.Context, request *trillian.CreateTreeRequest) (*trillian.Tree, error) {
+	tree, err := s.createTreeImpl(ctx, request)
+	if err != nil {
+		return nil, errors.WrapError(err)
+	}
+	return tree, err
+}
+
+func (s *Server) createTreeImpl(ctx context.Context, request *trillian.CreateTreeRequest) (*trillian.Tree, error) {
 	tx, err := s.registry.AdminStorage.Begin(ctx)
 	if err != nil {
 		return nil, err

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -15,14 +15,21 @@
 package errors
 
 import (
+	"database/sql"
+
 	te "github.com/google/trillian/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
-// WrapError wraps err as a gRPC error if err is a TrillianError, else err is
-// returned unmodified.
+// WrapError wraps err as a gRPC error if err is a TrillianError or a well-known
+// error instance (such as canonical sql errors), else err is returned
+// unmodified.
 func WrapError(err error) error {
+	if err == sql.ErrNoRows {
+		return grpc.Errorf(codes.NotFound, err.Error())
+	}
+
 	switch err := err.(type) {
 	case te.TrillianError:
 		return grpc.Errorf(codes.Code(err.Code()), err.Error())

--- a/server/errors/errors_test.go
+++ b/server/errors/errors_test.go
@@ -15,6 +15,7 @@
 package errors
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -44,6 +45,10 @@ func TestWrapError(t *testing.T) {
 		{
 			err:     err,
 			wantErr: err,
+		},
+		{
+			err:     sql.ErrNoRows,
+			wantErr: grpc.Errorf(codes.NotFound, sql.ErrNoRows.Error()),
 		},
 	}
 	for _, test := range tests {

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/errors"
 )
 
 func TestValidateTreeForCreation(t *testing.T) {
@@ -162,8 +163,11 @@ func TestValidateTreeForCreation(t *testing.T) {
 	}
 	for i, test := range tests {
 		err := ValidateTreeForCreation(test.tree)
-		if hasErr := err != nil; hasErr != test.wantErr {
+		switch hasErr := err != nil; {
+		case hasErr != test.wantErr:
 			t.Errorf("%v: ValidateTreeForCreation() = %v, wantErr = %v", i, err, test.wantErr)
+		case hasErr && errors.ErrorCode(err) != errors.InvalidArgument:
+			t.Errorf("%v: ValidateTreeForCreation() = %v, wantCode = %v", i, err, errors.InvalidArgument)
 		}
 	}
 }
@@ -263,8 +267,11 @@ func TestValidateTreeForUpdate(t *testing.T) {
 		test.updatefn(tree)
 
 		err := ValidateTreeForUpdate(&baseTree, tree)
-		if hasErr := err != nil; hasErr != test.wantErr {
+		switch hasErr := err != nil; {
+		case hasErr != test.wantErr:
 			t.Errorf("%v: ValidateTreeForUpdate() = %v, wantErr = %v", test.desc, err, test.wantErr)
+		case hasErr && errors.ErrorCode(err) != errors.InvalidArgument:
+			t.Errorf("%v: ValidateTreeForUpdate() = %v, wantCode = %d", test.desc, err, errors.InvalidArgument)
 		}
 	}
 }


### PR DESCRIPTION
This PR wires trillian/errors to the most common error sources on admin.Server.
It also adds a method to read the errors.Code from generic errors.

Errors originating from the admin storage layer are still unmmapped, therefore
their code is implied to be Unknown. While other codes would be more appropriate
(Unavailable for Begin errors, Internal for enum-mapping errors, so on), that
should be acceptable for now, as those errors are relatively uncommon.