### PR TITLE
Interceptor for Trillian RPCs

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -50,7 +50,7 @@ func (i *TreeInterceptor) UnaryInterceptor(ctx context.Context, req interface{},
 	return handler(ctx, req)
 }
 
-// rpcInfo contains information about an RPC, as extract from its request message.
+// rpcInfo contains information about an RPC, as extracted from its request message.
 type rpcInfo struct {
 	// doesNotHaveTree states whether the RPC is tied to a specific tree.
 	// Examples of RPCs without trees are CreateTree (no tree exists yet) and ListTrees
@@ -59,6 +59,7 @@ type rpcInfo struct {
 	// treeID is the tree ID tied to this RPC, if any.
 	treeID int64
 	// opts is the trees.GetOpts appropriate to this RPC (TreeType, readonly vs readwrite, etc).
+	// opts is not set if doesNotHaveTree is true.
 	opts trees.GetOpts
 }
 
@@ -71,7 +72,8 @@ func getRPCInfo(req interface{}) (*rpcInfo, error) {
 	case *trillian.GetTreeRequest:
 		return &rpcInfo{
 			treeID: req.GetTreeId(),
-			opts:   trees.GetOpts{Readonly: true}}, nil
+			opts:   trees.GetOpts{Readonly: true},
+		}, nil
 	case *trillian.DeleteTreeRequest:
 		return &rpcInfo{treeID: req.GetTreeId()}, nil
 	case *trillian.ListTreesRequest:
@@ -83,57 +85,70 @@ func getRPCInfo(req interface{}) (*rpcInfo, error) {
 	case *trillian.GetConsistencyProofRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetEntryAndProofRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetInclusionProofByHashRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetInclusionProofRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetLatestSignedLogRootRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetLeavesByHashRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetLeavesByIndexRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.GetSequencedLeafCountRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
+		}, nil
 	case *trillian.QueueLeafRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG},
+		}, nil
 	case *trillian.QueueLeavesRequest:
 		return &rpcInfo{
 			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG},
+		}, nil
 
 	// TrillianMap
 	case *trillian.GetMapLeavesRequest:
 		return &rpcInfo{
 			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true},
+		}, nil
 	case *trillian.SetMapLeavesRequest:
 		return &rpcInfo{
 			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP},
+		}, nil
 	case *trillian.GetSignedMapRootRequest:
 		return &rpcInfo{
 			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true}}, nil
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true},
+		}, nil
 	}
 
 	return nil, errors.Errorf(errors.Internal, "request type not configured for interception: %T", req)

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package interceptor defines gRPC interceptors for Trillian.
+package interceptor
+
+import (
+	"github.com/google/trillian"
+	"github.com/google/trillian/errors"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/trees"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// TreeInterceptor ensures that all requests pertaining a specific tree are of correct type and
+// respect the current tree state (frozen, deleted, etc).
+type TreeInterceptor struct {
+	Admin storage.AdminStorage
+}
+
+// UnaryInterceptor executes the TreeInterceptor logic for unary RPCs.
+func (i *TreeInterceptor) UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	rpcInfo, err := getRPCInfo(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if rpcInfo.doesNotHaveTree {
+		return handler(ctx, req)
+	}
+
+	tree, err := trees.GetTree(ctx, i.Admin, rpcInfo.treeID, rpcInfo.opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = trees.NewContext(ctx, tree)
+	return handler(ctx, req)
+}
+
+// rpcInfo contains information about an RPC, as extract from its request message.
+type rpcInfo struct {
+	// doesNotHaveTree states whether the RPC is tied to a specific tree.
+	// Examples of RPCs without trees are CreateTree (no tree exists yet) and ListTrees
+	// (zero to many trees returned).
+	doesNotHaveTree bool
+	// treeID is the tree ID tied to this RPC, if any.
+	treeID int64
+	// opts is the trees.GetOpts appropriate to this RPC (TreeType, readonly vs readwrite, etc).
+	opts trees.GetOpts
+}
+
+// getRPCInfo returns the rpcInfo for the given request, or an error if the request is not mapped.
+func getRPCInfo(req interface{}) (*rpcInfo, error) {
+	switch req := req.(type) {
+	// TrillianAdmin
+	case *trillian.CreateTreeRequest:
+		return &rpcInfo{doesNotHaveTree: true}, nil
+	case *trillian.GetTreeRequest:
+		return &rpcInfo{
+			treeID: req.GetTreeId(),
+			opts:   trees.GetOpts{Readonly: true}}, nil
+	case *trillian.DeleteTreeRequest:
+		return &rpcInfo{treeID: req.GetTreeId()}, nil
+	case *trillian.ListTreesRequest:
+		return &rpcInfo{doesNotHaveTree: true}, nil
+	case *trillian.UpdateTreeRequest:
+		return &rpcInfo{treeID: req.GetTree().GetTreeId()}, nil
+
+	// TrillianLog
+	case *trillian.GetConsistencyProofRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetEntryAndProofRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetInclusionProofByHashRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetInclusionProofRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetLatestSignedLogRootRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetLeavesByHashRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetLeavesByIndexRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.GetSequencedLeafCountRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}}, nil
+	case *trillian.QueueLeafRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG}}, nil
+	case *trillian.QueueLeavesRequest:
+		return &rpcInfo{
+			treeID: req.GetLogId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG}}, nil
+
+	// TrillianMap
+	case *trillian.GetMapLeavesRequest:
+		return &rpcInfo{
+			treeID: req.GetMapId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true}}, nil
+	case *trillian.SetMapLeavesRequest:
+		return &rpcInfo{
+			treeID: req.GetMapId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP}}, nil
+	case *trillian.GetSignedMapRootRequest:
+		return &rpcInfo{
+			treeID: req.GetMapId(),
+			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true}}, nil
+	}
+
+	return nil, errors.Errorf(errors.Internal, "request type not configured for interception: %T", req)
+}
+
+// Combine combines multiple unary interceptors. Interceptors are executed in the supplied order.
+// If an interceptor fails (non-nil error), processing will stop and the error will be returned.
+// If all interceptors succeed the handler will be called.
+// Contexts are propagated between calls: the context of the first interceptor, as passed in to the
+// handler function, is used for the second interceptor call and so on, until the handler is
+// invoked. This ensures that request-level variables, transmitted via contexts, behave properly.
+func Combine(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(initialCtx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// Save and forward the ctx passed by interceptors, otherwise we lose the data they add.
+		ctx := initialCtx
+		ctxHandler := func(innerCtx context.Context, req interface{}) (interface{}, error) {
+			ctx = innerCtx
+			return nil, nil
+		}
+		for _, intercept := range interceptors {
+			_, err := intercept(ctx, req, info, ctxHandler)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return handler(ctx, req)
+	}
+}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -16,6 +16,8 @@
 package interceptor
 
 import (
+	"strings"
+
 	"github.com/google/trillian"
 	"github.com/google/trillian/errors"
 	"github.com/google/trillian/storage"
@@ -32,7 +34,7 @@ type TreeInterceptor struct {
 
 // UnaryInterceptor executes the TreeInterceptor logic for unary RPCs.
 func (i *TreeInterceptor) UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	rpcInfo, err := getRPCInfo(req)
+	rpcInfo, err := getRPCInfo(req, info.FullMethod)
 	if err != nil {
 		return nil, err
 	}
@@ -64,94 +66,83 @@ type rpcInfo struct {
 }
 
 // getRPCInfo returns the rpcInfo for the given request, or an error if the request is not mapped.
-func getRPCInfo(req interface{}) (*rpcInfo, error) {
-	switch req := req.(type) {
-	// TrillianAdmin
+// Full method is the full RPC method name, as acquired from grpc.UnaryServerInfo (e.g.,
+// /trillian.TrillianLog/GetInclusionProof).
+func getRPCInfo(req interface{}, fullMethod string) (*rpcInfo, error) {
+	// Whitelisted to skip tree validation
+	switch req.(type) {
 	case *trillian.CreateTreeRequest:
 		return &rpcInfo{doesNotHaveTree: true}, nil
-	case *trillian.GetTreeRequest:
-		return &rpcInfo{
-			treeID: req.GetTreeId(),
-			opts:   trees.GetOpts{Readonly: true},
-		}, nil
-	case *trillian.DeleteTreeRequest:
-		return &rpcInfo{treeID: req.GetTreeId()}, nil
 	case *trillian.ListTreesRequest:
 		return &rpcInfo{doesNotHaveTree: true}, nil
-	case *trillian.UpdateTreeRequest:
-		return &rpcInfo{treeID: req.GetTree().GetTreeId()}, nil
-
-	// TrillianLog
-	case *trillian.GetConsistencyProofRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetEntryAndProofRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetInclusionProofByHashRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetInclusionProofRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetLatestSignedLogRootRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetLeavesByHashRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetLeavesByIndexRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.GetSequencedLeafCountRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true},
-		}, nil
-	case *trillian.QueueLeafRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG},
-		}, nil
-	case *trillian.QueueLeavesRequest:
-		return &rpcInfo{
-			treeID: req.GetLogId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_LOG},
-		}, nil
-
-	// TrillianMap
-	case *trillian.GetMapLeavesRequest:
-		return &rpcInfo{
-			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true},
-		}, nil
-	case *trillian.SetMapLeavesRequest:
-		return &rpcInfo{
-			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP},
-		}, nil
-	case *trillian.GetSignedMapRootRequest:
-		return &rpcInfo{
-			treeID: req.GetMapId(),
-			opts:   trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: true},
-		}, nil
 	}
 
-	return nil, errors.Errorf(errors.Internal, "request type not configured for interception: %T", req)
+	var treeID int64
+	switch req := req.(type) {
+	case treeIDRequest:
+		treeID = req.GetTreeId()
+	case treeRequest:
+		treeID = req.GetTree().GetTreeId()
+	case logIDRequest:
+		treeID = req.GetLogId()
+	case mapIDRequest:
+		treeID = req.GetMapId()
+	default:
+		return nil, errors.Errorf(errors.Internal, "cannot retrieve treeID from request: %T", req)
+	}
+
+	serviceName, methodName, err := parseFullMethod(fullMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	var treeType trillian.TreeType
+	switch serviceName {
+	case "trillian.TrillianAdmin":
+		treeType = trillian.TreeType_UNKNOWN_TREE_TYPE // unrestricted
+	case "trillian.TrillianLog":
+		treeType = trillian.TreeType_LOG
+	case "trillian.TrillianMap":
+		treeType = trillian.TreeType_MAP
+	default:
+		return nil, errors.Errorf(errors.Internal, "cannot determine treeType for request: %T", req)
+	}
+
+	readonly := strings.HasPrefix(methodName, "Get") || strings.HasPrefix(methodName, "List")
+
+	return &rpcInfo{
+		treeID: treeID,
+		opts:   trees.GetOpts{TreeType: treeType, Readonly: readonly},
+	}, nil
+}
+
+// parseFullMethod returns the service and method names as separate strings, without a trailing
+// slash in either of them.
+func parseFullMethod(fullMethod string) (string, string, error) {
+	if !strings.HasPrefix(fullMethod, "/") {
+		return "", "", errors.Errorf(errors.Internal, "fullMethod must begin with '/': %v", fullMethod)
+	}
+	tmp := strings.Split(fullMethod[1:], "/")
+	if len(tmp) != 2 {
+		return "", "", errors.Errorf(errors.Internal, "unexpected number of components in fullMethod (%v != 2): %v", len(tmp), fullMethod)
+	}
+	return tmp[0], tmp[1], nil
+}
+
+type treeIDRequest interface {
+	GetTreeId() int64
+}
+
+type treeRequest interface {
+	GetTree() *trillian.Tree
+}
+
+type logIDRequest interface {
+	GetLogId() int64
+}
+
+type mapIDRequest interface {
+	GetMapId() int64
 }
 
 // Combine combines multiple unary interceptors. Interceptors are executed in the supplied order.

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -1,0 +1,310 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/trees"
+	"github.com/kylelemons/godebug/pretty"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+func TestTreeInterceptor_UnaryInterceptor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logTree := *testonly.LogTree
+	logTree.TreeId = 10
+	mapTree := *testonly.MapTree
+	mapTree.TreeId = 11
+	unknownTreeID := int64(999)
+
+	admin := storage.NewMockAdminStorage(ctrl)
+	adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
+	admin.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(adminTX, nil)
+	adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(&logTree, nil)
+	adminTX.EXPECT().GetTree(gomock.Any(), mapTree.TreeId).AnyTimes().Return(&mapTree, nil)
+	adminTX.EXPECT().GetTree(gomock.Any(), unknownTreeID).AnyTimes().Return(nil, errors.New("not found"))
+	adminTX.EXPECT().Close().AnyTimes().Return(nil)
+	adminTX.EXPECT().Commit().AnyTimes().Return(nil)
+
+	tests := []struct {
+		desc       string
+		req        interface{}
+		handlerErr error
+		wantErr    bool
+		wantTree   *trillian.Tree
+	}{
+		{
+			desc: "rpcWithoutTree",
+			req:  &trillian.CreateTreeRequest{},
+		},
+		{
+			desc:     "adminRPC",
+			req:      &trillian.GetTreeRequest{TreeId: logTree.TreeId},
+			wantTree: &logTree,
+		},
+		{
+			desc:     "logRPC",
+			req:      &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
+			wantTree: &logTree,
+		},
+		{
+			desc:     "mapRPC",
+			req:      &trillian.GetSignedMapRootRequest{MapId: mapTree.TreeId},
+			wantTree: &mapTree,
+		},
+		{
+			desc:    "unknownRequest",
+			req:     "not-a-request",
+			wantErr: true,
+		},
+		{
+			desc:    "unknownTree",
+			req:     &trillian.GetTreeRequest{TreeId: unknownTreeID},
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	intercept := TreeInterceptor{Admin: admin}
+	for _, test := range tests {
+		handler := &fakeHandler{resp: "handler response", err: test.handlerErr}
+
+		resp, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run)
+		if hasErr := err != nil && err != test.handlerErr; hasErr != test.wantErr {
+			t.Errorf("%v: UnaryInterceptor() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
+			continue
+		} else if hasErr {
+			continue
+		}
+
+		if want := 1; handler.calls != want {
+			t.Errorf("%v: handler called %v times, want = %v", test.desc, handler.calls, want)
+			continue
+		}
+		if handler.resp != resp {
+			t.Errorf("%v: resp = %v, want = %v", test.desc, resp, handler.resp)
+		}
+		if handler.err != err {
+			t.Errorf("%v: err = %v, want = %v", test.desc, err, handler.err)
+		}
+
+		if test.wantTree != nil {
+			switch tree, ok := trees.FromContext(handler.ctx); {
+			case !ok:
+				t.Errorf("%v: tree not in handler ctx", test.desc)
+			case !proto.Equal(tree, test.wantTree):
+				diff := pretty.Compare(tree, test.wantTree)
+				t.Errorf("%v: post-FromContext diff:\n%v", test.desc, diff)
+			}
+		}
+	}
+}
+
+func TestGetRPCInfo(t *testing.T) {
+	tests := []struct {
+		req interface{}
+	}{
+		// Please keep in alphabetical order
+		{req: &trillian.CreateTreeRequest{}},
+		{req: &trillian.DeleteTreeRequest{}},
+		{req: &trillian.GetConsistencyProofRequest{}},
+		{req: &trillian.GetEntryAndProofRequest{}},
+		{req: &trillian.GetInclusionProofByHashRequest{}},
+		{req: &trillian.GetInclusionProofRequest{}},
+		{req: &trillian.GetLatestSignedLogRootRequest{}},
+		{req: &trillian.GetLeavesByHashRequest{}},
+		{req: &trillian.GetLeavesByIndexRequest{}},
+		{req: &trillian.GetMapLeavesRequest{}},
+		{req: &trillian.GetSequencedLeafCountRequest{}},
+		{req: &trillian.GetSignedMapRootRequest{}},
+		{req: &trillian.GetTreeRequest{}},
+		{req: &trillian.ListTreesRequest{}},
+		{req: &trillian.QueueLeafRequest{}},
+		{req: &trillian.QueueLeavesRequest{}},
+		{req: &trillian.SetMapLeavesRequest{}},
+		{req: &trillian.UpdateTreeRequest{}},
+	}
+	for _, test := range tests {
+		// We don't care about specifics on the returned info here. There's little logic on
+		// getRPCInfo other than a hard-written mapping; testing for treeID/type/readonly
+		// is too close to a change detector test to be worth it.
+		// Testing that requests are mapped, OTOH, helps avoid regressions.
+		_, err := getRPCInfo(test.req)
+		if err != nil {
+			t.Errorf("RPC not mapped: %T", err)
+		}
+	}
+}
+
+func TestCombine(t *testing.T) {
+	i1 := &fakeInterceptor{key: "key1", val: "foo"}
+	i2 := &fakeInterceptor{key: "key2", val: "bar"}
+	i3 := &fakeInterceptor{key: "key3", val: "baz"}
+	e1 := &fakeInterceptor{err: errors.New("intercept error")}
+
+	handlerErr := errors.New("handler error")
+
+	tests := []struct {
+		desc         string
+		interceptors []*fakeInterceptor
+		handlerErr   error
+		wantCalled   int
+		wantErr      error
+	}{
+		{
+			desc: "noInterceptors",
+		},
+		{
+			desc:         "single",
+			interceptors: []*fakeInterceptor{i1},
+			wantCalled:   1,
+		},
+		{
+			desc:         "multi1",
+			interceptors: []*fakeInterceptor{i1, i2, i3},
+			wantCalled:   3,
+		},
+		{
+			desc:         "multi2",
+			interceptors: []*fakeInterceptor{i3, i1, i2},
+			wantCalled:   3,
+		},
+		{
+			desc:         "handlerErr",
+			interceptors: []*fakeInterceptor{i1, i2},
+			handlerErr:   handlerErr,
+			wantCalled:   2,
+			wantErr:      handlerErr,
+		},
+		{
+			desc:         "interceptErr",
+			interceptors: []*fakeInterceptor{i1, e1, i2},
+			wantCalled:   2,
+			wantErr:      e1.err,
+		},
+	}
+
+	ctx := context.Background()
+	req := "request"
+	info := &grpc.UnaryServerInfo{}
+	for _, test := range tests {
+		if l := len(test.interceptors); l < test.wantCalled {
+			t.Errorf("%v: len(interceptors) = %v, want >= %v", test.desc, l, test.wantCalled)
+			continue
+		}
+
+		intercepts := []grpc.UnaryServerInterceptor{}
+		for _, i := range test.interceptors {
+			i.calls = 0
+			intercepts = append(intercepts, i.run)
+		}
+		intercept := Combine(intercepts...)
+
+		handler := &fakeHandler{resp: "response", err: test.handlerErr}
+		resp, err := intercept(ctx, req, info, handler.run)
+		if err != test.wantErr {
+			t.Errorf("%v: err = %q, want = %q", test.desc, err, test.wantErr)
+			continue
+		}
+
+		called := 0
+		callsStopped := false
+		for _, i := range test.interceptors {
+			switch {
+			case i.calls == 0:
+				// No calls should have happened from here on
+				callsStopped = true
+			case i.calls == 1:
+				if callsStopped {
+					t.Errorf("%v: interceptor called out of order: %v", test.desc, i)
+				}
+				called++
+			case i.calls > 1:
+				// This shouldn't happen, it means different tests are interfering
+				// with each other.
+				t.Fatalf("%v: interceptor called too many times: %v", test.desc, i)
+			}
+		}
+		if called != test.wantCalled {
+			t.Errorf("%v: called %v interceptors, want = %v", test.desc, called, test.wantCalled)
+		}
+
+		// Assertions below this point assume that the handler was called (ie, all
+		// interceptors succeeded).
+		if err != nil && err != test.handlerErr {
+			continue
+		}
+
+		if resp != handler.resp {
+			t.Errorf("%v: resp = %v, want = %v", test.desc, resp, handler.resp)
+		}
+
+		// Chain the ctxs for all called interceptors and verify it got through to the
+		// handler.
+		wantCtx := ctx
+		for i := 0; i < test.wantCalled; i++ {
+			h := &fakeHandler{resp: "ok"}
+			_, err = test.interceptors[i].run(wantCtx, req, info, h.run)
+			if err != nil {
+				t.Fatalf("%v: unexpected handler failure: %v", test.desc, err)
+			}
+			wantCtx = h.ctx
+		}
+		if diff := pretty.Compare(handler.ctx, wantCtx); diff != "" {
+			t.Errorf("%v: handler ctx diff:\n%v", test.desc, diff)
+		}
+	}
+}
+
+type fakeHandler struct {
+	calls int
+	resp  interface{}
+	err   error
+	// Attributes recorded by run calls
+	ctx context.Context
+	req interface{}
+}
+
+func (h *fakeHandler) run(ctx context.Context, req interface{}) (interface{}, error) {
+	h.calls++
+	h.ctx = ctx
+	h.req = req
+	return h.resp, h.err
+}
+
+type fakeInterceptor struct {
+	key   interface{}
+	val   interface{}
+	calls int
+	err   error
+}
+
+func (i *fakeInterceptor) run(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	i.calls++
+	if i.err != nil {
+		return nil, i.err
+	}
+	return handler(context.WithValue(ctx, i.key, i.val), req)
+}

--- a/server/vmap/trillian_map_server/main.go
+++ b/server/vmap/trillian_map_server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/server"
+	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/server/vmap"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -55,7 +56,8 @@ func main() {
 		MapStorage:    mysql.NewMapStorage(db),
 	}
 
-	s := grpc.NewServer()
+	ti := interceptor.TreeInterceptor{Admin: registry.AdminStorage}
+	s := grpc.NewServer(grpc.UnaryInterceptor(ti.UnaryInterceptor))
 	// No defer: server ownership is delegated to server.Main
 
 	httpEndpoint := ""


### PR DESCRIPTION
Add an interceptor for tree-based RPCs (and wire it into servers). RPCs that
don't match the requested tree (non-existing, wrong type, write on frozen tree,
etc) will be blocked at the interceptor layer.

RPCs that do succeed have the requested tree set in context, as to avoid future
queries of the same data within the scope of a request.

The mechanisms introduced here allow for easy addition of new interceptors, for
example auth and rate limiting.