### PR TITLE
server: per-Tree option to force re-signing after interval

### DIFF
--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -37,6 +37,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -56,6 +57,7 @@ var (
 	signatureAlgorithm = flag.String("signature_algorithm", sigpb.DigitallySigned_RSA.String(), "Signature algorithm of the new tree")
 	displayName        = flag.String("display_name", "", "Display name of the new tree")
 	description        = flag.String("description", "", "Description of the new tree")
+	maxRootDuration    = flag.Duration("max_root_duration", 0, "Interval after which a new signed root is produced despite no submissions; zero means never")
 
 	privateKeyFormat = flag.String("private_key_format", "PEMKeyFile", "Type of private key to be used")
 	pemKeyPath       = flag.String("pem_key_path", "", "Path to the private key PEM file")
@@ -67,6 +69,7 @@ var (
 type createOpts struct {
 	addr                                                                                     string
 	treeState, treeType, hashStrategy, hashAlgorithm, sigAlgorithm, displayName, description string
+	maxRootDuration                                                                          time.Duration
 	privateKeyType, pemKeyPath, pemKeyPass                                                   string
 }
 
@@ -125,14 +128,15 @@ func newRequest(opts *createOpts) (*trillian.CreateTreeRequest, error) {
 	}
 
 	tree := &trillian.Tree{
-		TreeState:          trillian.TreeState(ts),
-		TreeType:           trillian.TreeType(tt),
-		HashStrategy:       trillian.HashStrategy(hs),
-		HashAlgorithm:      sigpb.DigitallySigned_HashAlgorithm(ha),
-		SignatureAlgorithm: sigpb.DigitallySigned_SignatureAlgorithm(sa),
-		DisplayName:        opts.displayName,
-		Description:        opts.description,
-		PrivateKey:         pk,
+		TreeState:             trillian.TreeState(ts),
+		TreeType:              trillian.TreeType(tt),
+		HashStrategy:          trillian.HashStrategy(hs),
+		HashAlgorithm:         sigpb.DigitallySigned_HashAlgorithm(ha),
+		SignatureAlgorithm:    sigpb.DigitallySigned_SignatureAlgorithm(sa),
+		DisplayName:           opts.displayName,
+		Description:           opts.description,
+		PrivateKey:            pk,
+		MaxRootDurationMillis: opts.maxRootDuration.Nanoseconds() / int64(time.Millisecond),
 	}
 	return &trillian.CreateTreeRequest{Tree: tree}, nil
 }
@@ -158,17 +162,18 @@ func newPK(opts *createOpts) (*any.Any, error) {
 
 func newOptsFromFlags() *createOpts {
 	return &createOpts{
-		addr:           *adminServerAddr,
-		treeState:      *treeState,
-		treeType:       *treeType,
-		hashStrategy:   *hashStrategy,
-		hashAlgorithm:  *hashAlgorithm,
-		sigAlgorithm:   *signatureAlgorithm,
-		displayName:    *displayName,
-		description:    *description,
-		privateKeyType: *privateKeyFormat,
-		pemKeyPath:     *pemKeyPath,
-		pemKeyPass:     *pemKeyPassword,
+		addr:            *adminServerAddr,
+		treeState:       *treeState,
+		treeType:        *treeType,
+		hashStrategy:    *hashStrategy,
+		hashAlgorithm:   *hashAlgorithm,
+		sigAlgorithm:    *signatureAlgorithm,
+		displayName:     *displayName,
+		description:     *description,
+		maxRootDuration: *maxRootDuration,
+		privateKeyType:  *privateKeyFormat,
+		pemKeyPath:      *pemKeyPath,
+		pemKeyPass:      *pemKeyPassword,
 	}
 }
 

--- a/integration/ct_config.sh
+++ b/integration/ct_config.sh
@@ -24,6 +24,7 @@ for i in $(seq ${num_logs}); do
   # TODO(daviddrysdale): Consider using distinct keys for each log
   tree_id=$(./createtree \
     --admin_server="${ADMIN_SERVER}" \
+    --max_root_duration=12h \
     --pem_key_path=testdata/log-rpc-server.privkey.pem \
     --pem_key_password=towel \
     --signature_algorithm=ECDSA)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -47,6 +47,9 @@ type Sequencer struct {
 	// sequencerGuardWindow is used to ensure entries newer than the guard window will not be
 	// sequenced until they fall outside it. By default there is no guard window.
 	sequencerGuardWindow time.Duration
+	// maxRootDurationInterval is used to ensure that a new signed log root is generated after a while,
+	// even if no entries have been added to the log.  Zero duration disables this behavior.
+	maxRootDurationInterval time.Duration
 }
 
 // maxTreeDepth sets an upper limit on the size of Log trees.
@@ -69,6 +72,13 @@ func NewSequencer(hasher merkle.TreeHasher, timeSource util.TimeSource, logStora
 // being eligible for sequencing. The default is a zero interval.
 func (s *Sequencer) SetGuardWindow(sequencerGuardWindow time.Duration) {
 	s.sequencerGuardWindow = sequencerGuardWindow
+}
+
+// SetMaxRootDurationInterval changes the interval after which a log root is generated regardless of
+// whether entries have been added to the log. The default is a zero interval, which
+// disables the behavior.
+func (s *Sequencer) SetMaxRootDurationInterval(interval time.Duration) {
+	s.maxRootDurationInterval = interval
 }
 
 // TODO: This currently doesn't use the batch api for fetching the required nodes. This
@@ -197,12 +207,17 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 		return 0, s.SignRoot(ctx, logID)
 	}
 
-	// There might be no work to be done. But we possibly still need to create an STH if the
+	// There might be no work to be done. But we possibly still need to create an signed root if the
 	// current one is too old. If there's work to be done then we'll be creating a root anyway.
 	if len(leaves) == 0 {
-		// We have nothing to integrate into the tree
-		glog.V(1).Infof("No leaves sequenced in this signing operation.")
-		return 0, tx.Commit()
+		nowNanos := s.timeSource.Now().UnixNano()
+		interval := time.Duration(nowNanos - currentRoot.TimestampNanos)
+		if s.maxRootDurationInterval == 0 || interval < s.maxRootDurationInterval {
+			// We have nothing to integrate into the tree
+			glog.V(1).Infof("No leaves sequenced in this signing operation.")
+			return 0, tx.Commit()
+		}
+		glog.Infof("Force new root generation as %v since last root", interval)
 	}
 
 	merkleTree, err := s.initMerkleTreeFromStorage(ctx, currentRoot, tx)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -42,14 +42,6 @@ type Sequencer struct {
 	timeSource util.TimeSource
 	logStorage storage.LogStorage
 	signer     *crypto.Signer
-
-	// These parameters could theoretically be adjusted during operation
-	// sequencerGuardWindow is used to ensure entries newer than the guard window will not be
-	// sequenced until they fall outside it. By default there is no guard window.
-	sequencerGuardWindow time.Duration
-	// maxRootDurationInterval is used to ensure that a new signed log root is generated after a while,
-	// even if no entries have been added to the log.  Zero duration disables this behavior.
-	maxRootDurationInterval time.Duration
 }
 
 // maxTreeDepth sets an upper limit on the size of Log trees.
@@ -66,19 +58,6 @@ func NewSequencer(hasher merkle.TreeHasher, timeSource util.TimeSource, logStora
 		logStorage: logStorage,
 		signer:     signer,
 	}
-}
-
-// SetGuardWindow changes the interval that must elapse between leaves being queued and them
-// being eligible for sequencing. The default is a zero interval.
-func (s *Sequencer) SetGuardWindow(sequencerGuardWindow time.Duration) {
-	s.sequencerGuardWindow = sequencerGuardWindow
-}
-
-// SetMaxRootDurationInterval changes the interval after which a log root is generated regardless of
-// whether entries have been added to the log. The default is a zero interval, which
-// disables the behavior.
-func (s *Sequencer) SetMaxRootDurationInterval(interval time.Duration) {
-	s.maxRootDurationInterval = interval
 }
 
 // TODO: This currently doesn't use the batch api for fetching the required nodes. This
@@ -177,7 +156,7 @@ func (s Sequencer) createRootSignature(ctx context.Context, root trillian.Signed
 // TODO(Martin2112): Can possibly improve by deferring a function that attempts to rollback,
 // which will fail if the tx was committed. Should only do this if we can hide the details of
 // the underlying storage transactions and it doesn't create other problems.
-func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (int, error) {
+func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int, guardWindow, maxRootDurationInterval time.Duration) (int, error) {
 	tx, err := s.logStorage.BeginForTree(ctx, logID)
 	if err != nil {
 		glog.Warningf("%v: Sequencer failed to start tx: %v", logID, err)
@@ -186,7 +165,7 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	defer tx.Close()
 
 	// Very recent leaves inside the guard window will not be available for sequencing
-	guardCutoffTime := s.timeSource.Now().Add(-s.sequencerGuardWindow)
+	guardCutoffTime := s.timeSource.Now().Add(-guardWindow)
 	leaves, err := tx.DequeueLeaves(ctx, limit, guardCutoffTime)
 	if err != nil {
 		glog.Warningf("%v: Sequencer failed to dequeue leaves: %v", logID, err)
@@ -212,7 +191,7 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	if len(leaves) == 0 {
 		nowNanos := s.timeSource.Now().UnixNano()
 		interval := time.Duration(nowNanos - currentRoot.TimestampNanos)
-		if s.maxRootDurationInterval == 0 || interval < s.maxRootDurationInterval {
+		if maxRootDurationInterval == 0 || interval < maxRootDurationInterval {
 			// We have nothing to integrate into the tree
 			glog.V(1).Infof("No leaves sequenced in this signing operation.")
 			return 0, tx.Commit()

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -19,6 +19,7 @@ import (
 	gocrypto "crypto"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,8 +45,15 @@ var (
 	}
 )
 
+var fakeTimeForTest = fakeTime()
+
 // RootHash can't be nil because that's how the sequencer currently detects that there was no stored tree head.
-var testRoot16 = trillian.SignedLogRoot{TreeSize: 16, TreeRevision: 5, RootHash: []byte{}}
+var testRoot16 = trillian.SignedLogRoot{
+	TreeSize:       16,
+	TreeRevision:   5,
+	RootHash:       []byte{},
+	TimestampNanos: fakeTimeForTest.Add(-10 * time.Millisecond).UnixNano(),
+}
 
 // These will be accepted in either order because of custom sorting in the mock
 var updatedNodes = []storage.Node{
@@ -56,7 +64,6 @@ var updatedNodes = []storage.Node{
 		Hash:   testonly.MustDecodeBase64("R57DrKTGuZdjCNXjv6InGrm4rABLOn9yWpdHmYOoLwU="), NodeRevision: 6},
 }
 
-var fakeTimeForTest = fakeTime()
 var expectedSignedRoot = trillian.SignedLogRoot{
 	RootHash:       []byte{71, 158, 195, 172, 164, 198, 185, 151, 99, 8, 213, 227, 191, 162, 39, 26, 185, 184, 172, 0, 75, 58, 127, 114, 90, 151, 71, 153, 131, 168, 47, 5},
 	TimestampNanos: fakeTimeForTest.UnixNano(),
@@ -247,496 +254,397 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 // Tests for sequencer. Currently relies on having a database set up. This might change in future
 // as it would be better if it was not tied to a specific storage mechanism.
 
-func TestBeginTXFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	params := testParameters{
-		logID:               154035,
-		beginFails:          true,
-		skipDequeue:         true,
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leaves, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leaves != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leaves)
-	}
-	testonly.EnsureErrorContains(t, err, "TX")
-}
-
-func TestSequenceWithNothingQueued(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	params := testParameters{
-		logID:               154035,
-		dequeueLimit:        1,
-		shouldCommit:        true,
-		latestSignedRoot:    &testRoot16,
-		dequeuedLeaves:      []*trillian.LogLeaf{},
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leaves, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leaves != 0 || err != nil {
-		t.Errorf("SequenceBatch()=(%v,%v); want (0,nil)", leaves, err)
-	}
-}
-
-func TestSequenceWithNothingQueuedNewRoot(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
+func TestSequenceBatch(t *testing.T) {
+	signer1, err := newSignerWithFixedSig(expectedSignedRoot.Signature)
 	if err != nil {
 		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-
-	noLeaves := []*trillian.LogLeaf{}
-	noNodes := []storage.Node{}
-	params := testParameters{
-		logID:            154035,
-		dequeueLimit:     1,
-		shouldCommit:     true,
-		latestSignedRoot: &testRoot16,
-		dequeuedLeaves:   []*trillian.LogLeaf{},
-		writeRevision:    testRoot16.TreeRevision + 1,
-		updatedLeaves:    &noLeaves,
-		merkleNodesSet:   &noNodes,
-		signer:           signer,
-		storeSignedRoot: &trillian.SignedLogRoot{
-			TimestampNanos: fakeTimeForTest.UnixNano(),
-			TreeSize:       16,
-			TreeRevision:   6,
-			RootHash:       []byte{},
-			Signature: &sigpb.DigitallySigned{
-				SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
-				HashAlgorithm:      sigpb.DigitallySigned_SHA256,
-				Signature:          []byte("signed"),
-			},
-		},
+	signer16, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
+	if err != nil {
+		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leaves, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 1*time.Millisecond)
-	if leaves != 0 || err != nil {
-		t.Errorf("SequenceBatch()=(%v,%v); want (0,nil)", leaves, err)
+	signerErr, err := newSignerWithErr(errors.New("signerfailed"))
+	if err != nil {
+		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-}
-
-// Tests that the guard interval is being passed to storage correctly. Actual operation of the
-// window is tested by storage tests.
-func TestGuardWindowPassthrough(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
+	leaves16 := []*trillian.LogLeaf{testLeaf16}
 	guardWindow := time.Second * 10
 	expectedCutoffTime := fakeTimeForTest.Add(-guardWindow)
-	params := testParameters{
-		logID:               154035,
-		dequeueLimit:        1,
-		shouldCommit:        true,
-		latestSignedRoot:    &testRoot16,
-		dequeuedLeaves:      []*trillian.LogLeaf{},
-		skipStoreSignedRoot: true,
-		overrideDequeueTime: &expectedCutoffTime,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leaves, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, guardWindow, 0)
-	if leaves != 0 || err != nil {
-		t.Errorf("SequenceBatch()=(%v,%v); want (0,nil)", leaves, err)
-	}
-}
-
-func TestDequeueError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	params := testParameters{
-		logID:               154035,
-		dequeueLimit:        1,
-		dequeuedError:       errors.New("dequeue"),
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	testonly.EnsureErrorContains(t, err, "dequeue")
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-}
-
-func TestLatestRootError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	params := testParameters{
-		logID:                 154035,
-		dequeueLimit:          1,
-		dequeuedLeaves:        leaves,
-		latestSignedRoot:      &testRoot16,
-		latestSignedRootError: errors.New("root"),
-		skipStoreSignedRoot:   true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "root")
-}
-
-func TestUpdateSequencedLeavesError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-	params := testParameters{
-		logID:               154035,
-		writeRevision:       testRoot16.TreeRevision + 1,
-		dequeueLimit:        1,
-		dequeuedLeaves:      leaves,
-		latestSignedRoot:    &testRoot16,
-		updatedLeaves:       &updatedLeaves,
-		updatedLeavesError:  errors.New("unsequenced"),
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "unsequenced")
-}
-
-func TestSetMerkleNodesError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-	params := testParameters{
-		logID:               154035,
-		writeRevision:       testRoot16.TreeRevision + 1,
-		dequeueLimit:        1,
-		dequeuedLeaves:      leaves,
-		latestSignedRoot:    &testRoot16,
-		updatedLeaves:       &updatedLeaves,
-		merkleNodesSet:      &updatedNodes,
-		merkleNodesSetError: errors.New("setmerklenodes"),
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "setmerklenodes")
-}
-
-func TestStoreSignedRootError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
+	noLeaves := []*trillian.LogLeaf{}
+	noNodes := []storage.Node{}
+	newRoot16 := trillian.SignedLogRoot{
+		TimestampNanos: fakeTimeForTest.UnixNano(),
+		TreeSize:       16,
+		TreeRevision:   6,
+		RootHash:       []byte{},
+		Signature: &sigpb.DigitallySigned{
+			SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+			HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+			Signature:          []byte("signed"),
+		},
 	}
 
-	params := testParameters{
-		logID:                154035,
-		writeRevision:        testRoot16.TreeRevision + 1,
-		dequeueLimit:         1,
-		dequeuedLeaves:       leaves,
-		latestSignedRoot:     &testRoot16,
-		updatedLeaves:        &updatedLeaves,
-		merkleNodesSet:       &updatedNodes,
-		storeSignedRoot:      nil,
-		storeSignedRootError: errors.New("storesignedroot"),
-		signer:               signer,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "storesignedroot")
-}
-
-func TestStoreSignedRootSignerFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-
-	signer, err := newSignerWithErr(errors.New("signerfailed"))
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
-	}
-
-	params := testParameters{
-		logID:               154035,
-		writeRevision:       testRoot16.TreeRevision + 1,
-		dequeueLimit:        1,
-		dequeuedLeaves:      leaves,
-		latestSignedRoot:    &testRoot16,
-		updatedLeaves:       &updatedLeaves,
-		merkleNodesSet:      &updatedNodes,
-		storeSignedRoot:     nil,
-		signer:              signer,
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "signerfailed")
-}
-
-func TestCommitFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
-	}
-
-	params := testParameters{
-		logID:            154035,
-		writeRevision:    testRoot16.TreeRevision + 1,
-		dequeueLimit:     1,
-		shouldCommit:     true,
-		commitFails:      true,
-		commitError:      errors.New("commit"),
-		dequeuedLeaves:   leaves,
-		latestSignedRoot: &testRoot16,
-		updatedLeaves:    &updatedLeaves,
-		merkleNodesSet:   &updatedNodes,
-		storeSignedRoot:  nil,
-		signer:           signer,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if leafCount != 0 {
-		t.Fatalf("Unexpectedly sequenced %d leaves on error", leafCount)
-	}
-	testonly.EnsureErrorContains(t, err, "commit")
-}
-
-// TODO: We used a perfect tree size so this isn't testing code that loads the compact Merkle
-// tree. This will be done later as it's planned to refactor it anyway.
-func TestSequenceBatch(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	leaves := []*trillian.LogLeaf{getLeaf42()}
-	updatedLeaves := []*trillian.LogLeaf{testLeaf16}
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot.Signature)
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
-	}
-
-	params := testParameters{
-		logID:            154035,
-		writeRevision:    testRoot16.TreeRevision + 1,
-		dequeueLimit:     1,
-		shouldCommit:     true,
-		dequeuedLeaves:   leaves,
-		latestSignedRoot: &testRoot16,
-		updatedLeaves:    &updatedLeaves,
-		merkleNodesSet:   &updatedNodes,
-		storeSignedRoot:  &expectedSignedRoot,
-		signer:           signer,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	leafCount, err := c.sequencer.SequenceBatch(ctx, params.logID, 1, 0, 0)
-	if err != nil {
-		t.Fatalf("Expected sequencing to succeed, but got err: %v", err)
-	}
-	if got, want := leafCount, 1; got != want {
-		t.Fatalf("Sequenced %d leaf, expected %d", got, want)
-	}
-}
-
-func TestSignBeginTxFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	params := testParameters{
-		logID:               154035,
-		beginFails:          true,
-		skipDequeue:         true,
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	err := c.sequencer.SignRoot(ctx, params.logID)
-	testonly.EnsureErrorContains(t, err, "TX")
-}
-
-func TestSignLatestRootFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	params := testParameters{
-		logID:                 154035,
-		writeRevision:         testRoot16.TreeRevision + 1,
-		dequeueLimit:          1,
-		latestSignedRoot:      &testRoot16,
-		latestSignedRootError: errors.New("root"),
-		skipDequeue:           true,
-		skipStoreSignedRoot:   true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	err := c.sequencer.SignRoot(ctx, params.logID)
-	testonly.EnsureErrorContains(t, err, "root")
-}
-
-func TestSignRootSignerFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	signer, err := newSignerWithErr(errors.New("signerfailed"))
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
-	}
-
-	params := testParameters{
-		logID:               154035,
-		writeRevision:       testRoot16.TreeRevision + 1,
-		dequeueLimit:        1,
-		latestSignedRoot:    &testRoot16,
-		storeSignedRoot:     nil,
-		signer:              signer,
-		skipDequeue:         true,
-		skipStoreSignedRoot: true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	err = c.sequencer.SignRoot(ctx, params.logID)
-	testonly.EnsureErrorContains(t, err, "signer")
-}
-
-func TestSignRootStoreSignedRootFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
-	}
-
-	params := testParameters{
-		logID:                154035,
-		writeRevision:        testRoot16.TreeRevision + 1,
-		latestSignedRoot:     &testRoot16,
-		storeSignedRoot:      nil,
-		storeSignedRootError: errors.New("storesignedroot"),
-		signer:               signer,
-		skipDequeue:          true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	err = c.sequencer.SignRoot(ctx, params.logID)
-	testonly.EnsureErrorContains(t, err, "storesignedroot")
-}
-
-func TestSignRootCommitFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
-	if err != nil {
-		t.Fatalf("Failed to create test signer (%v)", err)
+	var tests = []struct {
+		desc            string
+		params          testParameters
+		guardWindow     time.Duration
+		maxRootDuration time.Duration
+		want            int
+		errStr          string
+	}{
+		{
+			desc: "begin-tx-fails",
+			params: testParameters{
+				logID:               154035,
+				beginFails:          true,
+				skipDequeue:         true,
+				skipStoreSignedRoot: true,
+			},
+			errStr: "TX",
+		},
+		{
+			desc: "nothing-queued-no-max",
+			params: testParameters{
+				logID:               154035,
+				dequeueLimit:        1,
+				shouldCommit:        true,
+				latestSignedRoot:    &testRoot16,
+				dequeuedLeaves:      noLeaves,
+				skipStoreSignedRoot: true,
+			},
+			want: 0,
+		},
+		{
+			desc: "nothing-queued-within-max",
+			params: testParameters{
+				logID:               154035,
+				dequeueLimit:        1,
+				shouldCommit:        true,
+				latestSignedRoot:    &testRoot16,
+				dequeuedLeaves:      noLeaves,
+				skipStoreSignedRoot: true,
+			},
+			maxRootDuration: 15 * time.Millisecond,
+			want:            0,
+		},
+		{
+			desc: "nothing-queued-after-max",
+			params: testParameters{
+				logID:            154035,
+				dequeueLimit:     1,
+				shouldCommit:     true,
+				latestSignedRoot: &testRoot16,
+				dequeuedLeaves:   noLeaves,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				updatedLeaves:    &noLeaves,
+				merkleNodesSet:   &noNodes,
+				signer:           signer16,
+				storeSignedRoot:  &newRoot16,
+			},
+			maxRootDuration: 9 * time.Millisecond,
+			want:            0,
+		},
+		{
+			desc: "nothing-queued-on-max",
+			params: testParameters{
+				logID:            154035,
+				dequeueLimit:     1,
+				shouldCommit:     true,
+				latestSignedRoot: &testRoot16,
+				dequeuedLeaves:   noLeaves,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				updatedLeaves:    &noLeaves,
+				merkleNodesSet:   &noNodes,
+				signer:           signer16,
+				storeSignedRoot:  &newRoot16,
+			},
+			maxRootDuration: 10 * time.Millisecond,
+			want:            0,
+		},
+		{
+			// Tests that the guard interval is being passed to storage correctly.
+			// Actual operation of the window is tested by storage tests.
+			desc: "guard-interval",
+			params: testParameters{
+				logID:               154035,
+				dequeueLimit:        1,
+				shouldCommit:        true,
+				latestSignedRoot:    &testRoot16,
+				dequeuedLeaves:      []*trillian.LogLeaf{},
+				skipStoreSignedRoot: true,
+				overrideDequeueTime: &expectedCutoffTime,
+			},
+			guardWindow: guardWindow,
+		},
+		{
+			desc: "dequeue-fails",
+			params: testParameters{
+				logID:               154035,
+				dequeueLimit:        1,
+				dequeuedError:       errors.New("dequeue"),
+				skipStoreSignedRoot: true,
+			},
+			errStr: "dequeue",
+		},
+		{
+			desc: "get-signed-root-fails",
+			params: testParameters{
+				logID:                 154035,
+				dequeueLimit:          1,
+				dequeuedLeaves:        []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:      &testRoot16,
+				latestSignedRootError: errors.New("root"),
+				skipStoreSignedRoot:   true,
+			},
+			errStr: "root",
+		},
+		{
+			desc: "update-seq-leaves-fails",
+			params: testParameters{
+				logID:               154035,
+				writeRevision:       testRoot16.TreeRevision + 1,
+				dequeueLimit:        1,
+				dequeuedLeaves:      []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:    &testRoot16,
+				updatedLeaves:       &leaves16,
+				updatedLeavesError:  errors.New("unsequenced"),
+				skipStoreSignedRoot: true,
+			},
+			errStr: "unsequenced",
+		},
+		{
+			desc: "set-merkle-nodes-fails",
+			params: testParameters{
+				logID:               154035,
+				writeRevision:       testRoot16.TreeRevision + 1,
+				dequeueLimit:        1,
+				dequeuedLeaves:      []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:    &testRoot16,
+				updatedLeaves:       &leaves16,
+				merkleNodesSet:      &updatedNodes,
+				merkleNodesSetError: errors.New("setmerklenodes"),
+				skipStoreSignedRoot: true,
+			},
+			errStr: "setmerklenodes",
+		},
+		{
+			desc: "store-root-fails",
+			params: testParameters{
+				logID:                154035,
+				writeRevision:        testRoot16.TreeRevision + 1,
+				dequeueLimit:         1,
+				dequeuedLeaves:       []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:     &testRoot16,
+				updatedLeaves:        &leaves16,
+				merkleNodesSet:       &updatedNodes,
+				storeSignedRoot:      nil,
+				storeSignedRootError: errors.New("storesignedroot"),
+				signer:               signer16,
+			},
+			errStr: "storesignedroot",
+		},
+		{
+			desc: "signer-fails",
+			params: testParameters{
+				logID:               154035,
+				writeRevision:       testRoot16.TreeRevision + 1,
+				dequeueLimit:        1,
+				dequeuedLeaves:      []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:    &testRoot16,
+				updatedLeaves:       &leaves16,
+				merkleNodesSet:      &updatedNodes,
+				storeSignedRoot:     nil,
+				signer:              signerErr,
+				skipStoreSignedRoot: true,
+			},
+			errStr: "signerfailed",
+		},
+		{
+			desc: "commit-fails",
+			params: testParameters{
+				logID:            154035,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				dequeueLimit:     1,
+				shouldCommit:     true,
+				commitFails:      true,
+				commitError:      errors.New("commit"),
+				dequeuedLeaves:   []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot: &testRoot16,
+				updatedLeaves:    &leaves16,
+				merkleNodesSet:   &updatedNodes,
+				storeSignedRoot:  nil,
+				signer:           signer16,
+			},
+			errStr: "commit",
+		},
+		{
+			// TODO: We used a perfect tree size so this isn't testing code that loads the compact Merkle
+			// tree. This will be done later as it's planned to refactor it anyway.
+			desc: "sequence-leaf-16",
+			params: testParameters{
+				logID:            154035,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				dequeueLimit:     1,
+				shouldCommit:     true,
+				dequeuedLeaves:   []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot: &testRoot16,
+				updatedLeaves:    &leaves16,
+				merkleNodesSet:   &updatedNodes,
+				storeSignedRoot:  &expectedSignedRoot,
+				signer:           signer1,
+			},
+			want: 1,
+		},
 	}
 
-	params := testParameters{
-		logID:            154035,
-		writeRevision:    testRoot16.TreeRevision + 1,
-		shouldCommit:     true,
-		commitFails:      true,
-		commitError:      errors.New("commit"),
-		latestSignedRoot: &testRoot16,
-		storeSignedRoot:  nil,
-		signer:           signer,
-		skipDequeue:      true,
-	}
-	c, ctx := createTestContext(ctrl, params)
+	for _, test := range tests {
+		func() {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c, ctx := createTestContext(ctrl, test.params)
 
-	err = c.sequencer.SignRoot(ctx, params.logID)
-	testonly.EnsureErrorContains(t, err, "commit")
+			got, err := c.sequencer.SequenceBatch(ctx, test.params.logID, 1, test.guardWindow, test.maxRootDuration)
+			if err != nil {
+				if test.errStr == "" {
+					t.Errorf("SequenceBatch(%+v)=%v,%v; want _,nil", test.params, got, err)
+				} else if !strings.Contains(err.Error(), test.errStr) || got != 0 {
+					t.Errorf("SequenceBatch(%+v)=%v,%v; want 0, error with %q", test.params, got, err, test.errStr)
+				}
+				return
+			}
+			if got != test.want {
+				t.Errorf("SequenceBatch(%+v)=%v,nil; want %v,nil", test.params, got, test.want)
+			}
+		}()
+	}
 }
 
 func TestSignRoot(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
+	signer0, err := newSignerWithFixedSig(expectedSignedRoot0.Signature)
 	if err != nil {
 		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-
-	params := testParameters{
-		logID:            154035,
-		writeRevision:    testRoot16.TreeRevision + 1,
-		latestSignedRoot: &testRoot16,
-		storeSignedRoot:  &expectedSignedRoot16,
-		signer:           signer,
-		shouldCommit:     true,
-		skipDequeue:      true,
-	}
-	c, ctx := createTestContext(ctrl, params)
-
-	if err := c.sequencer.SignRoot(ctx, params.logID); err != nil {
-		t.Fatalf("Expected signing to succeed, but got err: %v", err)
-	}
-}
-
-func TestSignRootNoExistingRoot(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	signer, err := newSignerWithFixedSig(expectedSignedRoot0.Signature)
+	signer16, err := newSignerWithFixedSig(expectedSignedRoot16.Signature)
 	if err != nil {
 		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-
-	params := testParameters{
-		logID:            154035,
-		writeRevision:    testRoot16.TreeRevision + 1,
-		latestSignedRoot: &trillian.SignedLogRoot{},
-		storeSignedRoot:  &expectedSignedRoot0,
-		signer:           signer,
-		shouldCommit:     true,
-		skipDequeue:      true,
+	signerErr, err := newSignerWithErr(errors.New("signerfailed"))
+	if err != nil {
+		t.Fatalf("Failed to create test signer (%v)", err)
 	}
-	c, ctx := createTestContext(ctrl, params)
+	var tests = []struct {
+		desc   string
+		params testParameters
+		errStr string
+	}{
+		{
+			desc: "begin-tx-fails",
+			params: testParameters{
+				logID:               154035,
+				beginFails:          true,
+				skipDequeue:         true,
+				skipStoreSignedRoot: true,
+			},
+			errStr: "TX",
+		},
+		{
+			desc: "sign-latest-root-fails",
+			params: testParameters{
+				logID:                 154035,
+				writeRevision:         testRoot16.TreeRevision + 1,
+				dequeueLimit:          1,
+				latestSignedRoot:      &testRoot16,
+				latestSignedRootError: errors.New("root"),
+				skipDequeue:           true,
+				skipStoreSignedRoot:   true,
+			},
+			errStr: "root",
+		},
+		{
+			desc: "signer-fails",
+			params: testParameters{
+				logID:               154035,
+				writeRevision:       testRoot16.TreeRevision + 1,
+				dequeueLimit:        1,
+				latestSignedRoot:    &testRoot16,
+				storeSignedRoot:     nil,
+				signer:              signerErr,
+				skipDequeue:         true,
+				skipStoreSignedRoot: true,
+			},
+			errStr: "signer",
+		},
+		{
+			desc: "store-root-fail",
+			params: testParameters{
+				logID:                154035,
+				writeRevision:        testRoot16.TreeRevision + 1,
+				latestSignedRoot:     &testRoot16,
+				storeSignedRoot:      nil,
+				storeSignedRootError: errors.New("storesignedroot"),
+				signer:               signer16,
+				skipDequeue:          true,
+			},
+			errStr: "storesignedroot",
+		},
+		{
+			desc: "root-commit-fail",
+			params: testParameters{
+				logID:            154035,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				shouldCommit:     true,
+				commitFails:      true,
+				commitError:      errors.New("commit"),
+				latestSignedRoot: &testRoot16,
+				storeSignedRoot:  nil,
+				signer:           signer16,
+				skipDequeue:      true,
+			},
+			errStr: "commit",
+		},
+		{
+			desc: "existing-root",
+			params: testParameters{
+				logID:            154035,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				latestSignedRoot: &testRoot16,
+				storeSignedRoot:  &expectedSignedRoot16,
+				signer:           signer16,
+				shouldCommit:     true,
+				skipDequeue:      true,
+			},
+		},
+		{
+			desc: "no-existing-root",
+			params: testParameters{
+				logID:            154035,
+				writeRevision:    testRoot16.TreeRevision + 1,
+				latestSignedRoot: &trillian.SignedLogRoot{},
+				storeSignedRoot:  &expectedSignedRoot0,
+				signer:           signer0,
+				shouldCommit:     true,
+				skipDequeue:      true,
+			},
+		},
+	}
 
-	if err := c.sequencer.SignRoot(ctx, params.logID); err != nil {
-		t.Fatalf("Expected signing to succeed, but got err: %v", err)
+	for _, test := range tests {
+		func() {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c, ctx := createTestContext(ctrl, test.params)
+			err := c.sequencer.SignRoot(ctx, test.params.logID)
+			if test.errStr != "" {
+				if err == nil {
+					t.Errorf("SignRoot(%+v)=nil; want error with %q", test.params, test.errStr)
+				} else if !strings.Contains(err.Error(), test.errStr) {
+					t.Errorf("SignRoot(%+v)=%v; want error with %q", test.params, err, test.errStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("SignRoot(%+v)=%v; want nil", test.params, err)
+			}
+		}()
 	}
 }

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -76,10 +76,8 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 	}
 
 	sequencer := log.NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer)
-	sequencer.SetGuardWindow(s.guardWindow)
-	sequencer.SetMaxRootDurationInterval(time.Duration(tree.MaxRootDurationMillis * int64(time.Millisecond)))
 
-	leaves, err := sequencer.SequenceBatch(ctx, logID, info.BatchSize)
+	leaves, err := sequencer.SequenceBatch(ctx, logID, info.BatchSize, s.guardWindow, time.Duration(tree.MaxRootDurationMillis*int64(time.Millisecond)))
 	if err != nil {
 		return 0, fmt.Errorf("failed to sequence batch for %v: %v", logID, err)
 	}

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -77,6 +77,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 
 	sequencer := log.NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer)
 	sequencer.SetGuardWindow(s.guardWindow)
+	sequencer.SetMaxRootDurationInterval(time.Duration(tree.MaxRootDurationMillis * int64(time.Millisecond)))
 
 	leaves, err := sequencer.SequenceBatch(ctx, logID, info.BatchSize)
 	if err != nil {

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -45,7 +45,8 @@ const (
 			CreateTimeMillis,
 			UpdateTimeMillis,
 			PrivateKey,
-			PublicKey
+			PublicKey,
+			MaxRootDurationMillis
 		FROM Trees`
 	selectTreeByID = selectTrees + " WHERE TreeId = ?"
 )
@@ -140,7 +141,7 @@ func readTree(row row) (*trillian.Tree, error) {
 
 	// Enums and Datetimes need an extra conversion step
 	var treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm string
-	var createMillis, updateMillis int64
+	var createMillis, updateMillis, maxRootDurationMillis int64
 	var displayName, description sql.NullString
 	var privateKey, publicKey []byte
 	err := row.Scan(
@@ -156,6 +157,7 @@ func readTree(row row) (*trillian.Tree, error) {
 		&updateMillis,
 		&privateKey,
 		&publicKey,
+		&maxRootDurationMillis,
 	)
 	if err != nil {
 		return nil, err
@@ -206,6 +208,7 @@ func readTree(row row) (*trillian.Tree, error) {
 
 	tree.CreateTimeMillisSinceEpoch = createMillis
 	tree.UpdateTimeMillisSinceEpoch = updateMillis
+	tree.MaxRootDurationMillis = maxRootDurationMillis
 
 	tree.PrivateKey = &any.Any{}
 	if err := proto.Unmarshal(privateKey, tree.PrivateKey); err != nil {
@@ -303,8 +306,9 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 			CreateTimeMillis,
 			UpdateTimeMillis,
 			PrivateKey,
-			PublicKey)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+			PublicKey,
+			MaxRootDurationMillis)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return nil, err
 	}
@@ -329,6 +333,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 		newTree.UpdateTimeMillisSinceEpoch,
 		privateKey,
 		newTree.PublicKey.GetDer(),
+		newTree.MaxRootDurationMillis,
 	)
 	if err != nil {
 		return nil, err
@@ -390,7 +395,7 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	stmt, err := t.tx.PrepareContext(
 		ctx,
 		`UPDATE Trees
-		SET TreeState = ?, DisplayName = ?, Description = ?, UpdateTimeMillis = ?
+		SET TreeState = ?, DisplayName = ?, Description = ?, UpdateTimeMillis = ?, MaxRootDurationMillis = ?
 		WHERE TreeId = ?`)
 	if err != nil {
 		return nil, err
@@ -403,6 +408,7 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 		tree.DisplayName,
 		tree.Description,
 		tree.UpdateTimeMillisSinceEpoch,
+		tree.MaxRootDurationMillis,
 		tree.TreeId); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS Trees(
   Description           VARCHAR(200),
   CreateTimeMillis      BIGINT NOT NULL,
   UpdateTimeMillis      BIGINT NOT NULL,
+  MaxRootDurationMillis BIGINT NOT NULL,
   PrivateKey            MEDIUMBLOB NOT NULL,
   PublicKey             MEDIUMBLOB NOT NULL,
   PRIMARY KEY(TreeId)
@@ -150,4 +151,3 @@ CREATE TABLE IF NOT EXISTS MapHead(
   UNIQUE INDEX TreeRevisionIdx(TreeId, MapRevision),
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
 );
-

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -73,6 +73,7 @@ var (
 		PublicKey: &keyspb.PublicKey{
 			Der: loadPublicPEMFileAsDER("../../testdata/log-rpc-server.pubkey.pem"),
 		},
+		MaxRootDurationMillis: 0,
 	}
 
 	// MapTree is a valid, MAP-type trillian.Tree for tests.
@@ -91,6 +92,7 @@ var (
 		PublicKey: &keyspb.PublicKey{
 			Der: loadPublicPEMFileAsDER("../../testdata/map-rpc-server.pubkey.pem"),
 		},
+		MaxRootDurationMillis: 0,
 	}
 )
 

--- a/storage/tree_validation.go
+++ b/storage/tree_validation.go
@@ -108,6 +108,8 @@ func validateMutableTreeFields(tree *trillian.Tree) error {
 		return errors.Errorf(errors.InvalidArgument, "display_name too big, max length is %v: %v", maxDisplayNameLength, tree.DisplayName)
 	case len(tree.Description) > maxDescriptionLength:
 		return errors.Errorf(errors.InvalidArgument, "description too big, max length is %v: %v", maxDescriptionLength, tree.Description)
+	case tree.MaxRootDurationMillis < 0:
+		return errors.Errorf(errors.InvalidArgument, "max_root_duration negative: %v", tree.MaxRootDurationMillis)
 	}
 
 	// Implementations may vary, so let's assume storage_settings is mutable.

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -89,6 +89,9 @@ func TestValidateTreeForCreation(t *testing.T) {
 	validSettings := newTree()
 	validSettings.StorageSettings = settings
 
+	invalidRootDuration := newTree()
+	invalidRootDuration.MaxRootDurationMillis = -1
+
 	tests := []struct {
 		desc    string
 		tree    *trillian.Tree
@@ -191,6 +194,11 @@ func TestValidateTreeForCreation(t *testing.T) {
 			desc: "validSettings",
 			tree: validSettings,
 		},
+		{
+			desc:    "invalidRootDuration",
+			tree:    invalidRootDuration,
+			wantErr: true,
+		},
 	}
 	for _, test := range tests {
 		err := ValidateTreeForCreation(test.tree)
@@ -236,6 +244,19 @@ func TestValidateTreeForUpdate(t *testing.T) {
 			desc: "invalidSettings",
 			updatefn: func(tree *trillian.Tree) {
 				tree.StorageSettings = &any.Any{Value: []byte("foobar")}
+			},
+			wantErr: true,
+		},
+		{
+			desc: "validRootDuration",
+			updatefn: func(tree *trillian.Tree) {
+				tree.MaxRootDurationMillis = 200
+			},
+		},
+		{
+			desc: "invalidRootDuration",
+			updatefn: func(tree *trillian.Tree) {
+				tree.MaxRootDurationMillis = -200
 			},
 			wantErr: true,
 		},
@@ -334,14 +355,15 @@ func newTree() *trillian.Tree {
 	}
 
 	return &trillian.Tree{
-		TreeState:          trillian.TreeState_ACTIVE,
-		TreeType:           trillian.TreeType_LOG,
-		HashStrategy:       trillian.HashStrategy_RFC_6962,
-		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
-		SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
-		DisplayName:        "Llamas Log",
-		Description:        "Registry of publicly-owned llamas",
-		PrivateKey:         privateKey,
-		PublicKey:          &keyspb.PublicKey{Der: publicKeyPEM.Bytes},
+		TreeState:             trillian.TreeState_ACTIVE,
+		TreeType:              trillian.TreeType_LOG,
+		HashStrategy:          trillian.HashStrategy_RFC_6962,
+		HashAlgorithm:         sigpb.DigitallySigned_SHA256,
+		SignatureAlgorithm:    sigpb.DigitallySigned_ECDSA,
+		DisplayName:           "Llamas Log",
+		Description:           "Registry of publicly-owned llamas",
+		PrivateKey:            privateKey,
+		PublicKey:             &keyspb.PublicKey{Der: publicKeyPEM.Bytes},
+		MaxRootDurationMillis: 1000,
 	}
 }

--- a/trillian.pb.go
+++ b/trillian.pb.go
@@ -168,6 +168,9 @@ type Tree struct {
 	// The public key used for verifying tree heads and entry timestamps.
 	// Readonly.
 	PublicKey *keyspb.PublicKey `protobuf:"bytes,14,opt,name=public_key,json=publicKey" json:"public_key,omitempty"`
+	// Interval after which a new signed root is produced even if there have been
+	// no submission.  If zero, this behavior is disabled.
+	MaxRootDurationMillis int64 `protobuf:"varint,15,opt,name=max_root_duration_millis,json=maxRootDurationMillis" json:"max_root_duration_millis,omitempty"`
 }
 
 func (m *Tree) Reset()                    { *m = Tree{} }
@@ -264,6 +267,13 @@ func (m *Tree) GetPublicKey() *keyspb.PublicKey {
 		return m.PublicKey
 	}
 	return nil
+}
+
+func (m *Tree) GetMaxRootDurationMillis() int64 {
+	if m != nil {
+		return m.MaxRootDurationMillis
+	}
+	return 0
 }
 
 type SignedEntryTimestamp struct {

--- a/trillian.proto
+++ b/trillian.proto
@@ -144,6 +144,10 @@ message Tree {
   // The public key used for verifying tree heads and entry timestamps.
   // Readonly.
   keyspb.PublicKey public_key = 14;
+
+  // Interval after which a new signed root is produced even if there have been
+  // no submission.  If zero, this behavior is disabled.
+  int64 max_root_duration_millis = 15;
 }
 
 message SignedEntryTimestamp {


### PR DESCRIPTION
For a CT log, RFC 6962 s3.5 specifies that the log should produce a new
STH within the MMD even if there have been no additions to the log.

To allow a CT personality to get the same behavior, add a per-Tree option
to force regeneration of a signed log root after an interval.

This option is implemented in the signer rather than in the personality
because a different user of Trillian-as-a-service may also have the same
requirement that led to RFC 6962 s3.5.

Note that similar functionality was previously removed in commit 0b66fd9
("Remove the code for signing log roots if the last one is too old.")

Addresses issue #575