### PR TITLE
Don't require a PEM password in cmd/createtree

### DIFF
--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -146,13 +146,9 @@ func newPK(opts *createOpts) (*any.Any, error) {
 		if _, err := os.Stat(path); err != nil {
 			return nil, fmt.Errorf("error reading PEM key file at %v: %v", path, err)
 		}
-		pass := opts.pemKeyPass
-		if pass == "" {
-			return nil, errors.New("empty PEM key password")
-		}
 		pemKey := &trillian.PEMKeyFile{
 			Path:     path,
-			Password: pass,
+			Password: opts.pemKeyPass,
 		}
 		return ptypes.MarshalAny(pemKey)
 	default:

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -138,11 +138,6 @@ func TestRun(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:    "emptyPEMPass",
-			opts:    &emptyPEMPass,
-			wantErr: true,
-		},
-		{
 			desc:      "createErr",
 			opts:      validOpts,
 			createErr: errors.New("create tree failed"),
@@ -158,9 +153,9 @@ func TestRun(t *testing.T) {
 		switch hasErr := err != nil; {
 		case hasErr != test.wantErr:
 			t.Errorf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
-			return
+			continue
 		case hasErr:
-			return
+			continue
 		}
 
 		if diff := pretty.Compare(tree, test.wantTree); diff != "" {


### PR DESCRIPTION
PEM file may not be password protected so don't require one.

Also fixes the `cmd/createtree` tests, previously they would `return` from the loop at the first `test.wantErr` or `hasErr` instead of using `continue` which prevented the rest of the tests from running.