### PR TITLE
Use context-aware database/sql methods

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -210,18 +210,18 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	if !params.skipDequeue {
 		if params.overrideDequeueTime != nil {
-			mockTx.EXPECT().DequeueLeaves(params.dequeueLimit, *params.overrideDequeueTime).Return(params.dequeuedLeaves, params.dequeuedError)
+			mockTx.EXPECT().DequeueLeaves(gomock.Any(), params.dequeueLimit, *params.overrideDequeueTime).Return(params.dequeuedLeaves, params.dequeuedError)
 		} else {
-			mockTx.EXPECT().DequeueLeaves(params.dequeueLimit, fakeTimeForTest).Return(params.dequeuedLeaves, params.dequeuedError)
+			mockTx.EXPECT().DequeueLeaves(gomock.Any(), params.dequeueLimit, fakeTimeForTest).Return(params.dequeuedLeaves, params.dequeuedError)
 		}
 	}
 
 	if params.latestSignedRoot != nil {
-		mockTx.EXPECT().LatestSignedLogRoot().Return(*params.latestSignedRoot, params.latestSignedRootError)
+		mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*params.latestSignedRoot, params.latestSignedRootError)
 	}
 
 	if params.updatedLeaves != nil {
-		mockTx.EXPECT().UpdateSequencedLeaves(*params.updatedLeaves).Return(params.updatedLeavesError)
+		mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), *params.updatedLeaves).Return(params.updatedLeavesError)
 	}
 
 	if params.merkleNodesSet != nil {
@@ -230,10 +230,10 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	if !params.skipStoreSignedRoot {
 		if params.storeSignedRoot != nil {
-			mockTx.EXPECT().StoreSignedLogRoot(*params.storeSignedRoot).Return(params.storeSignedRootError)
+			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), *params.storeSignedRoot).Return(params.storeSignedRootError)
 		} else {
 			// At the moment if we're going to fail the operation we accept any root
-			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any()).Return(params.storeSignedRootError)
+			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), gomock.Any()).Return(params.storeSignedRootError)
 		}
 	}
 

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -209,7 +209,7 @@ func (l *LogOperationManager) getLogIDs(ctx context.Context) ([]int64, error) {
 	}
 	defer tx.Close()
 
-	logIDs, err := tx.GetActiveLogIDs()
+	logIDs, err := tx.GetActiveLogIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active logIDs: %v", err)
 	}

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -65,7 +65,7 @@ func TestLogOperationManagerGetLogsFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
-	mockTx.EXPECT().GetActiveLogIDs().Return(nil, errors.New("getactivelogs"))
+	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return(nil, errors.New("getactivelogs"))
 	mockTx.EXPECT().Close().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
@@ -88,7 +88,7 @@ func TestLogOperationManagerCommitFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
-	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{}, nil)
+	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return([]int64{}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("commit"))
 	mockTx.EXPECT().Close().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)
@@ -131,7 +131,7 @@ func TestLogOperationManagerPassesIDs(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
-	mockTx.EXPECT().GetActiveLogIDs().Return([]int64{logID1, logID2}, nil)
+	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return([]int64{logID1, logID2}, nil)
 	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
 	mockTx.EXPECT().Close().AnyTimes().Return(nil)
 	mockStorage := storage.NewMockLogStorage(ctrl)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -94,7 +94,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	}
 	defer tx.Close()
 
-	existingLeaves, err := tx.QueueLeaves(req.Leaves, t.timeSource.Now())
+	existingLeaves, err := tx.QueueLeaves(ctx, req.Leaves, t.timeSource.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 	}
 	defer tx.Close()
 
-	root, err := tx.LatestSignedLogRoot()
+	root, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 
 	// Find the leaf index of the supplied hash
 	leafHashes := [][]byte{req.LeafHash}
-	leaves, err := tx.GetLeavesByHash(leafHashes, req.OrderBySequence)
+	leaves, err := tx.GetLeavesByHash(ctx, leafHashes, req.OrderBySequence)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 		return nil, status.Errorf(codes.NotFound, "No leaves for hash: %x", req.LeafHash)
 	}
 
-	root, err := tx.LatestSignedLogRoot()
+	root, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 	}
 	defer tx.Close()
 
-	root, err := tx.LatestSignedLogRoot()
+	root, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ func (t *TrillianLogRPCServer) GetLatestSignedLogRoot(ctx context.Context, req *
 	}
 	defer tx.Close()
 
-	signedRoot, err := tx.LatestSignedLogRoot()
+	signedRoot, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (t *TrillianLogRPCServer) GetSequencedLeafCount(ctx context.Context, req *t
 	}
 	defer tx.Close()
 
-	leafCount, err := tx.GetSequencedLeafCount()
+	leafCount, err := tx.GetSequencedLeafCount(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 	}
 	defer tx.Close()
 
-	leaves, err := tx.GetLeavesByIndex(req.LeafIndex)
+	leaves, err := tx.GetLeavesByIndex(ctx, req.LeafIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 // entries so this may return more results than the number of hashes in the request.
 func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillian.GetLeavesByHashRequest) (*trillian.GetLeavesByHashResponse, error) {
 	return t.getLeavesByHashInternal(ctx, "GetLeavesByHash", req, func(tx storage.ReadOnlyLogTreeTX, hashes [][]byte, sequenceOrder bool) ([]*trillian.LogLeaf, error) {
-		return tx.GetLeavesByHash(hashes, sequenceOrder)
+		return tx.GetLeavesByHash(ctx, hashes, sequenceOrder)
 	})
 }
 
@@ -364,7 +364,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 	}
 	defer tx.Close()
 
-	root, err := tx.LatestSignedLogRoot()
+	root, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 	}
 
 	// We also need the leaf entry
-	leaves, err := tx.GetLeavesByIndex([]int64{req.LeafIndex})
+	leaves, err := tx.GetLeavesByIndex(ctx, []int64{req.LeafIndex})
 	if err != nil {
 		return nil, err
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -112,7 +112,7 @@ func TestGetLeavesByIndexStorageError(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetLeavesByIndex", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetLeavesByIndex([]int64{0}).Return(nil, errors.New("STORAGE"))
+			t.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return(nil, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLeavesByIndex(context.Background(), &leaf0Request)
@@ -142,7 +142,7 @@ func TestGetLeavesByIndexCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetLeavesByIndex", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetLeavesByIndex([]int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
+			t.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLeavesByIndex(context.Background(), &leaf0Request)
@@ -159,7 +159,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().GetLeavesByIndex([]int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -187,7 +187,7 @@ func TestGetLeavesByIndexMultiple(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf03Request.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().GetLeavesByIndex([]int64{0, 3}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0, 3}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -222,7 +222,7 @@ func TestQueueLeavesStorageError(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "QueueLeaves", readWrite,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return(nil, errors.New("STORAGE"))
+			t.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return(nil, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.QueueLeaves(context.Background(), &queueRequest0)
@@ -252,7 +252,7 @@ func TestQueueLeavesCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "QueueLeaves", readWrite,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
+			t.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.QueueLeaves(context.Background(), &queueRequest0)
@@ -270,7 +270,7 @@ func TestQueueLeaves(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
+	mockTx.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -300,7 +300,7 @@ func TestQueueLeaves(t *testing.T) {
 	// Repeating the operation gives ALREADY_EXISTS.
 	server.registry.AdminStorage = mockAdminStorage(ctrl, queueRequest0.LogId)
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().QueueLeaves([]*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{leaf1}, nil)
+	mockTx.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -372,7 +372,7 @@ func TestGetLatestSignedLogRootStorageFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "LatestSignedLogRoot", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(trillian.SignedLogRoot{}, errors.New("STORAGE"))
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(trillian.SignedLogRoot{}, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLatestSignedLogRoot(context.Background(), &getLogRootRequest1)
@@ -388,7 +388,7 @@ func TestGetLatestSignedLogRootCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "LatestSignedLogRoot", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(trillian.SignedLogRoot{}, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(trillian.SignedLogRoot{}, nil)
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLatestSignedLogRoot(context.Background(), &getLogRootRequest1)
@@ -419,7 +419,7 @@ func TestGetLatestSignedLogRoot(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getLogRootRequest1.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -490,7 +490,7 @@ func TestGetLeavesByHashStorageFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetLeavesByHash", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetLeavesByHash([][]byte{[]byte("test"), []byte("data")}, false).Return(nil, errors.New("STORAGE"))
+			t.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLeavesByHash(context.Background(), &getByHashRequest1)
@@ -506,7 +506,7 @@ func TestLeavesByHashCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetLeavesByHash", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetLeavesByHash([][]byte{[]byte("test"), []byte("data")}, false).Return(nil, nil)
+			t.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, nil)
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetLeavesByHash(context.Background(), &getByHashRequest1)
@@ -537,7 +537,7 @@ func TestGetLeavesByHash(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId).Return(mockTx, nil)
-	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("test"), []byte("data")}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
+	mockTx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -577,7 +577,7 @@ func TestGetProofByHashNoLeafForHash(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetInclusionProofByHash", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return(nil, errors.New("STORAGE"))
+			t.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(nil, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetInclusionProofByHash(context.Background(), &getInclusionProofByHashRequest25)
@@ -593,9 +593,9 @@ func TestGetProofByHashGetNodesFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetInclusionProofByHash", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
-			t.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+			t.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
@@ -614,9 +614,9 @@ func TestGetProofByHashWrongNodeCountFetched(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
-	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+	mockTx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 	// The server expects three nodes from storage but we return only two
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -641,9 +641,9 @@ func TestGetProofByHashWrongNodeReturned(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
-	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+	mockTx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 	// We set this up so one of the returned nodes has the wrong ID
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: testonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -666,9 +666,9 @@ func TestGetProofByHashCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetInclusionProofByHash", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
-			t.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+			t.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 		},
 		func(s *TrillianLogRPCServer) error {
@@ -687,9 +687,9 @@ func TestGetProofByHash(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
-	mockTx.EXPECT().GetLeavesByHash([][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+	mockTx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
@@ -743,7 +743,7 @@ func TestGetProofByIndexGetNodesFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetInclusionProof", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("STORAGE"))
 		},
@@ -764,7 +764,7 @@ func TestGetProofByIndexWrongNodeCountFetched(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId).Return(mockTx, nil)
 
 	// The server expects three nodes from storage but we return only two
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -790,7 +790,7 @@ func TestGetProofByIndexWrongNodeReturned(t *testing.T) {
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId).Return(mockTx, nil)
 
 	// We set this up so one of the returned nodes has the wrong ID
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: testonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -813,7 +813,7 @@ func TestGetProofByIndexCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetInclusionProof", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 		},
@@ -833,7 +833,7 @@ func TestGetProofByIndex(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
@@ -894,7 +894,7 @@ func TestGetEntryAndProofGetMerkleNodesFails(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("GetNodes"))
 	mockTx.EXPECT().Close().Return(nil)
@@ -919,13 +919,13 @@ func TestGetEntryAndProofGetLeavesFails(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
-	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return(nil, errors.New("GetLeaves"))
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return(nil, errors.New("GetLeaves"))
 	mockTx.EXPECT().Close().Return(nil)
 
 	registry := extension.Registry{
@@ -948,14 +948,14 @@ func TestGetEntryAndProofGetLeavesReturnsMultiple(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 	// Code passed one leaf index so expects one result, but we return more
-	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Close().Return(nil)
 
 	registry := extension.Registry{
@@ -978,13 +978,13 @@ func TestGetEntryAndProofCommitFails(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
-	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("COMMIT"))
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -1008,13 +1008,13 @@ func TestGetEntryAndProof(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 		{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 		{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 		{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
-	mockTx.EXPECT().GetLeavesByIndex([]int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
+	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -1066,7 +1066,7 @@ func TestGetSequencedLeafCountStorageFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetSequencedLeafCount", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetSequencedLeafCount().Return(int64(0), errors.New("STORAGE"))
+			t.EXPECT().GetSequencedLeafCount(gomock.Any()).Return(int64(0), errors.New("STORAGE"))
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetSequencedLeafCount(context.Background(), &trillian.GetSequencedLeafCountRequest{LogId: logID1})
@@ -1082,7 +1082,7 @@ func TestGetSequencedLeafCountCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetSequencedLeafCount", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().GetSequencedLeafCount().Return(int64(27), nil)
+			t.EXPECT().GetSequencedLeafCount(gomock.Any()).Return(int64(27), nil)
 		},
 		func(s *TrillianLogRPCServer) error {
 			_, err := s.GetSequencedLeafCount(context.Background(), &trillian.GetSequencedLeafCountRequest{LogId: logID1})
@@ -1100,7 +1100,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID1).Return(mockTx, nil)
 
-	mockTx.EXPECT().GetSequencedLeafCount().Return(int64(268), nil)
+	mockTx.EXPECT().GetSequencedLeafCount(gomock.Any()).Return(int64(268), nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 
@@ -1140,7 +1140,7 @@ func TestGetConsistencyProofGetNodesFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{}, errors.New("STORAGE"))
 		},
@@ -1160,7 +1160,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongCount(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getConsistencyProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	// The server expects one node from storage but we return two
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
@@ -1186,7 +1186,7 @@ func TestGetConsistencyProofGetNodesReturnsWrongNode(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getConsistencyProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	// Return an unexpected node that wasn't requested
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(1, 2, 64), NodeRevision: 3}}, nil)
@@ -1210,7 +1210,7 @@ func TestGetConsistencyProofCommitFails(t *testing.T) {
 
 	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
 		func(t *storage.MockLogTreeTX) {
-			t.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+			t.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			t.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 			t.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3}}, nil)
 		},
@@ -1230,7 +1230,7 @@ func TestGetConsistencyProof(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getConsistencyProofRequest7.LogId).Return(mockTx, nil)
 
-	mockTx.EXPECT().LatestSignedLogRoot().Return(signedRoot1, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
 	mockTx.EXPECT().GetMerkleNodes(revision1, nodeIdsConsistencySize4ToSize7).Return([]storage.Node{{NodeID: testonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}}, nil)
 	mockTx.EXPECT().Commit().Return(nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -125,8 +125,8 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
-	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
-	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]*trillian.LogLeaf{}, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil)
+	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil)
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
@@ -168,8 +168,8 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 		gomock.InOrder(
 			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil),
-			mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
-			mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil),
+			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
+			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),
 			mockTx.EXPECT().Commit().Return(nil),
 			mockTx.EXPECT().Close().Return(nil),
@@ -259,11 +259,11 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(testRoot0.TreeRevision + 1)
-	mockTx.EXPECT().DequeueLeaves(50, fakeTime).Return([]*trillian.LogLeaf{testLeaf0}, nil)
-	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
-	mockTx.EXPECT().UpdateSequencedLeaves([]*trillian.LogLeaf{testLeaf0Updated}).Return(nil)
+	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{testLeaf0}, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil)
+	mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), []*trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(updatedNodes0).Return(nil)
-	mockTx.EXPECT().StoreSignedLogRoot(updatedRoot).Return(nil)
+	mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), updatedRoot).Return(nil)
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
@@ -304,9 +304,9 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
-	mockTx.EXPECT().LatestSignedLogRoot().Return(testRoot0, nil)
+	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil)
 	// Expect a 5 second guard window to be passed from manager -> sequencer -> storage
-	mockTx.EXPECT().DequeueLeaves(50, fakeTime.Add(-time.Second*5)).Return([]*trillian.LogLeaf{}, nil)
+	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime.Add(-time.Second*5)).Return([]*trillian.LogLeaf{}, nil)
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)

--- a/server/vmap/trillian_map_server.go
+++ b/server/vmap/trillian_map_server.go
@@ -64,7 +64,7 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 	var root *trillian.SignedMapRoot
 	if req.Revision < 0 {
 		// need to know the newest published revision
-		r, err := tx.LatestSignedMapRoot()
+		r, err := tx.LatestSignedMapRoot(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +74,7 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 
 	smtReader := merkle.NewSparseMerkleTreeReader(req.Revision, hasher, tx)
 
-	leaves, err := tx.Get(req.Revision, req.Index)
+	leaves, err := tx.Get(ctx, req.Revision, req.Index)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		// TODO(gbelvin) use LeafHash rather than computing here.
 		l.LeafHash = hasher.HashLeaf(l.LeafValue)
 
-		if err = tx.Set(l.Index, *l); err != nil {
+		if err = tx.Set(ctx, l.Index, *l); err != nil {
 			return nil, err
 		}
 		if err = smtWriter.SetLeaves([]merkle.HashKeyValue{
@@ -157,7 +157,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 	}
 
 	// TODO(al): need an smtWriter.Rollback() or similar I think.
-	if err = tx.StoreSignedMapRoot(newRoot); err != nil {
+	if err = tx.StoreSignedMapRoot(ctx, newRoot); err != nil {
 		return nil, err
 	}
 
@@ -179,7 +179,7 @@ func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.
 	}
 	defer tx.Close()
 
-	r, err := tx.LatestSignedMapRoot()
+	r, err := tx.LatestSignedMapRoot(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -94,7 +94,7 @@ type LeafQueuer interface {
 	//  - nil otherwise.
 	// Duplicates are only reported if the underlying tree does not permit duplicates, and are
 	// considered duplicate if their leaf.LeafIdentityHash matches.
-	QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error)
+	QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error)
 }
 
 // LeafDequeuer provides an interface for reading previously queued leaves for integration into the tree.
@@ -103,41 +103,41 @@ type LeafDequeuer interface {
 	// Leaves which have been dequeued within a Rolled-back Tx will become available for dequeing again.
 	// Leaves queued more recently than the cutoff time will not be returned. This allows for
 	// guard intervals to be configured.
-	DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error)
-	UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error
+	DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error)
+	UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error
 }
 
 // LeafReader provides a read only interface to stored tree leaves
 type LeafReader interface {
 	// GetSequencedLeafCount returns the total number of leaves that have been integrated into the
 	// tree via sequencing.
-	GetSequencedLeafCount() (int64, error)
+	GetSequencedLeafCount(ctx context.Context) (int64, error)
 	// GetLeavesByIndex returns leaf metadata and data for a set of specified sequenced leaf indexes.
-	GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error)
+	GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error)
 	// GetLeavesByHash looks up sequenced leaf metadata and data by their Merkle leaf hash. If the
 	// tree permits duplicate leaves callers must be prepared to handle multiple results with the
 	// same hash but different sequence numbers. If orderBySequence is true then the returned data
 	// will be in ascending sequence number order.
-	GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error)
+	GetLeavesByHash(ctx context.Context, leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error)
 }
 
 // LogRootReader provides an interface for reading SignedLogRoots.
 type LogRootReader interface {
 	// LatestSignedLogRoot returns the most recent SignedLogRoot, if any.
-	LatestSignedLogRoot() (trillian.SignedLogRoot, error)
+	LatestSignedLogRoot(ctx context.Context) (trillian.SignedLogRoot, error)
 }
 
 // LogRootWriter provides an interface for storing new SignedLogRoots.
 type LogRootWriter interface {
 	// StoreSignedLogRoot stores a freshly created SignedLogRoot.
-	StoreSignedLogRoot(root trillian.SignedLogRoot) error
+	StoreSignedLogRoot(ctx context.Context, root trillian.SignedLogRoot) error
 }
 
 // LogMetadata provides access to information about the logs in storage
 type LogMetadata interface {
 	// GetActiveLogs returns a list of the IDs of all the logs that are configured in storage
-	GetActiveLogIDs() ([]int64, error)
+	GetActiveLogIDs(ctx context.Context) ([]int64, error)
 	// GetActiveLogIDsWithPendingWork returns a list of IDs of logs that have
 	// pending queued leaves that need to be integrated into the log.
-	GetActiveLogIDsWithPendingWork() ([]int64, error)
+	GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error)
 }

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -82,7 +82,7 @@ type MapStorage interface {
 // Setter allows the setting of key->value pairs on the map.
 type Setter interface {
 	// Set sets key to leaf
-	Set(keyHash []byte, value trillian.MapLeaf) error
+	Set(ctx context.Context, keyHash []byte, value trillian.MapLeaf) error
 }
 
 // Getter allows access to the values stored in the map.
@@ -93,17 +93,17 @@ type Getter interface {
 	// The returned array of MapLeaves will only contain entries for which values
 	// exist.  i.e. requesting a set of unknown keys would result in a
 	// zero-length array being returned.
-	Get(revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, error)
+	Get(ctx context.Context, revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, error)
 }
 
 // MapRootReader provides access to the map roots.
 type MapRootReader interface {
 	// LatestSignedMapRoot returns the most recently created SignedMapRoot.
-	LatestSignedMapRoot() (trillian.SignedMapRoot, error)
+	LatestSignedMapRoot(ctx context.Context) (trillian.SignedMapRoot, error)
 }
 
 // MapRootWriter allows the storage of new SignedMapRoots
 type MapRootWriter interface {
 	// StoreSignedMapRoot stores root.
-	StoreSignedMapRoot(root trillian.SignedMapRoot) error
+	StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error
 }

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -548,15 +548,15 @@ func (_mr *_MockMapTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockMapTreeTX) Get(_param0 int64, _param1 [][]byte) ([]trillian.MapLeaf, error) {
-	ret := _m.ctrl.Call(_m, "Get", _param0, _param1)
+func (_m *MockMapTreeTX) Get(_param0 context.Context, _param1 int64, _param2 [][]byte) ([]trillian.MapLeaf, error) {
+	ret := _m.ctrl.Call(_m, "Get", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]trillian.MapLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMapTreeTXRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockMapTreeTXRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockMapTreeTX) GetMerkleNodes(_param0 int64, _param1 []NodeID) ([]Node, error) {
@@ -580,15 +580,15 @@ func (_mr *_MockMapTreeTXRecorder) IsOpen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOpen")
 }
 
-func (_m *MockMapTreeTX) LatestSignedMapRoot() (trillian.SignedMapRoot, error) {
-	ret := _m.ctrl.Call(_m, "LatestSignedMapRoot")
+func (_m *MockMapTreeTX) LatestSignedMapRoot(_param0 context.Context) (trillian.SignedMapRoot, error) {
+	ret := _m.ctrl.Call(_m, "LatestSignedMapRoot", _param0)
 	ret0, _ := ret[0].(trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMapTreeTXRecorder) LatestSignedMapRoot() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedMapRoot")
+func (_mr *_MockMapTreeTXRecorder) LatestSignedMapRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedMapRoot", arg0)
 }
 
 func (_m *MockMapTreeTX) ReadRevision() int64 {
@@ -611,14 +611,14 @@ func (_mr *_MockMapTreeTXRecorder) Rollback() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Rollback")
 }
 
-func (_m *MockMapTreeTX) Set(_param0 []byte, _param1 trillian.MapLeaf) error {
-	ret := _m.ctrl.Call(_m, "Set", _param0, _param1)
+func (_m *MockMapTreeTX) Set(_param0 context.Context, _param1 []byte, _param2 trillian.MapLeaf) error {
+	ret := _m.ctrl.Call(_m, "Set", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMapTreeTXRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0, arg1)
+func (_mr *_MockMapTreeTXRecorder) Set(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0, arg1, arg2)
 }
 
 func (_m *MockMapTreeTX) SetMerkleNodes(_param0 []Node) error {
@@ -631,14 +631,14 @@ func (_mr *_MockMapTreeTXRecorder) SetMerkleNodes(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMerkleNodes", arg0)
 }
 
-func (_m *MockMapTreeTX) StoreSignedMapRoot(_param0 trillian.SignedMapRoot) error {
-	ret := _m.ctrl.Call(_m, "StoreSignedMapRoot", _param0)
+func (_m *MockMapTreeTX) StoreSignedMapRoot(_param0 context.Context, _param1 trillian.SignedMapRoot) error {
+	ret := _m.ctrl.Call(_m, "StoreSignedMapRoot", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMapTreeTXRecorder) StoreSignedMapRoot(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedMapRoot", arg0)
+func (_mr *_MockMapTreeTXRecorder) StoreSignedMapRoot(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedMapRoot", arg0, arg1)
 }
 
 func (_m *MockMapTreeTX) WriteRevision() int64 {
@@ -985,15 +985,15 @@ func (_mr *_MockReadOnlyMapTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockReadOnlyMapTreeTX) Get(_param0 int64, _param1 [][]byte) ([]trillian.MapLeaf, error) {
-	ret := _m.ctrl.Call(_m, "Get", _param0, _param1)
+func (_m *MockReadOnlyMapTreeTX) Get(_param0 context.Context, _param1 int64, _param2 [][]byte) ([]trillian.MapLeaf, error) {
+	ret := _m.ctrl.Call(_m, "Get", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]trillian.MapLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyMapTreeTXRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockReadOnlyMapTreeTXRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockReadOnlyMapTreeTX) GetMerkleNodes(_param0 int64, _param1 []NodeID) ([]Node, error) {
@@ -1017,15 +1017,15 @@ func (_mr *_MockReadOnlyMapTreeTXRecorder) IsOpen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOpen")
 }
 
-func (_m *MockReadOnlyMapTreeTX) LatestSignedMapRoot() (trillian.SignedMapRoot, error) {
-	ret := _m.ctrl.Call(_m, "LatestSignedMapRoot")
+func (_m *MockReadOnlyMapTreeTX) LatestSignedMapRoot(_param0 context.Context) (trillian.SignedMapRoot, error) {
+	ret := _m.ctrl.Call(_m, "LatestSignedMapRoot", _param0)
 	ret0, _ := ret[0].(trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyMapTreeTXRecorder) LatestSignedMapRoot() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedMapRoot")
+func (_mr *_MockReadOnlyMapTreeTXRecorder) LatestSignedMapRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedMapRoot", arg0)
 }
 
 func (_m *MockReadOnlyMapTreeTX) ReadRevision() int64 {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -274,59 +274,59 @@ func (_mr *_MockLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockLogTreeTX) DequeueLeaves(_param0 int, _param1 time.Time) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0, _param1)
+func (_m *MockLogTreeTX) DequeueLeaves(_param0 context.Context, _param1 int, _param2 time.Time) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "DequeueLeaves", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) DequeueLeaves(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DequeueLeaves", arg0, arg1)
+func (_mr *_MockLogTreeTXRecorder) DequeueLeaves(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DequeueLeaves", arg0, arg1, arg2)
 }
 
-func (_m *MockLogTreeTX) GetActiveLogIDs() ([]int64, error) {
-	ret := _m.ctrl.Call(_m, "GetActiveLogIDs")
+func (_m *MockLogTreeTX) GetActiveLogIDs(_param0 context.Context) ([]int64, error) {
+	ret := _m.ctrl.Call(_m, "GetActiveLogIDs", _param0)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDs() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDs")
+func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDs(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDs", arg0)
 }
 
-func (_m *MockLogTreeTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
-	ret := _m.ctrl.Call(_m, "GetActiveLogIDsWithPendingWork")
+func (_m *MockLogTreeTX) GetActiveLogIDsWithPendingWork(_param0 context.Context) ([]int64, error) {
+	ret := _m.ctrl.Call(_m, "GetActiveLogIDsWithPendingWork", _param0)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
+func (_mr *_MockLogTreeTXRecorder) GetActiveLogIDsWithPendingWork(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork", arg0)
 }
 
-func (_m *MockLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
+func (_m *MockLogTreeTX) GetLeavesByHash(_param0 context.Context, _param1 [][]byte, _param2 bool) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
+func (_mr *_MockLogTreeTXRecorder) GetLeavesByHash(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1, arg2)
 }
 
-func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
+func (_m *MockLogTreeTX) GetLeavesByIndex(_param0 context.Context, _param1 []int64) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0, _param1)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) GetLeavesByIndex(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByIndex", arg0)
+func (_mr *_MockLogTreeTXRecorder) GetLeavesByIndex(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByIndex", arg0, arg1)
 }
 
 func (_m *MockLogTreeTX) GetMerkleNodes(_param0 int64, _param1 []NodeID) ([]Node, error) {
@@ -340,15 +340,15 @@ func (_mr *_MockLogTreeTXRecorder) GetMerkleNodes(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMerkleNodes", arg0, arg1)
 }
 
-func (_m *MockLogTreeTX) GetSequencedLeafCount() (int64, error) {
-	ret := _m.ctrl.Call(_m, "GetSequencedLeafCount")
+func (_m *MockLogTreeTX) GetSequencedLeafCount(_param0 context.Context) (int64, error) {
+	ret := _m.ctrl.Call(_m, "GetSequencedLeafCount", _param0)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) GetSequencedLeafCount() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSequencedLeafCount")
+func (_mr *_MockLogTreeTXRecorder) GetSequencedLeafCount(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSequencedLeafCount", arg0)
 }
 
 func (_m *MockLogTreeTX) IsOpen() bool {
@@ -361,26 +361,26 @@ func (_mr *_MockLogTreeTXRecorder) IsOpen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOpen")
 }
 
-func (_m *MockLogTreeTX) LatestSignedLogRoot() (trillian.SignedLogRoot, error) {
-	ret := _m.ctrl.Call(_m, "LatestSignedLogRoot")
+func (_m *MockLogTreeTX) LatestSignedLogRoot(_param0 context.Context) (trillian.SignedLogRoot, error) {
+	ret := _m.ctrl.Call(_m, "LatestSignedLogRoot", _param0)
 	ret0, _ := ret[0].(trillian.SignedLogRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) LatestSignedLogRoot() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot")
+func (_mr *_MockLogTreeTXRecorder) LatestSignedLogRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot", arg0)
 }
 
-func (_m *MockLogTreeTX) QueueLeaves(_param0 []*trillian.LogLeaf, _param1 time.Time) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0, _param1)
+func (_m *MockLogTreeTX) QueueLeaves(_param0 context.Context, _param1 []*trillian.LogLeaf, _param2 time.Time) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "QueueLeaves", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLogTreeTXRecorder) QueueLeaves(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "QueueLeaves", arg0, arg1)
+func (_mr *_MockLogTreeTXRecorder) QueueLeaves(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "QueueLeaves", arg0, arg1, arg2)
 }
 
 func (_m *MockLogTreeTX) ReadRevision() int64 {
@@ -413,24 +413,24 @@ func (_mr *_MockLogTreeTXRecorder) SetMerkleNodes(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMerkleNodes", arg0)
 }
 
-func (_m *MockLogTreeTX) StoreSignedLogRoot(_param0 trillian.SignedLogRoot) error {
-	ret := _m.ctrl.Call(_m, "StoreSignedLogRoot", _param0)
+func (_m *MockLogTreeTX) StoreSignedLogRoot(_param0 context.Context, _param1 trillian.SignedLogRoot) error {
+	ret := _m.ctrl.Call(_m, "StoreSignedLogRoot", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockLogTreeTXRecorder) StoreSignedLogRoot(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedLogRoot", arg0)
+func (_mr *_MockLogTreeTXRecorder) StoreSignedLogRoot(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StoreSignedLogRoot", arg0, arg1)
 }
 
-func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 []*trillian.LogLeaf) error {
-	ret := _m.ctrl.Call(_m, "UpdateSequencedLeaves", _param0)
+func (_m *MockLogTreeTX) UpdateSequencedLeaves(_param0 context.Context, _param1 []*trillian.LogLeaf) error {
+	ret := _m.ctrl.Call(_m, "UpdateSequencedLeaves", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockLogTreeTXRecorder) UpdateSequencedLeaves(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSequencedLeaves", arg0)
+func (_mr *_MockLogTreeTXRecorder) UpdateSequencedLeaves(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSequencedLeaves", arg0, arg1)
 }
 
 func (_m *MockLogTreeTX) WriteRevision() int64 {
@@ -786,26 +786,26 @@ func (_mr *_MockReadOnlyLogTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockReadOnlyLogTX) GetActiveLogIDs() ([]int64, error) {
-	ret := _m.ctrl.Call(_m, "GetActiveLogIDs")
+func (_m *MockReadOnlyLogTX) GetActiveLogIDs(_param0 context.Context) ([]int64, error) {
+	ret := _m.ctrl.Call(_m, "GetActiveLogIDs", _param0)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDs() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDs")
+func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDs(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDs", arg0)
 }
 
-func (_m *MockReadOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
-	ret := _m.ctrl.Call(_m, "GetActiveLogIDsWithPendingWork")
+func (_m *MockReadOnlyLogTX) GetActiveLogIDsWithPendingWork(_param0 context.Context) ([]int64, error) {
+	ret := _m.ctrl.Call(_m, "GetActiveLogIDsWithPendingWork", _param0)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDsWithPendingWork() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork")
+func (_mr *_MockReadOnlyLogTXRecorder) GetActiveLogIDsWithPendingWork(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDsWithPendingWork", arg0)
 }
 
 func (_m *MockReadOnlyLogTX) Rollback() error {
@@ -859,26 +859,26 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) Commit() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Commit")
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 [][]byte, _param1 bool) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1)
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByHash(_param0 context.Context, _param1 [][]byte, _param2 bool) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByHash(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1)
+func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByHash(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByHash", arg0, arg1, arg2)
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 []int64) ([]*trillian.LogLeaf, error) {
-	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0)
+func (_m *MockReadOnlyLogTreeTX) GetLeavesByIndex(_param0 context.Context, _param1 []int64) ([]*trillian.LogLeaf, error) {
+	ret := _m.ctrl.Call(_m, "GetLeavesByIndex", _param0, _param1)
 	ret0, _ := ret[0].([]*trillian.LogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByIndex(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByIndex", arg0)
+func (_mr *_MockReadOnlyLogTreeTXRecorder) GetLeavesByIndex(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLeavesByIndex", arg0, arg1)
 }
 
 func (_m *MockReadOnlyLogTreeTX) GetMerkleNodes(_param0 int64, _param1 []NodeID) ([]Node, error) {
@@ -892,15 +892,15 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) GetMerkleNodes(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMerkleNodes", arg0, arg1)
 }
 
-func (_m *MockReadOnlyLogTreeTX) GetSequencedLeafCount() (int64, error) {
-	ret := _m.ctrl.Call(_m, "GetSequencedLeafCount")
+func (_m *MockReadOnlyLogTreeTX) GetSequencedLeafCount(_param0 context.Context) (int64, error) {
+	ret := _m.ctrl.Call(_m, "GetSequencedLeafCount", _param0)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTreeTXRecorder) GetSequencedLeafCount() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSequencedLeafCount")
+func (_mr *_MockReadOnlyLogTreeTXRecorder) GetSequencedLeafCount(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSequencedLeafCount", arg0)
 }
 
 func (_m *MockReadOnlyLogTreeTX) IsOpen() bool {
@@ -913,15 +913,15 @@ func (_mr *_MockReadOnlyLogTreeTXRecorder) IsOpen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOpen")
 }
 
-func (_m *MockReadOnlyLogTreeTX) LatestSignedLogRoot() (trillian.SignedLogRoot, error) {
-	ret := _m.ctrl.Call(_m, "LatestSignedLogRoot")
+func (_m *MockReadOnlyLogTreeTX) LatestSignedLogRoot(_param0 context.Context) (trillian.SignedLogRoot, error) {
+	ret := _m.ctrl.Call(_m, "LatestSignedLogRoot", _param0)
 	ret0, _ := ret[0].(trillian.SignedLogRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReadOnlyLogTreeTXRecorder) LatestSignedLogRoot() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot")
+func (_mr *_MockReadOnlyLogTreeTXRecorder) LatestSignedLogRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestSignedLogRoot", arg0)
 }
 
 func (_m *MockReadOnlyLogTreeTX) ReadRevision() int64 {

--- a/storage/mysql/admin_storage_test.go
+++ b/storage/mysql/admin_storage_test.go
@@ -49,7 +49,7 @@ func TestAdminTX_CreateTree_InitializesStorageStructures(t *testing.T) {
 	// Check if TreeControl is correctly written.
 	var signingEnabled, sequencingEnabled bool
 	var sequenceIntervalSeconds int
-	if err := DB.QueryRow(selectTreeControlByID, tree.TreeId).Scan(&signingEnabled, &sequencingEnabled, &sequenceIntervalSeconds); err != nil {
+	if err := DB.QueryRowContext(ctx, selectTreeControlByID, tree.TreeId).Scan(&signingEnabled, &sequencingEnabled, &sequenceIntervalSeconds); err != nil {
 		t.Fatalf("Failed to read TreeControl: %v", err)
 	}
 	// We don't mind about specific values, defaults change, but let's check
@@ -71,7 +71,7 @@ func TestAdminTX_TreeWithNulls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTree() failed: %v", err)
 	}
-	if err := setNulls(DB, tree.TreeId); err != nil {
+	if err := setNulls(ctx, DB, tree.TreeId); err != nil {
 		t.Fatalf("setNulls() = %v, want = nil", err)
 	}
 
@@ -212,12 +212,12 @@ func updateTreeInternal(ctx context.Context, s storage.AdminStorage, treeID int6
 	return newTree, nil
 }
 
-func setNulls(db *sql.DB, treeID int64) error {
-	stmt, err := db.Prepare("UPDATE Trees SET DisplayName = NULL, Description = NULL WHERE TreeId = ?")
+func setNulls(ctx context.Context, db *sql.DB, treeID int64) error {
+	stmt, err := db.PrepareContext(ctx, "UPDATE Trees SET DisplayName = NULL, Description = NULL WHERE TreeId = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
-	_, err = stmt.Exec(treeID)
+	_, err = stmt.ExecContext(ctx, treeID)
 	return err
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -125,8 +125,8 @@ func (m *mySQLLogStorage) getDeleteUnsequencedStmt(num int) (*sql.Stmt, error) {
 	return m.getStmt(deleteUnsequencedSQL, num, "?", "?")
 }
 
-func getActiveLogIDsInternal(tx *sql.Tx, sql string) ([]int64, error) {
-	rows, err := tx.QueryContext(context.TODO(), sql)
+func getActiveLogIDsInternal(ctx context.Context, tx *sql.Tx, sql string) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -148,12 +148,12 @@ func getActiveLogIDsInternal(tx *sql.Tx, sql string) ([]int64, error) {
 	return logIDs, nil
 }
 
-func getActiveLogIDs(tx *sql.Tx) ([]int64, error) {
-	return getActiveLogIDsInternal(tx, selectActiveLogsSQL)
+func getActiveLogIDs(ctx context.Context, tx *sql.Tx) ([]int64, error) {
+	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsSQL)
 }
 
-func getActiveLogIDsWithPendingWork(tx *sql.Tx) ([]int64, error) {
-	return getActiveLogIDsInternal(tx, selectActiveLogsWithUnsequencedSQL)
+func getActiveLogIDsWithPendingWork(ctx context.Context, tx *sql.Tx) ([]int64, error) {
+	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsWithUnsequencedSQL)
 }
 
 // readOnlyLogTX implements storage.ReadOnlyLogTX
@@ -186,12 +186,12 @@ func (t *readOnlyLogTX) Close() error {
 	return nil
 }
 
-func (t *readOnlyLogTX) GetActiveLogIDs() ([]int64, error) {
-	return getActiveLogIDs(t.tx)
+func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDs(ctx, t.tx)
 }
 
-func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
-	return getActiveLogIDsWithPendingWork(t.tx)
+func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDsWithPendingWork(ctx, t.tx)
 }
 
 func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
@@ -218,7 +218,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 		ls:     m,
 	}
 
-	ltx.root, err = ltx.fetchLatestRoot()
+	ltx.root, err = ltx.fetchLatestRoot(ctx)
 	if err != nil {
 		ttx.Rollback()
 		return nil, err
@@ -254,8 +254,8 @@ func (t *logTreeTX) WriteRevision() int64 {
 	return t.treeTX.writeRevision
 }
 
-func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {
-	stx, err := t.tx.PrepareContext(context.TODO(), selectQueuedLeavesSQL)
+func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {
+	stx, err := t.tx.PrepareContext(ctx, selectQueuedLeavesSQL)
 
 	if err != nil {
 		glog.Warningf("Failed to prepare dequeue select: %s", err)
@@ -263,7 +263,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.
 	}
 
 	leaves := make([]*trillian.LogLeaf, 0, limit)
-	rows, err := stx.QueryContext(context.TODO(), t.treeID, cutoffTime.UnixNano(), limit)
+	rows, err := stx.QueryContext(ctx, t.treeID, cutoffTime.UnixNano(), limit)
 
 	if err != nil {
 		glog.Warningf("Failed to select rows for work: %s", err)
@@ -304,7 +304,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.
 	// The convention is that if leaf processing succeeds (by committing this tx)
 	// then the unsequenced entries for them are removed
 	if len(leaves) > 0 {
-		err = t.removeSequencedLeaves(leaves)
+		err = t.removeSequencedLeaves(ctx, leaves)
 	}
 
 	if err != nil {
@@ -316,7 +316,7 @@ func (t *logTreeTX) DequeueLeaves(limit int, cutoffTime time.Time) ([]*trillian.
 	return leaves, nil
 }
 
-func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
 	// Don't accept batches if any of the leaves are invalid.
 	for _, leaf := range leaves {
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
@@ -335,7 +335,7 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 
 	for i, leafPos := range orderedLeaves {
 		leaf := leafPos.leaf
-		_, err := t.tx.ExecContext(context.TODO(), insertUnsequencedLeafSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
+		_, err := t.tx.ExecContext(ctx, insertUnsequencedLeafSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
 		if isDuplicateErr(err) {
 			// Remember the duplicate leaf, using the requested leaf for now.
 			existingLeaves[leafPos.idx] = leaf
@@ -357,7 +357,7 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 		messageID := hasher.Sum(nil)
 
 		_, err = t.tx.ExecContext(
-			context.TODO(),
+			ctx,
 			insertUnsequencedEntrySQL,
 			t.treeID,
 			leaf.LeafIdentityHash,
@@ -381,7 +381,7 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 			toRetrieve = append(toRetrieve, existing.LeafIdentityHash)
 		}
 	}
-	results, err := t.getLeafDataByIdentityHash(toRetrieve)
+	results, err := t.getLeafDataByIdentityHash(ctx, toRetrieve)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve existing leaves: %v", err)
 	}
@@ -411,10 +411,10 @@ func (t *logTreeTX) QueueLeaves(leaves []*trillian.LogLeaf, queueTimestamp time.
 	return existingLeaves, nil
 }
 
-func (t *logTreeTX) GetSequencedLeafCount() (int64, error) {
+func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
 	var sequencedLeafCount int64
 
-	err := t.tx.QueryRowContext(context.TODO(), selectSequencedLeafCountSQL, t.treeID).Scan(&sequencedLeafCount)
+	err := t.tx.QueryRowContext(ctx, selectSequencedLeafCountSQL, t.treeID).Scan(&sequencedLeafCount)
 
 	if err != nil {
 		glog.Warningf("Error getting sequenced leaf count: %s", err)
@@ -423,18 +423,18 @@ func (t *logTreeTX) GetSequencedLeafCount() (int64, error) {
 	return sequencedLeafCount, err
 }
 
-func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error) {
+func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByIndexStmt(len(leaves))
 	if err != nil {
 		return nil, err
 	}
-	stx := t.tx.StmtContext(context.TODO(), tmpl)
+	stx := t.tx.StmtContext(ctx, tmpl)
 	var args []interface{}
 	for _, nodeID := range leaves {
 		args = append(args, interface{}(int64(nodeID)))
 	}
 	args = append(args, interface{}(t.treeID))
-	rows, err := stx.QueryContext(context.TODO(), args...)
+	rows, err := stx.QueryContext(ctx, args...)
 	if err != nil {
 		glog.Warningf("Failed to get leaves by idx: %s", err)
 		return nil, err
@@ -462,38 +462,38 @@ func (t *logTreeTX) GetLeavesByIndex(leaves []int64) ([]*trillian.LogLeaf, error
 	return ret, nil
 }
 
-func (t *logTreeTX) GetLeavesByHash(leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error) {
+func (t *logTreeTX) GetLeavesByHash(ctx context.Context, leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByMerkleHashStmt(len(leafHashes), orderBySequence)
 	if err != nil {
 		return nil, err
 	}
 
-	return t.getLeavesByHashInternal(leafHashes, tmpl, "merkle")
+	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "merkle")
 }
 
 // getLeafDataByIdentityHash retrieves leaf data by LeafIdentityHash, returned
 // as a slice of LogLeaf objects for convenience.  However, note that the
 // returned LogLeaf objects will not have a valid MerkleLeafHash or LeafIndex.
-func (t *logTreeTX) getLeafDataByIdentityHash(leafHashes [][]byte) ([]*trillian.LogLeaf, error) {
+func (t *logTreeTX) getLeafDataByIdentityHash(ctx context.Context, leafHashes [][]byte) ([]*trillian.LogLeaf, error) {
 	tmpl, err := t.ls.getLeavesByLeafIdentityHashStmt(len(leafHashes))
 	if err != nil {
 		return nil, err
 	}
-	return t.getLeavesByHashInternal(leafHashes, tmpl, "leaf-identity")
+	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "leaf-identity")
 }
 
-func (t *logTreeTX) LatestSignedLogRoot() (trillian.SignedLogRoot, error) {
+func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
 	return t.root, nil
 }
 
 // fetchLatestRoot reads the latest SignedLogRoot from the DB and returns it.
-func (t *logTreeTX) fetchLatestRoot() (trillian.SignedLogRoot, error) {
+func (t *logTreeTX) fetchLatestRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
 	var timestamp, treeSize, treeRevision int64
 	var rootHash, rootSignatureBytes []byte
 	var rootSignature spb.DigitallySigned
 
 	err := t.tx.QueryRowContext(
-		context.TODO(), selectLatestSignedLogRootSQL, t.treeID).Scan(
+		ctx, selectLatestSignedLogRootSQL, t.treeID).Scan(
 		&timestamp, &treeSize, &rootHash, &treeRevision, &rootSignatureBytes)
 
 	// It's possible there are no roots for this tree yet
@@ -518,7 +518,7 @@ func (t *logTreeTX) fetchLatestRoot() (trillian.SignedLogRoot, error) {
 	}, nil
 }
 
-func (t *logTreeTX) StoreSignedLogRoot(root trillian.SignedLogRoot) error {
+func (t *logTreeTX) StoreSignedLogRoot(ctx context.Context, root trillian.SignedLogRoot) error {
 	signatureBytes, err := proto.Marshal(root.Signature)
 
 	if err != nil {
@@ -527,7 +527,7 @@ func (t *logTreeTX) StoreSignedLogRoot(root trillian.SignedLogRoot) error {
 	}
 
 	res, err := t.tx.ExecContext(
-		context.TODO(),
+		ctx,
 		insertTreeHeadSQL,
 		t.treeID,
 		root.TimestampNanos,
@@ -542,7 +542,7 @@ func (t *logTreeTX) StoreSignedLogRoot(root trillian.SignedLogRoot) error {
 	return checkResultOkAndRowCountIs(res, err, 1)
 }
 
-func (t *logTreeTX) UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error {
+func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
 	// TODO: In theory we can do this with CASE / WHEN in one SQL statement but it's more fiddly
 	// and can be implemented later if necessary
 	for _, leaf := range leaves {
@@ -552,7 +552,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error {
 		}
 
 		_, err := t.tx.ExecContext(
-			context.TODO(),
+			ctx,
 			insertSequencedLeafSQL,
 			t.treeID,
 			leaf.LeafIdentityHash,
@@ -569,7 +569,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(leaves []*trillian.LogLeaf) error {
 
 // removeSequencedLeaves removes the passed in leaves slice (which may be
 // modified as part of the operation).
-func (t *logTreeTX) removeSequencedLeaves(leaves []*trillian.LogLeaf) error {
+func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
 	// Delete in order of the hash values in the leaves.
 	sort.Sort(byLeafIdentityHash(leaves))
 
@@ -578,13 +578,13 @@ func (t *logTreeTX) removeSequencedLeaves(leaves []*trillian.LogLeaf) error {
 		glog.Warningf("Failed to get delete statement for sequenced work: %s", err)
 		return err
 	}
-	stx := t.tx.StmtContext(context.TODO(), tmpl)
+	stx := t.tx.StmtContext(ctx, tmpl)
 	var args []interface{}
 	for _, leaf := range leaves {
 		args = append(args, interface{}(leaf.LeafIdentityHash))
 	}
 	args = append(args, interface{}(t.treeID))
-	result, err := stx.ExecContext(context.TODO(), args...)
+	result, err := stx.ExecContext(ctx, args...)
 
 	if err != nil {
 		// Error is handled by checkResultOkAndRowCountIs() below
@@ -600,14 +600,14 @@ func (t *logTreeTX) removeSequencedLeaves(leaves []*trillian.LogLeaf) error {
 	return nil
 }
 
-func (t *logTreeTX) getLeavesByHashInternal(leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]*trillian.LogLeaf, error) {
-	stx := t.tx.StmtContext(context.TODO(), tmpl)
+func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]*trillian.LogLeaf, error) {
+	stx := t.tx.StmtContext(ctx, tmpl)
 	var args []interface{}
 	for _, hash := range leafHashes {
 		args = append(args, interface{}([]byte(hash)))
 	}
 	args = append(args, interface{}(t.treeID))
-	rows, err := stx.QueryContext(context.TODO(), args...)
+	rows, err := stx.QueryContext(ctx, args...)
 	if err != nil {
 		glog.Warningf("Query() %s hash = %v", desc, err)
 		return nil, err
@@ -636,14 +636,14 @@ func (t *logTreeTX) getLeavesByHashInternal(leafHashes [][]byte, tmpl *sql.Stmt,
 }
 
 // GetActiveLogIDs returns a list of the IDs of all configured logs
-func (t *logTreeTX) GetActiveLogIDs() ([]int64, error) {
-	return getActiveLogIDs(t.tx)
+func (t *logTreeTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDs(ctx, t.tx)
 }
 
 // GetActiveLogIDsWithPendingWork returns a list of the IDs of all configured logs
 // that have queued unsequenced leaves that need to be integrated
-func (t *logTreeTX) GetActiveLogIDsWithPendingWork() ([]int64, error) {
-	return getActiveLogIDsWithPendingWork(t.tx)
+func (t *logTreeTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDsWithPendingWork(ctx, t.tx)
 }
 
 // byLeafIdentityHash allows sorting of leaves by their identity hash, so DB

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -56,9 +56,9 @@ const sequenceNumber int64 = 237
 // run in parallel or race conditions / unexpected interactions. Tests that pass should hold
 // no locks afterwards.
 
-func createFakeLeaf(db *sql.DB, logID int64, rawHash, hash, data, extraData []byte, seq int64, t *testing.T) *trillian.LogLeaf {
-	_, err := db.ExecContext(context.TODO(), "INSERT INTO LeafData(TreeId, LeafIdentityHash, LeafValue, ExtraData) VALUES(?,?,?,?)", logID, rawHash, data, extraData)
-	_, err2 := db.ExecContext(context.TODO(), "INSERT INTO SequencedLeafData(TreeId, SequenceNumber, LeafIdentityHash, MerkleLeafHash) VALUES(?,?,?,?)", logID, seq, rawHash, hash)
+func createFakeLeaf(ctx context.Context, db *sql.DB, logID int64, rawHash, hash, data, extraData []byte, seq int64, t *testing.T) *trillian.LogLeaf {
+	_, err := db.ExecContext(ctx, "INSERT INTO LeafData(TreeId, LeafIdentityHash, LeafValue, ExtraData) VALUES(?,?,?,?)", logID, rawHash, data, extraData)
+	_, err2 := db.ExecContext(ctx, "INSERT INTO SequencedLeafData(TreeId, SequenceNumber, LeafIdentityHash, MerkleLeafHash) VALUES(?,?,?,?)", logID, seq, rawHash, hash)
 
 	if err != nil || err2 != nil {
 		t.Fatalf("Failed to create test leaves: %v %v", err, err2)
@@ -184,7 +184,7 @@ func TestBeginSnapshot(t *testing.T) {
 			}
 			defer tx.Close()
 
-			root, err := tx.LatestSignedLogRoot()
+			root, err := tx.LatestSignedLogRoot(ctx)
 			if err != nil {
 				t.Errorf("%v: LatestSignedLogRoot() returned err = %v", test.desc, err)
 			}
@@ -247,6 +247,8 @@ func TestIsOpenCommitRollbackClosed(t *testing.T) {
 }
 
 func TestQueueDuplicateLeaf(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -281,7 +283,7 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 		func() {
 			tx := beginLogTx(s, logID, t)
 			defer tx.Close()
-			existing, err := tx.QueueLeaves(test.leaves, fakeQueueTime)
+			existing, err := tx.QueueLeaves(ctx, test.leaves, fakeQueueTime)
 			if err != nil {
 				t.Fatalf("Failed to queue leaves: %v", err)
 			}
@@ -320,7 +322,7 @@ func TestQueueLeaves(t *testing.T) {
 	defer tx.Close()
 
 	leaves := createTestLeaves(leavesToInsert, 20)
-	if _, err := tx.QueueLeaves(leaves, fakeQueueTime); err != nil {
+	if _, err := tx.QueueLeaves(ctx, leaves, fakeQueueTime); err != nil {
 		t.Fatalf("Failed to queue leaves: %v", err)
 	}
 	commit(tx, t)
@@ -345,6 +347,8 @@ func TestQueueLeaves(t *testing.T) {
 }
 
 func TestDequeueLeavesNoneQueued(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -352,7 +356,7 @@ func TestDequeueLeavesNoneQueued(t *testing.T) {
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
 
-	leaves, err := tx.DequeueLeaves(999, fakeDequeueCutoffTime)
+	leaves, err := tx.DequeueLeaves(ctx, 999, fakeDequeueCutoffTime)
 	if err != nil {
 		t.Fatalf("Didn't expect an error on dequeue with no work to be done: %v", err)
 	}
@@ -363,6 +367,8 @@ func TestDequeueLeavesNoneQueued(t *testing.T) {
 }
 
 func TestDequeueLeaves(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -371,7 +377,7 @@ func TestDequeueLeaves(t *testing.T) {
 		tx := beginLogTx(s, logID, t)
 		defer tx.Close()
 		leaves := createTestLeaves(leavesToInsert, 20)
-		if _, err := tx.QueueLeaves(leaves, fakeDequeueCutoffTime); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves, fakeDequeueCutoffTime); err != nil {
 			t.Fatalf("Failed to queue leaves: %v", err)
 		}
 		commit(tx, t)
@@ -381,7 +387,7 @@ func TestDequeueLeaves(t *testing.T) {
 		// Now try to dequeue them
 		tx2 := beginLogTx(s, logID, t)
 		defer tx2.Close()
-		leaves2, err := tx2.DequeueLeaves(99, fakeDequeueCutoffTime)
+		leaves2, err := tx2.DequeueLeaves(ctx, 99, fakeDequeueCutoffTime)
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves: %v", err)
 		}
@@ -396,7 +402,7 @@ func TestDequeueLeaves(t *testing.T) {
 		// If we dequeue again then we should now get nothing
 		tx3 := beginLogTx(s, logID, t)
 		defer tx3.Close()
-		leaves3, err := tx3.DequeueLeaves(99, fakeDequeueCutoffTime)
+		leaves3, err := tx3.DequeueLeaves(ctx, 99, fakeDequeueCutoffTime)
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves (second time): %v", err)
 		}
@@ -408,6 +414,8 @@ func TestDequeueLeaves(t *testing.T) {
 }
 
 func TestDequeueLeavesTwoBatches(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -419,7 +427,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 		tx := beginLogTx(s, logID, t)
 		defer tx.Close()
 		leaves := createTestLeaves(leavesToInsert, 20)
-		if _, err := tx.QueueLeaves(leaves, fakeDequeueCutoffTime); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves, fakeDequeueCutoffTime); err != nil {
 			t.Fatalf("Failed to queue leaves: %v", err)
 		}
 		commit(tx, t)
@@ -429,7 +437,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 		// Now try to dequeue some of them
 		tx2 := beginLogTx(s, logID, t)
 		defer tx2.Close()
-		leaves2, err := tx2.DequeueLeaves(leavesToDequeue1, fakeDequeueCutoffTime)
+		leaves2, err := tx2.DequeueLeaves(ctx, leavesToDequeue1, fakeDequeueCutoffTime)
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves: %v", err)
 		}
@@ -442,7 +450,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 		// Now try to dequeue the rest of them
 		tx3 := beginLogTx(s, logID, t)
 		defer tx3.Close()
-		leaves3, err := tx3.DequeueLeaves(leavesToDequeue2, fakeDequeueCutoffTime)
+		leaves3, err := tx3.DequeueLeaves(ctx, leavesToDequeue2, fakeDequeueCutoffTime)
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves: %v", err)
 		}
@@ -461,7 +469,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 		// If we dequeue again then we should now get nothing
 		tx4 := beginLogTx(s, logID, t)
 		defer tx4.Close()
-		leaves5, err := tx4.DequeueLeaves(99, fakeDequeueCutoffTime)
+		leaves5, err := tx4.DequeueLeaves(ctx, 99, fakeDequeueCutoffTime)
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves (second time): %v", err)
 		}
@@ -476,6 +484,8 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 // return nothing. Then retry with an inclusive guard cutoff and ensure the leaves
 // are returned.
 func TestDequeueLeavesGuardInterval(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -484,7 +494,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 		tx := beginLogTx(s, logID, t)
 		defer tx.Close()
 		leaves := createTestLeaves(leavesToInsert, 20)
-		if _, err := tx.QueueLeaves(leaves, fakeQueueTime); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves, fakeQueueTime); err != nil {
 			t.Fatalf("Failed to queue leaves: %v", err)
 		}
 		commit(tx, t)
@@ -494,7 +504,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 		// Now try to dequeue them using a cutoff that means we should get none
 		tx2 := beginLogTx(s, logID, t)
 		defer tx2.Close()
-		leaves2, err := tx2.DequeueLeaves(99, fakeQueueTime.Add(-time.Second))
+		leaves2, err := tx2.DequeueLeaves(ctx, 99, fakeQueueTime.Add(-time.Second))
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves: %v", err)
 		}
@@ -503,7 +513,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 		}
 
 		// Try to dequeue again using a cutoff that should include them
-		leaves2, err = tx2.DequeueLeaves(99, fakeQueueTime.Add(time.Second))
+		leaves2, err = tx2.DequeueLeaves(ctx, 99, fakeQueueTime.Add(time.Second))
 		if err != nil {
 			t.Fatalf("Failed to dequeue leaves: %v", err)
 		}
@@ -516,6 +526,8 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 }
 
 func TestDequeueLeavesTimeOrdering(t *testing.T) {
+	ctx := context.Background()
+
 	// Queue two small batches of leaves at different timestamps. Do two separate dequeue
 	// transactions and make sure the returned leaves are respecting the time ordering of the
 	// queue.
@@ -530,11 +542,11 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 	{
 		tx := beginLogTx(s, logID, t)
 		defer tx.Close()
-		if _, err := tx.QueueLeaves(leaves, fakeQueueTime); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves, fakeQueueTime); err != nil {
 			t.Fatalf("QueueLeaves(1st batch) = %v", err)
 		}
 		// These are one second earlier so should be dequeued first
-		if _, err := tx.QueueLeaves(leaves2, fakeQueueTime.Add(-time.Second)); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves2, fakeQueueTime.Add(-time.Second)); err != nil {
 			t.Fatalf("QueueLeaves(2nd batch) = %v", err)
 		}
 		commit(tx, t)
@@ -544,7 +556,7 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 		// Now try to dequeue two leaves and we should get the second batch
 		tx2 := beginLogTx(s, logID, t)
 		defer tx2.Close()
-		dequeue1, err := tx2.DequeueLeaves(batchSize, fakeQueueTime)
+		dequeue1, err := tx2.DequeueLeaves(ctx, batchSize, fakeQueueTime)
 		if err != nil {
 			t.Fatalf("DequeueLeaves(1st) = %v", err)
 		}
@@ -563,7 +575,7 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 		// Try to dequeue again and we should get the batch that was queued first, though at a later time
 		tx3 := beginLogTx(s, logID, t)
 		defer tx3.Close()
-		dequeue2, err := tx3.DequeueLeaves(batchSize, fakeQueueTime)
+		dequeue2, err := tx3.DequeueLeaves(ctx, batchSize, fakeQueueTime)
 		if err != nil {
 			t.Fatalf("DequeueLeaves(2nd) = %v", err)
 		}
@@ -581,6 +593,8 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 }
 
 func TestGetLeavesByHashNotPresent(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -589,7 +603,7 @@ func TestGetLeavesByHashNotPresent(t *testing.T) {
 	defer tx.Close()
 
 	hashes := [][]byte{[]byte("thisdoesn'texist")}
-	leaves, err := tx.GetLeavesByHash(hashes, false)
+	leaves, err := tx.GetLeavesByHash(ctx, hashes, false)
 	if err != nil {
 		t.Fatalf("Error getting leaves by hash: %v", err)
 	}
@@ -600,6 +614,8 @@ func TestGetLeavesByHashNotPresent(t *testing.T) {
 }
 
 func TestGetLeavesByIndexNotPresent(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -607,26 +623,28 @@ func TestGetLeavesByIndexNotPresent(t *testing.T) {
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
 
-	if _, err := tx.GetLeavesByIndex([]int64{99999}); err == nil {
+	if _, err := tx.GetLeavesByIndex(ctx, []int64{99999}); err == nil {
 		t.Fatalf("Returned ok for leaf index when nothing inserted: %v", err)
 	}
 	commit(tx, t)
 }
 
 func TestGetLeavesByHash(t *testing.T) {
+	ctx := context.Background()
+
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
 
 	data := []byte("some data")
-	createFakeLeaf(DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
+	createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
 
 	hashes := [][]byte{dummyHash}
-	leaves, err := tx.GetLeavesByHash(hashes, false)
+	leaves, err := tx.GetLeavesByHash(ctx, hashes, false)
 	if err != nil {
 		t.Fatalf("Unexpected error getting leaf by hash: %v", err)
 	}
@@ -638,15 +656,17 @@ func TestGetLeavesByHash(t *testing.T) {
 }
 
 func TestGetLeafDataByIdentityHash(t *testing.T) {
+	ctx := context.Background()
+
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
 	data := []byte("some data")
-	leaf := createFakeLeaf(DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
+	leaf := createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
 	leaf.LeafIndex = -1
 	leaf.MerkleLeafHash = []byte(dummyMerkleLeafHash)
-	leaf2 := createFakeLeaf(DB, logID, dummyHash2, dummyHash2, data, someExtraData, sequenceNumber+1, t)
+	leaf2 := createFakeLeaf(ctx, DB, logID, dummyHash2, dummyHash2, data, someExtraData, sequenceNumber+1, t)
 	leaf2.LeafIndex = -1
 	leaf2.MerkleLeafHash = []byte(dummyMerkleLeafHash)
 
@@ -677,7 +697,7 @@ func TestGetLeafDataByIdentityHash(t *testing.T) {
 			tx := beginLogTx(s, logID, t)
 			defer tx.Close()
 
-			leaves, err := tx.(*logTreeTX).getLeafDataByIdentityHash(test.hashes)
+			leaves, err := tx.(*logTreeTX).getLeafDataByIdentityHash(ctx, test.hashes)
 			if err != nil {
 				t.Errorf("getLeavesByIdentityHash(_) = (_,%v); want (_,nil)", err)
 				return
@@ -698,18 +718,20 @@ func TestGetLeafDataByIdentityHash(t *testing.T) {
 }
 
 func TestGetLeavesByIndex(t *testing.T) {
+	ctx := context.Background()
+
 	// Create fake leaf as if it had been sequenced, read it back and check contents
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
 
 	data := []byte("some data")
-	createFakeLeaf(DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
+	createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
 
-	leaves, err := tx.GetLeavesByIndex([]int64{sequenceNumber})
+	leaves, err := tx.GetLeavesByIndex(ctx, []int64{sequenceNumber})
 	if err != nil {
 		t.Fatalf("Unexpected error getting leaf by index: %v", err)
 	}
@@ -721,6 +743,8 @@ func TestGetLeavesByIndex(t *testing.T) {
 }
 
 func TestLatestSignedRootNoneWritten(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -728,7 +752,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
 
-	root, err := tx.LatestSignedLogRoot()
+	root, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		t.Fatalf("Failed to read an empty log root: %v", err)
 	}
@@ -739,6 +763,8 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 }
 
 func TestLatestSignedLogRoot(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -754,7 +780,7 @@ func TestLatestSignedLogRoot(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 		Signature:      &spb.DigitallySigned{Signature: []byte("notempty")},
 	}
-	if err := tx.StoreSignedLogRoot(root); err != nil {
+	if err := tx.StoreSignedLogRoot(ctx, root); err != nil {
 		t.Fatalf("Failed to store signed root: %v", err)
 	}
 	commit(tx, t)
@@ -762,7 +788,7 @@ func TestLatestSignedLogRoot(t *testing.T) {
 	{
 		tx2 := beginLogTx(s, logID, t)
 		defer tx2.Close()
-		root2, err := tx2.LatestSignedLogRoot()
+		root2, err := tx2.LatestSignedLogRoot(ctx)
 		if err != nil {
 			t.Fatalf("Failed to read back new log root: %v", err)
 		}
@@ -774,6 +800,8 @@ func TestLatestSignedLogRoot(t *testing.T) {
 }
 
 func TestDuplicateSignedLogRoot(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
 	s := NewLogStorage(DB)
@@ -789,17 +817,19 @@ func TestDuplicateSignedLogRoot(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 		Signature:      &spb.DigitallySigned{Signature: []byte("notempty")},
 	}
-	if err := tx.StoreSignedLogRoot(root); err != nil {
+	if err := tx.StoreSignedLogRoot(ctx, root); err != nil {
 		t.Fatalf("Failed to store signed root: %v", err)
 	}
 	// Shouldn't be able to do it again
-	if err := tx.StoreSignedLogRoot(root); err == nil {
+	if err := tx.StoreSignedLogRoot(ctx, root); err == nil {
 		t.Fatal("Allowed duplicate signed root")
 	}
 	commit(tx, t)
 }
 
 func TestLogRootUpdate(t *testing.T) {
+	ctx := context.Background()
+
 	// Write two roots for a log and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
@@ -815,7 +845,7 @@ func TestLogRootUpdate(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 		Signature:      &spb.DigitallySigned{Signature: []byte("notempty")},
 	}
-	if err := tx.StoreSignedLogRoot(root); err != nil {
+	if err := tx.StoreSignedLogRoot(ctx, root); err != nil {
 		t.Fatalf("Failed to store signed root: %v", err)
 	}
 	root2 := trillian.SignedLogRoot{
@@ -826,14 +856,14 @@ func TestLogRootUpdate(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 		Signature:      &spb.DigitallySigned{Signature: []byte("notempty")},
 	}
-	if err := tx.StoreSignedLogRoot(root2); err != nil {
+	if err := tx.StoreSignedLogRoot(ctx, root2); err != nil {
 		t.Fatalf("Failed to store signed root: %v", err)
 	}
 	commit(tx, t)
 
 	tx2 := beginLogTx(s, logID, t)
 	defer tx2.Close()
-	root3, err := tx2.LatestSignedLogRoot()
+	root3, err := tx2.LatestSignedLogRoot(ctx)
 	if err != nil {
 		t.Fatalf("Failed to read back new log root: %v", err)
 	}
@@ -845,7 +875,7 @@ func TestLogRootUpdate(t *testing.T) {
 
 // getActiveLogIDsFn creates a TX, calls the appropriate GetActiveLogIDs* function, commits the TX
 // and returns the results.
-type getActiveLogIDsFn func(storage.LogStorage, context.Context, int64) ([]int64, error)
+type getActiveLogIDsFn func(context.Context, storage.LogStorage, int64) ([]int64, error)
 
 type getActiveIDsTest struct {
 	name string
@@ -862,10 +892,10 @@ func toIDsMap(ids []int64) map[int64]bool {
 
 // runTestGetActiveLogIDsInternal calls test.fn (which is either GetActiveLogIDs or
 // GetActiveLogIDsWithPendingWork) and check that the result matches wantIds.
-func runTestGetActiveLogIDsInternal(t *testing.T, test getActiveIDsTest, logID int64, wantIds []int64) {
+func runTestGetActiveLogIDsInternal(ctx context.Context, t *testing.T, test getActiveIDsTest, logID int64, wantIds []int64) {
 	s := NewLogStorage(DB)
 
-	logIDs, err := test.fn(s, context.Background(), logID)
+	logIDs, err := test.fn(ctx, s, logID)
 	if err != nil {
 		t.Errorf("%v = (_, %v), want = (_, nil)", test.name, err)
 		return
@@ -881,16 +911,16 @@ func runTestGetActiveLogIDsInternal(t *testing.T, test getActiveIDsTest, logID i
 	}
 }
 
-func runTestGetActiveLogIDs(t *testing.T, test getActiveIDsTest) {
+func runTestGetActiveLogIDs(ctx context.Context, t *testing.T, test getActiveIDsTest) {
 	cleanTestDB(DB)
 	logID1 := createLogForTests(DB)
 	logID2 := createLogForTests(DB)
 	logID3 := createLogForTests(DB)
 	wantIds := []int64{logID1, logID2, logID3}
-	runTestGetActiveLogIDsInternal(t, test, logID1, wantIds)
+	runTestGetActiveLogIDsInternal(ctx, t, test, logID1, wantIds)
 }
 
-func runTestGetActiveLogIDsWithPendingWork(t *testing.T, test getActiveIDsTest) {
+func runTestGetActiveLogIDsWithPendingWork(ctx context.Context, t *testing.T, test getActiveIDsTest) {
 	cleanTestDB(DB)
 	logID1 := createLogForTests(DB)
 	logID2 := createLogForTests(DB)
@@ -898,14 +928,14 @@ func runTestGetActiveLogIDsWithPendingWork(t *testing.T, test getActiveIDsTest) 
 	s := NewLogStorage(DB)
 
 	// Do a first run without any pending logs
-	runTestGetActiveLogIDsInternal(t, test, logID1, nil)
+	runTestGetActiveLogIDsInternal(ctx, t, test, logID1, nil)
 
 	for _, logID := range []int64{logID1, logID2, logID3} {
 		func() {
 			tx := beginLogTx(s, logID, t)
 			defer tx.Close()
 			leaves := createTestLeaves(leavesToInsert, 2)
-			if _, err := tx.QueueLeaves(leaves, fakeQueueTime); err != nil {
+			if _, err := tx.QueueLeaves(ctx, leaves, fakeQueueTime); err != nil {
 				t.Fatalf("Failed to queue leaves for log %v: %v", logID, err)
 			}
 			commit(tx, t)
@@ -913,17 +943,17 @@ func runTestGetActiveLogIDsWithPendingWork(t *testing.T, test getActiveIDsTest) 
 	}
 
 	wantIds := []int64{logID1, logID2, logID3}
-	runTestGetActiveLogIDsInternal(t, test, logID1, wantIds)
+	runTestGetActiveLogIDsInternal(ctx, t, test, logID1, wantIds)
 }
 
 func TestGetActiveLogIDs(t *testing.T) {
-	getActiveIDsBegin := func(s storage.LogStorage, ctx context.Context, logID int64) ([]int64, error) {
+	getActiveIDsBegin := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
 		tx, err := s.BeginForTree(ctx, logID)
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Close()
-		ids, err := tx.GetActiveLogIDs()
+		ids, err := tx.GetActiveLogIDs(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -932,13 +962,13 @@ func TestGetActiveLogIDs(t *testing.T) {
 		}
 		return ids, nil
 	}
-	getActiveIDsSnapshot := func(s storage.LogStorage, ctx context.Context, logID int64) ([]int64, error) {
+	getActiveIDsSnapshot := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
 		tx, err := s.Snapshot(ctx)
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Close()
-		ids, err := tx.GetActiveLogIDs()
+		ids, err := tx.GetActiveLogIDs(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -952,12 +982,16 @@ func TestGetActiveLogIDs(t *testing.T) {
 		{name: "getActiveIDsBegin", fn: getActiveIDsBegin},
 		{name: "getActiveIDsSnapshot", fn: getActiveIDsSnapshot},
 	}
+
+	ctx := context.Background()
 	for _, test := range tests {
-		runTestGetActiveLogIDs(t, test)
+		runTestGetActiveLogIDs(ctx, t, test)
 	}
 }
 
 func TestGetActiveLogIDsEmpty(t *testing.T) {
+	ctx := context.Background()
+
 	cleanTestDB(DB)
 	s := NewLogStorage(DB)
 
@@ -967,7 +1001,7 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 	}
 	defer tx.Close()
 
-	activeIDs, err := tx.GetActiveLogIDs()
+	activeIDs, err := tx.GetActiveLogIDs(ctx)
 	if err != nil {
 		t.Fatalf("GetActiveLogIDs() = (_, %v), want = (_, nil)", err)
 	}
@@ -981,13 +1015,13 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 }
 
 func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
-	getActiveIDsBegin := func(s storage.LogStorage, ctx context.Context, logID int64) ([]int64, error) {
+	getActiveIDsBegin := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
 		tx, err := s.BeginForTree(ctx, logID)
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Close()
-		ids, err := tx.GetActiveLogIDsWithPendingWork()
+		ids, err := tx.GetActiveLogIDsWithPendingWork(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -996,13 +1030,13 @@ func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
 		}
 		return ids, nil
 	}
-	getActiveIDsSnapshot := func(s storage.LogStorage, ctx context.Context, logID int64) ([]int64, error) {
+	getActiveIDsSnapshot := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
 		tx, err := s.Snapshot(ctx)
 		if err != nil {
 			return nil, err
 		}
 		defer tx.Close()
-		ids, err := tx.GetActiveLogIDsWithPendingWork()
+		ids, err := tx.GetActiveLogIDsWithPendingWork(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1016,20 +1050,22 @@ func TestGetActiveLogIDsWithPendingWork(t *testing.T) {
 		{name: "getActiveIDsBegin", fn: getActiveIDsBegin},
 		{name: "getActiveIDsSnapshot", fn: getActiveIDsSnapshot},
 	}
+	ctx := context.Background()
 	for _, test := range tests {
-		runTestGetActiveLogIDsWithPendingWork(t, test)
+		runTestGetActiveLogIDsWithPendingWork(ctx, t, test)
 	}
 }
 
 func TestReadOnlyLogTX_Rollback(t *testing.T) {
+	ctx := context.Background()
 	cleanTestDB(DB)
 	s := NewLogStorage(DB)
-	tx, err := s.Snapshot(context.Background())
+	tx, err := s.Snapshot(ctx)
 	if err != nil {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
 	}
 	defer tx.Close()
-	if _, err := tx.GetActiveLogIDs(); err != nil {
+	if _, err := tx.GetActiveLogIDs(ctx); err != nil {
 		t.Fatalf("GetActiveLogIDs() = (_, %v), want = (_, nil)", err)
 	}
 	// It's a bit hard to have a more meaningful test. This should suffice.
@@ -1039,6 +1075,8 @@ func TestReadOnlyLogTX_Rollback(t *testing.T) {
 }
 
 func TestGetSequencedLeafCount(t *testing.T) {
+	ctx := context.Background()
+
 	// We'll create leaves for two different trees
 	cleanTestDB(DB)
 	logID1 := createLogForTests(DB)
@@ -1048,19 +1086,19 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	{
 		// Create fake leaf as if it had been sequenced
 		data := []byte("some data")
-		createFakeLeaf(DB, logID1, dummyHash, dummyRawHash, data, someExtraData, sequenceNumber, t)
+		createFakeLeaf(ctx, DB, logID1, dummyHash, dummyRawHash, data, someExtraData, sequenceNumber, t)
 
 		// Create fake leaves for second tree as if they had been sequenced
 		data2 := []byte("some data 2")
 		data3 := []byte("some data 3")
-		createFakeLeaf(DB, logID2, dummyHash2, dummyRawHash, data2, someExtraData, sequenceNumber, t)
-		createFakeLeaf(DB, logID2, dummyHash3, dummyRawHash, data3, someExtraData, sequenceNumber+1, t)
+		createFakeLeaf(ctx, DB, logID2, dummyHash2, dummyRawHash, data2, someExtraData, sequenceNumber, t)
+		createFakeLeaf(ctx, DB, logID2, dummyHash3, dummyRawHash, data3, someExtraData, sequenceNumber+1, t)
 	}
 
 	// Read back the leaf counts from both trees
 	tx := beginLogTx(s, logID1, t)
 	defer tx.Close()
-	count1, err := tx.GetSequencedLeafCount()
+	count1, err := tx.GetSequencedLeafCount(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error getting leaf count: %v", err)
 	}
@@ -1071,7 +1109,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 
 	tx = beginLogTx(s, logID2, t)
 	defer tx.Close()
-	count2, err := tx.GetSequencedLeafCount()
+	count2, err := tx.GetSequencedLeafCount(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error getting leaf count2: %v", err)
 	}

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -229,7 +229,7 @@ func openTestDBOrDie() *sql.DB {
 // cleanTestDB deletes all the entries in the database.
 func cleanTestDB(db *sql.DB) {
 	for _, table := range allTables {
-		if _, err := db.Exec(fmt.Sprintf("DELETE FROM %s", table)); err != nil {
+		if _, err := db.ExecContext(context.TODO(), fmt.Sprintf("DELETE FROM %s", table)); err != nil {
 			panic(fmt.Errorf("Failed to delete rows in %s: %s", table, err))
 		}
 	}

--- a/storage/tools/fetch_leaves/main.go
+++ b/storage/tools/fetch_leaves/main.go
@@ -61,7 +61,7 @@ func main() {
 		panic(err)
 	}
 
-	leafCount, err := tx.GetSequencedLeafCount()
+	leafCount, err := tx.GetSequencedLeafCount(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ func main() {
 			panic(err)
 		}
 
-		fetchedLeaves, err := tx.GetLeavesByHash([][]byte{hash}, false)
+		fetchedLeaves, err := tx.GetLeavesByHash(ctx, [][]byte{hash}, false)
 		if err != nil {
 			panic(err)
 		}
@@ -91,7 +91,7 @@ func main() {
 			leaves = append(leaves, int64(leafNumber))
 		}
 
-		fetchedLeaves, err := tx.GetLeavesByIndex(leaves)
+		fetchedLeaves, err := tx.GetLeavesByIndex(ctx, leaves)
 		if err != nil {
 			panic(err)
 		}

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -85,7 +85,7 @@ func main() {
 		leaves = append(leaves, leaf)
 
 		if len(leaves) >= *queueBatchSizeFlag {
-			_, err := tx.QueueLeaves(leaves, time.Now())
+			_, err := tx.QueueLeaves(ctx, leaves, time.Now())
 			leaves = leaves[:0] // starting new batch
 
 			if err != nil {
@@ -96,7 +96,7 @@ func main() {
 
 	// There might be some leaves left over that didn't get queued yet
 	if len(leaves) > 0 {
-		if _, err := tx.QueueLeaves(leaves, time.Now()); err != nil {
+		if _, err := tx.QueueLeaves(ctx, leaves, time.Now()); err != nil {
 			panic(err)
 		}
 	}

--- a/testonly/integration/db.go
+++ b/testonly/integration/db.go
@@ -15,6 +15,7 @@
 package integration
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -46,7 +47,7 @@ func GetTestDB(testID string) (*sql.DB, error) {
 		fmt.Sprintf("CREATE DATABASE %v;", dbName),
 	}
 	for _, sqlText := range resetSQL {
-		if _, err := dbRoot.Exec(sqlText); err != nil {
+		if _, err := dbRoot.ExecContext(context.TODO(), sqlText); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +65,7 @@ func GetTestDB(testID string) (*sql.DB, error) {
 	sqlSlice := strings.Split(string(createSQL), ";\n")
 	// Omit the last element of the slice, since it will be "".
 	for _, sqlText := range sqlSlice[:len(sqlSlice)-1] {
-		if _, err := dbTest.Exec(sqlText); err != nil {
+		if _, err := dbTest.ExecContext(context.TODO(), sqlText); err != nil {
 			return nil, err
 		}
 	}

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -113,7 +113,7 @@ func main() {
 		}
 		glog.Infof("CalculateRoot (%d), root: %s", x, base64.StdEncoding.EncodeToString(root))
 
-		if err := tx.StoreSignedMapRoot(trillian.SignedMapRoot{
+		if err := tx.StoreSignedMapRoot(ctx, trillian.SignedMapRoot{
 			TimestampNanos: time.Now().UnixNano(),
 			RootHash:       root,
 			MapId:          mapID,


### PR DESCRIPTION
Replace Begin/Exec/Prepare/Query/QueryRow/Stmt with their context-aware counterparts.

LogStorage and MapStorage now have a ctx method to all their methods. Places that still need a proper ctx to be propagated are using context.TODO() for easy future discovery.