### PR TITLE
Add a resetdb.sh script that works with Kubernetes

### DIFF
--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -3,10 +3,11 @@ echo "Completely wipe and reset database 'test'."
 read -p "Are you sure? " -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # A command line supplied -u will override the first argument.
-    mysql -u root "$@" -e 'DROP DATABASE IF EXISTS test;'
-    mysql -u root "$@" -e 'CREATE DATABASE test;'
-    mysql -u root "$@" -e "GRANT ALL ON test.* TO 'test'@'localhost' IDENTIFIED BY 'zaphod';"
-    mysql -u root "$@" -D test < $(go env GOPATH)/src/github.com/google/trillian/storage/mysql/storage.sql
+    # User-supplied arguments must be first. This is because some flags, such
+    # as --defaults-extra-file, must be at the start.
+    mysql "$@" -u root -e 'DROP DATABASE IF EXISTS test;'
+    mysql "$@" -u root -e 'CREATE DATABASE test;'
+    mysql "$@" -u root -e "GRANT ALL ON test.* TO 'test'@'localhost' IDENTIFIED BY 'zaphod';"
+    mysql "$@" -u root -D test < $(go env GOPATH)/src/github.com/google/trillian/storage/mysql/storage.sql
 fi
 echo

--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
+
 echo "Completely wipe and reset database 'test'."
 read -p "Are you sure? " -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
@@ -8,6 +11,6 @@ then
     mysql "$@" -u root -e 'DROP DATABASE IF EXISTS test;'
     mysql "$@" -u root -e 'CREATE DATABASE test;'
     mysql "$@" -u root -e "GRANT ALL ON test.* TO 'test'@'localhost' IDENTIFIED BY 'zaphod';"
-    mysql "$@" -u root -D test < $(go env GOPATH)/src/github.com/google/trillian/storage/mysql/storage.sql
+    mysql "$@" -u root -D test < ${TRILLIAN_PATH}/storage/mysql/storage.sql
 fi
 echo

--- a/storage/mysql/kubernetes/README.md
+++ b/storage/mysql/kubernetes/README.md
@@ -21,6 +21,12 @@ kubectl proxy
 This dashboard will also show the external IP of the cluster on the
 "Services" page, on the row for the "mysql" service.
 
+Once the cluster has been provisioned, prepare the database for use by Trillian
+by running:
+```shell
+$GOPATH/src/github.com/google/trillian/storage/mysql/kubernetes/resetdb.sh
+```
+
 ### Firewall
 
 By default, the load balancer that exposes the MySQL service will only accept

--- a/storage/mysql/kubernetes/README.md
+++ b/storage/mysql/kubernetes/README.md
@@ -8,13 +8,13 @@ To run a Galera MySQL cluster on Google Cloud, install the
 [Cloud SDK](https://cloud.google.com/sdk/) and configure it for your project.
 [Provision a Container cluster](https://cloud.google.com/container-engine/docs/clusters/operations),
 then run the following command:
-```
-kubectl apply -f galera.yaml
+```shell
+kubectl apply -f $GOPATH/src/github.com/google/trillian/storage/mysql/kubernetes
 ```
 
 This will start the Galera cluster. You can monitor provisoning of this cluster
 by visiting http://127.0.0.1:8001/ui/ after running:
-```
+```shell
 kubectl proxy
 ```
 
@@ -54,5 +54,5 @@ The following modifications have been made:
 - Added some utility scripts:
   - image/env.sh
   - image/push.sh
-- Added liveness and readiness probes to the Kubernetes config.
+- Added readiness probes to the Kubernetes config.
 - Moved usernames and passwords into [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).

--- a/storage/mysql/kubernetes/image/docker-entrypoint.sh
+++ b/storage/mysql/kubernetes/image/docker-entrypoint.sh
@@ -23,9 +23,6 @@
 # initialized, creates the database according to the following environment
 # variables:
 # - $MYSQL_ROOT_PASSWORD
-# - $MYSQL_DATABASE
-# - $MYSQL_USER
-# - $MYSQL_PASSWORD
 # - $WSREP_SST_USER
 # - $WSREP_SST_PASSWORD
 # 2. Configures MySQL for the Galera cluster.

--- a/storage/mysql/kubernetes/resetdb.sh
+++ b/storage/mysql/kubernetes/resetdb.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
+
+readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
 
 # Pick a random port between 2000 - 34767. Will fail if unlucky and the port is in use.
 readonly port=$((${RANDOM} + 2000))
@@ -15,8 +17,7 @@ user=root
 password="$(kubectl get secrets mysql-credentials --template '{{index .data "root-password"}}' | base64 -d)"
 EOF
 
-"${GOPATH}/src/github.com/google/trillian/scripts/resetdb.sh" \
-  --defaults-extra-file="${options_file}"
+"${TRILLIAN_PATH}/scripts/resetdb.sh" --defaults-extra-file="${options_file}"
 
 rm "${options_file}"
 

--- a/storage/mysql/kubernetes/resetdb.sh
+++ b/storage/mysql/kubernetes/resetdb.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Pick a random port between 2000 - 34767. Will fail if unlucky and the port is in use.
+readonly port=$((${RANDOM} + 2000))
+kubectl port-forward "galera-0" "${port}:3306" >/dev/null &
+proxy_pid=$!
+
+options_file=$(mktemp)
+chmod 0600 "${options_file}"
+echo > ${options_file} <<EOF
+[client]
+host=localhost
+port=${port}
+user=root
+password="$(kubectl get secrets mysql-credentials --template '{{index .data "root-password"}}' | base64 -d)"
+EOF
+
+"${GOPATH}/src/github.com/google/trillian/scripts/resetdb.sh" \
+  --defaults-extra-file="${options_file}"
+
+rm "${options_file}"
+
+kill "${proxy_pid}"
+wait "${proxy_pid}" 2>/dev/null
+


### PR DESCRIPTION
Adds a script that can reset a Trillian MySQL database running on Kubernetes, by:

1. Setting up port forwarding to the MySQL port of a Galera node.
2. Passing connection details to scripts/resetdb.sh.
3. Shutting down port forwarding.