### PR TITLE
Fix cmd/createtree tests

### DIFF
--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -157,10 +157,9 @@ func TestRun(t *testing.T) {
 		tree, err := createTree(ctx, test.opts)
 		switch hasErr := err != nil; {
 		case hasErr != test.wantErr:
-			t.Errorf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
-			return
+			t.Fatalf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
 		case hasErr:
-			return
+			continue
 		}
 
 		if diff := pretty.Compare(tree, test.wantTree); diff != "" {

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -157,7 +157,8 @@ func TestRun(t *testing.T) {
 		tree, err := createTree(ctx, test.opts)
 		switch hasErr := err != nil; {
 		case hasErr != test.wantErr:
-			t.Fatalf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
+			t.Errorf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
+			continue
 		case hasErr:
 			continue
 		}


### PR DESCRIPTION
Split off from #532.

Uses `t.Fatalf` instead of `t.Errorf` in the first case to maintain previous fail-fast behavior on test failures, otherwise just uses `continue` instead of `return` so all tests are actually ran.