### PR TITLE
Create empty entries for nonexistent subtrees in cache preload

### DIFF
--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -13,7 +13,7 @@ RPC_PORT=$(pickUnusedPort)
 
 echo "Starting Map RPC server on port ${RPC_PORT}"
 pushd "${TRILLIAN_ROOT}" > /dev/null
-./trillian_map_server --port ${RPC_PORT} &
+./trillian_map_server --port ${RPC_PORT} -alsologtostderr &
 RPC_SERVER_PID=$!
 popd > /dev/null
 waitForServerStartup ${RPC_PORT}

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -13,7 +13,7 @@ RPC_PORT=$(pickUnusedPort)
 
 echo "Starting Map RPC server on port ${RPC_PORT}"
 pushd "${TRILLIAN_ROOT}" > /dev/null
-./trillian_map_server --port ${RPC_PORT} -alsologtostderr &
+./trillian_map_server --port ${RPC_PORT} &
 RPC_SERVER_PID=$!
 popd > /dev/null
 waitForServerStartup ${RPC_PORT}

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -195,7 +195,6 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 		list = append(list, *v)
 	}
 	subtrees, err := getSubtrees(list)
-	glog.Warningf("Preload wanted these: [%v] and got: %d subtrees: %v", want, len(subtrees), err)
 	if err != nil {
 		return err
 	}
@@ -210,7 +209,6 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 	for _, id := range want {
 		prefixLen := id.PrefixLenBits / depthQuantum
 		px := id.Path[:prefixLen]
-		glog.Warningf("Adding new empty tree for prefix: %s %d", string(px), len(px))
 		t := s.newEmptySubtree(*id, px)
 		s.subtrees[string(px)] = t
 	}
@@ -221,12 +219,6 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 // GetNodes returns the requested nodes, calling the getSubtrees function if
 // they are not already cached.
 func (s *SubtreeCache) GetNodes(ids []storage.NodeID, getSubtrees GetSubtreesFunc) ([]storage.Node, error) {
-	idstr := ""
-	for _, id := range ids {
-		idstr = idstr + "(" + id.String() + ") "
-	}
-
-	glog.Warningf("GetNodes: preloading for: %v %s", ids, idstr)
 	if err := s.preload(ids, getSubtrees); err != nil {
 		return nil, err
 	}
@@ -238,7 +230,7 @@ func (s *SubtreeCache) GetNodes(ids []storage.NodeID, getSubtrees GetSubtreesFun
 			func(n storage.NodeID) (*storagepb.SubtreeProto, error) {
 				// This should never happen - we should've already read all the data we
 				// need above, in Preload()
-				glog.Warningf("Unexpectedly reading from within GetNodeHash(): %v (%s)", n, n.String())
+				glog.Warningf("Unexpectedly reading from within GetNodeHash(): %s", n.String())
 				ret, err := getSubtrees([]storage.NodeID{n})
 				if err != nil || len(ret) == 0 {
 					return nil, err

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -173,7 +173,6 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 
 	// Figure out the set of subtrees we need:
 	want := make(map[string]*storage.NodeID)
-	wantK := make(map[string][]byte)
 	for _, id := range ids {
 		id := id
 		px, _ := s.splitNodeID(id)
@@ -183,7 +182,6 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 		id.PrefixLenBits = len(px) * depthQuantum
 		if !ok {
 			want[pxKey] = &id
-			wantK[pxKey] = px
 		}
 	}
 
@@ -205,16 +203,16 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 		s.populate(t)
 		s.subtrees[string(t.Prefix)] = t
 		delete(want, string(t.Prefix))
-		delete(wantK, string(t.Prefix))
 	}
 
 	// We might not have got all the subtrees we requested, if they don't already exist.
 	// Create empty subtrees for anything left over.
 	for _, id := range want {
-		px, _ := s.splitNodeID(*id)
-		glog.Warningf("Adding new empty tree for prefix: %s", wantK[string(px)])
+		prefixLen := id.PrefixLenBits / depthQuantum
+		px := id.Path[:prefixLen]
+		glog.Warningf("Adding new empty tree for prefix: %s %d", string(px), len(px))
 		t := s.newEmptySubtree(*id, px)
-		s.subtrees[string(wantK[string(px)])] = t
+		s.subtrees[string(px)] = t
 	}
 
 	return nil

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -211,11 +211,12 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 	for _, id := range want {
 		prefixLen := id.PrefixLenBits / depthQuantum
 		px := id.Path[:prefixLen]
-		_, exists := s.subtrees[string(px)]
+		pxKey := string(px)
+		_, exists := s.subtrees[pxKey]
 		if exists {
 			return fmt.Errorf("preload tried to clobber existing subtree for: %v", *id)
 		}
-		s.subtrees[string(px)] = s.newEmptySubtree(*id, px)
+		s.subtrees[pxKey] = s.newEmptySubtree(*id, px)
 	}
 
 	return nil

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -211,13 +211,11 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 	for _, id := range want {
 		prefixLen := id.PrefixLenBits / depthQuantum
 		px := id.Path[:prefixLen]
-		t := s.newEmptySubtree(*id, px)
-		_, ok := s.subtrees[string(px)]
-		if !ok {
-			s.subtrees[string(px)] = t
-		} else {
-			glog.Warningf("Preload tried to clobber existing subtree for: %v", *id)
+		_, exists := s.subtrees[string(px)]
+		if exists {
+			return fmt.Errorf("preload tried to clobber existing subtree for: %v", *id)
 		}
+		s.subtrees[string(px)] = s.newEmptySubtree(*id, px)
 	}
 
 	return nil


### PR DESCRIPTION
Create empty subtrees in cache for any that preload fails to retrieve because they don't exist yet. This prevents a double fetch of these subtrees, which will be unsuccessful both times and logged warnings for each time this would happen. This was common for maps because of the way the sparse merkle tree works but not an issue for log trees.

Closes #345.
