### PR TITLE
Replace SignerFactory use of *any.Any with proto.Message

### DIFF
--- a/crypto/keys/mock_keys.go
+++ b/crypto/keys/mock_keys.go
@@ -6,8 +6,8 @@ package keys
 import (
 	context "context"
 	crypto "crypto"
+	proto "github.com/gogo/protobuf/proto"
 	gomock "github.com/golang/mock/gomock"
-	any "github.com/golang/protobuf/ptypes/any"
 	keyspb "github.com/google/trillian/crypto/keyspb"
 )
 
@@ -32,9 +32,9 @@ func (_m *MockSignerFactory) EXPECT() *_MockSignerFactoryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSignerFactory) Generate(_param0 context.Context, _param1 *keyspb.Specification) (*any.Any, error) {
+func (_m *MockSignerFactory) Generate(_param0 context.Context, _param1 *keyspb.Specification) (proto.Message, error) {
 	ret := _m.ctrl.Call(_m, "Generate", _param0, _param1)
-	ret0, _ := ret[0].(*any.Any)
+	ret0, _ := ret[0].(proto.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -43,7 +43,7 @@ func (_mr *_MockSignerFactoryRecorder) Generate(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Generate", arg0, arg1)
 }
 
-func (_m *MockSignerFactory) NewSigner(_param0 context.Context, _param1 *any.Any) (crypto.Signer, error) {
+func (_m *MockSignerFactory) NewSigner(_param0 context.Context, _param1 proto.Message) (crypto.Signer, error) {
 	ret := _m.ctrl.Call(_m, "NewSigner", _param0, _param1)
 	ret0, _ := ret[0].(crypto.Signer)
 	ret1, _ := ret[1].(error)

--- a/crypto/keys/private_keys.go
+++ b/crypto/keys/private_keys.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/golang/protobuf/ptypes/any"
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
@@ -43,11 +43,11 @@ const MinRsaKeySizeInBits = 2048
 // examples.
 type SignerFactory interface {
 	// NewSigner uses the information in the provided protobuf message to obtain and return a crypto.Signer.
-	NewSigner(context.Context, *any.Any) (crypto.Signer, error)
+	NewSigner(context.Context, proto.Message) (crypto.Signer, error)
 
 	// Generate creates a new private key based on a key specification.
 	// It returns a proto that can be used as the value of tree.PrivateKey.
-	Generate(context.Context, *keyspb.Specification) (*any.Any, error)
+	Generate(context.Context, *keyspb.Specification) (proto.Message, error)
 }
 
 // NewFromPrivatePEMFile reads a PEM-encoded private key from a file.

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian/crypto/keyspb"
 )
@@ -160,14 +159,6 @@ func (tester *SignerFactoryTester) TestGenerate(t *testing.T) {
 			}
 		}
 	}
-}
-
-func mustMarshalAny(pb proto.Message) *any.Any {
-	a, err := ptypes.MarshalAny(pb)
-	if err != nil {
-		panic(err)
-	}
-	return a
 }
 
 // verify checks that sig is a valid signature for a digest (hash of some data).

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -67,30 +67,46 @@ func (tester *SignerFactoryTester) TestNewSigner(t *testing.T) {
 			WantErr:  true,
 		},
 	}...) {
+		sf := tester.NewSignerFactory()
+
 		anyKeyProto, err := ptypes.MarshalAny(test.KeyProto)
 		if err != nil {
 			t.Errorf("%v: Could not marshal test.KeyProto as protobuf Any: %v", test.Name, err)
 		}
 
-		signer, err := tester.NewSignerFactory().NewSigner(context.Background(), anyKeyProto)
-		switch gotErr := err != nil; {
-		case gotErr != test.WantErr:
-			t.Errorf("%v: Signer() = (%v, %v), want err? %v", test.Name, signer, err, test.WantErr)
-			continue
-		case gotErr:
-			continue
-		}
+		for _, subtest := range []struct {
+			desc     string
+			keyProto proto.Message
+		}{
+			{
+				desc:     "unmodified",
+				keyProto: test.KeyProto,
+			},
+			{
+				desc:     "marshaled as protobuf Any",
+				keyProto: anyKeyProto,
+			},
+		} {
+			signer, err := sf.NewSigner(context.Background(), subtest.keyProto)
+			switch gotErr := err != nil; {
+			case gotErr != test.WantErr:
+				t.Errorf("%v (%v): Signer() = (%v, %v), want err? %v", test.Name, subtest.desc, signer, err, test.WantErr)
+				continue
+			case gotErr:
+				continue
+			}
 
-		// Check that the returned signer can produce signatures successfully.
-		hasher := crypto.SHA256
-		digest := sha256.Sum256([]byte("test"))
-		signature, err := signer.Sign(rand.Reader, digest[:], hasher)
-		if err != nil {
-			t.Errorf("%v: Signer().Sign() = (_, %v), want (_, nil)", test.Name, err)
-		}
+			// Check that the returned signer can produce signatures successfully.
+			hasher := crypto.SHA256
+			digest := sha256.Sum256([]byte("test"))
+			signature, err := signer.Sign(rand.Reader, digest[:], hasher)
+			if err != nil {
+				t.Errorf("%v (%v): Signer().Sign() = (_, %v), want (_, nil)", test.Name, subtest.desc, err)
+			}
 
-		if err := verify(signer.Public(), digest[:], signature, hasher, hasher); err != nil {
-			t.Errorf("%v: %v", test.Name, err)
+			if err := verify(signer.Public(), digest[:], signature, hasher, hasher); err != nil {
+				t.Errorf("%v (%v): %v", test.Name, subtest.desc, err)
+			}
 		}
 	}
 }

--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
@@ -98,7 +99,11 @@ func (s *Server) CreateTree(ctx context.Context, request *trillian.CreateTreeReq
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to generate private key: %v", err.Error())
 		}
-		tree.PrivateKey = key
+
+		tree.PrivateKey, err = ptypes.MarshalAny(key)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to marshal private key: %v", err.Error())
+		}
 	}
 
 	if tree.PrivateKey == nil {

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -440,14 +440,15 @@ func TestServer_CreateTree(t *testing.T) {
 				continue
 			}
 
-			keyProto, err := ptypes.MarshalAny(&keyspb.PrivateKey{Der: keyDER})
+			keyProto := &keyspb.PrivateKey{Der: keyDER}
+			marshaledKeyProto, err := ptypes.MarshalAny(keyProto)
 			if err != nil {
 				t.Errorf("%v: failed to marshal test private key as proto: %v", test.desc, err)
 				continue
 			}
 
 			sf.EXPECT().Generate(gomock.Any(), test.req.GetKeySpec()).Return(keyProto, nil)
-			sf.EXPECT().NewSigner(gomock.Any(), keyProto).Return(privateKey, nil)
+			sf.EXPECT().NewSigner(gomock.Any(), marshaledKeyProto).Return(privateKey, nil)
 
 			publicKeyDER, err = x509.MarshalPKIXPublicKey(privateKey.Public())
 			if err != nil {

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 )
 
-// mustMarshal panics if ptypes.MarshalAny fails.
+// mustMarshalAny panics if ptypes.MarshalAny fails.
 func mustMarshalAny(pb proto.Message) *any.Any {
 	value, err := ptypes.MarshalAny(pb)
 	if err != nil {


### PR DESCRIPTION
Avoids having to marshal a protobuf message as a protobuf `Any` before passing it or returning it from a `SignerFactory`. If the caller then wants to store it in a `trillian.Tree`, they will need to do this marshaling.