### PR TITLE
Use the trees package to acquire Trees, Hashers and Signers

### DIFF
--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -26,7 +26,8 @@ go build ./cmd/createtree/
 tree_id=$(./createtree \
     --admin_server=localhost:8090 \
     --pem_key_path=testdata/log-rpc-server.privkey.pem \
-    --pem_key_password=towel)
+    --pem_key_password=towel \
+    --signature_algorithm=ECDSA)
 ./mapper \
     -source http://ct.googleapis.com/pilot \
     -map_id=${tree_id} \

--- a/integration/ct_config.sh
+++ b/integration/ct_config.sh
@@ -22,7 +22,11 @@ go build ${GOFLAGS} ./cmd/createtree/
 num_logs=$(grep -c '@TREE_ID@' "${CT_CFG}")
 for i in $(seq ${num_logs}); do
   # TODO(daviddrysdale): Consider using distinct keys for each log
-  tree_id=$(./createtree --admin_server="${ADMIN_SERVER}" --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
+  tree_id=$(./createtree \
+    --admin_server="${ADMIN_SERVER}" \
+    --pem_key_path=testdata/log-rpc-server.privkey.pem \
+    --pem_key_password=towel \
+    --signature_algorithm=ECDSA)
   echo "Created tree ${tree_id}"
   sed -i "0,/@TREE_ID@/s/@TREE_ID@/${tree_id}/" "${CT_CFG}"
 done

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -19,7 +19,11 @@ RPC_SERVER_PID=$!
 popd > /dev/null
 waitForServerStartup ${RPC_PORT}
 
-TEST_TREE_ID=$(./createtree --admin_server="localhost:${RPC_PORT}" --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
+TEST_TREE_ID=$(./createtree \
+  --admin_server="localhost:${RPC_PORT}" \
+  --pem_key_path=testdata/log-rpc-server.privkey.pem \
+  --pem_key_password=towel \
+  --signature_algorithm=ECDSA)
 echo "Created tree ${TEST_TREE_ID}"
 
 # Ensure we kill the RPC server once we're done.

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -18,7 +18,7 @@ RPC_SERVER_PID=$!
 popd > /dev/null
 waitForServerStartup ${RPC_PORT}
 
-TEST_TREE_ID=$(./createtree --admin_server="localhost:${RPC_PORT}" --tree_type=LOG --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
+TEST_TREE_ID=$(./createtree --admin_server="localhost:${RPC_PORT}" --tree_type=MAP --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
 echo "Created tree ${TEST_TREE_ID}"
 
 # Ensure we kill the RPC server once we're done.

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -18,7 +18,12 @@ RPC_SERVER_PID=$!
 popd > /dev/null
 waitForServerStartup ${RPC_PORT}
 
-TEST_TREE_ID=$(./createtree --admin_server="localhost:${RPC_PORT}" --tree_type=MAP --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
+TEST_TREE_ID=$(./createtree \
+  --admin_server="localhost:${RPC_PORT}" \
+  --tree_type=MAP \
+  --pem_key_path=testdata/log-rpc-server.privkey.pem \
+  --pem_key_password=towel \
+  --signature_algorithm=ECDSA)
 echo "Created tree ${TEST_TREE_ID}"
 
 # Ensure we kill the RPC server once we're done.

--- a/merkle/tree_hasher.go
+++ b/merkle/tree_hasher.go
@@ -40,6 +40,7 @@ var hashTypes = map[string]TreeHasher{
 }
 
 // Factory supports fetching custom hashers based on tree types.
+// TODO(codingllama): Get rid of Factory and hashTypes. It's never used by production code.
 func Factory(hashType string) (TreeHasher, error) {
 	h, ok := hashTypes[hashType]
 	if !ok {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -78,7 +78,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	if err := validateQueueLeavesRequest(req); err != nil {
 		return nil, err
 	}
-	logID := req.GetLogId()
+	logID := req.LogId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, false /* readonly */)
 	if err != nil {
@@ -130,7 +130,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 	if err := validateGetInclusionProofRequest(req); err != nil {
 		return nil, err
 	}
-	logID := req.GetLogId()
+	logID := req.LogId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
 	if err != nil {
@@ -170,7 +170,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 	if err := validateGetInclusionProofByHashRequest(req); err != nil {
 		return nil, err
 	}
-	logID := req.GetLogId()
+	logID := req.LogId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
 	if err != nil {
@@ -228,7 +228,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 	if err := validateGetConsistencyProofRequest(req); err != nil {
 		return nil, err
 	}
-	logID := req.GetLogId()
+	logID := req.LogId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
 	if err != nil {
@@ -357,7 +357,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 	if err := validateGetEntryAndProofRequest(req); err != nil {
 		return nil, err
 	}
-	logID := req.GetLogId()
+	logID := req.LogId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
 	if err != nil {
@@ -495,7 +495,8 @@ func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int6
 	tree, err := trees.GetTree(
 		ctx,
 		t.registry.AdminStorage,
-		treeID, trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+		treeID,
+		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/trees"
 	"github.com/google/trillian/util"
 	"golang.org/x/net/context"
 	"google.golang.org/genproto/googleapis/rpc/code"
@@ -74,18 +75,23 @@ func (t *TrillianLogRPCServer) QueueLeaf(ctx context.Context, req *trillian.Queu
 
 // QueueLeaves submits a batch of leaves to the log for later integration into the underlying tree.
 func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.QueueLeavesRequest) (*trillian.QueueLeavesResponse, error) {
-	ctx = util.NewLogContext(ctx, req.LogId)
 	if err := validateQueueLeavesRequest(req); err != nil {
 		return nil, err
 	}
+	logID := req.GetLogId()
 
-	// TODO(al): Hasher must be selected based on log config.
-	th, _ := merkle.Factory(merkle.RFC6962SHA256Type)
+	tree, hasher, err := t.getTreeAndHasher(ctx, logID, false /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewLogContext(ctx, logID)
+
 	for i := range req.Leaves {
-		req.Leaves[i].MerkleLeafHash = th.HashLeaf(req.Leaves[i].LeafValue)
+		req.Leaves[i].MerkleLeafHash = hasher.HashLeaf(req.Leaves[i].LeafValue)
 	}
 
-	tx, err := t.prepareStorageTx(ctx, req.LogId)
+	tx, err := t.prepareStorageTx(ctx, logID)
 	if err != nil {
 		return nil, err
 	}
@@ -121,10 +127,17 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 // GetInclusionProof obtains the proof of inclusion in the tree for a leaf that has been sequenced.
 // Similar to the get proof by hash handler but one less step as we don't need to look up the index
 func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trillian.GetInclusionProofRequest) (*trillian.GetInclusionProofResponse, error) {
-	ctx = util.NewLogContext(ctx, req.LogId)
 	if err := validateGetInclusionProofRequest(req); err != nil {
 		return nil, err
 	}
+	logID := req.GetLogId()
+
+	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewLogContext(ctx, logID)
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
@@ -139,12 +152,11 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 		return nil, err
 	}
 
-	proof, err := getInclusionProofForLeafIndex(tx, req.TreeSize, req.LeafIndex, root.TreeSize)
+	proof, err := getInclusionProofForLeafIndex(tx, hasher, req.TreeSize, req.LeafIndex, root.TreeSize)
 	if err != nil {
 		return nil, err
 	}
 
-	// The work is complete, can return the response
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -155,10 +167,17 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 // GetInclusionProofByHash obtains proofs of inclusion by leaf hash. Because some logs can
 // contain duplicate hashes it is possible for multiple proofs to be returned.
 func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req *trillian.GetInclusionProofByHashRequest) (*trillian.GetInclusionProofByHashResponse, error) {
-	ctx = util.NewLogContext(ctx, req.LogId)
 	if err := validateGetInclusionProofByHashRequest(req); err != nil {
 		return nil, err
 	}
+	logID := req.GetLogId()
+
+	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewLogContext(ctx, logID)
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
@@ -186,14 +205,13 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 	// TODO(Martin2112): Need to define a limit on number of results or some form of paging etc.
 	proofs := make([]*trillian.Proof, 0, len(leaves))
 	for _, leaf := range leaves {
-		proof, err := getInclusionProofForLeafIndex(tx, req.TreeSize, leaf.LeafIndex, root.TreeSize)
+		proof, err := getInclusionProofForLeafIndex(tx, hasher, req.TreeSize, leaf.LeafIndex, root.TreeSize)
 		if err != nil {
 			return nil, err
 		}
 		proofs = append(proofs, &proof)
 	}
 
-	// The work is complete, can return the response
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -207,12 +225,19 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 // other and that the later tree includes all the entries of the prior one. For more details
 // see the example trees in RFC 6962.
 func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *trillian.GetConsistencyProofRequest) (*trillian.GetConsistencyProofResponse, error) {
-	ctx = util.NewLogContext(ctx, req.LogId)
 	if err := validateGetConsistencyProofRequest(req); err != nil {
 		return nil, err
 	}
+	logID := req.GetLogId()
 
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewLogContext(ctx, logID)
+
+	tx, err := t.prepareReadOnlyStorageTx(ctx, logID)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +255,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 
 	// Do all the node fetches at the second tree revision, which is what the node ids were calculated
 	// against.
-	proof, err := fetchNodesAndBuildProof(tx, tx.ReadRevision(), 0, nodeFetches)
+	proof, err := fetchNodesAndBuildProof(tx, hasher, tx.ReadRevision(), 0, nodeFetches)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +354,17 @@ func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillia
 // GetEntryAndProof returns both a Merkle Leaf entry and an inclusion proof for a given index
 // and tree size.
 func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trillian.GetEntryAndProofRequest) (*trillian.GetEntryAndProofResponse, error) {
-	ctx = util.NewLogContext(ctx, req.LogId)
 	if err := validateGetEntryAndProofRequest(req); err != nil {
 		return nil, err
 	}
+	logID := req.GetLogId()
+
+	tree, hasher, err := t.getTreeAndHasher(ctx, logID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewLogContext(ctx, logID)
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
@@ -347,7 +379,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 		return nil, err
 	}
 
-	proof, err := getInclusionProofForLeafIndex(tx, req.TreeSize, req.LeafIndex, root.TreeSize)
+	proof, err := getInclusionProofForLeafIndex(tx, hasher, req.TreeSize, req.LeafIndex, root.TreeSize)
 	if err != nil {
 		return nil, err
 	}
@@ -421,14 +453,14 @@ func validateLeafHashes(leafHashes [][]byte) bool {
 // getInclusionProofForLeafIndex is used by multiple handlers. It does the storage fetching
 // and makes additional checks on the returned proof. Returns a Proof suitable for inclusion in
 // an RPC response
-func getInclusionProofForLeafIndex(tx storage.ReadOnlyLogTreeTX, snapshot, leafIndex, treeSize int64) (trillian.Proof, error) {
+func getInclusionProofForLeafIndex(tx storage.ReadOnlyLogTreeTX, hasher merkle.TreeHasher, snapshot, leafIndex, treeSize int64) (trillian.Proof, error) {
 	// We have the tree size and leaf index so we know the nodes that we need to serve the proof
 	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize, proofMaxBitLen)
 	if err != nil {
 		return trillian.Proof{}, err
 	}
 
-	return fetchNodesAndBuildProof(tx, tx.ReadRevision(), leafIndex, proofNodeIDs)
+	return fetchNodesAndBuildProof(tx, hasher, tx.ReadRevision(), leafIndex, proofNodeIDs)
 }
 
 // getLeavesByHashInternal does the work of fetching leaves by either their raw data or merkle
@@ -457,4 +489,19 @@ func (t *TrillianLogRPCServer) getLeavesByHashInternal(ctx context.Context, desc
 	return &trillian.GetLeavesByHashResponse{
 		Leaves: leaves,
 	}, nil
+}
+
+func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, merkle.TreeHasher, error) {
+	tree, err := trees.GetTree(
+		ctx,
+		t.registry.AdminStorage,
+		treeID, trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+	if err != nil {
+		return nil, nil, err
+	}
+	hasher, err := trees.Hasher(tree)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tree, hasher, nil
 }

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -68,7 +68,12 @@ var n2n3n4 = &trillian.Node{NodeHash: th.HashChildren(h4, th.HashChildren(h3, h2
 var n4n5 = &trillian.Node{NodeHash: th.HashChildren(h5, h4)}
 
 func TestRehasher(t *testing.T) {
-	var rehashTests = []rehashTest{
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		t.Fatalf("Error getting hasher: %v", err)
+	}
+
+	rehashTests := []rehashTest{
 		{
 			desc:    "no rehash",
 			index:   126,
@@ -122,7 +127,7 @@ func TestRehasher(t *testing.T) {
 	}
 
 	for _, rehashTest := range rehashTests {
-		r := newRehasher()
+		r := &rehasher{th: hasher}
 		for i, node := range rehashTest.nodes {
 			r.process(node, rehashTest.fetches[i])
 		}
@@ -141,6 +146,11 @@ func TestRehasher(t *testing.T) {
 }
 
 func TestTree813FetchAll(t *testing.T) {
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		t.Fatalf("Error getting hasher: %v", err)
+	}
+
 	const ts int64 = 813
 
 	mt := treeAtSize(int(ts))
@@ -155,7 +165,7 @@ func TestTree813FetchAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		proof, err := fetchNodesAndBuildProof(r, testTreeRevision, int64(l), fetches)
+		proof, err := fetchNodesAndBuildProof(r, hasher, testTreeRevision, int64(l), fetches)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -179,6 +189,11 @@ func TestTree813FetchAll(t *testing.T) {
 }
 
 func TestTree32InclusionProofFetchAll(t *testing.T) {
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		t.Fatalf("Error getting hasher: %v", err)
+	}
+
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
@@ -192,7 +207,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				proof, err := fetchNodesAndBuildProof(r, testTreeRevision, int64(l), fetches)
+				proof, err := fetchNodesAndBuildProof(r, hasher, testTreeRevision, int64(l), fetches)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -215,6 +230,11 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 }
 
 func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		t.Fatalf("Error getting hasher: %v", err)
+	}
+
 	mt := treeAtSize(32)
 	// The reader is built up with multiple batches, 4 batches x 8 leaves each
 	r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
@@ -232,7 +252,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 			}
 
 			// Use the highest tree revision that should be available from the node reader
-			proof, err := fetchNodesAndBuildProof(r, testTreeRevision+3, l, fetches)
+			proof, err := fetchNodesAndBuildProof(r, hasher, testTreeRevision+3, l, fetches)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -254,6 +274,11 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 }
 
 func TestTree32ConsistencyProofFetchAll(t *testing.T) {
+	hasher, err := merkle.Factory(merkle.RFC6962SHA256Type)
+	if err != nil {
+		t.Fatalf("Error getting hasher: %v", err)
+	}
+
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
@@ -267,7 +292,7 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				proof, err := fetchNodesAndBuildProof(r, testTreeRevision, int64(s1), fetches)
+				proof, err := fetchNodesAndBuildProof(r, hasher, testTreeRevision, int64(s1), fetches)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -98,24 +99,10 @@ func newSignerWithFixedSig(sig *sigpb.DigitallySigned) (crypto.Signer, error) {
 	}
 
 	if keys.SignatureAlgorithm(key) != sig.GetSignatureAlgorithm() {
-		return nil, fmt.Errorf("signature algorithm does not match demo public key")
+		return nil, errors.New("signature algorithm does not match demo public key")
 	}
 
 	return testonly.NewSignerWithFixedSig(key, sig.Signature), nil
-}
-
-func TestSequencerManagerNothingToDo(t *testing.T) {
-	ctx := util.NewLogContext(context.Background(), -1)
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	registry := extension.Registry{
-		LogStorage: storage.NewMockLogStorage(mockCtrl),
-	}
-
-	sm := NewSequencerManager(registry, zeroDuration)
-
-	sm.ExecutePass(ctx, 0, createTestInfo(registry))
 }
 
 func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -75,7 +75,6 @@ func main() {
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls
 	// both sequencing and signing.
-	// TODO(Martin2112): Should respect read only mode and the flags in tree control etc
 	ctx, cancel := context.WithCancel(context.Background())
 	go util.AwaitSignal(cancel)
 

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -75,6 +75,7 @@ func main() {
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls
 	// both sequencing and signing.
+	// TODO(Martin2112): Should respect read only mode and the flags in tree control etc
 	ctx, cancel := context.WithCancel(context.Background())
 	go util.AwaitSignal(cancel)
 

--- a/server/vmap/trillian_map_server.go
+++ b/server/vmap/trillian_map_server.go
@@ -48,7 +48,7 @@ func (t *TrillianMapServer) IsHealthy() error {
 
 // GetLeaves implements the GetLeaves RPC method.
 func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapLeavesRequest) (*trillian.GetMapLeavesResponse, error) {
-	mapID := req.GetMapId()
+	mapID := req.MapId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, true /* readonly */)
 	if err != nil {
@@ -107,7 +107,7 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 
 // SetLeaves implements the SetLeaves RPC method.
 func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapLeavesRequest) (*trillian.SetMapLeavesResponse, error) {
-	mapID := req.GetMapId()
+	mapID := req.MapId
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, false /* readonly */)
 	if err != nil {

--- a/server/vmap/trillian_map_server.go
+++ b/server/vmap/trillian_map_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/trees"
 	"github.com/google/trillian/util"
 	"golang.org/x/net/context"
 )
@@ -45,31 +46,24 @@ func (t *TrillianMapServer) IsHealthy() error {
 	return t.registry.MapStorage.CheckDatabaseAccessible(context.Background())
 }
 
-func (t *TrillianMapServer) getHasherForMap(mapID int64) (merkle.MapHasher, error) {
-	// TODO(al): actually return tailored hashers.
-	h, err := merkle.Factory(merkle.RFC6962SHA256Type)
-	if err != nil {
-		return merkle.MapHasher{}, err
-	}
-	return merkle.NewMapHasher(h), nil
-}
-
 // GetLeaves implements the GetLeaves RPC method.
 func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapLeavesRequest) (*trillian.GetMapLeavesResponse, error) {
-	ctx = util.NewMapContext(ctx, req.MapId)
-	tx, err := t.registry.MapStorage.SnapshotForTree(ctx, req.MapId)
+	mapID := req.GetMapId()
+
+	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewMapContext(ctx, mapID)
+
+	tx, err := t.registry.MapStorage.SnapshotForTree(ctx, mapID)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Close()
 
-	kh, err := t.getHasherForMap(req.MapId)
-	if err != nil {
-		return nil, err
-	}
-
 	var root *trillian.SignedMapRoot
-
 	if req.Revision < 0 {
 		// need to know the newest published revision
 		r, err := tx.LatestSignedMapRoot()
@@ -80,7 +74,7 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 		req.Revision = root.MapRevision
 	}
 
-	smtReader := merkle.NewSparseMerkleTreeReader(req.Revision, kh, tx)
+	smtReader := merkle.NewSparseMerkleTreeReader(req.Revision, hasher, tx)
 
 	leaves, err := tx.Get(req.Revision, req.Index)
 	if err != nil {
@@ -113,20 +107,22 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 
 // SetLeaves implements the SetLeaves RPC method.
 func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapLeavesRequest) (*trillian.SetMapLeavesResponse, error) {
-	ctx = util.NewMapContext(ctx, req.MapId)
+	mapID := req.GetMapId()
+
+	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, false /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ctx = trees.NewContext(ctx, tree)
+	ctx = util.NewMapContext(ctx, mapID)
+
 	tx, err := t.registry.MapStorage.BeginForTree(ctx, req.MapId)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Close()
 
-	hasher, err := t.getHasherForMap(req.MapId)
-	if err != nil {
-		return nil, err
-	}
-
 	glog.Infof("%s: Writing at revision %d", util.MapIDPrefix(ctx), tx.WriteRevision())
-
 	smtWriter, err := merkle.NewSparseMerkleTreeWriter(tx.WriteRevision(), hasher, func() (storage.TreeTX, error) {
 		return t.registry.MapStorage.BeginForTree(ctx, req.MapId)
 	})
@@ -200,4 +196,20 @@ func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.
 	return &trillian.GetSignedMapRootResponse{
 		MapRoot: &r,
 	}, nil
+}
+
+func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, merkle.MapHasher, error) {
+	tree, err := trees.GetTree(
+		ctx,
+		t.registry.AdminStorage,
+		treeID,
+		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
+	if err != nil {
+		return nil, merkle.MapHasher{}, err
+	}
+	th, err := trees.Hasher(tree)
+	if err != nil {
+		return nil, merkle.MapHasher{}, err
+	}
+	return tree, merkle.NewMapHasher(th), nil
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -88,12 +88,12 @@ var (
 )
 
 type mySQLLogStorage struct {
-	admin storage.AdminStorage
 	*mySQLTreeStorage
+	admin storage.AdminStorage
 }
 
 // NewLogStorage creates a storage.LogStorage instance for the specified MySQL URL.
-// It assumes storage.AdminStorage is backed by MySQL as well.
+// It assumes storage.AdminStorage is backed by the same MySQL database as well.
 func NewLogStorage(db *sql.DB) storage.LogStorage {
 	return &mySQLLogStorage{
 		admin:            NewAdminStorage(db),

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -30,10 +30,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	spb "github.com/google/trillian/crypto/sigpb"
-	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/monitoring/metric"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/trees"
 )
 
 const (
@@ -88,12 +88,15 @@ var (
 )
 
 type mySQLLogStorage struct {
+	admin storage.AdminStorage
 	*mySQLTreeStorage
 }
 
-// NewLogStorage creates a mySQLLogStorage instance for the specified MySQL URL.
+// NewLogStorage creates a storage.LogStorage instance for the specified MySQL URL.
+// It assumes storage.AdminStorage is backed by MySQL as well.
 func NewLogStorage(db *sql.DB) storage.LogStorage {
 	return &mySQLLogStorage{
+		admin:            NewAdminStorage(db),
 		mySQLTreeStorage: newTreeStorage(db),
 	}
 }
@@ -191,19 +194,16 @@ func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
 	return getActiveLogIDsWithPendingWork(t.tx)
 }
 
-func (m *mySQLLogStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
-	// TODO(codingllama): read hash algorithm from storage.
-	return merkle.Factory(merkle.RFC6962SHA256Type)
-}
-
-func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	// TODO(codingllama): Validate treeType, read configuration from storage
-	var num int
-	if err := m.db.QueryRow("SELECT 1 FROM Trees WHERE TreeId = ?", treeID).Scan(&num); err != nil {
-		return nil, fmt.Errorf("failed to get tree row for treeID %v: %v", treeID, err)
+func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
+	tree, err := trees.GetTree(
+		ctx,
+		m.admin,
+		treeID,
+		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+	if err != nil {
+		return nil, err
 	}
-
-	hasher, err := m.hasher(treeID)
+	hasher, err := trees.Hasher(tree)
 	if err != nil {
 		return nil, err
 	}
@@ -229,11 +229,11 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64) (stor
 }
 
 func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	return m.beginInternal(ctx, treeID)
+	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
 func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
-	tx, err := m.beginInternal(ctx, treeID)
+	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -53,12 +53,12 @@ const (
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
 type mySQLMapStorage struct {
-	admin storage.AdminStorage
 	*mySQLTreeStorage
+	admin storage.AdminStorage
 }
 
 // NewMapStorage creates a storage.MapStorage instance for the specified MySQL URL.
-// It assumes storage.AdminStorage is backed by MySQL as well.
+// It assumes storage.AdminStorage is backed by the same MySQL database as well.
 func NewMapStorage(db *sql.DB) storage.MapStorage {
 	return &mySQLMapStorage{
 		admin:            NewAdminStorage(db),

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -22,9 +22,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	spb "github.com/google/trillian/crypto/sigpb"
-	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/trees"
 )
 
 const (
@@ -53,12 +53,15 @@ const (
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
 
 type mySQLMapStorage struct {
+	admin storage.AdminStorage
 	*mySQLTreeStorage
 }
 
-// NewMapStorage creates a mySQLMapStorage instance for the specified MySQL URL.
+// NewMapStorage creates a storage.MapStorage instance for the specified MySQL URL.
+// It assumes storage.AdminStorage is backed by MySQL as well.
 func NewMapStorage(db *sql.DB) storage.MapStorage {
 	return &mySQLMapStorage{
+		admin:            NewAdminStorage(db),
 		mySQLTreeStorage: newTreeStorage(db),
 	}
 }
@@ -95,14 +98,16 @@ func (t *readOnlyMapTX) Close() error {
 	return nil
 }
 
-func (m *mySQLMapStorage) hasher(treeID int64) (merkle.TreeHasher, error) {
-	// TODO: read hash algorithm from storage.
-	return merkle.Factory(merkle.RFC6962SHA256Type)
-}
-
-func (m *mySQLMapStorage) BeginForTree(ctx context.Context, treeID int64) (storage.MapTreeTX, error) {
-	// TODO(codingllama): Validate treeType, read hash algorithm from storage
-	hasher, err := m.hasher(treeID)
+func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool) (storage.MapTreeTX, error) {
+	tree, err := trees.GetTree(
+		ctx,
+		m.admin,
+		treeID,
+		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
+	if err != nil {
+		return nil, err
+	}
+	hasher, err := trees.Hasher(tree)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +131,12 @@ func (m *mySQLMapStorage) BeginForTree(ctx context.Context, treeID int64) (stora
 	return mtx, nil
 }
 
+func (m *mySQLMapStorage) BeginForTree(ctx context.Context, treeID int64) (storage.MapTreeTX, error) {
+	return m.begin(ctx, treeID, false /* readonly */)
+}
+
 func (m *mySQLMapStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyMapTreeTX, error) {
-	tx, err := m.BeginForTree(ctx, treeID)
+	tx, err := m.begin(ctx, treeID, true /* readonly */)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -102,7 +102,7 @@ func TestMapBeginSnapshot(t *testing.T) {
 			defer tx.Close()
 			root, err := tx.LatestSignedMapRoot()
 			if err != nil {
-				t.Errorf("%v/%v: LatestSignedLogRoot() returned err = %v", test.desc, name, err)
+				t.Errorf("%v/%v: LatestSignedMapRoot() returned err = %v", test.desc, name, err)
 			}
 			if err := tx.Commit(); err != nil {
 				t.Errorf("%v/%v: Commit() returned err = %v", test.desc, name, err)

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -272,6 +272,25 @@ func createTree(db *sql.DB, tree *trillian.Tree) (*trillian.Tree, error) {
 	return newTree, nil
 }
 
+// updateTree updates the specified tree using AdminStorage.
+func updateTree(db *sql.DB, treeID int64, updateFn func(*trillian.Tree)) (*trillian.Tree, error) {
+	s := NewAdminStorage(db)
+	ctx := context.Background()
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Close()
+	tree, err := tx.UpdateTree(ctx, treeID, updateFn)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
 // DB is the database used for tests. It's initialized and closed by TestMain().
 var DB *sql.DB
 


### PR DESCRIPTION
Make servers use storage settings when creating hashers and signers. This also makes it so that frozen, deleted and mismatched trees (log vs map) are correctly detected before usage.

Both server and storage layers rely on `trees.GetTree` to acquire trees with the correct validations applied. Trees acquired by upper layers (server / sequencer) are added to the context to avoid re-reading the same data during a single request.