### PR TITLE
Make key paths work regardless of working directory

### DIFF
--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/trillian"
 	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
+	testonly2 "github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -49,7 +50,7 @@ var (
 		DisplayName:        "Llamas Log",
 		Description:        "Registry of publicly-owned llamas",
 		PrivateKey: mustMarshalAny(&trillian.PEMKeyFile{
-			Path:     "testdata/log-rpc-server.privkey.pem",
+			Path:     testonly2.RelativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
 			Password: "towel",
 		}),
 	}
@@ -65,7 +66,7 @@ var (
 		DisplayName:        "Llamas Map",
 		Description:        "Key Transparency map for all your digital llama needs.",
 		PrivateKey: mustMarshalAny(&trillian.PEMKeyFile{
-			Path:     "testdata/map-rpc-server.privkey.pem",
+			Path:     testonly2.RelativeToPackage("../../testdata/map-rpc-server.privkey.pem"),
 			Password: "dirk",
 		}),
 	}

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/trillian"
 	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
-	testonly2 "github.com/google/trillian/testonly"
+	ttestonly "github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -50,7 +50,7 @@ var (
 		DisplayName:        "Llamas Log",
 		Description:        "Registry of publicly-owned llamas",
 		PrivateKey: mustMarshalAny(&trillian.PEMKeyFile{
-			Path:     testonly2.RelativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
+			Path:     ttestonly.RelativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
 			Password: "towel",
 		}),
 	}
@@ -66,7 +66,7 @@ var (
 		DisplayName:        "Llamas Map",
 		Description:        "Key Transparency map for all your digital llama needs.",
 		PrivateKey: mustMarshalAny(&trillian.PEMKeyFile{
-			Path:     testonly2.RelativeToPackage("../../testdata/map-rpc-server.privkey.pem"),
+			Path:     ttestonly.RelativeToPackage("../../testdata/map-rpc-server.privkey.pem"),
 			Password: "dirk",
 		}),
 	}

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
-	strtestonly "github.com/google/trillian/storage/testonly"
+	stestonly "github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
@@ -188,7 +188,7 @@ func (env *LogEnv) CreateLog() (int64, error) {
 		return 0, err
 	}
 
-	tree := strtestonly.LogTree
+	tree := stestonly.LogTree
 	tree.PrivateKey, err = ptypes.MarshalAny(privateKeyInfo)
 	if err != nil {
 		return 0, err

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -30,7 +30,8 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
-	"github.com/google/trillian/storage/testonly"
+	strtestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
 	"google.golang.org/grpc"
 )
@@ -40,9 +41,9 @@ var (
 	batchSize        = 50
 	sleepBetweenRuns = 100 * time.Millisecond
 	timeSource       = util.SystemTimeSource{}
-	publicKeyPath    = relativeToPackage("../../testdata/log-rpc-server.pubkey.pem")
+	publicKeyPath    = testonly.RelativeToPackage("../../testdata/log-rpc-server.pubkey.pem")
 	privateKeyInfo   = &trillian.PEMKeyFile{
-		Path:     relativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
+		Path:     testonly.RelativeToPackage("../../testdata/log-rpc-server.privkey.pem"),
 		Password: "towel",
 	}
 )
@@ -187,7 +188,7 @@ func (env *LogEnv) CreateLog() (int64, error) {
 		return 0, err
 	}
 
-	tree := testonly.LogTree
+	tree := strtestonly.LogTree
 	tree.PrivateKey, err = ptypes.MarshalAny(privateKeyInfo)
 	if err != nil {
 		return 0, err

--- a/testonly/integration/db.go
+++ b/testonly/integration/db.go
@@ -18,10 +18,9 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
-	"path"
-	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/google/trillian/testonly"
 )
 
 const (
@@ -58,7 +57,7 @@ func GetTestDB(testID string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	createSQL, err := ioutil.ReadFile(relativeToPackage(createSQLFile))
+	createSQL, err := ioutil.ReadFile(testonly.RelativeToPackage(createSQLFile))
 	if err != nil {
 		return nil, err
 	}
@@ -71,22 +70,4 @@ func GetTestDB(testID string) (*sql.DB, error) {
 	}
 
 	return dbTest, nil
-}
-
-// relativeToPackage returns the input path p as an absolute path, resolved relative to this
-// package.
-// The working directory for Go tests is the dir of test file. Using "plain" relative paths in test
-// utilities is, therefore, brittle, as the directory structure may change depending on where the
-// tests are placed.
-func relativeToPackage(p string) string {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("cannot get caller information")
-	}
-
-	absPath, err := filepath.Abs(filepath.Join(path.Dir(file), p))
-	if err != nil {
-		panic(err)
-	}
-	return absPath
 }

--- a/testonly/paths.go
+++ b/testonly/paths.go
@@ -1,0 +1,23 @@
+package testonly
+
+import (
+	"path"
+	"path/filepath"
+	"runtime"
+)
+
+// RelativeToPackage returns the input path p as an absolute path, resolved relative to the caller's package.
+// The working directory for Go tests is the dir of the test file. Using "plain" relative paths in test
+// utilities is, therefore, brittle, as the directory structure may change depending on where the tests are placed.
+func RelativeToPackage(p string) string {
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("cannot get caller information")
+	}
+
+	absPath, err := filepath.Abs(filepath.Join(path.Dir(file), p))
+	if err != nil {
+		panic(err)
+	}
+	return absPath
+}

--- a/testonly/paths.go
+++ b/testonly/paths.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testonly
 
 import (


### PR DESCRIPTION
`RelativeToPackage(path)` will convert `path` to an absolute path. This means the key files can be found regardless of the location of test.