### PR TITLE
Fix bug in creating hash keys for memory storage

### DIFF
--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -47,7 +47,7 @@ func seqLeafKey(treeID, seq int64) btree.Item {
 }
 
 func hashToSeqKey(treeID int64) btree.Item {
-	return &kv{k: fmt.Sprintf("/%d/h2s")}
+	return &kv{k: fmt.Sprintf("/%d/h2s", treeID)}
 }
 
 func sthKey(treeID, timestamp int64) btree.Item {


### PR DESCRIPTION
Looks like it would have worked OK for one tree, which might be all it's used for at the moment.