### PR TITLE
Update Docker files: Remove dump_metrics_interval flag

### DIFF
--- a/server/trillian_log_server/Dockerfile
+++ b/server/trillian_log_server/Dockerfile
@@ -20,7 +20,6 @@ ENTRYPOINT /go/bin/trillian_log_server \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \
 	--http_endpoint="$HOST:$HTTP_PORT" \
-	--dump_metrics_interval="$DUMP_METRICS" \ 
 	--alsologtostderr 
 
 EXPOSE $RPC_PORT

--- a/server/trillian_log_signer/Dockerfile
+++ b/server/trillian_log_signer/Dockerfile
@@ -9,7 +9,6 @@ ENV HOST=0.0.0.0 \
     HTTP_PORT=8091
 
 ENV SEQUENCER_GUARD_WINDOW=0s \
-    DUMP_METRICS=0s \
     FORCE_MASTER=true
 
 
@@ -22,7 +21,6 @@ RUN go get ./server/trillian_log_signer
 ENTRYPOINT /go/bin/trillian_log_signer \
 	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
 	--http_endpoint="$HOST:$HTTP_PORT" \
-	--dump_metrics_interval="$DUMP_METRICS" \
 	--sequencer_guard_window="$SEQUENCER_GUARD_WINDOW" \
 	--force_master="$FORCE_MASTER" \
 	--alsologtostderr


### PR DESCRIPTION
Update the Docker files to match current available flags:
- catch-up with #654 (where the flag was removed in the go-code)
- needed for google/keytransparency#578

Error was:
```
trillian-log-signer_1  | flag provided but not defined: -dump_metrics_interval
trillian-log-signer_1  | Usage of /go/bin/trillian_log_signer:
```
