### PR TITLE
Ignore storage_settings on Create/Update tests in AdminStorageTester

### DIFF
--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -159,6 +159,8 @@ func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 			wantTree.TreeId = newTree.TreeId
 			wantTree.CreateTimeMillisSinceEpoch = createTimeMillis
 			wantTree.UpdateTimeMillisSinceEpoch = updateTimeMillis
+			// Ignore storage_settings changes (OK to vary between implementations)
+			wantTree.StorageSettings = newTree.StorageSettings
 			if !proto.Equal(newTree, &wantTree) {
 				diff := pretty.Compare(newTree, &wantTree)
 				t.Errorf("%v: post-CreateTree diff:\n%v", test.desc, diff)
@@ -302,6 +304,8 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 		wantTree.TreeId = updatedTree.TreeId
 		wantTree.CreateTimeMillisSinceEpoch = updatedTree.CreateTimeMillisSinceEpoch
 		wantTree.UpdateTimeMillisSinceEpoch = updatedTree.UpdateTimeMillisSinceEpoch
+		// Ignore storage_settings changes (OK to vary between implementations)
+		wantTree.StorageSettings = updatedTree.StorageSettings
 		if !proto.Equal(updatedTree, &wantTree) {
 			diff := pretty.Compare(updatedTree, &wantTree)
 			t.Errorf("%v: updatedTree doesn't match wantTree:\n%s", test.desc, diff)


### PR DESCRIPTION
storage_settings is implementation based and may be set to reasonable defaults
even if not provided in the request.