### PR TITLE
Add Docker build files

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,8 @@
+FROM mysql
+
+ENV MYSQL_PASSWORD=zaphod \
+    MYSQL_USER=test \
+    MYSQL_DATABASE=test \
+    MYSQL_RANDOM_ROOT_PASSWORD=yes
+
+ADD storage/mysql/storage.sql /docker-entrypoint-initdb.d/storage.sql

--- a/server/trillian_log_server/Dockerfile
+++ b/server/trillian_log_server/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang
+
+ENV DB_USER=test \
+    DB_PASSWORD=zaphod \
+    DB_DATABASE=test \
+    DB_HOST=127.0.0.0:3306 
+
+ENV HOST=0.0.0.0 \
+    RPC_PORT=8090 \
+    HTTP_PORT=8091 
+
+ENV DUMP_METRICS 0s
+
+ADD . /go/src/github.com/google/trillian
+WORKDIR /go/src/github.com/google/trillian 
+
+RUN go get -v ./server/trillian_log_server
+
+ENTRYPOINT /go/bin/trillian_log_server \
+	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
+	--rpc_endpoint="$HOST:$RPC_PORT" \
+	--http_endpoint="$HOST:$HTTP_PORT" \
+	--dump_metrics_interval="$DUMP_METRICS"
+
+EXPOSE $RPC_PORT
+EXPOSE $HTTP_PORT
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1

--- a/server/trillian_log_server/Dockerfile
+++ b/server/trillian_log_server/Dockerfile
@@ -11,7 +11,7 @@ ENV HOST=0.0.0.0 \
 
 ENV DUMP_METRICS 0s
 
-ADD . /go/src/github.com/google/trillian
+ADD . /go/src/github.com/google/trillian 
 WORKDIR /go/src/github.com/google/trillian 
 
 RUN go get -v ./server/trillian_log_server
@@ -20,7 +20,8 @@ ENTRYPOINT /go/bin/trillian_log_server \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \
 	--http_endpoint="$HOST:$HTTP_PORT" \
-	--dump_metrics_interval="$DUMP_METRICS"
+	--dump_metrics_interval="$DUMP_METRICS" \ 
+	--alsologtostderr 
 
 EXPOSE $RPC_PORT
 EXPOSE $HTTP_PORT

--- a/server/trillian_log_signer/Dockerfile
+++ b/server/trillian_log_signer/Dockerfile
@@ -16,7 +16,7 @@ ENV SEQUENCER_GUARD_WINDOW=0s \
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian 
 
-RUN go get -v ./server/trillian_log_signer
+RUN go get ./server/trillian_log_signer
 
 # Run the outyet command by default when the container starts.
 ENTRYPOINT /go/bin/trillian_log_signer \
@@ -24,7 +24,8 @@ ENTRYPOINT /go/bin/trillian_log_signer \
 	--http_endpoint="$HOST:$HTTP_PORT" \
 	--dump_metrics_interval="$DUMP_METRICS" \
 	--sequencer_guard_window="$SEQUENCER_GUARD_WINDOW" \
-	--force_master="$FORCE_MASTER"
+	--force_master="$FORCE_MASTER" \
+	--alsologtostderr
 
 EXPOSE $HTTP_PORT
 

--- a/server/trillian_log_signer/Dockerfile
+++ b/server/trillian_log_signer/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang
+
+ENV DB_USER=test \
+    DB_PASSWORD=zaphod \
+    DB_DATABASE=test \
+    DB_HOST=127.0.0.0:3306
+
+ENV HOST=0.0.0.0 \
+    HTTP_PORT=8091
+
+ENV SEQUENCER_GUARD_WINDOW=0s \
+    DUMP_METRICS=0s
+
+ADD . /go/src/github.com/google/trillian
+WORKDIR /go/src/github.com/google/trillian 
+
+RUN go get -v ./server/trillian_log_signer
+
+# Run the outyet command by default when the container starts.
+ENTRYPOINT /go/bin/trillian_log_signer \
+	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
+	--http_endpoint="$HOST:$HTTP_PORT" \
+	--dump_metrics_interval="$DUMP_METRICS" \
+	--sequencer_guard_window="$SEQUENCER_GUARD_WINDOW"
+
+EXPOSE $HTTP_PORT
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1

--- a/server/trillian_log_signer/Dockerfile
+++ b/server/trillian_log_signer/Dockerfile
@@ -9,7 +9,9 @@ ENV HOST=0.0.0.0 \
     HTTP_PORT=8091
 
 ENV SEQUENCER_GUARD_WINDOW=0s \
-    DUMP_METRICS=0s
+    DUMP_METRICS=0s \
+    FORCE_MASTER=true
+
 
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian 
@@ -21,7 +23,8 @@ ENTRYPOINT /go/bin/trillian_log_signer \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--http_endpoint="$HOST:$HTTP_PORT" \
 	--dump_metrics_interval="$DUMP_METRICS" \
-	--sequencer_guard_window="$SEQUENCER_GUARD_WINDOW"
+	--sequencer_guard_window="$SEQUENCER_GUARD_WINDOW" \
+	--force_master="$FORCE_MASTER"
 
 EXPOSE $HTTP_PORT
 

--- a/server/vmap/trillian_map_server/Dockerfile
+++ b/server/vmap/trillian_map_server/Dockerfile
@@ -9,20 +9,17 @@ ENV HOST=0.0.0.0 \
     RPC_PORT=8090 \
     HTTP_PORT=8091 
 
-ENV SEQUENCER_GUARD_WINDOW=0s \
-    DUMP_METRICS=0s
-
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian 
 
-RUN go get -v ./server/vmap/trillian_map_server
+RUN go get ./server/vmap/trillian_map_server
 
 # Run the outyet command by default when the container starts.
 ENTRYPOINT /go/bin/trillian_map_server \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \
 	--http_endpoint="$HOST:$HTTP_PORT" \ 
-	--alsologtostderr \
+	--alsologtostderr
 
 EXPOSE $HTTP_PORT
 

--- a/server/vmap/trillian_map_server/Dockerfile
+++ b/server/vmap/trillian_map_server/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR /go/src/github.com/google/trillian
 
 RUN go get ./server/vmap/trillian_map_server
 
-# Run the outyet command by default when the container starts.
 ENTRYPOINT /go/bin/trillian_map_server \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \

--- a/server/vmap/trillian_map_server/Dockerfile
+++ b/server/vmap/trillian_map_server/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang
+
+ENV DB_USER=test \
+    DB_PASSWORD=zaphod \
+    DB_DATABASE=test \
+    DB_HOST=127.0.0.0:3306 
+
+ENV HOST=0.0.0.0 \
+    RPC_PORT=8090 \
+    HTTP_PORT=8091 
+
+ENV SEQUENCER_GUARD_WINDOW=0s \
+    DUMP_METRICS=0s
+
+ADD . /go/src/github.com/google/trillian
+WORKDIR /go/src/github.com/google/trillian 
+
+RUN go get -v ./server/vmap/trillian_map_server
+
+# Run the outyet command by default when the container starts.
+ENTRYPOINT /go/bin/trillian_map_server \
+	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
+	--rpc_endpoint="$HOST:$RPC_PORT" \
+	--http_endpoint="$HOST:$HTTP_PORT" 
+
+EXPOSE $HTTP_PORT
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1
+

--- a/server/vmap/trillian_map_server/Dockerfile
+++ b/server/vmap/trillian_map_server/Dockerfile
@@ -21,7 +21,8 @@ RUN go get -v ./server/vmap/trillian_map_server
 ENTRYPOINT /go/bin/trillian_map_server \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \
-	--http_endpoint="$HOST:$HTTP_PORT" 
+	--http_endpoint="$HOST:$HTTP_PORT" \ 
+	--alsologtostderr \
 
 EXPOSE $HTTP_PORT
 


### PR DESCRIPTION
Support building trillian clusters by defining docker build files.
They should be run like so:
`docker build -f server/trillian_log_server/Dockerfile .` from `$GOPATH/src/github.com/google/trillian`

Please correct me if these are the wrong binaries to be defining definitions for. 
I see that there's also a `server/main.go` which has some duplicate functionality. 