### PR TITLE
Move most of pem_signer_factory_test.go into signer_factory_tester.go

### DIFF
--- a/crypto/keys/pem_signer_factory_test.go
+++ b/crypto/keys/pem_signer_factory_test.go
@@ -21,49 +21,49 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 )
 
-var tester = SignerFactoryTester{
-	NewSignerFactory: func() SignerFactory { return PEMSignerFactory{} },
-	NewSignerTests: []NewSignerTest{
-		{
-			Name: "PEMKeyFile",
-			Tree: &trillian.Tree{
-				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-					Path:     "../../testdata/log-rpc-server.privkey.pem",
-					Password: "towel",
-				}),
-			},
-		},
-		{
-			Name: "PemKeyFile with non-existent file",
-			Tree: &trillian.Tree{
-				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-					Path: "non-existent.pem",
-				}),
-			},
-			WantErr: true,
-		},
-		{
-			Name: "PemKeyFile with wrong password",
-			Tree: &trillian.Tree{
-				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-					Path:     "../../testdata/log-rpc-server.privkey.pem",
-					Password: "wrong-password",
-				}),
-			},
-			WantErr: true,
-		},
-		{
-			Name: "PemKeyFile with missing password",
-			Tree: &trillian.Tree{
-				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-					Path: "../../testdata/log-rpc-server.privkey.pem",
-				}),
-			},
-			WantErr: true,
-		},
-	},
-}
-
 func TestPEMSignerFactory(t *testing.T) {
+	tester := SignerFactoryTester{
+		NewSignerFactory: func() SignerFactory { return PEMSignerFactory{} },
+		NewSignerTests: []NewSignerTest{
+			{
+				Name: "PEMKeyFile",
+				Tree: &trillian.Tree{
+					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
+						Path:     "../../testdata/log-rpc-server.privkey.pem",
+						Password: "towel",
+					}),
+				},
+			},
+			{
+				Name: "PemKeyFile with non-existent file",
+				Tree: &trillian.Tree{
+					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
+						Path: "non-existent.pem",
+					}),
+				},
+				WantErr: true,
+			},
+			{
+				Name: "PemKeyFile with wrong password",
+				Tree: &trillian.Tree{
+					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
+						Path:     "../../testdata/log-rpc-server.privkey.pem",
+						Password: "wrong-password",
+					}),
+				},
+				WantErr: true,
+			},
+			{
+				Name: "PemKeyFile with missing password",
+				Tree: &trillian.Tree{
+					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
+						Path: "../../testdata/log-rpc-server.privkey.pem",
+					}),
+				},
+				WantErr: true,
+			},
+		},
+	}
+
 	tester.RunAllTests(t)
 }

--- a/crypto/keys/pem_signer_factory_test.go
+++ b/crypto/keys/pem_signer_factory_test.go
@@ -15,207 +15,55 @@
 package keys
 
 import (
-	"context"
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
-	"github.com/google/trillian/crypto/sigpb"
 )
 
-func marshalAny(pb proto.Message) *any.Any {
-	a, err := ptypes.MarshalAny(pb)
-	if err != nil {
-		panic(err)
-	}
-	return a
-}
-
-func TestPEMSignerFactoryNewSigner(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		tree    *trillian.Tree
-		wantErr bool
-	}{
+var tester = SignerFactoryTester{
+	NewSignerFactory: func() SignerFactory { return PEMSignerFactory{} },
+	NewSignerTests: []NewSignerTest{
 		{
-			name: "PEMKeyFile",
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&keyspb.PEMKeyFile{
+			Name: "PEMKeyFile",
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
 					Path:     "../../testdata/log-rpc-server.privkey.pem",
 					Password: "towel",
 				}),
 			},
 		},
 		{
-			name: "PemKeyFile with non-existent file",
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&keyspb.PEMKeyFile{
+			Name: "PemKeyFile with non-existent file",
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
 					Path: "non-existent.pem",
 				}),
 			},
-			wantErr: true,
+			WantErr: true,
 		},
 		{
-			name: "PemKeyFile with wrong password",
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&keyspb.PEMKeyFile{
+			Name: "PemKeyFile with wrong password",
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
 					Path:     "../../testdata/log-rpc-server.privkey.pem",
 					Password: "wrong-password",
 				}),
 			},
-			wantErr: true,
+			WantErr: true,
 		},
 		{
-			name: "PemKeyFile with missing password",
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&keyspb.PEMKeyFile{
+			Name: "PemKeyFile with missing password",
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
 					Path: "../../testdata/log-rpc-server.privkey.pem",
 				}),
 			},
-			wantErr: true,
+			WantErr: true,
 		},
-		{
-			name: "Unsupported PrivateKey type",
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&trillian.Tree{}),
-			},
-			wantErr: true,
-		},
-		{
-			name:    "No PrivateKey",
-			tree:    &trillian.Tree{},
-			wantErr: true,
-		},
-	} {
-		signer, err := PEMSignerFactory{}.NewSigner(context.Background(), test.tree)
-		switch gotErr := err != nil; {
-		case gotErr != test.wantErr:
-			t.Errorf("%v: Signer(_, %v) = (%v, %v), want err? %v", test.name, test.tree, signer, err, test.wantErr)
-			continue
-		case gotErr:
-			continue
-		}
-
-		// Check that the returned signer can produce signatures successfully.
-		digest := sha256.Sum256([]byte("test"))
-		if _, err := signer.Sign(rand.Reader, digest[:], crypto.SHA256); err != nil {
-			t.Errorf("%v: Signer(_, %v).Sign() = (_, %v), want err? false", test.name, test.tree, err)
-		}
-	}
+	},
 }
 
-func TestPEMSignerFactoryGenerate(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		keySpec *keyspb.Specification
-		tree    *trillian.Tree
-		wantErr bool
-	}{
-		{
-			name: "RSA",
-			keySpec: &keyspb.Specification{
-				Params: &keyspb.Specification_RsaParams{
-					RsaParams: &keyspb.Specification_RSA{},
-				},
-			},
-			tree: &trillian.Tree{
-				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
-			},
-		},
-		{
-			name: "ECDSA",
-			keySpec: &keyspb.Specification{
-				Params: &keyspb.Specification_EcdsaParams{
-					EcdsaParams: &keyspb.Specification_ECDSA{},
-				},
-			},
-			tree: &trillian.Tree{
-				SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
-			},
-		},
-		{
-			name: "Tree already has a PrivateKey",
-			keySpec: &keyspb.Specification{
-				Params: &keyspb.Specification_EcdsaParams{
-					EcdsaParams: &keyspb.Specification_ECDSA{},
-				},
-			},
-			tree: &trillian.Tree{
-				PrivateKey: marshalAny(&keyspb.PEMKeyFile{
-					Path: "non-existent.pem",
-				}),
-				PublicKey: &keyspb.PublicKey{
-					Der: []byte("foo"),
-				},
-				SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
-			},
-			wantErr: true,
-		},
-		{
-			name: "Mismatched Specification.Params and tree.SignatureAlgorithm",
-			keySpec: &keyspb.Specification{
-				Params: &keyspb.Specification_EcdsaParams{
-					EcdsaParams: &keyspb.Specification_ECDSA{},
-				},
-			},
-			tree: &trillian.Tree{
-				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
-			},
-			wantErr: true,
-		},
-		{
-			name: "RSA with insufficient key size",
-			keySpec: &keyspb.Specification{
-				Params: &keyspb.Specification_RsaParams{
-					RsaParams: &keyspb.Specification_RSA{
-						Bits: 1024,
-					},
-				},
-			},
-			tree: &trillian.Tree{
-				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
-			},
-			wantErr: true,
-		},
-	} {
-		ctx := context.Background()
-		var sf PEMSignerFactory
-
-		key, err := sf.Generate(ctx, test.tree, test.keySpec)
-		if gotErr := err != nil; gotErr != test.wantErr {
-			t.Errorf("%v: Generate() = (_, %v), want err? %v", test.name, err, test.wantErr)
-			continue
-		} else if gotErr {
-			continue
-		}
-
-		newTree := *test.tree
-		newTree.PrivateKey = key
-
-		signer, err := sf.NewSigner(ctx, &newTree)
-		if err != nil {
-			t.Errorf("%v: NewSigner(_, %v) = (_, %v), want (_, nil)", test.name, newTree, err)
-			continue
-		}
-
-		publicKey := signer.Public()
-		switch test.keySpec.Params.(type) {
-		case *keyspb.Specification_RsaParams:
-			if _, ok := publicKey.(*rsa.PublicKey); !ok {
-				t.Errorf("%v: signer.Public() = %T, want *rsa.PublicKey", test.name, publicKey)
-			}
-		case *keyspb.Specification_EcdsaParams:
-			if _, ok := publicKey.(*ecdsa.PublicKey); !ok {
-				t.Errorf("%v: signer.Public() = %T, want *ecdsa.PublicKey", test.name, publicKey)
-			}
-		}
-	}
+func TestPEMSignerFactory(t *testing.T) {
+	tester.RunAllTests(t)
 }

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -1,0 +1,261 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keyspb"
+	"github.com/google/trillian/crypto/sigpb"
+)
+
+// NewSignerTest is a test case to be run by TestNewSigner().
+type NewSignerTest struct {
+	// Name describes the test.
+	Name string
+	// Tree is passed to SignerFactory.NewSigner().
+	Tree *trillian.Tree
+	// WantErr should be true if SignerFactory.NewSigner() is expected to return an error.
+	WantErr bool
+}
+
+// SignerFactoryTester runs a suite of tests against a SignerFactory implementation.
+type SignerFactoryTester struct {
+	// NewSignerFactory returns an SignerFactory instance setup for testing.
+	NewSignerFactory func() SignerFactory
+	// NewSignerTests are additional test cases to exercise the specific
+	// PrivateKey protos that this SignerFactory implementation supports.
+	NewSignerTests []NewSignerTest
+}
+
+// RunAllTests runs all SignerFactory tests.
+func (tester *SignerFactoryTester) RunAllTests(t *testing.T) {
+	t.Run("TestNewSigner", tester.TestNewSigner)
+	t.Run("TestGenerate", tester.TestGenerate)
+}
+
+// TestNewSigner runs test on the SignerFactory's NewSigner() method.
+func (tester *SignerFactoryTester) TestNewSigner(t *testing.T) {
+	for _, test := range append(tester.NewSignerTests, []NewSignerTest{
+		{
+			Name: "Unsupported PrivateKey type",
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&empty.Empty{}),
+			},
+			WantErr: true,
+		},
+		{
+			Name:    "No PrivateKey",
+			Tree:    &trillian.Tree{},
+			WantErr: true,
+		},
+	}...) {
+		signer, err := tester.NewSignerFactory().NewSigner(context.Background(), test.Tree)
+		switch gotErr := err != nil; {
+		case gotErr != test.WantErr:
+			t.Errorf("%v: Signer(_, %v) = (%v, %v), want err? %v", test.Name, test.Tree, signer, err, test.WantErr)
+			continue
+		case gotErr:
+			continue
+		}
+
+		// Check that the returned signer can produce signatures successfully.
+		hasher := crypto.SHA256
+		digest := sha256.Sum256([]byte("test"))
+		signature, err := signer.Sign(rand.Reader, digest[:], hasher)
+		if err != nil {
+			t.Errorf("%v: Signer(_, %v).Sign() = (_, %v), want err? false", test.Name, test.Tree, err)
+		}
+
+		if err := verify(signer.Public(), digest[:], signature, hasher, hasher); err != nil {
+			t.Errorf("%v: %v", test.Name, err)
+		}
+	}
+}
+
+// TestGenerate runs test on the SignerFactory's Generate() method.
+func (tester *SignerFactoryTester) TestGenerate(t *testing.T) {
+	for _, test := range []struct {
+		Name    string
+		KeySpec *keyspb.Specification
+		Tree    *trillian.Tree
+		WantErr bool
+	}{
+		{
+			Name: "RSA",
+			KeySpec: &keyspb.Specification{
+				Params: &keyspb.Specification_RsaParams{
+					RsaParams: &keyspb.Specification_RSA{},
+				},
+			},
+			Tree: &trillian.Tree{
+				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
+			},
+		},
+		{
+			Name: "ECDSA",
+			KeySpec: &keyspb.Specification{
+				Params: &keyspb.Specification_EcdsaParams{
+					EcdsaParams: &keyspb.Specification_ECDSA{},
+				},
+			},
+			Tree: &trillian.Tree{
+				SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+			},
+		},
+		{
+			Name: "Tree already has a PrivateKey",
+			KeySpec: &keyspb.Specification{
+				Params: &keyspb.Specification_EcdsaParams{
+					EcdsaParams: &keyspb.Specification_ECDSA{},
+				},
+			},
+			Tree: &trillian.Tree{
+				PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
+					Path: "non-existent.pem",
+				}),
+				PublicKey: &keyspb.PublicKey{
+					Der: []byte("foo"),
+				},
+				SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+			},
+			WantErr: true,
+		},
+		{
+			Name: "Mismatched Specification.Params and tree.SignatureAlgorithm",
+			KeySpec: &keyspb.Specification{
+				Params: &keyspb.Specification_EcdsaParams{
+					EcdsaParams: &keyspb.Specification_ECDSA{},
+				},
+			},
+			Tree: &trillian.Tree{
+				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
+			},
+			WantErr: true,
+		},
+		{
+			Name: "RSA with insufficient key size",
+			KeySpec: &keyspb.Specification{
+				Params: &keyspb.Specification_RsaParams{
+					RsaParams: &keyspb.Specification_RSA{
+						Bits: 1024,
+					},
+				},
+			},
+			Tree: &trillian.Tree{
+				SignatureAlgorithm: sigpb.DigitallySigned_RSA,
+			},
+			WantErr: true,
+		},
+	} {
+		ctx := context.Background()
+		sf := tester.NewSignerFactory()
+
+		key, err := sf.Generate(ctx, test.Tree, test.KeySpec)
+		if gotErr := err != nil; gotErr != test.WantErr {
+			t.Errorf("%v: Generate() = (_, %v), want err? %v", test.Name, err, test.WantErr)
+			continue
+		} else if gotErr {
+			continue
+		}
+
+		newTree := *test.Tree
+		newTree.PrivateKey = key
+
+		signer, err := sf.NewSigner(ctx, &newTree)
+		if err != nil {
+			t.Errorf("%v: NewSigner(_, %v) = (_, %v), want (_, nil)", test.Name, newTree, err)
+			continue
+		}
+
+		publicKey := signer.Public()
+		switch test.KeySpec.Params.(type) {
+		case *keyspb.Specification_RsaParams:
+			if _, ok := publicKey.(*rsa.PublicKey); !ok {
+				t.Errorf("%v: signer.Public() = %T, want *rsa.PublicKey", test.Name, publicKey)
+			}
+		case *keyspb.Specification_EcdsaParams:
+			if _, ok := publicKey.(*ecdsa.PublicKey); !ok {
+				t.Errorf("%v: signer.Public() = %T, want *ecdsa.PublicKey", test.Name, publicKey)
+			}
+		}
+	}
+}
+
+func mustMarshalAny(pb proto.Message) *any.Any {
+	a, err := ptypes.MarshalAny(pb)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+// Verify checks that sig is a valid signature for a digest (hash of some data).
+// A private key will have been used to generate the signature;
+// the corresponding public key must be provided in order to verify the signature.
+// Hasher must identify the hash algorithm that was used to produce digest.
+// The options, if any, that were used when generating the signature must be provided.
+// If sig is an RSA PSS signature, opts must be *rsa.PSSOptions.
+func verify(pub crypto.PublicKey, digest, sig []byte, hasher crypto.Hash, opts crypto.SignerOpts) error {
+	switch pub := pub.(type) {
+	case *ecdsa.PublicKey:
+		return verifyECDSA(pub, digest, sig)
+	case *rsa.PublicKey:
+		return verifyRSA(pub, digest, sig, hasher, opts)
+	}
+
+	return fmt.Errorf("unknown public key type: %T", pub)
+}
+
+func verifyECDSA(pub *ecdsa.PublicKey, digest, sig []byte) error {
+	var ecdsaSig struct {
+		R, S *big.Int
+	}
+
+	rest, err := asn1.Unmarshal(sig, &ecdsaSig)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("ECDSA signature %v bytes longer than expected", len(rest))
+	}
+
+	if !ecdsa.Verify(pub, digest, ecdsaSig.R, ecdsaSig.S) {
+		return errors.New("ECDSA signature failed verification")
+	}
+	return nil
+}
+
+func verifyRSA(pub *rsa.PublicKey, digest, sig []byte, hasher crypto.Hash, opts crypto.SignerOpts) error {
+	if pssOpts, ok := opts.(*rsa.PSSOptions); ok {
+		return rsa.VerifyPSS(pub, hasher, digest, sig, pssOpts)
+	}
+	return rsa.VerifyPKCS1v15(pub, hasher, digest, sig)
+}

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -217,7 +217,7 @@ func mustMarshalAny(pb proto.Message) *any.Any {
 	return a
 }
 
-// Verify checks that sig is a valid signature for a digest (hash of some data).
+// verify checks that sig is a valid signature for a digest (hash of some data).
 // A private key will have been used to generate the signature;
 // the corresponding public key must be provided in order to verify the signature.
 // Hasher must identify the hash algorithm that was used to produce digest.


### PR DESCRIPTION
Makes these tests reusable by other SignerFactory implementations. Required some refactoring to avoid import cycles and to export required code.

As requested by @codingllama. 

TODO: With some more refactoring (specifically, moving PEMSignerFactory into its own package), I should be able to move SignerFactoryTester into a "testonly" package, if requested.