### PR TITLE
In log integration test don't set the MerkleLeafHash for queued leaves

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -196,7 +196,6 @@ func queueLeaves(client trillian.TrillianLogClient, params TestParameters) error
 
 		leaf := &trillian.LogLeaf{
 			LeafIdentityHash: idHash[:],
-			MerkleLeafHash:   testonly.Hasher.HashLeaf(data),
 			LeafValue:        data,
 			ExtraData:        []byte(fmt.Sprintf("%sExtra %d", params.customLeafPrefix, leafNumber)),
 		}


### PR DESCRIPTION
This isn't a client responsibility and it gets overwritten in the server.