### PR TITLE
Allow Galera nodes to discover each other using DNS

### DIFF
--- a/storage/mysql/kubernetes/image/Dockerfile
+++ b/storage/mysql/kubernetes/image/Dockerfile
@@ -22,8 +22,10 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 ENV MYSQL_VERSION 5.7
 ENV TERM linux
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y perl --no-install-recommends && rm -rf /var/lib/apt/lists/*
+# Install perl.
+# Install dig, for discovering IP addresses of other Galera nodes.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y dnsutils perl --no-install-recommends
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A 9334A25F8507EFA5
 


### PR DESCRIPTION
Rather than only being able to connect to nodes that were created before them (e.g. galera-1 only being able to connect to galera-0), a node can now connect to any other running nodes by querying Kubernetes DNS.