### PR TITLE
Make clients responsible for managing the trusted root

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -48,16 +48,12 @@ type VerifyingLogClient interface {
 
 // LogVerifier verifies responses from a Trillian Log.
 type LogVerifier interface {
-	// Root provides the last root obtained by UpdateRoot.
-	Root() trillian.SignedLogRoot
-	// UpdateRoot applies a GetLatestSignedLogRootResponse to Root(), if valid.
-	// consistency may be nil if Root().TreeSize is zero.
-	UpdateRoot(resp *trillian.GetLatestSignedLogRootResponse,
-		consistency *trillian.GetConsistencyProofResponse) error
+	// VerifyRoot verifies that newRoot is a valid append-only operation from trusted.
+	// If trusted.TreeSize is zero, an append-only proof is not needed.
+	VerifyRoot(trusted, newRoot *trillian.SignedLogRoot, consistency [][]byte) error
 	// VerifyInclusionAtIndex verifies that the inclusion proof for data at index matches
 	// the currently trusted root. The inclusion proof must be requested for Root().TreeSize.
-	VerifyInclusionAtIndex(data []byte, leafIndex int64,
-		resp *trillian.GetInclusionProofResponse) error
+	VerifyInclusionAtIndex(trusted *trillian.SignedLogRoot, data []byte, leafIndex int64, proof [][]byte) error
 	// VerifyInclusionByHash verifies the inclusion proof for data
-	VerifyInclusionByHash(leafHash []byte, proof *trillian.Proof) error
+	VerifyInclusionByHash(trusted *trillian.SignedLogRoot, leafHash []byte, proof *trillian.Proof) error
 }

--- a/client/offline.go
+++ b/client/offline.go
@@ -39,8 +39,8 @@ func NewLogVerifier(hasher merkle.TreeHasher, pubKey crypto.PublicKey) LogVerifi
 	}
 }
 
-// VerifyRoot verifies that a resp is a valid append-only operation from trusted.
-// If trusted.TreeSize is zero, an append-only proof is not needed.
+// VerifyRoot verifies that newRoot is a valid append-only operation from trusted.
+// If trusted.TreeSize is zero, a consistency proof is not needed.
 func (c *logVerifier) VerifyRoot(trusted, newRoot *trillian.SignedLogRoot,
 	consistency [][]byte) error {
 


### PR DESCRIPTION
Previously, I had pulled out the logic around updating the trusted root into this sub-module. 
When I tried using it in key transparency, I realized I had introduced a module with difficult-to-test state as a deep dependency, making things difficult to reason about and test.

This PR keeps the authentication submodules stateless. 

While this reduces the responsibilities of this submodule to a thin wrapper, it still has value as an abstractable interface for testing and mocking, as well as clarify of function invocation. 