### PR TITLE
Logging about the sequencer being idle should be in verbose mode only

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -197,7 +197,7 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	// current one is too old. If there's work to be done then we'll be creating a root anyway.
 	if len(leaves) == 0 {
 		// We have nothing to integrate into the tree
-		glog.Infof("No leaves sequenced in this signing operation.")
+		glog.V(1).Infof("No leaves sequenced in this signing operation.")
 		return 0, tx.Commit()
 	}
 

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -107,8 +107,12 @@ func (s SequencerManager) ExecutePass(logIDs []int64, logctx LogOperationManager
 					glog.Warningf("%v: Error trying to sequence batch for: %v", logID, err)
 					continue
 				}
-				d := time.Now().Sub(start).Seconds()
-				glog.Infof("%v: sequenced %d leaves in %.2f seconds (%.2f qps)", logID, leaves, d, float64(leaves)/d)
+				if leaves > 0 {
+					d := time.Now().Sub(start).Seconds()
+					glog.Infof("%v: sequenced %d leaves in %.2f seconds (%.2f qps)", logID, leaves, d, float64(leaves)/d)
+				} else {
+					glog.V(1).Infof("%v: no leaves to sequence", logID)
+				}
 
 				mu.Lock()
 				successCount++


### PR DESCRIPTION
This reduces the amount of log spam when the sequencer is sitting idle.