### PR TITLE
Remove trillian.Tree parameter from SignerFactory interface

### DIFF
--- a/crypto/keys/mock_keys.go
+++ b/crypto/keys/mock_keys.go
@@ -8,7 +8,6 @@ import (
 	crypto "crypto"
 	gomock "github.com/golang/mock/gomock"
 	any "github.com/golang/protobuf/ptypes/any"
-	trillian "github.com/google/trillian"
 	keyspb "github.com/google/trillian/crypto/keyspb"
 )
 
@@ -33,18 +32,18 @@ func (_m *MockSignerFactory) EXPECT() *_MockSignerFactoryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSignerFactory) Generate(_param0 context.Context, _param1 *trillian.Tree, _param2 *keyspb.Specification) (*any.Any, error) {
-	ret := _m.ctrl.Call(_m, "Generate", _param0, _param1, _param2)
+func (_m *MockSignerFactory) Generate(_param0 context.Context, _param1 *keyspb.Specification) (*any.Any, error) {
+	ret := _m.ctrl.Call(_m, "Generate", _param0, _param1)
 	ret0, _ := ret[0].(*any.Any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockSignerFactoryRecorder) Generate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Generate", arg0, arg1, arg2)
+func (_mr *_MockSignerFactoryRecorder) Generate(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Generate", arg0, arg1)
 }
 
-func (_m *MockSignerFactory) NewSigner(_param0 context.Context, _param1 *trillian.Tree) (crypto.Signer, error) {
+func (_m *MockSignerFactory) NewSigner(_param0 context.Context, _param1 *any.Any) (crypto.Signer, error) {
 	ret := _m.ctrl.Call(_m, "NewSigner", _param0, _param1)
 	ret0, _ := ret[0].(crypto.Signer)
 	ret1, _ := ret[1].(error)

--- a/crypto/keys/pem_signer_factory.go
+++ b/crypto/keys/pem_signer_factory.go
@@ -17,33 +17,25 @@ package keys
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
-	"crypto/x509"
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
 // PEMSignerFactory handles PEM-encoded private keys.
-// It supports trees whose PrivateKey field is a:
-// - keyspb.PEMKeyFile
-// - keyspb.PrivateKey
 // It implements keys.SignerFactory.
 type PEMSignerFactory struct{}
 
-// NewSigner returns a crypto.Signer for the given tree.
-func (f PEMSignerFactory) NewSigner(ctx context.Context, tree *trillian.Tree) (crypto.Signer, error) {
-	if tree.GetPrivateKey() == nil {
-		return nil, fmt.Errorf("tree %d has no PrivateKey", tree.GetTreeId())
-	}
-
+// NewSigner uses the information in pb to return a crypto.Signer.
+// pb must be one of the following types:
+// - keyspb.PEMKeyFile
+// - keyspb.PrivateKey
+func (f PEMSignerFactory) NewSigner(ctx context.Context, pb *any.Any) (crypto.Signer, error) {
 	var privateKey ptypes.DynamicAny
-	if err := ptypes.UnmarshalAny(tree.GetPrivateKey(), &privateKey); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal private key for tree %d: %v", tree.GetTreeId(), err)
+	if err := ptypes.UnmarshalAny(pb, &privateKey); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal private key: %v", err)
 	}
 
 	switch privateKey := privateKey.Message.(type) {
@@ -53,43 +45,21 @@ func (f PEMSignerFactory) NewSigner(ctx context.Context, tree *trillian.Tree) (c
 		return NewFromPrivateDER(privateKey.GetDer())
 	}
 
-	return nil, fmt.Errorf("unsupported PrivateKey type for tree %d: %T", tree.GetTreeId(), privateKey.Message)
+	return nil, fmt.Errorf("unsupported PrivateKey type: %T", privateKey.Message)
 }
 
-// Generate creates a new private key for a tree based on a key specification.
-// It returns a proto that can be used as the value of tree.PrivateKey.
-func (f PEMSignerFactory) Generate(ctx context.Context, tree *trillian.Tree, spec *keyspb.Specification) (*any.Any, error) {
-	if tree.PrivateKey != nil {
-		return nil, fmt.Errorf("tree already has a private key: %v", tree.TreeId)
-	}
-
+// Generate creates a new private key based on a key specification.
+// It returns a proto that can be passed to NewSigner() to get a crypto.Signer.
+func (f PEMSignerFactory) Generate(ctx context.Context, spec *keyspb.Specification) (*any.Any, error) {
 	key, err := NewFromSpec(spec)
 	if err != nil {
 		return nil, fmt.Errorf("error generating key: %v", err)
 	}
 
-	if SignatureAlgorithm(key.Public()) != tree.GetSignatureAlgorithm() {
-		return nil, fmt.Errorf("specification produces %T, but tree.SignatureAlgorithm = %v", key, tree.GetSignatureAlgorithm())
-	}
-
-	return marshalPrivateKey(key)
-}
-
-func marshalPrivateKey(key crypto.Signer) (*any.Any, error) {
-	var privateKeyDER []byte
-	var err error
-
-	switch key := key.(type) {
-	case *ecdsa.PrivateKey:
-		privateKeyDER, err = x509.MarshalECPrivateKey(key)
-	case *rsa.PrivateKey:
-		privateKeyDER = x509.MarshalPKCS1PrivateKey(key)
-	default:
-		return nil, fmt.Errorf("unsupported key type: %T", key)
-	}
+	der, err := MarshalPrivateKey(key)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling private key as DER: %v", err)
 	}
 
-	return ptypes.MarshalAny(&keyspb.PrivateKey{Der: privateKeyDER})
+	return ptypes.MarshalAny(&keyspb.PrivateKey{Der: der})
 }

--- a/crypto/keys/pem_signer_factory_test.go
+++ b/crypto/keys/pem_signer_factory_test.go
@@ -17,7 +17,6 @@ package keys
 import (
 	"testing"
 
-	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
@@ -27,38 +26,30 @@ func TestPEMSignerFactory(t *testing.T) {
 		NewSignerTests: []NewSignerTest{
 			{
 				Name: "PEMKeyFile",
-				Tree: &trillian.Tree{
-					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-						Path:     "../../testdata/log-rpc-server.privkey.pem",
-						Password: "towel",
-					}),
+				KeyProto: &keyspb.PEMKeyFile{
+					Path:     "../../testdata/log-rpc-server.privkey.pem",
+					Password: "towel",
 				},
 			},
 			{
 				Name: "PemKeyFile with non-existent file",
-				Tree: &trillian.Tree{
-					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-						Path: "non-existent.pem",
-					}),
+				KeyProto: &keyspb.PEMKeyFile{
+					Path: "non-existent.pem",
 				},
 				WantErr: true,
 			},
 			{
 				Name: "PemKeyFile with wrong password",
-				Tree: &trillian.Tree{
-					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-						Path:     "../../testdata/log-rpc-server.privkey.pem",
-						Password: "wrong-password",
-					}),
+				KeyProto: &keyspb.PEMKeyFile{
+					Path:     "../../testdata/log-rpc-server.privkey.pem",
+					Password: "wrong-password",
 				},
 				WantErr: true,
 			},
 			{
 				Name: "PemKeyFile with missing password",
-				Tree: &trillian.Tree{
-					PrivateKey: mustMarshalAny(&keyspb.PEMKeyFile{
-						Path: "../../testdata/log-rpc-server.privkey.pem",
-					}),
+				KeyProto: &keyspb.PEMKeyFile{
+					Path: "../../testdata/log-rpc-server.privkey.pem",
 				},
 				WantErr: true,
 			},

--- a/crypto/keys/private_keys.go
+++ b/crypto/keys/private_keys.go
@@ -28,7 +28,6 @@ import (
 	"io/ioutil"
 
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
@@ -43,14 +42,12 @@ const MinRsaKeySizeInBits = 2048
 // or sending network requests to a remote key management service, to give a few
 // examples.
 type SignerFactory interface {
-	// NewSigner returns a signer for the given tree.
-	// It consults Tree.PrivateKey to determine how to retrieve the key.
-	NewSigner(context.Context, *trillian.Tree) (crypto.Signer, error)
+	// NewSigner uses the information in the provided protobuf message to obtain and return a crypto.Signer.
+	NewSigner(context.Context, *any.Any) (crypto.Signer, error)
 
-	// Generate creates a new private key for a tree based on a key specification.
+	// Generate creates a new private key based on a key specification.
 	// It returns a proto that can be used as the value of tree.PrivateKey.
-	// If tree.PrivateKey or tree.PublicKey is already set, it returns an error.
-	Generate(context.Context, *trillian.Tree, *keyspb.Specification) (*any.Any, error)
+	Generate(context.Context, *keyspb.Specification) (*any.Any, error)
 }
 
 // NewFromPrivatePEMFile reads a PEM-encoded private key from a file.
@@ -158,4 +155,16 @@ func curveFromParams(params *keyspb.Specification_ECDSA) elliptic.Curve {
 		return elliptic.P521()
 	}
 	return nil
+}
+
+// MarshalPrivateKey serializes an RSA or ECDSA private key as DER.
+func MarshalPrivateKey(key crypto.Signer) ([]byte, error) {
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		return x509.MarshalECPrivateKey(key)
+	case *rsa.PrivateKey:
+		return x509.MarshalPKCS1PrivateKey(key), nil
+	}
+
+	return nil, fmt.Errorf("unsupported key type: %T", key)
 }

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -15,6 +15,7 @@
 package admin
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -22,8 +23,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
@@ -271,21 +272,21 @@ func TestServer_CreateTree(t *testing.T) {
 	defer ctrl.Finish()
 
 	// PEM on the testonly trees is ECDSA, so let's use an ECDSA key for tests.
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	var defaultPrivateKey crypto.Signer
+	var err error
+	defaultPrivateKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("Error generating test key: %v", err)
 	}
 
-	publicKeyDER, err := x509.MarshalPKIXPublicKey(privateKey.Public())
+	defaultPublicKeyDER, err := x509.MarshalPKIXPublicKey(defaultPrivateKey.Public())
 	if err != nil {
 		t.Fatalf("Error marshaling public key: %v", err)
 	}
 
 	// Need to change the public key to correspond with the private key generated above.
 	validTree := *testonly.LogTree
-	validTree.PublicKey = &keyspb.PublicKey{
-		Der: publicKeyDER,
-	}
+	validTree.PublicKey = &keyspb.PublicKey{Der: defaultPublicKeyDER}
 
 	mismatchedPublicKey := *testonly.LogTree
 
@@ -350,6 +351,17 @@ func TestServer_CreateTree(t *testing.T) {
 			wantCommit: true,
 		},
 		{
+			// Tree specifies ECDSA signatures, but key specification provides RSA parameters.
+			desc: "privateKeySpecWithMismatchedAlgorithm",
+			req: &trillian.CreateTreeRequest{
+				Tree: &omittedKeys,
+				KeySpec: &keyspb.Specification{
+					Params: &keyspb.Specification_RsaParams{},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			desc: "privateKeySpecandPrivateKeyProvided",
 			req: &trillian.CreateTreeRequest{
 				Tree: &validTree,
@@ -412,21 +424,38 @@ func TestServer_CreateTree(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		sf := keys.NewMockSignerFactory(ctrl)
-		if test.req.GetKeySpec() != nil {
-			if test.req.Tree.GetPrivateKey() != nil || test.req.Tree.GetPublicKey() != nil {
-				sf.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("tree already has a key"))
-			} else {
-				keyProto, err := marshalECPrivateKeyAsAnyProto(privateKey)
-				if err != nil {
-					t.Errorf("%v: failed to marshal key for SignerFactory.Generate() expectation: %v", test.desc, err)
-					continue
-				}
+		privateKey := defaultPrivateKey
+		publicKeyDER := defaultPublicKeyDER
 
-				sf.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).Return(keyProto, nil)
-				sf.EXPECT().NewSigner(gomock.Any(), gomock.Any()).Return(privateKey, nil)
+		if test.req.GetKeySpec() != nil && test.req.Tree.GetPrivateKey() == nil && test.req.Tree.GetPublicKey() == nil {
+			privateKey, err = keys.NewFromSpec(test.req.GetKeySpec())
+			if err != nil {
+				t.Errorf("%v: failed to generate test private key: %v", test.desc, err)
+				continue
+			}
+
+			keyDER, err := keys.MarshalPrivateKey(privateKey)
+			if err != nil {
+				t.Errorf("%v: failed to marshal test private key as DER: %v", test.desc, err)
+				continue
+			}
+
+			keyProto, err := ptypes.MarshalAny(&keyspb.PrivateKey{Der: keyDER})
+			if err != nil {
+				t.Errorf("%v: failed to marshal test private key as proto: %v", test.desc, err)
+				continue
+			}
+
+			sf.EXPECT().Generate(gomock.Any(), test.req.GetKeySpec()).Return(keyProto, nil)
+			sf.EXPECT().NewSigner(gomock.Any(), keyProto).Return(privateKey, nil)
+
+			publicKeyDER, err = x509.MarshalPKIXPublicKey(privateKey.Public())
+			if err != nil {
+				t.Errorf("%v: failed to marshal test public key as DER: %v", test.desc, err)
+				continue
 			}
 		} else if test.req.Tree.GetPrivateKey() != nil {
-			sf.EXPECT().NewSigner(gomock.Any(), test.req.Tree).MaxTimes(1).Return(privateKey, nil)
+			sf.EXPECT().NewSigner(gomock.Any(), test.req.Tree.GetPrivateKey()).MaxTimes(1).Return(privateKey, nil)
 		}
 
 		setup := setupAdminServer(ctrl, sf, false /* snapshot */, test.wantCommit, test.commitErr)
@@ -443,7 +472,9 @@ func TestServer_CreateTree(t *testing.T) {
 			}).Return(&newTree, test.createErr)
 		}
 
-		tree, err := s.CreateTree(ctx, test.req)
+		// Copy test.req so that any changes CreateTree makes don't affect the original, which may be shared between tests.
+		reqCopy := proto.Clone(test.req).(*trillian.CreateTreeRequest)
+		tree, err := s.CreateTree(ctx, reqCopy)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("%v: CreateTree() = (_, %q), wantErr = %v", test.desc, err, test.wantErr)
 			continue

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -104,7 +104,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
@@ -149,7 +149,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 	// Expect only one call to SignerFactory.NewSigner, as the returned signer should be cached by SequencerManager
 	// and re-used for the second sequencing pass.
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	// Expect two sequencing passes.
 	for i := 0; i < 2; i++ {
@@ -187,7 +187,7 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree).Return(nil, errors.New("no signer for this tree"))
+	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(nil, errors.New("no signer for this tree"))
 
 	gomock.InOrder(
 		mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil),
@@ -220,7 +220,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	// Set up enough mockery to be able to sequence. We don't test all the error paths
 	// through sequencer as other tests cover this
@@ -261,7 +261,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)

--- a/trees/trees.go
+++ b/trees/trees.go
@@ -134,7 +134,7 @@ func Signer(ctx context.Context, sf keys.SignerFactory, tree *trillian.Tree) (*t
 		return nil, err
 	}
 
-	signer, err := sf.NewSigner(ctx, tree)
+	signer, err := sf.NewSigner(ctx, tree.PrivateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -336,7 +336,7 @@ func TestSigner(t *testing.T) {
 		tree.SignatureAlgorithm = test.sigAlgo
 
 		sf := keys.NewMockSignerFactory(ctrl)
-		sf.EXPECT().NewSigner(ctx, &tree).MaxTimes(1).Return(test.signer, test.signerFactoryErr)
+		sf.EXPECT().NewSigner(ctx, tree.PrivateKey).MaxTimes(1).Return(test.signer, test.signerFactoryErr)
 
 		signer, err := Signer(ctx, sf, &tree)
 		if hasErr := err != nil; hasErr != test.wantErr {


### PR DESCRIPTION
Allows SignerFactory to be used for things other than Trillian trees, e.g. personalities.