### PR TITLE
Client.VerifyLeaf

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -217,7 +217,7 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 	return nil
 }
 
-// VerifyInclusion ensures that the given leaf data has been included in the log.
+// VerifyInclusion updates the log root and ensures that the given leaf data has been included in the log.
 func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 	leaf := c.buildLeaf(data)
 	if err := c.UpdateRoot(ctx); err != nil {
@@ -226,7 +226,7 @@ func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 	return c.getInclusionProof(ctx, leaf.MerkleLeafHash, c.root.TreeSize)
 }
 
-// VerifyInclusionAtIndex ensures that the given leaf data has been included in the log at a particular index.
+// VerifyInclusionAtIndex updates the log root and ensures that the given leaf data has been included in the log at a particular index.
 func (c *LogClient) VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
 	leaf := c.buildLeaf(data)
 	if err := c.UpdateRoot(ctx); err != nil {
@@ -240,9 +240,6 @@ func (c *LogClient) VerifyInclusionAtIndex(ctx context.Context, data []byte, ind
 	resp, err := c.client.GetInclusionProof(ctx, req)
 	if err != nil {
 		return err
-	}
-	if len(resp.GetProof().ProofNode) < 1 {
-		return errors.New("no inclusion proof supplied")
 	}
 
 	v := merkle.NewLogVerifier(c.hasher)

--- a/client/client.go
+++ b/client/client.go
@@ -217,6 +217,40 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 	return nil
 }
 
+// VerifyInclusion ensures that the given leaf data has been included in the log.
+func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
+	leaf := c.buildLeaf(data)
+	if err := c.UpdateRoot(ctx); err != nil {
+		return fmt.Errorf("UpdateRoot(): %v", err)
+	}
+	return c.getInclusionProof(ctx, leaf.MerkleLeafHash, c.root.TreeSize)
+}
+
+// VerifyInclusionAtIndex ensures that the given leaf data has been included in the log at a particular index.
+func (c *LogClient) VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
+	leaf := c.buildLeaf(data)
+	if err := c.UpdateRoot(ctx); err != nil {
+		return fmt.Errorf("UpdateRoot(): %v", err)
+	}
+	req := &trillian.GetInclusionProofRequest{
+		LogId:     c.LogID,
+		LeafIndex: index,
+		TreeSize:  c.root.TreeSize,
+	}
+	resp, err := c.client.GetInclusionProof(ctx, req)
+	if err != nil {
+		return err
+	}
+	if len(resp.GetProof().ProofNode) < 1 {
+		return errors.New("no inclusion proof supplied")
+	}
+
+	v := merkle.NewLogVerifier(c.hasher)
+	return v.VerifyInclusionProof(req.LeafIndex, req.TreeSize,
+		convertProof(resp.Proof), c.root.RootHash,
+		leaf.MerkleLeafHash)
+}
+
 func (c *LogClient) getInclusionProof(ctx context.Context, leafHash []byte, treeSize int64) error {
 	req := &trillian.GetInclusionProofByHashRequest{
 		LogId:    c.LogID,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -121,6 +121,66 @@ func TestListByIndex(t *testing.T) {
 	}
 }
 
+func TestVerifyInclusion(t *testing.T) {
+	env, err := integration.NewLogEnv(context.Background(), 0, "TestVerifyInclusion")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+	logID, err := env.CreateLog()
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	cli := trillian.NewTrillianLogClient(env.ClientConn)
+	client := New(logID, cli, testonly.Hasher, env.PublicKey)
+	// Add a few test leaves.
+	leafData := [][]byte{
+		[]byte("A"),
+		[]byte("B"),
+	}
+
+	if err := addSequencedLeaves(env, client, leafData); err != nil {
+		t.Errorf("Failed to add leaves: %v", err)
+	}
+
+	for _, l := range leafData {
+		if err := client.VerifyInclusion(context.Background(), l); err != nil {
+			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
+		}
+	}
+}
+
+func TestVerifyInclusionAtIndex(t *testing.T) {
+	env, err := integration.NewLogEnv(context.Background(), 0, "TestVerifyInclusionAtIndex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+	logID, err := env.CreateLog()
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	cli := trillian.NewTrillianLogClient(env.ClientConn)
+	client := New(logID, cli, testonly.Hasher, env.PublicKey)
+	// Add a few test leaves.
+	leafData := [][]byte{
+		[]byte("A"),
+		[]byte("B"),
+	}
+
+	if err := addSequencedLeaves(env, client, leafData); err != nil {
+		t.Errorf("Failed to add leaves: %v", err)
+	}
+
+	for i, l := range leafData {
+		if err := client.VerifyInclusionAtIndex(context.Background(), l, int64(i)); err != nil {
+			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
+		}
+	}
+}
+
 func TestAddLeaf(t *testing.T) {
 	env, err := integration.NewLogEnv(context.Background(), 0, "TestAddLeaf")
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,7 +51,8 @@ func addSequencedLeaves(env *integration.LogEnv, client VerifyingLogClient, leav
 }
 
 func TestGetByIndex(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestGetByIndex")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestGetByIndex")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,9 +76,10 @@ func TestGetByIndex(t *testing.T) {
 	}
 
 	for i, l := range leafData {
-		leaf, err := client.GetByIndex(context.Background(), int64(i))
+		leaf, err := client.GetByIndex(ctx, int64(i))
 		if err != nil {
 			t.Errorf("Failed to GetByIndex(%v): %v", i, err)
+			continue
 		}
 		if got, want := leaf.LeafValue, l; !bytes.Equal(got, want) {
 			t.Errorf("GetByIndex(%v) = %x, want %x", i, got, want)
@@ -86,7 +88,8 @@ func TestGetByIndex(t *testing.T) {
 }
 
 func TestListByIndex(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestGetByIndex")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestGetByIndex")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +113,7 @@ func TestListByIndex(t *testing.T) {
 	}
 
 	// Fetch leaves.
-	leaves, err := client.ListByIndex(context.Background(), 0, 3)
+	leaves, err := client.ListByIndex(ctx, 0, 3)
 	if err != nil {
 		t.Errorf("Failed to ListByIndex: %v", err)
 	}
@@ -122,7 +125,8 @@ func TestListByIndex(t *testing.T) {
 }
 
 func TestVerifyInclusion(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestVerifyInclusion")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestVerifyInclusion")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,14 +149,15 @@ func TestVerifyInclusion(t *testing.T) {
 	}
 
 	for _, l := range leafData {
-		if err := client.VerifyInclusion(context.Background(), l); err != nil {
+		if err := client.VerifyInclusion(ctx, l); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
 		}
 	}
 }
 
 func TestVerifyInclusionAtIndex(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestVerifyInclusionAtIndex")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestVerifyInclusionAtIndex")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,14 +180,15 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 	}
 
 	for i, l := range leafData {
-		if err := client.VerifyInclusionAtIndex(context.Background(), l, int64(i)); err != nil {
+		if err := client.VerifyInclusionAtIndex(ctx, l, int64(i)); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
 		}
 	}
 }
 
 func TestAddLeaf(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestAddLeaf")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestAddLeaf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +241,8 @@ func TestAddLeaf(t *testing.T) {
 }
 
 func TestUpdateRoot(t *testing.T) {
-	env, err := integration.NewLogEnv(context.Background(), 0, "TestUpdateRoot")
+	ctx := context.Background()
+	env, err := integration.NewLogEnv(ctx, 0, "TestUpdateRoot")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -26,17 +26,22 @@ type VerifyingLogClient interface {
 	// is available. If no proof is available within the ctx deadline, DeadlineExceeded
 	// is returned.
 	AddLeaf(ctx context.Context, data []byte) error
-	// VerifyInclusion ensures that data has been included in the log.
+	// VerifyInclusion ensures that data has been included in the log
+	// via an inclusion proof.
 	VerifyInclusion(ctx context.Context, data []byte) error
-	// VerifyInclusionAtIndex ensures that data has been included in the log at a particular index.
+	// VerifyInclusionAtIndex ensures that data has been included in the log
+	// via in inclusion proof for a particular index.
 	VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error
-	// GetByIndex returns a single leaf. Does not verify the leaf's inclusion.
-	GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error)
-	// ListByIndex returns a contiguous range. Does not verify the leaf's inclusion.
-	ListByIndex(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error)
 	// UpdateRoot fetches and verifies the current SignedTreeRoot.
 	// It checks signatures as well as consistency proofs from the last-seen root.
 	UpdateRoot(ctx context.Context) error
 	// Root provides the last root obtained by UpdateRoot.
 	Root() trillian.SignedLogRoot
+
+	// The following methods do not perform cryptographic verification.
+
+	// GetByIndex returns a single leaf. Does not verify the leaf's inclusion proof.
+	GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error)
+	// ListByIndex returns a contiguous range. Does not verify the leaf's inclusion proof.
+	ListByIndex(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error)
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -26,9 +26,13 @@ type VerifyingLogClient interface {
 	// is available. If no proof is available within the ctx deadline, DeadlineExceeded
 	// is returned.
 	AddLeaf(ctx context.Context, data []byte) error
-	// GetByIndex returns a single leaf.
+	// VerifyInclusion ensures that data has been included in the log.
+	VerifyInclusion(ctx context.Context, data []byte) error
+	// VerifyInclusionAtIndex ensures that data has been included in the log at a particular index.
+	VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error
+	// GetByIndex returns a single leaf. Does not verify the leaf's inclusion.
 	GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error)
-	// ListByIndex returns a contiguous range.
+	// ListByIndex returns a contiguous range. Does not verify the leaf's inclusion.
 	ListByIndex(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error)
 	// UpdateRoot fetches and verifies the current SignedTreeRoot.
 	// It checks signatures as well as consistency proofs from the last-seen root.


### PR DESCRIPTION
Add functions for clients to verify inclusion of known leaves at any
location and at a particular index.

This supports Key Transparency's need to verify inclusion of
SignedMapHeads at particular locations in Trillian.