### PR TITLE
Cache signers in SequenceManager

### DIFF
--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -46,12 +46,12 @@ func NewSequencerManager(registry extension.Registry, gw time.Duration) *Sequenc
 }
 
 // Name returns the name of the object.
-func (s SequencerManager) Name() string {
+func (s *SequencerManager) Name() string {
 	return "Sequencer"
 }
 
 // ExecutePass performs sequencing for the specified Log.
-func (s SequencerManager) ExecutePass(ctx context.Context, logID int64, info *LogOperationInfo) (int, error) {
+func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *LogOperationInfo) (int, error) {
 	// TODO(Martin2112): Honor the sequencing enabled in log parameters, needs an API change
 	// so deferring it
 


### PR DESCRIPTION
This avoids having to reload the private key for each tree at the beginning of every sequencing pass.