### PR TITLE
Map Storage random optimizations

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -11,8 +11,8 @@ shared `TreeStorage` model which can store arbitrary nodes in a tree.
 Anyone poking around in here should be aware that there are some subtle
 wrinkles introduced by the fact that Log trees grow upwards (i.e. the Log
 considers nodes at level 0 to be the leaves), and in contrast the Map considers
-the leaves to be at level 255 (and the root at 0), this is based on the HStar2
-algorithm.
+the leaves to be at level 255 (and the root at 0), this is based on the [HStar2
+algorithm](https://www.links.org/files/RevocationTransparency.pdf).
 
 ## TreeStorage
 
@@ -35,15 +35,15 @@ subtree as a single unit.  Within these subtrees, only the (subtree-relative)
 "leaf" nodes are actually written to disk, the internal structure of the
 subtrees is re-calculated when the subtree is read from disk.
 
-Doing this compaction saves a considerable about of on-disk space, and at least
+Doing this compaction saves a considerable amout of on-disk space, and at least
 for the MySQL storage implementation, results in a ~20% speed increase.
 
 ### History
 
 Updates to the tree storage are performed in a batched fashion (i.e. some unit
-of update which provides for a self-consistent view of the tree - e.g.:
+of update which provides a self-consistent view of the tree - e.g.:
   * *n* `append leaf` operations along with internal node updates for the
-    LogStorage, and tagged with
+    LogStorage, and tagged with their sequence number.
   * *n* `set value` operations along with internal node updates for the
     MapStorage.
 

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -210,7 +210,6 @@ func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
 }
 
 func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
-
 	ret := make([]*trillian.LogLeaf, 0, len(leaves))
 	for _, seq := range leaves {
 		leaf := t.tx.Get(seqLeafKey(t.treeID, seq))

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -73,7 +73,7 @@ func (m *mySQLMapStorage) CheckDatabaseAccessible(ctx context.Context) error {
 }
 
 type readOnlyMapTX struct {
-	tx *sql.Tx
+	*sql.Tx
 }
 
 func (m *mySQLMapStorage) Snapshot(ctx context.Context) (storage.ReadOnlyMapTX, error) {
@@ -82,14 +82,6 @@ func (m *mySQLMapStorage) Snapshot(ctx context.Context) (storage.ReadOnlyMapTX, 
 		return nil, err
 	}
 	return &readOnlyMapTX{tx}, nil
-}
-
-func (t *readOnlyMapTX) Commit() error {
-	return t.tx.Commit()
-}
-
-func (t *readOnlyMapTX) Rollback() error {
-	return t.tx.Rollback()
 }
 
 func (t *readOnlyMapTX) Close() error {
@@ -138,11 +130,7 @@ func (m *mySQLMapStorage) BeginForTree(ctx context.Context, treeID int64) (stora
 }
 
 func (m *mySQLMapStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyMapTreeTX, error) {
-	tx, err := m.begin(ctx, treeID, true /* readonly */)
-	if err != nil {
-		return nil, err
-	}
-	return tx.(storage.ReadOnlyMapTreeTX), nil
+	return m.begin(ctx, treeID, true /* readonly */)
 }
 
 type mapTreeTX struct {

--- a/storage/types.go
+++ b/storage/types.go
@@ -63,11 +63,7 @@ type NodeID struct {
 
 // bytesForBits returns the number of bytes required to store numBits bits.
 func bytesForBits(numBits int) int {
-	numBytes := numBits / 8
-	if numBits%8 != 0 {
-		numBytes++
-	}
-	return numBytes
+	return (numBits + 7) >> 3
 }
 
 // NewNodeIDFromHash creates a new NodeID for the given Hash.


### PR DESCRIPTION
- Add documentaion links to storage README.
- Remove if statement from bit length calculation.
- Use anonymous type for readonlyMapTX.
  - Saves us from defining passthrough functions.