### PR TITLE
integration: cope with limited sed version

### DIFF
--- a/integration/ct_config.sh
+++ b/integration/ct_config.sh
@@ -24,7 +24,9 @@ for i in $(seq ${num_logs}); do
   # TODO(daviddrysdale): Consider using distinct keys for each log
   tree_id=$(./createtree --admin_server="${ADMIN_SERVER}" --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel)
   echo "Created tree ${tree_id}"
-  sed -i "0,/@TREE_ID@/s/@TREE_ID@/${tree_id}/" "${CT_CFG}"
+  # Need suffix for sed -i to cope with both GNU and non-GNU (e.g. OS X) sed.
+  sed -i'.bak' "1,/@TREE_ID@/s/@TREE_ID@/${tree_id}/" "${CT_CFG}"
+  rm -f "${CT_CFG}.bak"
 done
 
 echo "CT configuration:"


### PR DESCRIPTION
OSX doesn't have GNU grep, so:
 - start at line 1 for replace (assumes no match on first line, [1])
 - add a parameter for -i option (and delete the generated file)

[1] http://www.linuxtopia.org/online_books/linux_tool_guides/the_sed_faq/sedfaq4_004.html