### PR TITLE
CT: Allow setting MaxGetEntriesAllowed by flag to ct_server

### DIFF
--- a/examples/ct/ct_server/main.go
+++ b/examples/ct/ct_server/main.go
@@ -36,9 +36,15 @@ var serverPortFlag = flag.Int("port", 6962, "Port to serve CT log requests on")
 var rpcBackendFlag = flag.String("log_rpc_server", "localhost:8090", "Backend Log RPC server to use")
 var rpcDeadlineFlag = flag.Duration("rpc_deadline", time.Second*10, "Deadline for backend RPC requests")
 var logConfigFlag = flag.String("log_config", "", "File holding log config in JSON")
+var maxGetEntriesFlag = flag.Int64("maxGetEntriesAllowed", 0, "Max number of entries we allow in a get-entries request (default 50)")
 
 func main() {
 	flag.Parse()
+
+	if *maxGetEntriesFlag > 0 {
+		ct.MaxGetEntriesAllowed = *maxGetEntriesFlag
+	}
+
 	// Get log config from file before we start.
 	cfg, err := ct.LogConfigFromFile(*logConfigFlag)
 	if err != nil {

--- a/examples/ct/handlers.go
+++ b/examples/ct/handlers.go
@@ -64,7 +64,7 @@ const (
 	getEntryAndProofParamTreeSize = "tree_size"
 )
 
-// Max number of entries we allow in a get-entries request
+// MaxGetEntriesAllowed is the number of entries we allow in a get-entries request
 var MaxGetEntriesAllowed int64 = 50
 
 // EntrypointName identifies a CT entrypoint as defined in section 4 of RFC 6962.

--- a/examples/ct/handlers.go
+++ b/examples/ct/handlers.go
@@ -46,8 +46,6 @@ const (
 	contentTypeJSON string = "application/json"
 	// The name of the JSON response map key in get-roots responses
 	jsonMapKeyCertificates string = "certificates"
-	// Max number of entries we allow in a get-entries request
-	maxGetEntriesAllowed int64 = 50
 	// The name of the get-entries start parameter
 	getEntriesParamStart = "start"
 	// The name of the get-entries end parameter
@@ -65,6 +63,9 @@ const (
 	// The name of the get-entry-and-proof tree size parameter
 	getEntryAndProofParamTreeSize = "tree_size"
 )
+
+// Max number of entries we allow in a get-entries request
+var MaxGetEntriesAllowed int64 = 50
 
 // EntrypointName identifies a CT entrypoint as defined in section 4 of RFC 6962.
 type EntrypointName string
@@ -524,7 +525,7 @@ func getEntries(ctx context.Context, c LogContext, w http.ResponseWriter, r *htt
 	// The first job is to parse the params and make sure they're sensible. We just make
 	// sure the range is valid. We don't do an extra roundtrip to get the current tree
 	// size and prefer to let the backend handle this case
-	start, end, err := parseGetEntriesRange(r, maxGetEntriesAllowed)
+	start, end, err := parseGetEntriesRange(r, MaxGetEntriesAllowed)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("bad range on get-entries request: %v", err)
 	}


### PR DESCRIPTION
I started off doing this by moving `maxGetEntriesAllowed` to a field on `ct.LogContext` but it ended up being a bit of a pain to pipe it through everywhere. Instead I took the super lazy path of just changing the  `const` to a `var` and setting it via a flag at startup of `ct_server`, it's safe since it's set before the server starts but I'd be happy to go back to the complicated piping if anyone objects.