### PR TITLE
Set session affinity of MySQL load balancer to "ClientIP"

### DIFF
--- a/storage/mysql/kubernetes/galera.yaml
+++ b/storage/mysql/kubernetes/galera.yaml
@@ -17,6 +17,10 @@ spec:
     - port: 3306
       name: mysql
   type: LoadBalancer
+  # Make all connections from a particular client go to the same database
+  # replica. This avoids a sequencer connecting to different replicas in
+  # parallel and causing write conflicts that result in transaction rollbacks.
+  sessionAffinity: ClientIP
   selector:
     app: galera
 ---


### PR DESCRIPTION
This avoids a single sequencer connecting to multiple database replicas, which results in a large number of conflicts (it appears the parallel goroutines can start multiple transactions, with identical sequence numbers, only one of which can actually succeed).