### PR TITLE
Separate offline from online tasks in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -193,7 +193,7 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 		}
 	}
 
-	// Verify Consistency proof.
+	// Verify root update.
 	if err := c.LogVerifier.UpdateRoot(resp, consistency); err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -177,7 +177,8 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if resp.SignedLogRoot.TreeSize == c.root.TreeSize &&
+	if c.root.TreeSize > 0 &&
+		resp.SignedLogRoot.TreeSize == c.root.TreeSize &&
 		bytes.Equal(resp.SignedLogRoot.RootHash, c.root.RootHash) {
 		// Tree has not been updated.
 		return nil

--- a/client/client.go
+++ b/client/client.go
@@ -18,8 +18,7 @@ package client
 import (
 	"bytes"
 	"context"
-	gocrypto "crypto"
-	"crypto/sha256"
+	"crypto"
 	"errors"
 	"fmt"
 	"sort"
@@ -27,7 +26,6 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/client/backoff"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
@@ -38,25 +36,16 @@ import (
 type LogClient struct {
 	LogID  int64
 	client trillian.TrillianLogClient
-	hasher merkle.TreeHasher
-	root   trillian.SignedLogRoot
-	pubKey gocrypto.PublicKey
+	*LogVerifier
 }
 
 // New returns a new LogClient.
-func New(logID int64, client trillian.TrillianLogClient, hasher merkle.TreeHasher, pubKey gocrypto.PublicKey) *LogClient {
+func New(logID int64, client trillian.TrillianLogClient, hasher merkle.TreeHasher, pubKey crypto.PublicKey) *LogClient {
 	return &LogClient{
-		LogID:  logID,
-		client: client,
-		hasher: hasher,
-		pubKey: pubKey,
+		LogID:       logID,
+		client:      client,
+		LogVerifier: NewLogVerifier(hasher, pubKey),
 	}
-}
-
-// Root returns the last valid root seen by UpdateRoot.
-// Returns an empty SignedLogRoot if UpdateRoot has not been called.
-func (c *LogClient) Root() trillian.SignedLogRoot {
-	return c.root
 }
 
 // AddLeaf adds leaf to the append only log.
@@ -67,7 +56,7 @@ func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 		return err
 	}
 
-	leaf := c.buildLeaf(data)
+	leaf := c.LogVerifier.buildLeaf(data)
 	err := c.queueLeaf(ctx, leaf)
 	switch s, ok := status.FromError(err); {
 	case ok && s.Code() == codes.AlreadyExists:
@@ -177,56 +166,43 @@ func (c *LogClient) waitForRootUpdate(ctx context.Context) error {
 // UpdateRoot retrieves the current SignedLogRoot.
 // Verifies the signature, and the consistency proof if this is not the first root this client has seen.
 func (c *LogClient) UpdateRoot(ctx context.Context) error {
-	req := &trillian.GetLatestSignedLogRootRequest{
-		LogId: c.LogID,
-	}
-	resp, err := c.client.GetLatestSignedLogRoot(ctx, req)
+	resp, err := c.client.GetLatestSignedLogRoot(ctx,
+		&trillian.GetLatestSignedLogRootRequest{
+			LogId: c.LogID,
+		})
 	if err != nil {
 		return err
 	}
-	str := resp.SignedLogRoot
-
-	// Verify SignedLogRoot signature.
-	hash := crypto.HashLogRoot(*str)
-	if err := crypto.Verify(c.pubKey, hash, str.Signature); err != nil {
-		return err
-	}
-
-	// Verify Consistency proof.
-	if str.TreeSize == c.root.TreeSize &&
-		bytes.Equal(str.RootHash, c.root.RootHash) {
+	if resp.SignedLogRoot.TreeSize == c.root.TreeSize &&
+		bytes.Equal(resp.SignedLogRoot.RootHash, c.root.RootHash) {
 		// Tree has not been updated.
 		return nil
 	}
-
-	// Implicitly trust the first root we get.
+	// Fetch a consistency proof if this isn't the first root we've seen.
+	var consistency *trillian.GetConsistencyProofResponse
 	if c.root.TreeSize != 0 {
 		// Get consistency proof.
-		req := &trillian.GetConsistencyProofRequest{
-			LogId:          c.LogID,
-			FirstTreeSize:  c.root.TreeSize,
-			SecondTreeSize: str.TreeSize,
-		}
-		proof, err := c.client.GetConsistencyProof(ctx, req)
+		consistency, err = c.client.GetConsistencyProof(ctx,
+			&trillian.GetConsistencyProofRequest{
+				LogId:          c.LogID,
+				FirstTreeSize:  c.root.TreeSize,
+				SecondTreeSize: resp.SignedLogRoot.TreeSize,
+			})
 		if err != nil {
 			return err
 		}
-		// Verify consistency proof.
-		v := merkle.NewLogVerifier(c.hasher)
-		if err := v.VerifyConsistencyProof(
-			c.root.TreeSize, str.TreeSize,
-			c.root.RootHash, str.RootHash,
-			convertProof(proof.Proof)); err != nil {
-			return err
-		}
 	}
-	c.root = *str
+
+	// Verify Consistency proof.
+	if err := c.LogVerifier.UpdateRoot(resp, consistency); err != nil {
+		return err
+	}
 	return nil
 }
 
 // VerifyInclusion updates the log root and ensures that the given leaf data has been included in the log.
 func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
-	leaf := c.buildLeaf(data)
+	leaf := c.LogVerifier.buildLeaf(data)
 	if err := c.UpdateRoot(ctx); err != nil {
 		return fmt.Errorf("UpdateRoot(): %v", err)
 	}
@@ -235,33 +211,28 @@ func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 
 // VerifyInclusionAtIndex updates the log root and ensures that the given leaf data has been included in the log at a particular index.
 func (c *LogClient) VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
-	leaf := c.buildLeaf(data)
 	if err := c.UpdateRoot(ctx); err != nil {
 		return fmt.Errorf("UpdateRoot(): %v", err)
 	}
-	req := &trillian.GetInclusionProofRequest{
-		LogId:     c.LogID,
-		LeafIndex: index,
-		TreeSize:  c.root.TreeSize,
-	}
-	resp, err := c.client.GetInclusionProof(ctx, req)
+	resp, err := c.client.GetInclusionProof(ctx,
+		&trillian.GetInclusionProofRequest{
+			LogId:     c.LogID,
+			LeafIndex: index,
+			TreeSize:  c.root.TreeSize,
+		})
 	if err != nil {
 		return err
 	}
-
-	v := merkle.NewLogVerifier(c.hasher)
-	return v.VerifyInclusionProof(req.LeafIndex, req.TreeSize,
-		convertProof(resp.Proof), c.root.RootHash,
-		leaf.MerkleLeafHash)
+	return c.LogVerifier.VerifyInclusionAtIndex(data, index, resp)
 }
 
 func (c *LogClient) getInclusionProof(ctx context.Context, leafHash []byte, treeSize int64) error {
-	req := &trillian.GetInclusionProofByHashRequest{
-		LogId:    c.LogID,
-		LeafHash: leafHash,
-		TreeSize: treeSize,
-	}
-	resp, err := c.client.GetInclusionProofByHash(ctx, req)
+	resp, err := c.client.GetInclusionProofByHash(ctx,
+		&trillian.GetInclusionProofByHashRequest{
+			LogId:    c.LogID,
+			LeafHash: leafHash,
+			TreeSize: treeSize,
+		})
 	if err != nil {
 		return err
 	}
@@ -269,33 +240,11 @@ func (c *LogClient) getInclusionProof(ctx context.Context, leafHash []byte, tree
 		return errors.New("no inclusion proof supplied")
 	}
 	for _, proof := range resp.Proof {
-		neighbors := convertProof(proof)
-		v := merkle.NewLogVerifier(c.hasher)
-		if err := v.VerifyInclusionProof(proof.LeafIndex, treeSize, neighbors, c.root.RootHash, leafHash); err != nil {
+		if err := c.LogVerifier.VerifyInclusionByHash(leafHash, proof); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// convertProof returns a slice of neighbor nodes from a trillian Proof.
-// TODO(martin): adjust the public API to do this in the server before returning a proof.
-func convertProof(proof *trillian.Proof) [][]byte {
-	neighbors := make([][]byte, len(proof.ProofNode))
-	for i, node := range proof.ProofNode {
-		neighbors[i] = node.NodeHash
-	}
-	return neighbors
-}
-
-func (c *LogClient) buildLeaf(data []byte) *trillian.LogLeaf {
-	hash := sha256.Sum256(data)
-	leaf := &trillian.LogLeaf{
-		LeafValue:        data,
-		MerkleLeafHash:   c.hasher.HashLeaf(data),
-		LeafIdentityHash: hash[:],
-	}
-	return leaf
 }
 
 func (c *LogClient) queueLeaf(ctx context.Context, leaf *trillian.LogLeaf) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -239,6 +239,14 @@ func TestUpdateRoot(t *testing.T) {
 
 	before := client.Root().TreeSize
 
+	// UpdateRoot should succeed with no change.
+	if err := client.UpdateRoot(ctx); err != nil {
+		t.Error(err)
+	}
+	if got, want := client.Root().TreeSize, before; got != want {
+		t.Errorf("Tree size changed unexpectedly: %v, want %v", got, want)
+	}
+
 	// Add the leaf without polling for inclusion.
 	leaf := client.buildLeaf([]byte("foo"))
 	if err := client.queueLeaf(ctx, leaf); err != nil {

--- a/client/interface.go
+++ b/client/interface.go
@@ -45,3 +45,19 @@ type VerifyingLogClient interface {
 	// ListByIndex returns a contiguous range. Does not verify the leaf's inclusion proof.
 	ListByIndex(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error)
 }
+
+// LogVerifier verifies responses from a Trillian Log.
+type LogVerifier interface {
+	// Root provides the last root obtained by UpdateRoot.
+	Root() trillian.SignedLogRoot
+	// UpdateRoot applies a GetLatestSignedLogRootResponse to Root(), if valid.
+	// consistency may be nil if Root().TreeSize is zero.
+	UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
+		consistency *trillian.GetConsistencyProofResponse) error
+	// VerifyInclusionAtIndex verifies that the inclusion proof for data at index matches
+	// the currently trusted root. The inclusion proof must be requested for Root().TreeSize.
+	VerifyInclusionAtIndex(data []byte, leafIndex int64,
+		resp *trillian.GetInclusionProofResponse) error
+	// VerifyInclusionByHash verifies the inclusion proof for data
+	VerifyInclusionByHash(leafHash []byte, proof *trillian.Proof) error
+}

--- a/client/offline.go
+++ b/client/offline.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"crypto"
+	"crypto/sha256"
+
+	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
+	"github.com/google/trillian/merkle"
+)
+
+// LogVerifier contains state needed to verify output from Trillian Logs.
+type LogVerifier struct {
+	hasher merkle.TreeHasher
+	pubKey crypto.PublicKey
+	root   trillian.SignedLogRoot
+	v      merkle.LogVerifier
+}
+
+// NewLogVerifier returns an object that can verify output from Trillian Logs.
+func NewLogVerifier(hasher merkle.TreeHasher, pubKey crypto.PublicKey) *LogVerifier {
+	return &LogVerifier{
+		hasher: hasher,
+		pubKey: pubKey,
+		v:      merkle.NewLogVerifier(hasher),
+	}
+}
+
+// Root returns the last valid root seen by UpdateRoot.
+// Returns an empty SignedLogRoot if UpdateRoot has not been called.
+func (c *LogVerifier) Root() trillian.SignedLogRoot {
+	return c.root
+}
+
+// UpdateRoot applies a GetLatestSignedLogRootResponse to Root(), if valid.
+func (c *LogVerifier) UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
+	consistency *trillian.GetConsistencyProofResponse) error {
+	str := resp.SignedLogRoot
+
+	// Verify SignedLogRoot signature.
+	hash := tcrypto.HashLogRoot(*str)
+	if err := tcrypto.Verify(c.pubKey, hash, str.Signature); err != nil {
+		return err
+	}
+
+	// Implicitly trust the first root we get.
+	if c.root.TreeSize != 0 {
+		// Verify consistency proof.
+		if err := c.v.VerifyConsistencyProof(
+			c.root.TreeSize, str.TreeSize,
+			c.root.RootHash, str.RootHash,
+			convertProof(consistency.GetProof())); err != nil {
+			return err
+		}
+	}
+	c.root = *str
+	return nil
+}
+
+// VerifyInclusionAtIndex verifies that the inclusion proof for data at index matches the currently trusted root.
+func (c *LogVerifier) VerifyInclusionAtIndex(data []byte, leafIndex int64, resp *trillian.GetInclusionProofResponse) error {
+	leaf := c.buildLeaf(data)
+	// XXX: c.root.TreeSize used to be req.TreeSize.
+	return c.v.VerifyInclusionProof(leafIndex, c.root.TreeSize,
+		convertProof(resp.Proof), c.root.RootHash,
+		leaf.MerkleLeafHash)
+
+}
+
+// VerifyInclusionByHash verifies the inclusion proof for data with Tril
+func (c *LogVerifier) VerifyInclusionByHash(leafHash []byte, proof *trillian.Proof) error {
+	neighbors := convertProof(proof)
+	return c.v.VerifyInclusionProof(proof.LeafIndex, c.root.TreeSize, neighbors,
+		c.root.RootHash, leafHash)
+}
+
+func (c *LogVerifier) buildLeaf(data []byte) *trillian.LogLeaf {
+	hash := sha256.Sum256(data)
+	return &trillian.LogLeaf{
+		LeafValue:        data,
+		MerkleLeafHash:   c.hasher.HashLeaf(data),
+		LeafIdentityHash: hash[:],
+	}
+}
+
+// convertProof returns a slice of neighbor nodes from a trillian Proof.
+// TODO(martin): adjust the public API to do this in the server before returning a proof.
+func convertProof(proof *trillian.Proof) [][]byte {
+	if proof == nil {
+		return [][]byte{}
+	}
+	neighbors := make([][]byte, len(proof.ProofNode))
+	for i, node := range proof.ProofNode {
+		neighbors[i] = node.NodeHash
+	}
+	return neighbors
+}

--- a/client/offline.go
+++ b/client/offline.go
@@ -23,8 +23,8 @@ import (
 	"github.com/google/trillian/merkle"
 )
 
-// LogVerifier contains state needed to verify output from Trillian Logs.
-type LogVerifier struct {
+// logVerifier contains state needed to verify output from Trillian Logs.
+type logVerifier struct {
 	hasher merkle.TreeHasher
 	pubKey crypto.PublicKey
 	root   trillian.SignedLogRoot
@@ -32,8 +32,8 @@ type LogVerifier struct {
 }
 
 // NewLogVerifier returns an object that can verify output from Trillian Logs.
-func NewLogVerifier(hasher merkle.TreeHasher, pubKey crypto.PublicKey) *LogVerifier {
-	return &LogVerifier{
+func NewLogVerifier(hasher merkle.TreeHasher, pubKey crypto.PublicKey) LogVerifier {
+	return &logVerifier{
 		hasher: hasher,
 		pubKey: pubKey,
 		v:      merkle.NewLogVerifier(hasher),
@@ -42,13 +42,13 @@ func NewLogVerifier(hasher merkle.TreeHasher, pubKey crypto.PublicKey) *LogVerif
 
 // Root returns the last valid root seen by UpdateRoot.
 // Returns an empty SignedLogRoot if UpdateRoot has not been called.
-func (c *LogVerifier) Root() trillian.SignedLogRoot {
+func (c *logVerifier) Root() trillian.SignedLogRoot {
 	return c.root
 }
 
 // UpdateRoot applies a GetLatestSignedLogRootResponse to Root(), if valid.
 // consistency may be nil if Root().TreeSize is zero.
-func (c *LogVerifier) UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
+func (c *logVerifier) UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
 	consistency *trillian.GetConsistencyProofResponse) error {
 	str := resp.SignedLogRoot
 
@@ -74,7 +74,7 @@ func (c *LogVerifier) UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
 
 // VerifyInclusionAtIndex verifies that the inclusion proof for data at index matches
 // the currently trusted root. The inclusion proof must be requested for Root().TreeSize.
-func (c *LogVerifier) VerifyInclusionAtIndex(data []byte, leafIndex int64, resp *trillian.GetInclusionProofResponse) error {
+func (c *logVerifier) VerifyInclusionAtIndex(data []byte, leafIndex int64, resp *trillian.GetInclusionProofResponse) error {
 	leaf := c.buildLeaf(data)
 	return c.v.VerifyInclusionProof(leafIndex, c.root.TreeSize,
 		proofNodeHashes(resp.Proof), c.root.RootHash,
@@ -82,14 +82,14 @@ func (c *LogVerifier) VerifyInclusionAtIndex(data []byte, leafIndex int64, resp 
 
 }
 
-// VerifyInclusionByHash verifies the inclusion proof for data with Tril
-func (c *LogVerifier) VerifyInclusionByHash(leafHash []byte, proof *trillian.Proof) error {
+// VerifyInclusionByHash verifies the inclusion proof for data
+func (c *logVerifier) VerifyInclusionByHash(leafHash []byte, proof *trillian.Proof) error {
 	neighbors := proofNodeHashes(proof)
 	return c.v.VerifyInclusionProof(proof.LeafIndex, c.root.TreeSize, neighbors,
 		c.root.RootHash, leafHash)
 }
 
-func (c *LogVerifier) buildLeaf(data []byte) *trillian.LogLeaf {
+func (c *logVerifier) buildLeaf(data []byte) *trillian.LogLeaf {
 	hash := sha256.Sum256(data)
 	return &trillian.LogLeaf{
 		LeafValue:        data,


### PR DESCRIPTION
Personalitites will proxy responses from trillian logs back to their
callers. These callers will need a client that can verify those
responses even though they can't reach out and talk to the trillian log
itself.