### PR TITLE
Backoff and retry if a QueueLeaves request fails during integration testing

### DIFF
--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -15,6 +15,7 @@
 package backoff
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"time"
@@ -51,4 +52,19 @@ func (b *Backoff) Duration() time.Duration {
 // Reset sets the internal iteration count back to 0.
 func (b *Backoff) Reset() {
 	b.x = 0
+}
+
+// Retry calls a function until it succeeds or the context is done.
+// It will backoff if the function returns an error.
+// Once the context is done, retries will end and the most recent error will be returned.
+// Backoff is not reset by this function.
+func (b *Backoff) Retry(ctx context.Context, f func() error) error {
+	var err error
+	for ctx.Err() == nil {
+		if err = f(); err == nil {
+			break
+		}
+		time.Sleep(b.Duration())
+	}
+	return err
 }

--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -67,15 +67,15 @@ func (b *Backoff) Retry(ctx context.Context, f func() error) error {
 	// Try calling f until it doesn't return an error or ctx is done.
 	for {
 		err := f()
-		if err == nil {
-			return err
+		if err != nil {
+			select {
+			case <-time.After(b.Duration()):
+				continue
+			case <-ctx.Done():
+				return err
+			}
 		}
 
-		select {
-		case <-time.After(b.Duration()):
-			continue
-		case <-ctx.Done():
-			return err
-		}
+		return nil
 	}
 }

--- a/integration/log.go
+++ b/integration/log.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
 	"github.com/google/trillian"
+	"github.com/google/trillian/client/backoff"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/testonly"
 )
@@ -207,14 +207,20 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 			glog.Infof("Queueing %d leaves ...", len(leaves))
 
 			ctx, cancel := getRPCDeadlineContext(params)
-			b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
-			err := backoff.Retry(func() error {
+			b := &backoff.Backoff{
+				Min:    100 * time.Millisecond,
+				Max:    10 * time.Second,
+				Factor: 2,
+				Jitter: true,
+			}
+
+			err := b.Retry(ctx, func() error {
 				_, err := client.QueueLeaves(ctx, &trillian.QueueLeavesRequest{
 					LogId:  params.treeID,
 					Leaves: leaves,
 				})
 				return err
-			}, b)
+			})
 			cancel()
 
 			if err != nil {


### PR DESCRIPTION
This could occur due to transient issues, e.g. database server is momentarily unavailable.

TODO: Add retry logic to other requests.