### PR TITLE
Ignore vendor directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.swp
 *~
 default.etcd
+vendor/*/


### PR DESCRIPTION
Avoid copying the entire contents of the vendor directory into github.
This PR keeps vendor/vendor.json in scope while excluding any directory
underneath vendor.