### PR TITLE
examples/ct: allow multiple CA-roots files

### DIFF
--- a/examples/ct/instance.go
+++ b/examples/ct/instance.go
@@ -32,7 +32,7 @@ import (
 type LogConfig struct {
 	LogID           int64
 	Prefix          string
-	RootsPEMFile    string
+	RootsPEMFile    []string
 	PubKeyPEMFile   string
 	PrivKeyPEMFile  string
 	PrivKeyPassword string
@@ -95,8 +95,10 @@ func (cfg LogConfig) SetUpInstance(client trillian.TrillianLogClient, deadline t
 
 	// Load the trusted roots
 	roots := NewPEMCertPool()
-	if err := roots.AppendCertsFromPEMFile(cfg.RootsPEMFile); err != nil {
-		return nil, fmt.Errorf("failed to read trusted roots: %v", err)
+	for _, pemFile := range cfg.RootsPEMFile {
+		if err := roots.AppendCertsFromPEMFile(pemFile); err != nil {
+			return nil, fmt.Errorf("failed to read trusted roots: %v", err)
+		}
 	}
 
 	// Load the private key for this log.

--- a/integration/ct_integration_test.cfg
+++ b/integration/ct_integration_test.cfg
@@ -2,7 +2,7 @@
 	{
 		"LogID": @TREE_ID@,
 		"Prefix": "athos",
-		"RootsPEMFile": "@TESTDATA@/fake-ca.cert",
+		"RootsPEMFile": ["@TESTDATA@/fake-ca.cert"],
 		"PubKeyPEMFile": "@TESTDATA@/ct-http-server.pubkey.pem",
 		"PrivKeyPEMFile": "@TESTDATA@/ct-http-server.privkey.pem",
 		"PrivKeyPassword": "dirk"
@@ -10,7 +10,7 @@
 	{
 		"LogID": @TREE_ID@,
 		"Prefix": "porthos",
-		"RootsPEMFile": "@TESTDATA@/fake-ca.cert",
+		"RootsPEMFile": ["@TESTDATA@/fake-ca.cert"],
 		"PubKeyPEMFile": "@TESTDATA@/ct-http-server.pubkey.pem",
 		"PrivKeyPEMFile": "@TESTDATA@/ct-http-server.privkey.pem",
 		"PrivKeyPassword": "dirk"
@@ -18,7 +18,7 @@
 	{
 		"LogID": @TREE_ID@,
 		"Prefix": "aramis",
-		"RootsPEMFile": "@TESTDATA@/fake-ca.cert",
+		"RootsPEMFile": ["@TESTDATA@/fake-ca.cert"],
 		"PubKeyPEMFile": "@TESTDATA@/ct-http-server.pubkey.pem",
 		"PrivKeyPEMFile": "@TESTDATA@/ct-http-server.privkey.pem",
 		"PrivKeyPassword": "dirk"

--- a/integration/ct_integration_test.go
+++ b/integration/ct_integration_test.go
@@ -76,21 +76,21 @@ func TestInProcessCTIntegration(t *testing.T) {
 	cfgs := []*ct.LogConfig{
 		{
 			Prefix:          "athos",
-			RootsPEMFile:    rootsPEMFile,
+			RootsPEMFile:    []string{rootsPEMFile},
 			PubKeyPEMFile:   pubKeyPEMFile,
 			PrivKeyPEMFile:  privKeyPEMFile,
 			PrivKeyPassword: privKeyPassword,
 		},
 		{
 			Prefix:          "porthos",
-			RootsPEMFile:    rootsPEMFile,
+			RootsPEMFile:    []string{rootsPEMFile},
 			PubKeyPEMFile:   pubKeyPEMFile,
 			PrivKeyPEMFile:  privKeyPEMFile,
 			PrivKeyPassword: privKeyPassword,
 		},
 		{
 			Prefix:          "aramis",
-			RootsPEMFile:    rootsPEMFile,
+			RootsPEMFile:    []string{rootsPEMFile},
 			PubKeyPEMFile:   pubKeyPEMFile,
 			PrivKeyPEMFile:  privKeyPEMFile,
 			PrivKeyPassword: privKeyPassword,


### PR DESCRIPTION
This makes it easier to run variant configurations, e.g. a
test server with the base set of roots plus an extra testing root.