### PR TITLE
Replace deprecated gRPC methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,8 +30,8 @@ import (
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"google.golang.org/genproto/googleapis/rpc/code"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // LogClient represents a client for a given Trillian log instance.
@@ -69,15 +69,19 @@ func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 
 	leaf := c.buildLeaf(data)
 	err := c.queueLeaf(ctx, leaf)
-	switch {
-	case grpc.Code(err) == codes.AlreadyExists:
+	switch s, ok := status.FromError(err); {
+	case ok && s.Code() == codes.AlreadyExists:
 		// If the leaf already exists, don't wait for an update.
 		return c.getInclusionProof(ctx, leaf.MerkleLeafHash, c.root.TreeSize)
 	case err != nil:
 		return err
 	default:
-		err := grpc.Errorf(codes.NotFound, "Pre-loop condition")
-		for i := 0; grpc.Code(err) == codes.NotFound && ctx.Err() == nil; i++ {
+		err := status.Errorf(codes.NotFound, "Pre-loop condition")
+		for {
+			if s, ok := status.FromError(err); !ok || s.Code() != codes.NotFound || ctx.Err() != nil {
+				break
+			}
+
 			// Wait for TreeSize to update.
 			if err := c.waitForRootUpdate(ctx); err != nil {
 				return err
@@ -159,7 +163,7 @@ func (c *LogClient) waitForRootUpdate(ctx context.Context) error {
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
-			return grpc.Errorf(codes.DeadlineExceeded,
+			return status.Errorf(codes.DeadlineExceeded,
 				"%v. TreeSize: %v, want > %v. Tried %v times.",
 				err, c.root.TreeSize, startTreeSize, i+1)
 		}
@@ -303,7 +307,7 @@ func (c *LogClient) queueLeaf(ctx context.Context, leaf *trillian.LogLeaf) error
 	}
 	if rsp.QueuedLeaf.Status != nil && rsp.QueuedLeaf.Status.Code == int32(code.Code_ALREADY_EXISTS) {
 		// Convert this to AlreadyExists
-		return grpc.Errorf(codes.AlreadyExists, "leaf already exists")
+		return status.Errorf(codes.AlreadyExists, "leaf already exists")
 	}
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -78,7 +78,10 @@ func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 	default:
 		err := status.Errorf(codes.NotFound, "Pre-loop condition")
 		for {
-			if s, ok := status.FromError(err); !ok || s.Code() != codes.NotFound || ctx.Err() != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			if s, ok := status.FromError(err); !ok || s.Code() != codes.NotFound {
 				break
 			}
 

--- a/examples/ct/handlers_test.go
+++ b/examples/ct/handlers_test.go
@@ -43,10 +43,8 @@ import (
 	"github.com/google/trillian/mockclient"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
-	"google.golang.org/genproto/googleapis/rpc/code"
-	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Arbitrary time for use in tests
@@ -305,7 +303,7 @@ func TestAddChain(t *testing.T) {
 			chain:  []string{cttestonly.LeafSignedByFakeIntermediateCertPEM, cttestonly.FakeIntermediateCertPEM},
 			toSign: "1337d72a403b6539f58896decba416d5d4b3603bfa03e1f94bb9b4e898af897d",
 			want:   http.StatusInternalServerError,
-			err:    grpc.Errorf(codes.Internal, "error"),
+			err:    status.Errorf(codes.Internal, "error"),
 		},
 		{
 			descr:  "success-without-root",
@@ -352,7 +350,7 @@ func TestAddChain(t *testing.T) {
 			for i, leaf := range leaves {
 				queuedLeaves[i] = &trillian.QueuedLogLeaf{
 					Leaf:   leaf,
-					Status: &status.Status{Code: int32(code.Code_OK)},
+					Status: status.New(codes.OK, "ok").Proto(),
 				}
 			}
 			rsp := trillian.QueueLeavesResponse{QueuedLeaves: queuedLeaves}
@@ -409,7 +407,7 @@ func TestAddPrechain(t *testing.T) {
 			descr:  "backend-rpc-fail",
 			chain:  []string{cttestonly.PrecertPEMValid, cttestonly.CACertPEM},
 			toSign: "92ecae1a2dc67a6c5f9c96fa5cab4c2faf27c48505b696dad926f161b0ca675a",
-			err:    grpc.Errorf(codes.Internal, "error"),
+			err:    status.Errorf(codes.Internal, "error"),
 			want:   http.StatusInternalServerError,
 		},
 		{
@@ -457,7 +455,7 @@ func TestAddPrechain(t *testing.T) {
 			for i, leaf := range leaves {
 				queuedLeaves[i] = &trillian.QueuedLogLeaf{
 					Leaf:   leaf,
-					Status: &status.Status{Code: int32(code.Code_OK)},
+					Status: status.New(codes.OK, "ok").Proto(),
 				}
 			}
 			rsp := trillian.QueueLeavesResponse{QueuedLeaves: queuedLeaves}

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAdminServer_Unimplemented(t *testing.T) {
@@ -58,7 +59,8 @@ func TestAdminServer_Unimplemented(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		if err := test.fn(ctx, client); grpc.Code(err) != codes.Unimplemented {
+		err := test.fn(ctx, client)
+		if s, ok := status.FromError(err); !ok || s.Code() != codes.Unimplemented {
 			t.Errorf("%v: got = %v, want = %s", test.desc, err, codes.Unimplemented)
 		}
 	}
@@ -102,7 +104,7 @@ func TestAdminServer_CreateTree(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		createdTree, err := client.CreateTree(ctx, test.req)
-		if grpc.Code(err) != test.wantCode {
+		if s, ok := status.FromError(err); !ok || s.Code() != test.wantCode {
 			t.Errorf("%v: CreateTree() = (_, %v), wantCode = %v", test.desc, err, test.wantCode)
 			continue
 		} else if err != nil {
@@ -147,7 +149,7 @@ func TestAdminServer_GetTree(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		_, err := client.GetTree(ctx, &trillian.GetTreeRequest{TreeId: test.treeID})
-		if grpc.Code(err) != test.wantCode {
+		if s, ok := status.FromError(err); !ok || s.Code() != test.wantCode {
 			t.Errorf("%v: GetTree() = (_, %v), wantCode = %v", test.desc, err, test.wantCode)
 		}
 		// Success of GetTree is part of TestAdminServer_CreateTree, so it's not asserted here.

--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -21,11 +21,11 @@ import (
 	"github.com/google/trillian/server/errors"
 	"github.com/google/trillian/trees"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-var errNotImplemented = grpc.Errorf(codes.Unimplemented, "not implemented")
+var errNotImplemented = status.Errorf(codes.Unimplemented, "not implemented")
 
 // Server is an implementation of trillian.TrillianAdminServer.
 type Server struct {
@@ -104,13 +104,13 @@ func (s *Server) CreateTree(ctx context.Context, request *trillian.CreateTreeReq
 func (s *Server) createTreeImpl(ctx context.Context, request *trillian.CreateTreeRequest) (*trillian.Tree, error) {
 	tree := request.GetTree()
 	if tree == nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "a tree is required")
+		return nil, status.Errorf(codes.InvalidArgument, "a tree is required")
 	}
 	if _, err := trees.Hasher(tree); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "failed to create hasher for tree: %v", err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "failed to create hasher for tree: %v", err.Error())
 	}
 	if _, err := trees.Signer(ctx, s.registry.SignerFactory, tree); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "failed to create signer for tree: %v", err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "failed to create signer for tree: %v", err.Error())
 	}
 
 	tx, err := s.registry.AdminStorage.Begin(ctx)

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/google/trillian/storage/testonly"
 	"github.com/kylelemons/godebug/pretty"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestServer_Unimplemented(t *testing.T) {
@@ -58,7 +58,8 @@ func TestServer_Unimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Server{}
 	for _, test := range tests {
-		if err := test.fn(ctx, s); grpc.Code(err) != codes.Unimplemented {
+		err := test.fn(ctx, s)
+		if s, ok := status.FromError(err); !ok || s.Code() != codes.Unimplemented {
 			t.Errorf("%v: got = %v, want = %s", test.desc, err, codes.Unimplemented)
 		}
 	}

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -18,8 +18,8 @@ import (
 	"database/sql"
 
 	te "github.com/google/trillian/errors"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // WrapError wraps err as a gRPC error if err is a TrillianError or a well-known
@@ -27,12 +27,12 @@ import (
 // unmodified.
 func WrapError(err error) error {
 	if err == sql.ErrNoRows {
-		return grpc.Errorf(codes.NotFound, err.Error())
+		return status.Errorf(codes.NotFound, err.Error())
 	}
 
 	switch err := err.(type) {
 	case te.TrillianError:
-		return grpc.Errorf(codes.Code(err.Code()), err.Error())
+		return status.Errorf(codes.Code(err.Code()), err.Error())
 	default:
 		// Nothing to do: if it's a gRPC error it's already correct, if not gRPC will assume
 		// codes.Unknown.

--- a/server/errors/errors_test.go
+++ b/server/errors/errors_test.go
@@ -21,13 +21,13 @@ import (
 
 	te "github.com/google/trillian/errors"
 	"github.com/kylelemons/godebug/pretty"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestWrapError(t *testing.T) {
 	trillianErr := te.New(te.InvalidArgument, "invalid argument err")
-	grpcErr := grpc.Errorf(codes.NotFound, "not found err")
+	grpcErr := status.Errorf(codes.NotFound, "not found err")
 	err := errors.New("generic error")
 
 	tests := []struct {
@@ -36,7 +36,7 @@ func TestWrapError(t *testing.T) {
 	}{
 		{
 			err:     trillianErr,
-			wantErr: grpc.Errorf(codes.InvalidArgument, trillianErr.Error()),
+			wantErr: status.Errorf(codes.InvalidArgument, trillianErr.Error()),
 		},
 		{
 			err:     grpcErr,
@@ -48,7 +48,7 @@ func TestWrapError(t *testing.T) {
 		},
 		{
 			err:     sql.ErrNoRows,
-			wantErr: grpc.Errorf(codes.NotFound, sql.ErrNoRows.Error()),
+			wantErr: status.Errorf(codes.NotFound, sql.ErrNoRows.Error()),
 		},
 	}
 	for _, test := range tests {

--- a/server/validate.go
+++ b/server/validate.go
@@ -17,62 +17,62 @@ package server
 import (
 	"github.com/google/trillian"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func validateGetInclusionProofRequest(req *trillian.GetInclusionProofRequest) error {
 	if req.TreeSize <= 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.TreeSize: %v, want > 0", req.TreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.TreeSize: %v, want > 0", req.TreeSize)
 	}
 	if req.LeafIndex < 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.LeafIndex: %v, want >= 0", req.LeafIndex)
+		return status.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.LeafIndex: %v, want >= 0", req.LeafIndex)
 	}
 	if req.LeafIndex >= req.TreeSize {
-		return grpc.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.LeafIndex: %v >= TreeSize: %v, want < ", req.LeafIndex, req.TreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetInclusionProofRequest.LeafIndex: %v >= TreeSize: %v, want < ", req.LeafIndex, req.TreeSize)
 	}
 	return nil
 }
 
 func validateGetInclusionProofByHashRequest(req *trillian.GetInclusionProofByHashRequest) error {
 	if req.TreeSize <= 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetInclusionProofByHashRequest.TreeSize: %v, want > 0", req.TreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetInclusionProofByHashRequest.TreeSize: %v, want > 0", req.TreeSize)
 	}
 	if len(req.LeafHash) == 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetInclusionProofByHashRequest.LeafHash empty")
+		return status.Errorf(codes.InvalidArgument, "GetInclusionProofByHashRequest.LeafHash empty")
 	}
 	return nil
 }
 
 func validateGetConsistencyProofRequest(req *trillian.GetConsistencyProofRequest) error {
 	if req.FirstTreeSize <= 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v, want > 0", req.FirstTreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v, want > 0", req.FirstTreeSize)
 	}
 	if req.SecondTreeSize <= 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v, want > 0", req.SecondTreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v, want > 0", req.SecondTreeSize)
 	}
 	if req.SecondTreeSize <= req.FirstTreeSize {
-		return grpc.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want > ", req.FirstTreeSize, req.SecondTreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want > ", req.FirstTreeSize, req.SecondTreeSize)
 	}
 	return nil
 }
 
 func validateGetEntryAndProofRequest(req *trillian.GetEntryAndProofRequest) error {
 	if req.TreeSize <= 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.TreeSize: %v, want > 0", req.TreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.TreeSize: %v, want > 0", req.TreeSize)
 	}
 	if req.LeafIndex < 0 {
-		return grpc.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.LeafIndex: %v, want >= 0", req.LeafIndex)
+		return status.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.LeafIndex: %v, want >= 0", req.LeafIndex)
 	}
 	if req.LeafIndex >= req.TreeSize {
-		return grpc.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.LeafIndex: %v >= TreeSize: %v, want < ", req.LeafIndex, req.TreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetEntryAndProofRequest.LeafIndex: %v >= TreeSize: %v, want < ", req.LeafIndex, req.TreeSize)
 	}
 	return nil
 }
 
 func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
 	if len(req.Leaves) == 0 {
-		return grpc.Errorf(codes.InvalidArgument, "len(QueueLeavesRequest.Leaves)=0, want > 0")
+		return status.Errorf(codes.InvalidArgument, "len(QueueLeavesRequest.Leaves)=0, want > 0")
 	}
 	return nil
 }


### PR DESCRIPTION
As of the new grpc/status package, grpc.Code and grpc.Errorf are deprecated.

* "grpc.Errorf(...)" -> "status.Errorf(...)"
* "grpc.Code(x)" -> "s, ok := status.FromError(x); ok && s.Code()" (varies
  according to original intent)
* "(rpc.)status.Status{...}" -> "(grpc.)status.New(...).Proto()"