### PR TITLE
Ensure Trillian Log core is ok with adding duplicate entries.

### DIFF
--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -21,6 +21,9 @@ import (
 	"time"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keys"
+	"github.com/google/trillian/extension"
+	"github.com/google/trillian/storage/memory"
 	"github.com/google/trillian/testonly/integration"
 	"google.golang.org/grpc"
 )
@@ -95,6 +98,36 @@ func TestInProcessLogIntegration(t *testing.T) {
 
 	client := trillian.NewTrillianLogClient(env.ClientConn)
 	params := DefaultTestParameters(logID)
+	if err := RunLogIntegration(client, params); err != nil {
+		t.Fatalf("Test failed: %v", err)
+	}
+}
+
+func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
+	ctx := context.Background()
+	const numSequencers = 2
+	ms := memory.NewLogStorage()
+
+	reggie := extension.Registry{
+		AdminStorage:  memory.NewAdminStorage(ms),
+		SignerFactory: keys.PEMSignerFactory{},
+		LogStorage:    ms,
+	}
+
+	env, err := integration.NewLogEnvWithRegistry(ctx, numSequencers, "TestInProcessLogIntegrationDuplicateLeaves", reggie)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+
+	logID, err := env.CreateLog()
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	client := trillian.NewTrillianLogClient(env.ClientConn)
+	params := DefaultTestParameters(logID)
+	params.uniqueLeaves = 10
 	if err := RunLogIntegration(client, params); err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -194,12 +194,12 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	// TODO(mhs): Might be better to create empty root in provisioning API when it exists
 	if currentRoot.RootHash == nil {
 		glog.Warningf("%v: Fresh log - no previous TreeHeads exist.", logID)
-		// SignRoot starts a new transaction, and we've gone one open here until
+		// SignRoot starts a new transaction, and we've got one open here until
 		// this function returns.
 		// This explicit Close() is a work-around for the in-memory storage which
 		// locks the tree for each TX.
-		// TODO(al): The Close() is benign enough since implementations are all
-		// idempotent, but would be nice to not have to worry about it.
+		// TODO(al): Producing the first signed root for a new tree should be
+		// handled by the provisioning, move it there.
 		tx.Close()
 		return 0, s.SignRoot(ctx, logID)
 	}

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -194,6 +194,13 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int) (i
 	// TODO(mhs): Might be better to create empty root in provisioning API when it exists
 	if currentRoot.RootHash == nil {
 		glog.Warningf("%v: Fresh log - no previous TreeHeads exist.", logID)
+		// SignRoot starts a new transaction, and we've gone one open here until
+		// this function returns.
+		// This explicit Close() is a work-around for the in-memory storage which
+		// locks the tree for each TX.
+		// TODO(al): The Close() is benign enough since implementations are all
+		// idempotent, but would be nice to not have to worry about it.
+		tx.Close()
 		return 0, s.SignRoot(ctx, logID)
 	}
 

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -48,7 +48,7 @@ func (s *memoryAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error)
 
 type adminTX struct {
 	ms *memoryTreeStorage
-	// mu guards *direct* reads/writes on closed, which happen only on
+	// mu guards reads/writes on closed, which happen only on
 	// Commit/Rollback/IsClosed/Close methods.
 	// We don't check closed on *all* methods (apart from the ones above),
 	// as we trust tx to keep tabs on its state (and consequently fail to do

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -1,0 +1,422 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keyspb"
+	spb "github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/storage"
+)
+
+const (
+	defaultSequenceIntervalSeconds = 60
+	selectTrees                    = `
+		SELECT
+			TreeId,
+			TreeState,
+			TreeType,
+			HashStrategy,
+			HashAlgorithm,
+			SignatureAlgorithm,
+			DisplayName,
+			Description,
+			CreateTimeMillis,
+			UpdateTimeMillis,
+			PrivateKey,
+			PublicKey
+		FROM Trees`
+	selectTreeByID = selectTrees + " WHERE TreeId = ?"
+)
+
+// NewAdminStorage returns a MySQL storage.AdminStorage implementation backed by DB.
+func NewAdminStorage(db *sql.DB) storage.AdminStorage {
+	return &mysqlAdminStorage{db}
+}
+
+// mysqlAdminStorage implements storage.AdminStorage
+type mysqlAdminStorage struct {
+	db *sql.DB
+}
+
+func (s *mysqlAdminStorage) Snapshot(ctx context.Context) (storage.ReadOnlyAdminTX, error) {
+	return s.Begin(ctx)
+}
+
+func (s *mysqlAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error) {
+	tx, err := s.db.BeginTx(ctx, nil /* opts */)
+	if err != nil {
+		return nil, err
+	}
+	return &adminTX{tx: tx}, nil
+}
+
+type adminTX struct {
+	tx *sql.Tx
+
+	// mu guards *direct* reads/writes on closed, which happen only on
+	// Commit/Rollback/IsClosed/Close methods.
+	// We don't check closed on *all* methods (apart from the ones above),
+	// as we trust tx to keep tabs on its state (and consequently fail to do
+	// queries after closed).
+	mu     sync.RWMutex
+	closed bool
+}
+
+func (t *adminTX) Commit() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	return t.tx.Commit()
+}
+
+func (t *adminTX) Rollback() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	return t.tx.Rollback()
+}
+
+func (t *adminTX) IsClosed() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.closed
+}
+
+func (t *adminTX) Close() error {
+	// Acquire and release read lock manually, without defer, as if the txn
+	// is not closed Rollback() will attempt to acquire the rw lock.
+	t.mu.RLock()
+	closed := t.closed
+	t.mu.RUnlock()
+	if !closed {
+		err := t.Rollback()
+		if err != nil {
+			glog.Warningf("Rollback error on Close(): %v", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+	stmt, err := t.tx.PrepareContext(ctx, selectTreeByID)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	return readTree(stmt.QueryRowContext(ctx, treeID))
+}
+
+// There's no common interface between sql.Row and sql.Rows(!), so we have to
+// define one.
+type row interface {
+	Scan(dest ...interface{}) error
+}
+
+func readTree(row row) (*trillian.Tree, error) {
+	tree := &trillian.Tree{}
+
+	// Enums and Datetimes need an extra conversion step
+	var treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm string
+	var createMillis, updateMillis int64
+	var displayName, description sql.NullString
+	var privateKey, publicKey []byte
+	err := row.Scan(
+		&tree.TreeId,
+		&treeState,
+		&treeType,
+		&hashStrategy,
+		&hashAlgorithm,
+		&signatureAlgorithm,
+		&displayName,
+		&description,
+		&createMillis,
+		&updateMillis,
+		&privateKey,
+		&publicKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setNullStringIfValid(displayName, &tree.DisplayName)
+	setNullStringIfValid(description, &tree.Description)
+
+	// Convert all things!
+	if ts, ok := trillian.TreeState_value[treeState]; ok {
+		tree.TreeState = trillian.TreeState(ts)
+	} else {
+		return nil, fmt.Errorf("unknown TreeState: %v", treeState)
+	}
+	if tt, ok := trillian.TreeType_value[treeType]; ok {
+		tree.TreeType = trillian.TreeType(tt)
+	} else {
+		return nil, fmt.Errorf("unknown TreeType: %v", treeType)
+	}
+	if hs, ok := trillian.HashStrategy_value[hashStrategy]; ok {
+		tree.HashStrategy = trillian.HashStrategy(hs)
+	} else {
+		return nil, fmt.Errorf("unknown HashStrategy: %v", hashStrategy)
+	}
+	if ha, ok := spb.DigitallySigned_HashAlgorithm_value[hashAlgorithm]; ok {
+		tree.HashAlgorithm = spb.DigitallySigned_HashAlgorithm(ha)
+	} else {
+		return nil, fmt.Errorf("unknown HashAlgorithm: %v", hashAlgorithm)
+	}
+	if sa, ok := spb.DigitallySigned_SignatureAlgorithm_value[signatureAlgorithm]; ok {
+		tree.SignatureAlgorithm = spb.DigitallySigned_SignatureAlgorithm(sa)
+	} else {
+		return nil, fmt.Errorf("unknown SignatureAlgorithm: %v", signatureAlgorithm)
+	}
+
+	// Let's make sure we didn't mismatch any of the casts above
+	ok := tree.TreeState.String() == treeState
+	ok = ok && tree.TreeType.String() == treeType
+	ok = ok && tree.HashStrategy.String() == hashStrategy
+	ok = ok && tree.HashAlgorithm.String() == hashAlgorithm
+	ok = ok && tree.SignatureAlgorithm.String() == signatureAlgorithm
+	if !ok {
+		return nil, fmt.Errorf(
+			"mismatched enum: tree = %v, enums = [%v, %v, %v, %v, %v]",
+			tree,
+			treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm)
+	}
+
+	tree.CreateTimeMillisSinceEpoch = createMillis
+	tree.UpdateTimeMillisSinceEpoch = updateMillis
+
+	tree.PrivateKey = &any.Any{}
+	if err := proto.Unmarshal(privateKey, tree.PrivateKey); err != nil {
+		return nil, fmt.Errorf("could not unmarshal PrivateKey: %v", err)
+	}
+	tree.PublicKey = &keyspb.PublicKey{Der: publicKey}
+
+	return tree, nil
+}
+
+// setNullStringIfValid assigns src to dest if src is Valid.
+func setNullStringIfValid(src sql.NullString, dest *string) {
+	if src.Valid {
+		*dest = src.String
+	}
+}
+
+func (t *adminTX) ListTreeIDs(ctx context.Context) ([]int64, error) {
+	stmt, err := t.tx.PrepareContext(ctx, "SELECT TreeId FROM Trees")
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	treeIDs := []int64{}
+	var treeID int64
+	for rows.Next() {
+		if err := rows.Scan(&treeID); err != nil {
+			return nil, err
+		}
+		treeIDs = append(treeIDs, treeID)
+	}
+	return treeIDs, nil
+}
+
+func (t *adminTX) ListTrees(ctx context.Context) ([]*trillian.Tree, error) {
+	stmt, err := t.tx.PrepareContext(ctx, selectTrees)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	trees := []*trillian.Tree{}
+	for rows.Next() {
+		tree, err := readTree(rows)
+		if err != nil {
+			return nil, err
+		}
+		trees = append(trees, tree)
+	}
+	return trees, nil
+}
+
+func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillian.Tree, error) {
+	if err := storage.ValidateTreeForCreation(tree); err != nil {
+		return nil, err
+	}
+	if err := validateStorageSettings(tree); err != nil {
+		return nil, err
+	}
+
+	id, err := storage.NewTreeID()
+	if err != nil {
+		return nil, err
+	}
+
+	nowMillis := toMillisSinceEpoch(time.Now())
+
+	newTree := *tree
+	newTree.TreeId = id
+	newTree.CreateTimeMillisSinceEpoch = nowMillis
+	newTree.UpdateTimeMillisSinceEpoch = nowMillis
+
+	insertTreeStmt, err := t.tx.PrepareContext(
+		ctx,
+		`INSERT INTO Trees(
+			TreeId,
+			TreeState,
+			TreeType,
+			HashStrategy,
+			HashAlgorithm,
+			SignatureAlgorithm,
+			DisplayName,
+			Description,
+			CreateTimeMillis,
+			UpdateTimeMillis,
+			PrivateKey,
+			PublicKey)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return nil, err
+	}
+	defer insertTreeStmt.Close()
+
+	privateKey, err := proto.Marshal(newTree.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+	}
+
+	_, err = insertTreeStmt.ExecContext(
+		ctx,
+		newTree.TreeId,
+		newTree.TreeState.String(),
+		newTree.TreeType.String(),
+		newTree.HashStrategy.String(),
+		newTree.HashAlgorithm.String(),
+		newTree.SignatureAlgorithm.String(),
+		newTree.DisplayName,
+		newTree.Description,
+		newTree.CreateTimeMillisSinceEpoch,
+		newTree.UpdateTimeMillisSinceEpoch,
+		privateKey,
+		newTree.PublicKey.GetDer(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// MySQL silently truncates data when running in non-strict mode.
+	// We shouldn't be using non-strict modes, but let's guard against it
+	// anyway.
+	if _, err := t.GetTree(ctx, newTree.TreeId); err != nil {
+		// GetTree will fail for truncated enums (they get recorded as
+		// empty strings, which will not match any known value).
+		return nil, fmt.Errorf("enum truncated: %v", err)
+	}
+
+	// TODO(codingllama): There's a strong disconnect between trillian.Tree and TreeControl. Are we OK with that?
+	insertControlStmt, err := t.tx.PrepareContext(
+		ctx,
+		`INSERT INTO TreeControl(
+			TreeId,
+			SigningEnabled,
+			SequencingEnabled,
+			SequenceIntervalSeconds)
+		VALUES(?, ?, ?, ?)`)
+	if err != nil {
+		return nil, err
+	}
+	defer insertControlStmt.Close()
+	_, err = insertControlStmt.ExecContext(
+		ctx,
+		newTree.TreeId,
+		true, /* SigningEnabled */
+		true, /* SequencingEnabled */
+		defaultSequenceIntervalSeconds,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &newTree, nil
+}
+
+func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error) {
+	tree, err := t.GetTree(ctx, treeID)
+	if err != nil {
+		return nil, err
+	}
+
+	beforeUpdate := *tree
+	updateFunc(tree)
+	if err := storage.ValidateTreeForUpdate(&beforeUpdate, tree); err != nil {
+		return nil, err
+	}
+	if err := validateStorageSettings(tree); err != nil {
+		return nil, err
+	}
+
+	tree.UpdateTimeMillisSinceEpoch = toMillisSinceEpoch(time.Now())
+
+	stmt, err := t.tx.PrepareContext(
+		ctx,
+		`UPDATE Trees
+		SET TreeState = ?, DisplayName = ?, Description = ?, UpdateTimeMillis = ?
+		WHERE TreeId = ?`)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	if _, err = stmt.ExecContext(
+		ctx,
+		tree.TreeState.String(),
+		tree.DisplayName,
+		tree.Description,
+		tree.UpdateTimeMillisSinceEpoch,
+		tree.TreeId); err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+func toMillisSinceEpoch(t time.Time) int64 {
+	return t.UnixNano() / 1000000
+}
+
+func validateStorageSettings(tree *trillian.Tree) error {
+	if tree.StorageSettings != nil {
+		return fmt.Errorf("storage_settings not supported, but got %v", tree.StorageSettings)
+	}
+	return nil
+}

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -12,69 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mysql
+package memory
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keyspb"
-	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
 )
 
-const (
-	defaultSequenceIntervalSeconds = 60
-	selectTrees                    = `
-		SELECT
-			TreeId,
-			TreeState,
-			TreeType,
-			HashStrategy,
-			HashAlgorithm,
-			SignatureAlgorithm,
-			DisplayName,
-			Description,
-			CreateTimeMillis,
-			UpdateTimeMillis,
-			PrivateKey,
-			PublicKey
-		FROM Trees`
-	selectTreeByID = selectTrees + " WHERE TreeId = ?"
-)
+const defaultSequenceIntervalSeconds = 60
 
-// NewAdminStorage returns a MySQL storage.AdminStorage implementation backed by DB.
-func NewAdminStorage(db *sql.DB) storage.AdminStorage {
-	return &mysqlAdminStorage{db}
+// NewAdminStorage returns a storage.AdminStorage implementation backed by
+// memoryTreeStorage.
+func NewAdminStorage(ms storage.LogStorage) storage.AdminStorage {
+	return &memoryAdminStorage{ms.(*memoryLogStorage).memoryTreeStorage}
 }
 
-// mysqlAdminStorage implements storage.AdminStorage
-type mysqlAdminStorage struct {
-	db *sql.DB
+// memoryAdminStorage implements storage.AdminStorage
+type memoryAdminStorage struct {
+	ms *memoryTreeStorage
 }
 
-func (s *mysqlAdminStorage) Snapshot(ctx context.Context) (storage.ReadOnlyAdminTX, error) {
+func (s *memoryAdminStorage) Snapshot(ctx context.Context) (storage.ReadOnlyAdminTX, error) {
 	return s.Begin(ctx)
 }
 
-func (s *mysqlAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error) {
-	tx, err := s.db.BeginTx(ctx, nil /* opts */)
-	if err != nil {
-		return nil, err
-	}
-	return &adminTX{tx: tx}, nil
+func (s *memoryAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error) {
+	return &adminTX{ms: s.ms}, nil
 }
 
 type adminTX struct {
-	tx *sql.Tx
-
+	ms *memoryTreeStorage
 	// mu guards *direct* reads/writes on closed, which happen only on
 	// Commit/Rollback/IsClosed/Close methods.
 	// We don't check closed on *all* methods (apart from the ones above),
@@ -85,17 +58,19 @@ type adminTX struct {
 }
 
 func (t *adminTX) Commit() error {
+	// TODO(al): The admin implementation isn't transactional
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.closed = true
-	return t.tx.Commit()
+	return nil
 }
 
 func (t *adminTX) Rollback() error {
+	// TODO(al): The admin implementation isn't transactional
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.closed = true
-	return t.tx.Rollback()
+	return nil
 }
 
 func (t *adminTX) IsClosed() bool {
@@ -121,159 +96,43 @@ func (t *adminTX) Close() error {
 }
 
 func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-	stmt, err := t.tx.PrepareContext(ctx, selectTreeByID)
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-	return readTree(stmt.QueryRowContext(ctx, treeID))
-}
+	tree := t.ms.getTree(treeID)
+	tree.RLock()
+	defer tree.RUnlock()
 
-// There's no common interface between sql.Row and sql.Rows(!), so we have to
-// define one.
-type row interface {
-	Scan(dest ...interface{}) error
-}
-
-func readTree(row row) (*trillian.Tree, error) {
-	tree := &trillian.Tree{}
-
-	// Enums and Datetimes need an extra conversion step
-	var treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm string
-	var createMillis, updateMillis int64
-	var displayName, description sql.NullString
-	var privateKey, publicKey []byte
-	err := row.Scan(
-		&tree.TreeId,
-		&treeState,
-		&treeType,
-		&hashStrategy,
-		&hashAlgorithm,
-		&signatureAlgorithm,
-		&displayName,
-		&description,
-		&createMillis,
-		&updateMillis,
-		&privateKey,
-		&publicKey,
-	)
-	if err != nil {
-		return nil, err
+	if tree == nil {
+		return nil, fmt.Errorf("no such treeID %d", treeID)
 	}
-
-	setNullStringIfValid(displayName, &tree.DisplayName)
-	setNullStringIfValid(description, &tree.Description)
-
-	// Convert all things!
-	if ts, ok := trillian.TreeState_value[treeState]; ok {
-		tree.TreeState = trillian.TreeState(ts)
-	} else {
-		return nil, fmt.Errorf("unknown TreeState: %v", treeState)
-	}
-	if tt, ok := trillian.TreeType_value[treeType]; ok {
-		tree.TreeType = trillian.TreeType(tt)
-	} else {
-		return nil, fmt.Errorf("unknown TreeType: %v", treeType)
-	}
-	if hs, ok := trillian.HashStrategy_value[hashStrategy]; ok {
-		tree.HashStrategy = trillian.HashStrategy(hs)
-	} else {
-		return nil, fmt.Errorf("unknown HashStrategy: %v", hashStrategy)
-	}
-	if ha, ok := spb.DigitallySigned_HashAlgorithm_value[hashAlgorithm]; ok {
-		tree.HashAlgorithm = spb.DigitallySigned_HashAlgorithm(ha)
-	} else {
-		return nil, fmt.Errorf("unknown HashAlgorithm: %v", hashAlgorithm)
-	}
-	if sa, ok := spb.DigitallySigned_SignatureAlgorithm_value[signatureAlgorithm]; ok {
-		tree.SignatureAlgorithm = spb.DigitallySigned_SignatureAlgorithm(sa)
-	} else {
-		return nil, fmt.Errorf("unknown SignatureAlgorithm: %v", signatureAlgorithm)
-	}
-
-	// Let's make sure we didn't mismatch any of the casts above
-	ok := tree.TreeState.String() == treeState
-	ok = ok && tree.TreeType.String() == treeType
-	ok = ok && tree.HashStrategy.String() == hashStrategy
-	ok = ok && tree.HashAlgorithm.String() == hashAlgorithm
-	ok = ok && tree.SignatureAlgorithm.String() == signatureAlgorithm
-	if !ok {
-		return nil, fmt.Errorf(
-			"mismatched enum: tree = %v, enums = [%v, %v, %v, %v, %v]",
-			tree,
-			treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm)
-	}
-
-	tree.CreateTimeMillisSinceEpoch = createMillis
-	tree.UpdateTimeMillisSinceEpoch = updateMillis
-
-	tree.PrivateKey = &any.Any{}
-	if err := proto.Unmarshal(privateKey, tree.PrivateKey); err != nil {
-		return nil, fmt.Errorf("could not unmarshal PrivateKey: %v", err)
-	}
-	tree.PublicKey = &keyspb.PublicKey{Der: publicKey}
-
-	return tree, nil
-}
-
-// setNullStringIfValid assigns src to dest if src is Valid.
-func setNullStringIfValid(src sql.NullString, dest *string) {
-	if src.Valid {
-		*dest = src.String
-	}
+	return tree.meta, nil
 }
 
 func (t *adminTX) ListTreeIDs(ctx context.Context) ([]int64, error) {
-	stmt, err := t.tx.PrepareContext(ctx, "SELECT TreeId FROM Trees")
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
+	t.ms.mu.RLock()
+	defer t.ms.mu.RUnlock()
 
-	rows, err := stmt.QueryContext(ctx)
-	if err != nil {
-		return nil, err
+	var ret []int64
+	for _, v := range t.ms.trees {
+		ret = append(ret, v.meta.TreeId)
 	}
-	defer rows.Close()
-
-	treeIDs := []int64{}
-	var treeID int64
-	for rows.Next() {
-		if err := rows.Scan(&treeID); err != nil {
-			return nil, err
-		}
-		treeIDs = append(treeIDs, treeID)
-	}
-	return treeIDs, nil
+	return ret, nil
 }
 
 func (t *adminTX) ListTrees(ctx context.Context) ([]*trillian.Tree, error) {
-	stmt, err := t.tx.PrepareContext(ctx, selectTrees)
-	if err != nil {
-		return nil, err
+	t.ms.mu.RLock()
+	defer t.ms.mu.RUnlock()
+
+	var ret []*trillian.Tree
+	for _, v := range t.ms.trees {
+		ret = append(ret, v.meta)
 	}
-	defer stmt.Close()
-	rows, err := stmt.QueryContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	trees := []*trillian.Tree{}
-	for rows.Next() {
-		tree, err := readTree(rows)
-		if err != nil {
-			return nil, err
-		}
-		trees = append(trees, tree)
-	}
-	return trees, nil
+	return ret, nil
 }
 
-func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillian.Tree, error) {
-	if err := storage.ValidateTreeForCreation(tree); err != nil {
+func (t *adminTX) CreateTree(ctx context.Context, tr *trillian.Tree) (*trillian.Tree, error) {
+	if err := storage.ValidateTreeForCreation(tr); err != nil {
 		return nil, err
 	}
-	if err := validateStorageSettings(tree); err != nil {
+	if err := validateStorageSettings(tr); err != nil {
 		return nil, err
 	}
 
@@ -284,98 +143,26 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 
 	nowMillis := toMillisSinceEpoch(time.Now())
 
-	newTree := *tree
-	newTree.TreeId = id
-	newTree.CreateTimeMillisSinceEpoch = nowMillis
-	newTree.UpdateTimeMillisSinceEpoch = nowMillis
+	meta := *tr
+	meta.TreeId = id
+	meta.CreateTimeMillisSinceEpoch = nowMillis
+	meta.UpdateTimeMillisSinceEpoch = nowMillis
 
-	insertTreeStmt, err := t.tx.PrepareContext(
-		ctx,
-		`INSERT INTO Trees(
-			TreeId,
-			TreeState,
-			TreeType,
-			HashStrategy,
-			HashAlgorithm,
-			SignatureAlgorithm,
-			DisplayName,
-			Description,
-			CreateTimeMillis,
-			UpdateTimeMillis,
-			PrivateKey,
-			PublicKey)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return nil, err
-	}
-	defer insertTreeStmt.Close()
+	t.ms.mu.Lock()
+	defer t.ms.mu.Unlock()
+	t.ms.trees[id] = newTree(meta)
 
-	privateKey, err := proto.Marshal(newTree.PrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
-	}
+	glog.Infof("trees: %v", t.ms.trees)
 
-	_, err = insertTreeStmt.ExecContext(
-		ctx,
-		newTree.TreeId,
-		newTree.TreeState.String(),
-		newTree.TreeType.String(),
-		newTree.HashStrategy.String(),
-		newTree.HashAlgorithm.String(),
-		newTree.SignatureAlgorithm.String(),
-		newTree.DisplayName,
-		newTree.Description,
-		newTree.CreateTimeMillisSinceEpoch,
-		newTree.UpdateTimeMillisSinceEpoch,
-		privateKey,
-		newTree.PublicKey.GetDer(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// MySQL silently truncates data when running in non-strict mode.
-	// We shouldn't be using non-strict modes, but let's guard against it
-	// anyway.
-	if _, err := t.GetTree(ctx, newTree.TreeId); err != nil {
-		// GetTree will fail for truncated enums (they get recorded as
-		// empty strings, which will not match any known value).
-		return nil, fmt.Errorf("enum truncated: %v", err)
-	}
-
-	// TODO(codingllama): There's a strong disconnect between trillian.Tree and TreeControl. Are we OK with that?
-	insertControlStmt, err := t.tx.PrepareContext(
-		ctx,
-		`INSERT INTO TreeControl(
-			TreeId,
-			SigningEnabled,
-			SequencingEnabled,
-			SequenceIntervalSeconds)
-		VALUES(?, ?, ?, ?)`)
-	if err != nil {
-		return nil, err
-	}
-	defer insertControlStmt.Close()
-	_, err = insertControlStmt.ExecContext(
-		ctx,
-		newTree.TreeId,
-		true, /* SigningEnabled */
-		true, /* SequencingEnabled */
-		defaultSequenceIntervalSeconds,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &newTree, nil
+	return &meta, nil
 }
 
 func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error) {
-	tree, err := t.GetTree(ctx, treeID)
-	if err != nil {
-		return nil, err
-	}
+	mTree := t.ms.getTree(treeID)
+	mTree.mu.Lock()
+	defer mTree.mu.Unlock()
 
+	tree := mTree.meta
 	beforeUpdate := *tree
 	updateFunc(tree)
 	if err := storage.ValidateTreeForUpdate(&beforeUpdate, tree); err != nil {
@@ -386,27 +173,6 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	}
 
 	tree.UpdateTimeMillisSinceEpoch = toMillisSinceEpoch(time.Now())
-
-	stmt, err := t.tx.PrepareContext(
-		ctx,
-		`UPDATE Trees
-		SET TreeState = ?, DisplayName = ?, Description = ?, UpdateTimeMillis = ?
-		WHERE TreeId = ?`)
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	if _, err = stmt.ExecContext(
-		ctx,
-		tree.TreeState.String(),
-		tree.DisplayName,
-		tree.Description,
-		tree.UpdateTimeMillisSinceEpoch,
-		tree.TreeId); err != nil {
-		return nil, err
-	}
-
 	return tree, nil
 }
 

--- a/storage/memory/doc.go
+++ b/storage/memory/doc.go
@@ -20,13 +20,14 @@
 // an integration test which ensures that the Trillian Log is able to correctly
 // handle a tree which contains duplicate leaves.
 //
-// The storage implementation is based on a BTree, which provide an ordered
+// The storage implementation is based on a BTree, which provides an ordered
 // key-value space which can be used to store arbitrary items, as well as
 // scan ranges of keys in order.
 //
 // The implementation does provide transaction-like semantics for the
-// LogStorage interface, although conflict is avoided by each writa-transaction
-// exclusively locking the tree until it's committed or rolled-back.
+// LogStorage interface, although conflict is avoided by each writable
+// transaction exclusively locking the tree until it's committed or
+// rolled-back.
 //
 // Currently, the Admin Storage does not honor transactional semantics.
 package memory

--- a/storage/memory/doc.go
+++ b/storage/memory/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package memory provides a simple in-process implementation of the tree- and
+// log-storage interfaces.
+//
+// This implementation is intended SOLELY for use in integration tests which
+// exercise properties of the higher levels of Trillian componened - e.g.
+// an integration test which ensures that the Trillian Log is able to correctly
+// handle a tree which contains duplicate leaves.
+//
+// The storage implementation is based on a BTree, which provide an ordered
+// key-value space which can be used to store arbitrary items, as well as
+// scan ranges of keys in order.
+//
+// The implementation does provide transaction-like semantics for the
+// LogStorage interface, although conflict is avoided by each writa-transaction
+// exclusively locking the tree until it's committed or rolled-back.
+//
+// Currently, the Admin Storage does not honor transactional semantics.
+package memory

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,185 +12,102 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mysql
+package memory
 
 import (
 	"bytes"
+	"container/list"
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+	"github.com/google/btree"
 	"github.com/google/trillian"
-	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/monitoring/metric"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/trees"
 )
 
-const (
-	// If this statement ORDER BY clause is changed refer to the comment in removeSequencedLeaves
-	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos
-			FROM Unsequenced
-			WHERE TreeID=?
-			AND Bucket=0
-			AND QueueTimestampNanos<=?
-			ORDER BY QueueTimestampNanos,LeafIdentityHash ASC LIMIT ?`
-	insertUnsequencedLeafSQL = `INSERT INTO LeafData(TreeId,LeafIdentityHash,LeafValue,ExtraData)
-			VALUES(?,?,?,?)`
-	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos)
-			VALUES(?,0,?,?,?)`
-	insertSequencedLeafSQL = `INSERT INTO SequencedLeafData(TreeId,LeafIdentityHash,MerkleLeafHash,SequenceNumber)
-			VALUES(?,?,?,?)`
-	selectSequencedLeafCountSQL  = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
-	selectLatestSignedLogRootSQL = `SELECT TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature
-			FROM TreeHead WHERE TreeId=?
-			ORDER BY TreeHeadTimestamp DESC LIMIT 1`
-	deleteUnsequencedSQL = "DELETE FROM Unsequenced WHERE TreeId=? AND Bucket=0 AND QueueTimestampNanos=? AND LeafIdentityHash=?"
-
-	// These statements need to be expanded to provide the correct number of parameter placeholders.
-	selectLeavesByIndexSQL = `SELECT s.MerkleLeafHash,l.LeafIdentityHash,l.LeafValue,s.SequenceNumber,l.ExtraData
-			FROM LeafData l,SequencedLeafData s
-			WHERE l.LeafIdentityHash = s.LeafIdentityHash
-			AND s.SequenceNumber IN (` + placeholderSQL + `) AND l.TreeId = ? AND s.TreeId = l.TreeId`
-	selectLeavesByMerkleHashSQL = `SELECT s.MerkleLeafHash,l.LeafIdentityHash,l.LeafValue,s.SequenceNumber,l.ExtraData
-			FROM LeafData l,SequencedLeafData s
-			WHERE l.LeafIdentityHash = s.LeafIdentityHash
-			AND s.MerkleLeafHash IN (` + placeholderSQL + `) AND l.TreeId = ? AND s.TreeId = l.TreeId`
-	// TODO(drysdale): rework the code so the dummy hash isn't needed (e.g. this assumes hash size is 32)
-	dummyMerkleLeafHash = "00000000000000000000000000000000"
-	// This statement returns a dummy Merkle leaf hash value (which must be
-	// of the right size) so that its signature matches that of the other
-	// leaf-selection statements.
-	selectLeavesByLeafIdentityHashSQL = `SELECT '` + dummyMerkleLeafHash + `',l.LeafIdentityHash,l.LeafValue,-1,l.ExtraData
-			FROM LeafData l
-			WHERE l.LeafIdentityHash IN (` + placeholderSQL + `) AND l.TreeId = ?`
-
-	// Same as above except with leaves ordered by sequence so we only incur this cost when necessary
-	orderBySequenceNumberSQL                     = " ORDER BY s.SequenceNumber"
-	selectLeavesByMerkleHashOrderedBySequenceSQL = selectLeavesByMerkleHashSQL + orderBySequenceNumberSQL
-
-	// Error code returned by driver when inserting a duplicate row
-	errNumDuplicate = 1062
-)
-
 var (
 	defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
 
-	queuedCounter   = metric.NewCounter("mysql_queued_leaves")
-	dequeuedCounter = metric.NewCounter("mysql_dequeued_leaves")
+	queuedCounter   = metric.NewCounter("mem_queued_leaves")
+	dequeuedCounter = metric.NewCounter("mem_dequeued_leaves")
 )
 
-type mySQLLogStorage struct {
-	*mySQLTreeStorage
+func unseqKey(treeID int64) btree.Item {
+	return &kv{k: fmt.Sprintf("/%d/unseq", treeID)}
+}
+
+func seqLeafKey(treeID, seq int64) btree.Item {
+	return &kv{k: fmt.Sprintf("/%d/seq/%020d", treeID, seq)}
+}
+
+func hashToSeqKey(treeID int64) btree.Item {
+	return &kv{k: fmt.Sprintf("/%d/h2s")}
+}
+
+func sthKey(treeID, timestamp int64) btree.Item {
+	return &kv{k: fmt.Sprintf("/%d/sth/%020d", treeID, timestamp)}
+}
+
+type memoryLogStorage struct {
+	*memoryTreeStorage
 	admin storage.AdminStorage
 }
 
-// NewLogStorage creates a storage.LogStorage instance for the specified MySQL URL.
-// It assumes storage.AdminStorage is backed by the same MySQL database as well.
-func NewLogStorage(db *sql.DB) storage.LogStorage {
-	return &mySQLLogStorage{
-		admin:            NewAdminStorage(db),
-		mySQLTreeStorage: newTreeStorage(db),
+// NewLogStorage creates an in-memory LogStorage instance.
+func NewLogStorage() storage.LogStorage {
+	ret := &memoryLogStorage{
+		memoryTreeStorage: newTreeStorage(),
 	}
+	ret.admin = NewAdminStorage(ret)
+	return ret
 }
 
-func (m *mySQLLogStorage) CheckDatabaseAccessible(ctx context.Context) error {
-	return checkDatabaseAccessible(ctx, m.db)
+func (m *memoryLogStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return nil
 }
 
-func (m *mySQLLogStorage) getLeavesByIndexStmt(ctx context.Context, num int) (*sql.Stmt, error) {
-	return m.getStmt(ctx, selectLeavesByIndexSQL, num, "?", "?")
-}
-
-func (m *mySQLLogStorage) getLeavesByMerkleHashStmt(ctx context.Context, num int, orderBySequence bool) (*sql.Stmt, error) {
-	if orderBySequence {
-		return m.getStmt(ctx, selectLeavesByMerkleHashOrderedBySequenceSQL, num, "?", "?")
-	}
-
-	return m.getStmt(ctx, selectLeavesByMerkleHashSQL, num, "?", "?")
-}
-
-func (m *mySQLLogStorage) getLeavesByLeafIdentityHashStmt(ctx context.Context, num int) (*sql.Stmt, error) {
-	return m.getStmt(ctx, selectLeavesByLeafIdentityHashSQL, num, "?", "?")
-}
-
-func getActiveLogIDsInternal(ctx context.Context, tx *sql.Tx, sql string) ([]int64, error) {
-	rows, err := tx.QueryContext(ctx, sql)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	logIDs := make([]int64, 0)
-	for rows.Next() {
-		var treeID int64
-		if err := rows.Scan(&treeID); err != nil {
-			return nil, err
-		}
-		logIDs = append(logIDs, treeID)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return logIDs, nil
-}
-
-func getActiveLogIDs(ctx context.Context, tx *sql.Tx) ([]int64, error) {
-	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsSQL)
-}
-
-func getActiveLogIDsWithPendingWork(ctx context.Context, tx *sql.Tx) ([]int64, error) {
-	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsWithUnsequencedSQL)
-}
-
-// readOnlyLogTX implements storage.ReadOnlyLogTX
 type readOnlyLogTX struct {
-	tx *sql.Tx
+	ms *memoryTreeStorage
 }
 
-func (m *mySQLLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, error) {
-	tx, err := m.db.BeginTx(ctx, nil /* opts */)
-	if err != nil {
-		glog.Warningf("Could not start ReadOnlyLogTX: %s", err)
-		return nil, err
-	}
-	return &readOnlyLogTX{tx}, nil
+func (m *memoryLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, error) {
+	return &readOnlyLogTX{m.memoryTreeStorage}, nil
 }
 
 func (t *readOnlyLogTX) Commit() error {
-	return t.tx.Commit()
+	return nil
 }
 
 func (t *readOnlyLogTX) Rollback() error {
-	return t.tx.Rollback()
+	return nil
 }
 
 func (t *readOnlyLogTX) Close() error {
-	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
-		glog.Warningf("Rollback error on Close(): %v", err)
-		return err
-	}
 	return nil
 }
 
 func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
-	return getActiveLogIDs(ctx, t.tx)
+	t.ms.mu.RLock()
+	defer t.ms.mu.RUnlock()
+
+	ret := make([]int64, 0, len(t.ms.trees))
+	for k := range t.ms.trees {
+		ret = append(ret, k)
+	}
+	return ret, nil
 }
 
 func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
-	return getActiveLogIDsWithPendingWork(ctx, t.tx)
+	// just retusn all trees for now
+	return t.GetActiveLogIDs(ctx)
 }
 
-func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
+func (m *memoryLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
 	tree, err := trees.GetTree(
 		ctx,
 		m.admin,
@@ -204,7 +121,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 		return nil, err
 	}
 
-	ttx, err := m.beginTreeTx(ctx, treeID, hasher.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(hasher), cache.PrepareLogSubtreeWrite())
+	ttx, err := m.memoryTreeStorage.beginTreeTX(ctx, readonly, treeID, hasher.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(hasher), cache.PrepareLogSubtreeWrite())
 	if err != nil {
 		return nil, err
 	}
@@ -224,11 +141,11 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 	return ltx, nil
 }
 
-func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
+func (m *memoryLogStorage) BeginForTree(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
 	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
-func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
+func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil {
 		return nil, err
@@ -238,7 +155,7 @@ func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (st
 
 type logTreeTX struct {
 	treeTX
-	ls   *mySQLLogStorage
+	ls   *memoryLogStorage
 	root trillian.SignedLogRoot
 }
 
@@ -250,73 +167,16 @@ func (t *logTreeTX) WriteRevision() int64 {
 	return t.treeTX.writeRevision
 }
 
-// dequeuedLeaf is used internally and contains some data that is not part of the client API.
-type dequeuedLeaf struct {
-	queueTimestampNanos int64
-	leafIdentityHash    []byte
-}
-
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {
-	stx, err := t.tx.PrepareContext(ctx, selectQueuedLeavesSQL)
-
-	if err != nil {
-		glog.Warningf("Failed to prepare dequeue select: %s", err)
-		return nil, err
-	}
-
 	leaves := make([]*trillian.LogLeaf, 0, limit)
-	dql := make([]*dequeuedLeaf, 0, limit)
-	rows, err := stx.QueryContext(ctx, t.treeID, cutoffTime.UnixNano(), limit)
 
-	if err != nil {
-		glog.Warningf("Failed to select rows for work: %s", err)
-		return nil, err
+	q := t.tx.Get(unseqKey(t.treeID)).(*kv).v.(*list.List)
+	e := q.Front()
+	for i := 0; i < limit && e != nil; i++ {
+		// TODO(al): consider cutoffTime
+		leaves = append(leaves, e.Value.(*trillian.LogLeaf))
+		e = e.Next()
 	}
-
-	defer rows.Close()
-
-	for rows.Next() {
-		var leafIDHash []byte
-		var merkleHash []byte
-		var queueTimeNanos int64
-
-		err := rows.Scan(&leafIDHash, &merkleHash, &queueTimeNanos)
-
-		if err != nil {
-			glog.Warningf("Error scanning work rows: %s", err)
-			return nil, err
-		}
-
-		if len(leafIDHash) != t.hashSizeBytes {
-			return nil, errors.New("Dequeued a leaf with incorrect hash size")
-		}
-
-		// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
-		// sequencer. The sequencer only writes to the SequencedLeafData table and the client
-		// supplied data was already written to LeafData as part of queueing the leaf.
-		leaf := &trillian.LogLeaf{
-			LeafIdentityHash: leafIDHash,
-			MerkleLeafHash:   merkleHash,
-		}
-		leaves = append(leaves, leaf)
-		dql = append(dql, &dequeuedLeaf{queueTimestampNanos: queueTimeNanos, leafIdentityHash: leafIDHash})
-	}
-
-	if rows.Err() != nil {
-		return nil, rows.Err()
-	}
-
-	// The convention is that if leaf processing succeeds (by committing this tx)
-	// then the unsequenced entries for them are removed
-	if len(leaves) > 0 {
-		err = t.removeSequencedLeaves(ctx, dql)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	dequeuedCounter.Add(int64(len(leaves)))
 
 	return leaves, nil
 }
@@ -328,156 +188,55 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 			return nil, fmt.Errorf("queued leaf must have a leaf ID hash of length %d", t.hashSizeBytes)
 		}
 	}
-
-	// Insert in order of the hash values in the leaves, but track original position for return value.
-	// This is to make the order that row locks are acquired deterministic and helps to reduce
-	// the chance of deadlocks.
-	orderedLeaves := make([]leafAndPosition, len(leaves))
-	for i, leaf := range leaves {
-		orderedLeaves[i] = leafAndPosition{leaf: leaf, idx: i}
+	// No deduping in this storage!
+	k := unseqKey(t.treeID)
+	q := t.tx.Get(k).(*kv).v.(*list.List)
+	for _, l := range leaves {
+		q.PushBack(l)
 	}
-	sort.Sort(byLeafIdentityHashWithPosition(orderedLeaves))
-	existingCount := 0
-	existingLeaves := make([]*trillian.LogLeaf, len(leaves))
-
-	for i, leafPos := range orderedLeaves {
-		leaf := leafPos.leaf
-		_, err := t.tx.ExecContext(ctx, insertUnsequencedLeafSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
-		if isDuplicateErr(err) {
-			// Remember the duplicate leaf, using the requested leaf for now.
-			existingLeaves[leafPos.idx] = leaf
-			existingCount++
-			continue
-		}
-		if err != nil {
-			glog.Warningf("Error inserting %d into LeafData: %s", i, err)
-			return nil, err
-		}
-
-		// Create the work queue entry
-		_, err = t.tx.ExecContext(
-			ctx,
-			insertUnsequencedEntrySQL,
-			t.treeID,
-			leaf.LeafIdentityHash,
-			leaf.MerkleLeafHash,
-			queueTimestamp.UnixNano())
-		if err != nil {
-			glog.Warningf("Error inserting into Unsequenced: %s", err)
-			return nil, fmt.Errorf("Unsequenced: %v", err)
-		}
-	}
-
-	if existingCount == 0 {
-		queuedCounter.Add(int64(len(leaves)))
-		return existingLeaves, nil
-	}
-
-	// For existing leaves, we need to retrieve the contents.  First collate the desired LeafIdentityHash values.
-	var toRetrieve [][]byte
-	for _, existing := range existingLeaves {
-		if existing != nil {
-			toRetrieve = append(toRetrieve, existing.LeafIdentityHash)
-		}
-	}
-	results, err := t.getLeafDataByIdentityHash(ctx, toRetrieve)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve existing leaves: %v", err)
-	}
-	if len(results) != len(toRetrieve) {
-		return nil, fmt.Errorf("failed to retrieve all existing leaves: got %d, want %d", len(results), len(toRetrieve))
-	}
-	// Replace the requested leaves with the actual leaves.
-	for i, requested := range existingLeaves {
-		if requested == nil {
-			continue
-		}
-		found := false
-		for _, result := range results {
-			if bytes.Compare(result.LeafIdentityHash, requested.LeafIdentityHash) == 0 {
-				existingLeaves[i] = result
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("failed to find existing leaf for hash %x", requested.LeafIdentityHash)
-		}
-	}
-
-	queuedCounter.Add(int64(len(leaves)))
-	return existingLeaves, nil
+	return []*trillian.LogLeaf{}, nil
 }
 
 func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
 	var sequencedLeafCount int64
 
-	err := t.tx.QueryRowContext(ctx, selectSequencedLeafCountSQL, t.treeID).Scan(&sequencedLeafCount)
-
-	if err != nil {
-		glog.Warningf("Error getting sequenced leaf count: %s", err)
-	}
-
-	return sequencedLeafCount, err
+	t.tx.DescendRange(seqLeafKey(t.treeID, 9223372036854775807), seqLeafKey(t.treeID, 0), func(i btree.Item) bool {
+		sequencedLeafCount = i.(*kv).v.(*trillian.LogLeaf).LeafIndex + 1
+		return false
+	})
+	return sequencedLeafCount, nil
 }
 
 func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
-	tmpl, err := t.ls.getLeavesByIndexStmt(ctx, len(leaves))
-	if err != nil {
-		return nil, err
-	}
-	stx := t.tx.StmtContext(ctx, tmpl)
-	var args []interface{}
-	for _, nodeID := range leaves {
-		args = append(args, interface{}(int64(nodeID)))
-	}
-	args = append(args, interface{}(t.treeID))
-	rows, err := stx.QueryContext(ctx, args...)
-	if err != nil {
-		glog.Warningf("Failed to get leaves by idx: %s", err)
-		return nil, err
-	}
 
 	ret := make([]*trillian.LogLeaf, 0, len(leaves))
-	defer rows.Close()
-	for rows.Next() {
-		leaf := &trillian.LogLeaf{}
-		if err := rows.Scan(
-			&leaf.MerkleLeafHash,
-			&leaf.LeafIdentityHash,
-			&leaf.LeafValue,
-			&leaf.LeafIndex,
-			&leaf.ExtraData); err != nil {
-			glog.Warningf("Failed to scan merkle leaves: %s", err)
-			return nil, err
+	for _, seq := range leaves {
+		leaf := t.tx.Get(seqLeafKey(t.treeID, seq))
+		if leaf != nil {
+			ret = append(ret, leaf.(*kv).v.(*trillian.LogLeaf))
 		}
-		ret = append(ret, leaf)
-	}
-
-	if got, want := len(ret), len(leaves); got != want {
-		return nil, fmt.Errorf("len(ret): %d, want %d", got, want)
 	}
 	return ret, nil
 }
 
 func (t *logTreeTX) GetLeavesByHash(ctx context.Context, leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error) {
-	tmpl, err := t.ls.getLeavesByMerkleHashStmt(ctx, len(leafHashes), orderBySequence)
-	if err != nil {
-		return nil, err
-	}
+	m := t.tx.Get(hashToSeqKey(t.treeID)).(*kv).v.(map[string][]int64)
 
-	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "merkle")
-}
-
-// getLeafDataByIdentityHash retrieves leaf data by LeafIdentityHash, returned
-// as a slice of LogLeaf objects for convenience.  However, note that the
-// returned LogLeaf objects will not have a valid MerkleLeafHash or LeafIndex.
-func (t *logTreeTX) getLeafDataByIdentityHash(ctx context.Context, leafHashes [][]byte) ([]*trillian.LogLeaf, error) {
-	tmpl, err := t.ls.getLeavesByLeafIdentityHashStmt(ctx, len(leafHashes))
-	if err != nil {
-		return nil, err
+	ret := make([]*trillian.LogLeaf, 0, len(leafHashes))
+	for hash := range leafHashes {
+		seq, ok := m[string(hash)]
+		if !ok {
+			continue
+		}
+		for _, s := range seq {
+			l := t.tx.Get(seqLeafKey(t.treeID, s))
+			if l == nil {
+				continue
+			}
+			ret = append(ret, l.(*kv).v.(*trillian.LogLeaf))
+		}
 	}
-	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "leaf-identity")
+	return ret, nil
 }
 
 func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
@@ -486,151 +245,87 @@ func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (trillian.SignedLog
 
 // fetchLatestRoot reads the latest SignedLogRoot from the DB and returns it.
 func (t *logTreeTX) fetchLatestRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
-	var timestamp, treeSize, treeRevision int64
-	var rootHash, rootSignatureBytes []byte
-	var rootSignature spb.DigitallySigned
-
-	err := t.tx.QueryRowContext(
-		ctx, selectLatestSignedLogRootSQL, t.treeID).Scan(
-		&timestamp, &treeSize, &rootHash, &treeRevision, &rootSignatureBytes)
-
-	// It's possible there are no roots for this tree yet
-	if err == sql.ErrNoRows {
+	r := t.tx.Get(sthKey(t.treeID, t.tree.currentSTH))
+	if r == nil {
 		return trillian.SignedLogRoot{}, nil
 	}
-
-	err = proto.Unmarshal(rootSignatureBytes, &rootSignature)
-
-	if err != nil {
-		glog.Warningf("Failed to unmarshall root signature: %v", err)
-		return trillian.SignedLogRoot{}, err
-	}
-
-	return trillian.SignedLogRoot{
-		RootHash:       rootHash,
-		TimestampNanos: timestamp,
-		TreeRevision:   treeRevision,
-		Signature:      &rootSignature,
-		LogId:          t.treeID,
-		TreeSize:       treeSize,
-	}, nil
+	return r.(*kv).v.(trillian.SignedLogRoot), nil
 }
 
 func (t *logTreeTX) StoreSignedLogRoot(ctx context.Context, root trillian.SignedLogRoot) error {
-	signatureBytes, err := proto.Marshal(root.Signature)
+	k := sthKey(t.treeID, root.TimestampNanos)
+	k.(*kv).v = root
+	t.tx.ReplaceOrInsert(k)
 
-	if err != nil {
-		glog.Warningf("Failed to marshal root signature: %v %v", root.Signature, err)
-		return err
+	// TODO(alcutter): this breaks the transactional model
+	if root.TimestampNanos > t.tree.currentSTH {
+		t.tree.currentSTH = root.TimestampNanos
 	}
-
-	res, err := t.tx.ExecContext(
-		ctx,
-		insertTreeHeadSQL,
-		t.treeID,
-		root.TimestampNanos,
-		root.TreeSize,
-		root.RootHash,
-		root.TreeRevision,
-		signatureBytes)
-	if err != nil {
-		glog.Warningf("Failed to store signed root: %s", err)
-	}
-
-	return checkResultOkAndRowCountIs(res, err, 1)
+	return nil
 }
 
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
-	// TODO: In theory we can do this with CASE / WHEN in one SQL statement but it's more fiddly
-	// and can be implemented later if necessary
+	countByMerkleHash := make(map[string]int)
 	for _, leaf := range leaves {
 		// This should fail on insert but catch it early
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
 			return errors.New("Sequenced leaf has incorrect hash size")
 		}
+		mh := string(leaf.MerkleLeafHash)
+		countByMerkleHash[mh]++
+		// insert sequenced leaf:
+		k := seqLeafKey(t.treeID, leaf.LeafIndex)
+		k.(*kv).v = leaf
+		t.tx.ReplaceOrInsert(k)
+		// update merkle-to-seq mapping:
+		m := t.tx.Get(hashToSeqKey(t.treeID))
+		l := m.(*kv).v.(map[string][]int64)[string(leaf.MerkleLeafHash)]
+		l = append(l, leaf.LeafIndex)
+		m.(*kv).v.(map[string][]int64)[string(leaf.MerkleLeafHash)] = l
+	}
 
-		_, err := t.tx.ExecContext(
-			ctx,
-			insertSequencedLeafSQL,
-			t.treeID,
-			leaf.LeafIdentityHash,
-			leaf.MerkleLeafHash,
-			leaf.LeafIndex)
-		if err != nil {
-			glog.Warningf("Failed to update sequenced leaves: %s", err)
-			return err
+	q := t.tx.Get(unseqKey(t.treeID)).(*kv).v.(*list.List)
+	toRemove := make([]*list.Element, 0, q.Len())
+	for e := q.Front(); e != nil && len(countByMerkleHash) > 0; e = e.Next() {
+		h := e.Value.(*trillian.LogLeaf).MerkleLeafHash
+		mh := string(h)
+		if countByMerkleHash[mh] > 0 {
+			countByMerkleHash[mh]--
+			toRemove = append(toRemove, e)
+			if countByMerkleHash[mh] == 0 {
+				delete(countByMerkleHash, mh)
+			}
 		}
+	}
+	for _, e := range toRemove {
+		q.Remove(e)
+	}
+
+	if unknown := len(countByMerkleHash); unknown != 0 {
+		return fmt.Errorf("attempted to update %d unknown leaves: %x", unknown, countByMerkleHash)
 	}
 
 	return nil
 }
 
-// removeSequencedLeaves removes the passed in leaves slice (which may be
-// modified as part of the operation).
-func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, leaves []*dequeuedLeaf) error {
-	// Don't need to re-sort because the query ordered by leaf hash. If that changes because
-	// the query is expensive then the sort will need to be done here. See comment in
-	// QueueLeaves.
-	stx, err := t.tx.PrepareContext(ctx, deleteUnsequencedSQL)
-	if err != nil {
-		glog.Warningf("Failed to prep delete statement for sequenced work: %v", err)
-		return err
+func (t *logTreeTX) getActiveLogIDs(ctx context.Context) ([]int64, error) {
+	var ret []int64
+	for k := range t.ts.trees {
+		ret = append(ret, k)
 	}
-	for _, dql := range leaves {
-		result, err := stx.ExecContext(ctx, t.treeID, dql.queueTimestampNanos, dql.leafIdentityHash)
-		err = checkResultOkAndRowCountIs(result, err, int64(1))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]*trillian.LogLeaf, error) {
-	stx := t.tx.StmtContext(ctx, tmpl)
-	var args []interface{}
-	for _, hash := range leafHashes {
-		args = append(args, interface{}([]byte(hash)))
-	}
-	args = append(args, interface{}(t.treeID))
-	rows, err := stx.QueryContext(ctx, args...)
-	if err != nil {
-		glog.Warningf("Query() %s hash = %v", desc, err)
-		return nil, err
-	}
-
-	// The tree could include duplicates so we don't know how many results will be returned
-	var ret []*trillian.LogLeaf
-
-	defer rows.Close()
-	for rows.Next() {
-		leaf := &trillian.LogLeaf{}
-
-		if err := rows.Scan(&leaf.MerkleLeafHash, &leaf.LeafIdentityHash, &leaf.LeafValue, &leaf.LeafIndex, &leaf.ExtraData); err != nil {
-			glog.Warningf("LogID: %d Scan() %s = %s", t.treeID, desc, err)
-			return nil, err
-		}
-
-		if got, want := len(leaf.MerkleLeafHash), t.hashSizeBytes; got != want {
-			return nil, fmt.Errorf("LogID: %d Scanned leaf %s does not have hash length %d, got %d", t.treeID, desc, want, got)
-		}
-
-		ret = append(ret, leaf)
-	}
-
 	return ret, nil
 }
 
 // GetActiveLogIDs returns a list of the IDs of all configured logs
 func (t *logTreeTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
-	return getActiveLogIDs(ctx, t.tx)
+	return t.getActiveLogIDs(ctx)
 }
 
 // GetActiveLogIDsWithPendingWork returns a list of the IDs of all configured logs
 // that have queued unsequenced leaves that need to be integrated
 func (t *logTreeTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
-	return getActiveLogIDsWithPendingWork(ctx, t.tx)
+	// TODO(alcutter): only return trees with work to do
+	return t.getActiveLogIDs(ctx)
 }
 
 // byLeafIdentityHash allows sorting of leaves by their identity hash, so DB
@@ -665,14 +360,4 @@ func (l byLeafIdentityHashWithPosition) Swap(i, j int) {
 }
 func (l byLeafIdentityHashWithPosition) Less(i, j int) bool {
 	return bytes.Compare(l[i].leaf.LeafIdentityHash, l[j].leaf.LeafIdentityHash) == -1
-}
-
-func isDuplicateErr(err error) bool {
-	if err != nil {
-		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == errNumDuplicate {
-			return true
-		}
-	}
-
-	return false
 }

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -1,0 +1,678 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
+	spb "github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/monitoring/metric"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/trees"
+)
+
+const (
+	// If this statement ORDER BY clause is changed refer to the comment in removeSequencedLeaves
+	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos
+			FROM Unsequenced
+			WHERE TreeID=?
+			AND Bucket=0
+			AND QueueTimestampNanos<=?
+			ORDER BY QueueTimestampNanos,LeafIdentityHash ASC LIMIT ?`
+	insertUnsequencedLeafSQL = `INSERT INTO LeafData(TreeId,LeafIdentityHash,LeafValue,ExtraData)
+			VALUES(?,?,?,?)`
+	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos)
+			VALUES(?,0,?,?,?)`
+	insertSequencedLeafSQL = `INSERT INTO SequencedLeafData(TreeId,LeafIdentityHash,MerkleLeafHash,SequenceNumber)
+			VALUES(?,?,?,?)`
+	selectSequencedLeafCountSQL  = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
+	selectLatestSignedLogRootSQL = `SELECT TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature
+			FROM TreeHead WHERE TreeId=?
+			ORDER BY TreeHeadTimestamp DESC LIMIT 1`
+	deleteUnsequencedSQL = "DELETE FROM Unsequenced WHERE TreeId=? AND Bucket=0 AND QueueTimestampNanos=? AND LeafIdentityHash=?"
+
+	// These statements need to be expanded to provide the correct number of parameter placeholders.
+	selectLeavesByIndexSQL = `SELECT s.MerkleLeafHash,l.LeafIdentityHash,l.LeafValue,s.SequenceNumber,l.ExtraData
+			FROM LeafData l,SequencedLeafData s
+			WHERE l.LeafIdentityHash = s.LeafIdentityHash
+			AND s.SequenceNumber IN (` + placeholderSQL + `) AND l.TreeId = ? AND s.TreeId = l.TreeId`
+	selectLeavesByMerkleHashSQL = `SELECT s.MerkleLeafHash,l.LeafIdentityHash,l.LeafValue,s.SequenceNumber,l.ExtraData
+			FROM LeafData l,SequencedLeafData s
+			WHERE l.LeafIdentityHash = s.LeafIdentityHash
+			AND s.MerkleLeafHash IN (` + placeholderSQL + `) AND l.TreeId = ? AND s.TreeId = l.TreeId`
+	// TODO(drysdale): rework the code so the dummy hash isn't needed (e.g. this assumes hash size is 32)
+	dummyMerkleLeafHash = "00000000000000000000000000000000"
+	// This statement returns a dummy Merkle leaf hash value (which must be
+	// of the right size) so that its signature matches that of the other
+	// leaf-selection statements.
+	selectLeavesByLeafIdentityHashSQL = `SELECT '` + dummyMerkleLeafHash + `',l.LeafIdentityHash,l.LeafValue,-1,l.ExtraData
+			FROM LeafData l
+			WHERE l.LeafIdentityHash IN (` + placeholderSQL + `) AND l.TreeId = ?`
+
+	// Same as above except with leaves ordered by sequence so we only incur this cost when necessary
+	orderBySequenceNumberSQL                     = " ORDER BY s.SequenceNumber"
+	selectLeavesByMerkleHashOrderedBySequenceSQL = selectLeavesByMerkleHashSQL + orderBySequenceNumberSQL
+
+	// Error code returned by driver when inserting a duplicate row
+	errNumDuplicate = 1062
+)
+
+var (
+	defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
+
+	queuedCounter   = metric.NewCounter("mysql_queued_leaves")
+	dequeuedCounter = metric.NewCounter("mysql_dequeued_leaves")
+)
+
+type mySQLLogStorage struct {
+	*mySQLTreeStorage
+	admin storage.AdminStorage
+}
+
+// NewLogStorage creates a storage.LogStorage instance for the specified MySQL URL.
+// It assumes storage.AdminStorage is backed by the same MySQL database as well.
+func NewLogStorage(db *sql.DB) storage.LogStorage {
+	return &mySQLLogStorage{
+		admin:            NewAdminStorage(db),
+		mySQLTreeStorage: newTreeStorage(db),
+	}
+}
+
+func (m *mySQLLogStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return checkDatabaseAccessible(ctx, m.db)
+}
+
+func (m *mySQLLogStorage) getLeavesByIndexStmt(ctx context.Context, num int) (*sql.Stmt, error) {
+	return m.getStmt(ctx, selectLeavesByIndexSQL, num, "?", "?")
+}
+
+func (m *mySQLLogStorage) getLeavesByMerkleHashStmt(ctx context.Context, num int, orderBySequence bool) (*sql.Stmt, error) {
+	if orderBySequence {
+		return m.getStmt(ctx, selectLeavesByMerkleHashOrderedBySequenceSQL, num, "?", "?")
+	}
+
+	return m.getStmt(ctx, selectLeavesByMerkleHashSQL, num, "?", "?")
+}
+
+func (m *mySQLLogStorage) getLeavesByLeafIdentityHashStmt(ctx context.Context, num int) (*sql.Stmt, error) {
+	return m.getStmt(ctx, selectLeavesByLeafIdentityHashSQL, num, "?", "?")
+}
+
+func getActiveLogIDsInternal(ctx context.Context, tx *sql.Tx, sql string) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	logIDs := make([]int64, 0)
+	for rows.Next() {
+		var treeID int64
+		if err := rows.Scan(&treeID); err != nil {
+			return nil, err
+		}
+		logIDs = append(logIDs, treeID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return logIDs, nil
+}
+
+func getActiveLogIDs(ctx context.Context, tx *sql.Tx) ([]int64, error) {
+	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsSQL)
+}
+
+func getActiveLogIDsWithPendingWork(ctx context.Context, tx *sql.Tx) ([]int64, error) {
+	return getActiveLogIDsInternal(ctx, tx, selectActiveLogsWithUnsequencedSQL)
+}
+
+// readOnlyLogTX implements storage.ReadOnlyLogTX
+type readOnlyLogTX struct {
+	tx *sql.Tx
+}
+
+func (m *mySQLLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, error) {
+	tx, err := m.db.BeginTx(ctx, nil /* opts */)
+	if err != nil {
+		glog.Warningf("Could not start ReadOnlyLogTX: %s", err)
+		return nil, err
+	}
+	return &readOnlyLogTX{tx}, nil
+}
+
+func (t *readOnlyLogTX) Commit() error {
+	return t.tx.Commit()
+}
+
+func (t *readOnlyLogTX) Rollback() error {
+	return t.tx.Rollback()
+}
+
+func (t *readOnlyLogTX) Close() error {
+	if err := t.Rollback(); err != nil && err != sql.ErrTxDone {
+		glog.Warningf("Rollback error on Close(): %v", err)
+		return err
+	}
+	return nil
+}
+
+func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDs(ctx, t.tx)
+}
+
+func (t *readOnlyLogTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDsWithPendingWork(ctx, t.tx)
+}
+
+func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
+	tree, err := trees.GetTree(
+		ctx,
+		m.admin,
+		treeID,
+		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+	if err != nil {
+		return nil, err
+	}
+	hasher, err := trees.Hasher(tree)
+	if err != nil {
+		return nil, err
+	}
+
+	ttx, err := m.beginTreeTx(ctx, treeID, hasher.Size(), defaultLogStrata, cache.PopulateLogSubtreeNodes(hasher), cache.PrepareLogSubtreeWrite())
+	if err != nil {
+		return nil, err
+	}
+
+	ltx := &logTreeTX{
+		treeTX: ttx,
+		ls:     m,
+	}
+
+	ltx.root, err = ltx.fetchLatestRoot(ctx)
+	if err != nil {
+		ttx.Rollback()
+		return nil, err
+	}
+	ltx.treeTX.writeRevision = ltx.root.TreeRevision + 1
+
+	return ltx, nil
+}
+
+func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
+	return m.beginInternal(ctx, treeID, false /* readonly */)
+}
+
+func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
+	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	return tx.(storage.ReadOnlyLogTreeTX), err
+}
+
+type logTreeTX struct {
+	treeTX
+	ls   *mySQLLogStorage
+	root trillian.SignedLogRoot
+}
+
+func (t *logTreeTX) ReadRevision() int64 {
+	return t.root.TreeRevision
+}
+
+func (t *logTreeTX) WriteRevision() int64 {
+	return t.treeTX.writeRevision
+}
+
+// dequeuedLeaf is used internally and contains some data that is not part of the client API.
+type dequeuedLeaf struct {
+	queueTimestampNanos int64
+	leafIdentityHash    []byte
+}
+
+func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {
+	stx, err := t.tx.PrepareContext(ctx, selectQueuedLeavesSQL)
+
+	if err != nil {
+		glog.Warningf("Failed to prepare dequeue select: %s", err)
+		return nil, err
+	}
+
+	leaves := make([]*trillian.LogLeaf, 0, limit)
+	dql := make([]*dequeuedLeaf, 0, limit)
+	rows, err := stx.QueryContext(ctx, t.treeID, cutoffTime.UnixNano(), limit)
+
+	if err != nil {
+		glog.Warningf("Failed to select rows for work: %s", err)
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var leafIDHash []byte
+		var merkleHash []byte
+		var queueTimeNanos int64
+
+		err := rows.Scan(&leafIDHash, &merkleHash, &queueTimeNanos)
+
+		if err != nil {
+			glog.Warningf("Error scanning work rows: %s", err)
+			return nil, err
+		}
+
+		if len(leafIDHash) != t.hashSizeBytes {
+			return nil, errors.New("Dequeued a leaf with incorrect hash size")
+		}
+
+		// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
+		// sequencer. The sequencer only writes to the SequencedLeafData table and the client
+		// supplied data was already written to LeafData as part of queueing the leaf.
+		leaf := &trillian.LogLeaf{
+			LeafIdentityHash: leafIDHash,
+			MerkleLeafHash:   merkleHash,
+		}
+		leaves = append(leaves, leaf)
+		dql = append(dql, &dequeuedLeaf{queueTimestampNanos: queueTimeNanos, leafIdentityHash: leafIDHash})
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	// The convention is that if leaf processing succeeds (by committing this tx)
+	// then the unsequenced entries for them are removed
+	if len(leaves) > 0 {
+		err = t.removeSequencedLeaves(ctx, dql)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	dequeuedCounter.Add(int64(len(leaves)))
+
+	return leaves, nil
+}
+
+func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+	// Don't accept batches if any of the leaves are invalid.
+	for _, leaf := range leaves {
+		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
+			return nil, fmt.Errorf("queued leaf must have a leaf ID hash of length %d", t.hashSizeBytes)
+		}
+	}
+
+	// Insert in order of the hash values in the leaves, but track original position for return value.
+	// This is to make the order that row locks are acquired deterministic and helps to reduce
+	// the chance of deadlocks.
+	orderedLeaves := make([]leafAndPosition, len(leaves))
+	for i, leaf := range leaves {
+		orderedLeaves[i] = leafAndPosition{leaf: leaf, idx: i}
+	}
+	sort.Sort(byLeafIdentityHashWithPosition(orderedLeaves))
+	existingCount := 0
+	existingLeaves := make([]*trillian.LogLeaf, len(leaves))
+
+	for i, leafPos := range orderedLeaves {
+		leaf := leafPos.leaf
+		_, err := t.tx.ExecContext(ctx, insertUnsequencedLeafSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData)
+		if isDuplicateErr(err) {
+			// Remember the duplicate leaf, using the requested leaf for now.
+			existingLeaves[leafPos.idx] = leaf
+			existingCount++
+			continue
+		}
+		if err != nil {
+			glog.Warningf("Error inserting %d into LeafData: %s", i, err)
+			return nil, err
+		}
+
+		// Create the work queue entry
+		_, err = t.tx.ExecContext(
+			ctx,
+			insertUnsequencedEntrySQL,
+			t.treeID,
+			leaf.LeafIdentityHash,
+			leaf.MerkleLeafHash,
+			queueTimestamp.UnixNano())
+		if err != nil {
+			glog.Warningf("Error inserting into Unsequenced: %s", err)
+			return nil, fmt.Errorf("Unsequenced: %v", err)
+		}
+	}
+
+	if existingCount == 0 {
+		queuedCounter.Add(int64(len(leaves)))
+		return existingLeaves, nil
+	}
+
+	// For existing leaves, we need to retrieve the contents.  First collate the desired LeafIdentityHash values.
+	var toRetrieve [][]byte
+	for _, existing := range existingLeaves {
+		if existing != nil {
+			toRetrieve = append(toRetrieve, existing.LeafIdentityHash)
+		}
+	}
+	results, err := t.getLeafDataByIdentityHash(ctx, toRetrieve)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve existing leaves: %v", err)
+	}
+	if len(results) != len(toRetrieve) {
+		return nil, fmt.Errorf("failed to retrieve all existing leaves: got %d, want %d", len(results), len(toRetrieve))
+	}
+	// Replace the requested leaves with the actual leaves.
+	for i, requested := range existingLeaves {
+		if requested == nil {
+			continue
+		}
+		found := false
+		for _, result := range results {
+			if bytes.Compare(result.LeafIdentityHash, requested.LeafIdentityHash) == 0 {
+				existingLeaves[i] = result
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("failed to find existing leaf for hash %x", requested.LeafIdentityHash)
+		}
+	}
+
+	queuedCounter.Add(int64(len(leaves)))
+	return existingLeaves, nil
+}
+
+func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
+	var sequencedLeafCount int64
+
+	err := t.tx.QueryRowContext(ctx, selectSequencedLeafCountSQL, t.treeID).Scan(&sequencedLeafCount)
+
+	if err != nil {
+		glog.Warningf("Error getting sequenced leaf count: %s", err)
+	}
+
+	return sequencedLeafCount, err
+}
+
+func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
+	tmpl, err := t.ls.getLeavesByIndexStmt(ctx, len(leaves))
+	if err != nil {
+		return nil, err
+	}
+	stx := t.tx.StmtContext(ctx, tmpl)
+	var args []interface{}
+	for _, nodeID := range leaves {
+		args = append(args, interface{}(int64(nodeID)))
+	}
+	args = append(args, interface{}(t.treeID))
+	rows, err := stx.QueryContext(ctx, args...)
+	if err != nil {
+		glog.Warningf("Failed to get leaves by idx: %s", err)
+		return nil, err
+	}
+
+	ret := make([]*trillian.LogLeaf, 0, len(leaves))
+	defer rows.Close()
+	for rows.Next() {
+		leaf := &trillian.LogLeaf{}
+		if err := rows.Scan(
+			&leaf.MerkleLeafHash,
+			&leaf.LeafIdentityHash,
+			&leaf.LeafValue,
+			&leaf.LeafIndex,
+			&leaf.ExtraData); err != nil {
+			glog.Warningf("Failed to scan merkle leaves: %s", err)
+			return nil, err
+		}
+		ret = append(ret, leaf)
+	}
+
+	if got, want := len(ret), len(leaves); got != want {
+		return nil, fmt.Errorf("len(ret): %d, want %d", got, want)
+	}
+	return ret, nil
+}
+
+func (t *logTreeTX) GetLeavesByHash(ctx context.Context, leafHashes [][]byte, orderBySequence bool) ([]*trillian.LogLeaf, error) {
+	tmpl, err := t.ls.getLeavesByMerkleHashStmt(ctx, len(leafHashes), orderBySequence)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "merkle")
+}
+
+// getLeafDataByIdentityHash retrieves leaf data by LeafIdentityHash, returned
+// as a slice of LogLeaf objects for convenience.  However, note that the
+// returned LogLeaf objects will not have a valid MerkleLeafHash or LeafIndex.
+func (t *logTreeTX) getLeafDataByIdentityHash(ctx context.Context, leafHashes [][]byte) ([]*trillian.LogLeaf, error) {
+	tmpl, err := t.ls.getLeavesByLeafIdentityHashStmt(ctx, len(leafHashes))
+	if err != nil {
+		return nil, err
+	}
+	return t.getLeavesByHashInternal(ctx, leafHashes, tmpl, "leaf-identity")
+}
+
+func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
+	return t.root, nil
+}
+
+// fetchLatestRoot reads the latest SignedLogRoot from the DB and returns it.
+func (t *logTreeTX) fetchLatestRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
+	var timestamp, treeSize, treeRevision int64
+	var rootHash, rootSignatureBytes []byte
+	var rootSignature spb.DigitallySigned
+
+	err := t.tx.QueryRowContext(
+		ctx, selectLatestSignedLogRootSQL, t.treeID).Scan(
+		&timestamp, &treeSize, &rootHash, &treeRevision, &rootSignatureBytes)
+
+	// It's possible there are no roots for this tree yet
+	if err == sql.ErrNoRows {
+		return trillian.SignedLogRoot{}, nil
+	}
+
+	err = proto.Unmarshal(rootSignatureBytes, &rootSignature)
+
+	if err != nil {
+		glog.Warningf("Failed to unmarshall root signature: %v", err)
+		return trillian.SignedLogRoot{}, err
+	}
+
+	return trillian.SignedLogRoot{
+		RootHash:       rootHash,
+		TimestampNanos: timestamp,
+		TreeRevision:   treeRevision,
+		Signature:      &rootSignature,
+		LogId:          t.treeID,
+		TreeSize:       treeSize,
+	}, nil
+}
+
+func (t *logTreeTX) StoreSignedLogRoot(ctx context.Context, root trillian.SignedLogRoot) error {
+	signatureBytes, err := proto.Marshal(root.Signature)
+
+	if err != nil {
+		glog.Warningf("Failed to marshal root signature: %v %v", root.Signature, err)
+		return err
+	}
+
+	res, err := t.tx.ExecContext(
+		ctx,
+		insertTreeHeadSQL,
+		t.treeID,
+		root.TimestampNanos,
+		root.TreeSize,
+		root.RootHash,
+		root.TreeRevision,
+		signatureBytes)
+	if err != nil {
+		glog.Warningf("Failed to store signed root: %s", err)
+	}
+
+	return checkResultOkAndRowCountIs(res, err, 1)
+}
+
+func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
+	// TODO: In theory we can do this with CASE / WHEN in one SQL statement but it's more fiddly
+	// and can be implemented later if necessary
+	for _, leaf := range leaves {
+		// This should fail on insert but catch it early
+		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
+			return errors.New("Sequenced leaf has incorrect hash size")
+		}
+
+		_, err := t.tx.ExecContext(
+			ctx,
+			insertSequencedLeafSQL,
+			t.treeID,
+			leaf.LeafIdentityHash,
+			leaf.MerkleLeafHash,
+			leaf.LeafIndex)
+		if err != nil {
+			glog.Warningf("Failed to update sequenced leaves: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// removeSequencedLeaves removes the passed in leaves slice (which may be
+// modified as part of the operation).
+func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, leaves []*dequeuedLeaf) error {
+	// Don't need to re-sort because the query ordered by leaf hash. If that changes because
+	// the query is expensive then the sort will need to be done here. See comment in
+	// QueueLeaves.
+	stx, err := t.tx.PrepareContext(ctx, deleteUnsequencedSQL)
+	if err != nil {
+		glog.Warningf("Failed to prep delete statement for sequenced work: %v", err)
+		return err
+	}
+	for _, dql := range leaves {
+		result, err := stx.ExecContext(ctx, t.treeID, dql.queueTimestampNanos, dql.leafIdentityHash)
+		err = checkResultOkAndRowCountIs(result, err, int64(1))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]byte, tmpl *sql.Stmt, desc string) ([]*trillian.LogLeaf, error) {
+	stx := t.tx.StmtContext(ctx, tmpl)
+	var args []interface{}
+	for _, hash := range leafHashes {
+		args = append(args, interface{}([]byte(hash)))
+	}
+	args = append(args, interface{}(t.treeID))
+	rows, err := stx.QueryContext(ctx, args...)
+	if err != nil {
+		glog.Warningf("Query() %s hash = %v", desc, err)
+		return nil, err
+	}
+
+	// The tree could include duplicates so we don't know how many results will be returned
+	var ret []*trillian.LogLeaf
+
+	defer rows.Close()
+	for rows.Next() {
+		leaf := &trillian.LogLeaf{}
+
+		if err := rows.Scan(&leaf.MerkleLeafHash, &leaf.LeafIdentityHash, &leaf.LeafValue, &leaf.LeafIndex, &leaf.ExtraData); err != nil {
+			glog.Warningf("LogID: %d Scan() %s = %s", t.treeID, desc, err)
+			return nil, err
+		}
+
+		if got, want := len(leaf.MerkleLeafHash), t.hashSizeBytes; got != want {
+			return nil, fmt.Errorf("LogID: %d Scanned leaf %s does not have hash length %d, got %d", t.treeID, desc, want, got)
+		}
+
+		ret = append(ret, leaf)
+	}
+
+	return ret, nil
+}
+
+// GetActiveLogIDs returns a list of the IDs of all configured logs
+func (t *logTreeTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDs(ctx, t.tx)
+}
+
+// GetActiveLogIDsWithPendingWork returns a list of the IDs of all configured logs
+// that have queued unsequenced leaves that need to be integrated
+func (t *logTreeTX) GetActiveLogIDsWithPendingWork(ctx context.Context) ([]int64, error) {
+	return getActiveLogIDsWithPendingWork(ctx, t.tx)
+}
+
+// byLeafIdentityHash allows sorting of leaves by their identity hash, so DB
+// operations always happen in a consistent order.
+type byLeafIdentityHash []*trillian.LogLeaf
+
+func (l byLeafIdentityHash) Len() int {
+	return len(l)
+}
+func (l byLeafIdentityHash) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+func (l byLeafIdentityHash) Less(i, j int) bool {
+	return bytes.Compare(l[i].LeafIdentityHash, l[j].LeafIdentityHash) == -1
+}
+
+// leafAndPosition records original position before sort.
+type leafAndPosition struct {
+	leaf *trillian.LogLeaf
+	idx  int
+}
+
+// byLeafIdentityHashWithPosition allows sorting (as above), but where we need
+// to remember the original position
+type byLeafIdentityHashWithPosition []leafAndPosition
+
+func (l byLeafIdentityHashWithPosition) Len() int {
+	return len(l)
+}
+func (l byLeafIdentityHashWithPosition) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+func (l byLeafIdentityHashWithPosition) Less(i, j int) bool {
+	return bytes.Compare(l[i].leaf.LeafIdentityHash, l[j].leaf.LeafIdentityHash) == -1
+}
+
+func isDuplicateErr(err error) bool {
+	if err != nil {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == errNumDuplicate {
+			return true
+		}
+	}
+
+	return false
+}

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -116,7 +116,7 @@ func newTree(t trillian.Tree) *tree {
 	return ret
 }
 
-func (m *memoryTreeStorage) beginTreeTX(ctx context.Context, readonly bool, treeID int64, hashSizeBytes int, strataDepths []int, populate storage.PopulateSubtreeFunc, prepare storage.PrepareSubtreeWriteFunc) (treeTX, error) {
+func (m *memoryTreeStorage) beginTreeTX(ctx context.Context, readonly bool, treeID int64, hashSizeBytes int, cache cache.SubtreeCache) (treeTX, error) {
 	tree := m.getTree(treeID)
 	// Lock the tree for the duration of the TX.
 	// It will be unlocked by a call to Commit or Rollback.
@@ -134,7 +134,7 @@ func (m *memoryTreeStorage) beginTreeTX(ctx context.Context, readonly bool, tree
 		tree:          tree,
 		treeID:        treeID,
 		hashSizeBytes: hashSizeBytes,
-		subtreeCache:  cache.NewSubtreeCache(strataDepths, populate, prepare),
+		subtreeCache:  cache,
 		writeRevision: -1,
 		unlock:        unlock,
 	}, nil

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -1,0 +1,405 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/storage/storagepb"
+)
+
+// These statements are fixed
+const (
+	insertSubtreeMultiSQL = `INSERT INTO Subtree(TreeId, SubtreeId, Nodes, SubtreeRevision) ` + placeholderSQL
+	insertTreeHeadSQL     = `INSERT INTO TreeHead(TreeId,TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature)
+		 VALUES(?,?,?,?,?,?)`
+	selectTreeRevisionAtSizeOrLargerSQL = "SELECT TreeRevision,TreeSize FROM TreeHead WHERE TreeId=? AND TreeSize>=? ORDER BY TreeRevision LIMIT 1"
+	selectActiveLogsSQL                 = "SELECT TreeId from Trees where TreeType='LOG'"
+	selectActiveLogsWithUnsequencedSQL  = "SELECT DISTINCT t.TreeId from Trees t INNER JOIN Unsequenced u WHERE TreeType='LOG' AND t.TreeId=u.TreeId"
+
+	selectSubtreeSQL = `
+ SELECT x.SubtreeId, x.MaxRevision, Subtree.Nodes
+ FROM (
+ 	SELECT n.SubtreeId, max(n.SubtreeRevision) AS MaxRevision
+	FROM Subtree n
+	WHERE n.SubtreeId IN (` + placeholderSQL + `) AND
+	 n.TreeId = ? AND n.SubtreeRevision <= ?
+	GROUP BY n.SubtreeId
+ ) AS x
+ INNER JOIN Subtree 
+ ON Subtree.SubtreeId = x.SubtreeId 
+ AND Subtree.SubtreeRevision = x.MaxRevision 
+ AND Subtree.TreeId = ?`
+	placeholderSQL = "<placeholder>"
+)
+
+// mySQLTreeStorage is shared between the mySQLLog- and (forthcoming) mySQLMap-
+// Storage implementations, and contains functionality which is common to both,
+type mySQLTreeStorage struct {
+	db *sql.DB
+
+	// Must hold the mutex before manipulating the statement map. Sharing a lock because
+	// it only needs to be held while the statements are built, not while they execute and
+	// this will be a short time. These maps are from the number of placeholder '?'
+	// in the query to the statement that should be used.
+	statementMutex sync.Mutex
+	statements     map[string]map[int]*sql.Stmt
+}
+
+// OpenDB opens a database connection for all MySQL-based storage implementations.
+func OpenDB(dbURL string) (*sql.DB, error) {
+	db, err := sql.Open("mysql", dbURL)
+	if err != nil {
+		// Don't log uri as it could contain credentials
+		glog.Warningf("Could not open MySQL database, check config: %s", err)
+		return nil, err
+	}
+
+	if _, err := db.ExecContext(context.TODO(), "SET sql_mode = 'STRICT_ALL_TABLES'"); err != nil {
+		glog.Warningf("Failed to set strict mode on mysql db: %s", err)
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func newTreeStorage(db *sql.DB) *mySQLTreeStorage {
+	return &mySQLTreeStorage{
+		db:         db,
+		statements: make(map[string]map[int]*sql.Stmt),
+	}
+}
+
+// expandPlaceholderSQL expands an sql statement by adding a specified number of '?'
+// placeholder slots. At most one placeholder will be expanded.
+func expandPlaceholderSQL(sql string, num int, first, rest string) string {
+	if num <= 0 {
+		panic(fmt.Errorf("Trying to expand SQL placeholder with <= 0 parameters: %s", sql))
+	}
+
+	parameters := first + strings.Repeat(","+rest, num-1)
+
+	return strings.Replace(sql, placeholderSQL, parameters, 1)
+}
+
+// getStmt creates and caches sql.Stmt structs based on the passed in statement
+// and number of bound arguments.
+// TODO(al,martin): consider pulling this all out as a separate unit for reuse
+// elsewhere.
+func (m *mySQLTreeStorage) getStmt(ctx context.Context, statement string, num int, first, rest string) (*sql.Stmt, error) {
+	m.statementMutex.Lock()
+	defer m.statementMutex.Unlock()
+
+	if m.statements[statement] != nil {
+		if m.statements[statement][num] != nil {
+			// TODO(al,martin): we'll possibly need to expire Stmts from the cache,
+			// e.g. when DB connections break etc.
+			return m.statements[statement][num], nil
+		}
+	} else {
+		m.statements[statement] = make(map[int]*sql.Stmt)
+	}
+
+	s, err := m.db.PrepareContext(ctx, expandPlaceholderSQL(statement, num, first, rest))
+
+	if err != nil {
+		glog.Warningf("Failed to prepare statement %d: %s", num, err)
+		return nil, err
+	}
+
+	m.statements[statement][num] = s
+
+	return s, nil
+}
+
+func (m *mySQLTreeStorage) getSubtreeStmt(ctx context.Context, num int) (*sql.Stmt, error) {
+	return m.getStmt(ctx, selectSubtreeSQL, num, "?", "?")
+}
+
+func (m *mySQLTreeStorage) setSubtreeStmt(ctx context.Context, num int) (*sql.Stmt, error) {
+	return m.getStmt(ctx, insertSubtreeMultiSQL, num, "VALUES(?, ?, ?, ?)", "(?, ?, ?, ?)")
+}
+
+func (m *mySQLTreeStorage) beginTreeTx(ctx context.Context, treeID int64, hashSizeBytes int, strataDepths []int, populate storage.PopulateSubtreeFunc, prepare storage.PrepareSubtreeWriteFunc) (treeTX, error) {
+	t, err := m.db.BeginTx(ctx, nil /* opts */)
+	if err != nil {
+		glog.Warningf("Could not start tree TX: %s", err)
+		return treeTX{}, err
+	}
+	return treeTX{
+		tx:            t,
+		ts:            m,
+		treeID:        treeID,
+		hashSizeBytes: hashSizeBytes,
+		subtreeCache:  cache.NewSubtreeCache(strataDepths, populate, prepare),
+		writeRevision: -1,
+	}, nil
+}
+
+type treeTX struct {
+	closed        bool
+	tx            *sql.Tx
+	ts            *mySQLTreeStorage
+	treeID        int64
+	hashSizeBytes int
+	subtreeCache  cache.SubtreeCache
+	writeRevision int64
+}
+
+func (t *treeTX) getSubtree(ctx context.Context, treeRevision int64, nodeID storage.NodeID) (*storagepb.SubtreeProto, error) {
+	s, err := t.getSubtrees(ctx, treeRevision, []storage.NodeID{nodeID})
+	if err != nil {
+		return nil, err
+	}
+	switch len(s) {
+	case 0:
+		return nil, nil
+	case 1:
+		return s[0], nil
+	default:
+		return nil, fmt.Errorf("got %d subtrees, but expected 1", len(s))
+	}
+}
+
+func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+	if len(nodeIDs) == 0 {
+		return nil, nil
+	}
+
+	tmpl, err := t.ts.getSubtreeStmt(ctx, len(nodeIDs))
+	if err != nil {
+		return nil, err
+	}
+	stx := t.tx.StmtContext(ctx, tmpl)
+	defer stx.Close()
+
+	args := make([]interface{}, 0, len(nodeIDs)+3)
+
+	// populate args with nodeIDs
+	for _, nodeID := range nodeIDs {
+		if nodeID.PrefixLenBits%8 != 0 {
+			return nil, fmt.Errorf("invalid subtree ID - not multiple of 8: %d", nodeID.PrefixLenBits)
+		}
+
+		nodeIDBytes := nodeID.Path[:nodeID.PrefixLenBits/8]
+
+		args = append(args, interface{}(nodeIDBytes))
+	}
+
+	args = append(args, interface{}(t.treeID))
+	args = append(args, interface{}(treeRevision))
+	args = append(args, interface{}(t.treeID))
+
+	rows, err := stx.QueryContext(ctx, args...)
+	if err != nil {
+		glog.Warningf("Failed to get merkle subtrees: %s", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Err() != nil {
+		// Nothing from the DB
+		glog.Warningf("Nothing from DB: %s", rows.Err())
+		return nil, rows.Err()
+	}
+
+	ret := make([]*storagepb.SubtreeProto, 0, len(nodeIDs))
+
+	for rows.Next() {
+
+		var subtreeIDBytes []byte
+		var subtreeRev int64
+		var nodesRaw []byte
+		if err := rows.Scan(&subtreeIDBytes, &subtreeRev, &nodesRaw); err != nil {
+			glog.Warningf("Failed to scan merkle subtree: %s", err)
+			return nil, err
+		}
+		var subtree storagepb.SubtreeProto
+		if err := proto.Unmarshal(nodesRaw, &subtree); err != nil {
+			glog.Warningf("Failed to unmarshal SubtreeProto: %s", err)
+			return nil, err
+		}
+		if subtree.Prefix == nil {
+			subtree.Prefix = []byte{}
+		}
+		ret = append(ret, &subtree)
+	}
+
+	// The InternalNodes cache is possibly nil here, but the SubtreeCache (which called
+	// this method) will re-populate it.
+	return ret, nil
+}
+
+func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.SubtreeProto) error {
+	if len(subtrees) == 0 {
+		glog.Warning("attempted to store 0 subtrees...")
+		return nil
+	}
+
+	// TODO(al): probably need to be able to batch this in the case where we have
+	// a really large number of subtrees to store.
+	args := make([]interface{}, 0, len(subtrees))
+
+	for _, s := range subtrees {
+		s := s
+		if s.Prefix == nil {
+			panic(fmt.Errorf("nil prefix on %v", s))
+		}
+		subtreeBytes, err := proto.Marshal(s)
+		if err != nil {
+			return err
+		}
+		args = append(args, t.treeID)
+		args = append(args, s.Prefix)
+		args = append(args, subtreeBytes)
+		args = append(args, t.writeRevision)
+	}
+
+	tmpl, err := t.ts.setSubtreeStmt(ctx, len(subtrees))
+	if err != nil {
+		return err
+	}
+	stx := t.tx.StmtContext(ctx, tmpl)
+	defer stx.Close()
+
+	r, err := stx.ExecContext(ctx, args...)
+	if err != nil {
+		glog.Warningf("Failed to set merkle subtrees: %s", err)
+		return err
+	}
+	_, _ = r.RowsAffected()
+	return nil
+}
+
+func checkResultOkAndRowCountIs(res sql.Result, err error, count int64) error {
+	// The Exec() might have just failed
+	if err != nil {
+		return err
+	}
+
+	// Otherwise we have to look at the result of the operation
+	rowsAffected, rowsError := res.RowsAffected()
+
+	if rowsError != nil {
+		return rowsError
+	}
+
+	if rowsAffected != count {
+		return fmt.Errorf("Expected %d row(s) to be affected but saw: %d", count,
+			rowsAffected)
+	}
+
+	return nil
+}
+
+// GetTreeRevisionAtSize returns the max node version for a tree at a particular size.
+// It is an error to request tree sizes larger than the currently published tree size.
+// For an inexact tree size this implementation always returns the next largest revision if an
+// exact one does not exist but it isn't required to do so.
+func (t *treeTX) GetTreeRevisionIncludingSize(ctx context.Context, treeSize int64) (int64, int64, error) {
+	// Negative size is not sensible and a zero sized tree has no nodes so no revisions
+	if treeSize <= 0 {
+		return 0, 0, fmt.Errorf("invalid tree size: %d", treeSize)
+	}
+
+	var treeRevision, actualTreeSize int64
+	err := t.tx.QueryRowContext(ctx, selectTreeRevisionAtSizeOrLargerSQL, t.treeID, treeSize).Scan(&treeRevision, &actualTreeSize)
+
+	return treeRevision, actualTreeSize, err
+}
+
+// getSubtreesAtRev returns a GetSubtreesFunc which reads at the passed in rev.
+func (t *treeTX) getSubtreesAtRev(ctx context.Context, rev int64) cache.GetSubtreesFunc {
+	return func(ids []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+		return t.getSubtrees(ctx, rev, ids)
+	}
+}
+
+// GetMerkleNodes returns the requests nodes at (or below) the passed in treeRevision.
+func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]storage.Node, error) {
+	return t.subtreeCache.GetNodes(nodeIDs, t.getSubtreesAtRev(ctx, treeRevision))
+}
+
+func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []storage.Node) error {
+	for _, n := range nodes {
+		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,
+			func(nID storage.NodeID) (*storagepb.SubtreeProto, error) {
+				return t.getSubtree(ctx, t.writeRevision, nID)
+			})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *treeTX) Commit() error {
+	if t.writeRevision > -1 {
+		if err := t.subtreeCache.Flush(func(st []*storagepb.SubtreeProto) error {
+			return t.storeSubtrees(context.TODO(), st)
+		}); err != nil {
+			glog.Warningf("TX commit flush error: %v", err)
+			return err
+		}
+	}
+	t.closed = true
+	if err := t.tx.Commit(); err != nil {
+		glog.Warningf("TX commit error: %s", err)
+		return err
+	}
+	return nil
+}
+
+func (t *treeTX) Rollback() error {
+	t.closed = true
+	if err := t.tx.Rollback(); err != nil {
+		glog.Warningf("TX rollback error: %s", err)
+		return err
+	}
+	return nil
+}
+
+func (t *treeTX) Close() error {
+	if !t.closed {
+		err := t.Rollback()
+		if err != nil {
+			glog.Warningf("Rollback error on Close(): %v", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (t *treeTX) IsOpen() bool {
+	return !t.closed
+}
+
+func checkDatabaseAccessible(ctx context.Context, db *sql.DB) error {
+	stmt, err := db.PrepareContext(ctx, "SELECT TreeId FROM Trees LIMIT 1")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	_, err = stmt.ExecContext(ctx)
+	return err
+}


### PR DESCRIPTION
Goes some way to enforcing #619 

Commits add an in-memory based log storage, then add an integration test which uses it to store and retrieve dupe leaves.

This PR brought to you by the numbers 1 through 12 https://www.youtube.com/watch?v=VOaZbaPzdsk