### PR TITLE
Remove liveness probe for Galera instances

### DIFF
--- a/storage/mysql/kubernetes/galera.yaml
+++ b/storage/mysql/kubernetes/galera.yaml
@@ -86,8 +86,6 @@ spec:
           readinessProbe:
             exec:
               command: ["mysql", "-h", "127.0.0.1", "-u", "dummy", "-e", "SELECT 1"]
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
           image: us.gcr.io/trillian-test/galera:experimental
           imagePullPolicy: Always
           name: mysql

--- a/storage/mysql/kubernetes/galera.yaml
+++ b/storage/mysql/kubernetes/galera.yaml
@@ -83,11 +83,6 @@ spec:
         - resources:
             limits:
               cpu: 2
-          livenessProbe:
-            exec:
-              command: ["mysqladmin", "-u", "dummy", "ping"]
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
           readinessProbe:
             exec:
               command: ["mysql", "-h", "127.0.0.1", "-u", "dummy", "-e", "SELECT 1"]


### PR DESCRIPTION
If an SST was underway to replicate the database state, the recipient Galera instance would appear to be dead, according to this probe, until the SST completed. This would result in Kubernetes killing the recipient.

TODO: Devise a better liveness probe, perhaps checking whether the file "/data/mysql/sst_in_progress" exists.