### PR TITLE
Add a placeholder in schema for bucketed queue

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -39,19 +39,20 @@ const (
 	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos
 			FROM Unsequenced
 			WHERE TreeID=?
+			AND Bucket=0
 			AND QueueTimestampNanos<=?
 			ORDER BY QueueTimestampNanos,LeafIdentityHash ASC LIMIT ?`
 	insertUnsequencedLeafSQL = `INSERT INTO LeafData(TreeId,LeafIdentityHash,LeafValue,ExtraData)
 			VALUES(?,?,?,?)`
-	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos)
-			VALUES(?,?,?,?)`
+	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos)
+			VALUES(?,0,?,?,?)`
 	insertSequencedLeafSQL = `INSERT INTO SequencedLeafData(TreeId,LeafIdentityHash,MerkleLeafHash,SequenceNumber)
 			VALUES(?,?,?,?)`
 	selectSequencedLeafCountSQL  = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
 	selectLatestSignedLogRootSQL = `SELECT TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature
 			FROM TreeHead WHERE TreeId=?
 			ORDER BY TreeHeadTimestamp DESC LIMIT 1`
-	deleteUnsequencedSQL = "DELETE FROM Unsequenced WHERE TreeId=? AND QueueTimestampNanos=? AND LeafIdentityHash=?"
+	deleteUnsequencedSQL = "DELETE FROM Unsequenced WHERE TreeId=? AND Bucket=0 AND QueueTimestampNanos=? AND LeafIdentityHash=?"
 
 	// These statements need to be expanded to provide the correct number of parameter placeholders.
 	selectLeavesByIndexSQL = `SELECT s.MerkleLeafHash,l.LeafIdentityHash,l.LeafValue,s.SequenceNumber,l.ExtraData

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -111,6 +111,9 @@ CREATE TABLE IF NOT EXISTS SequencedLeafData(
 
 CREATE TABLE IF NOT EXISTS Unsequenced(
   TreeId               BIGINT NOT NULL,
+  -- The bucket field is to allow the use of time based ring bucketed schemes if desired. If
+  -- unused this should be set to zero for all entries.
+  Bucket               INTEGER NOT NULL,
   -- This is a personality specific hash of some subset of the leaf data.
   -- It's only purpose is to allow Trillian to identify duplicate entries in
   -- the context of the personality.
@@ -119,7 +122,7 @@ CREATE TABLE IF NOT EXISTS Unsequenced(
   -- CT this hash will include the leaf prefix byte as well as the leaf data.
   MerkleLeafHash       VARBINARY(255) NOT NULL,
   QueueTimestampNanos  BIGINT NOT NULL,
-  PRIMARY KEY (TreeId, QueueTimestampNanos, LeafIdentityHash)
+  PRIMARY KEY (TreeId, Bucket, QueueTimestampNanos, LeafIdentityHash)
 );
 
 


### PR DESCRIPTION
As it's currently unclear whether a bucketed queue strategy is an improvement for SQL based storage this adds a placeholder bucket to the queue that's always zero. We can then adopt various more complex queue strategies (if they prove to work) without further changes to the database.