### PR TITLE
scripts: make gocyclo check fatal

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -89,8 +89,7 @@ main() {
     printf '%s\n' ${go_srcs} | xargs -I'{}' go vet '{}'
 
     echo 'running gocyclo'
-    # Do not fail on gocyclo tests, hence the "|| true".
-    printf '%s\n' ${go_srcs} | xargs -I'{}' bash -c 'gocyclo -over 25 {} || true'
+    printf '%s\n' ${go_srcs} | xargs -I'{}' bash -c 'gocyclo -over 25 {}'
 
     echo 'running misspell'
     printf '%s\n' ${go_srcs} | xargs -I'{}' misspell -error -i cancelled,CANCELLED -locale US '{}'


### PR DESCRIPTION
Now the integration script has moved to the c-t-go repo
we no longer need to except gocyclo from the checks.