### PR TITLE
Replenish quota tokens based on sequenced entries

### DIFF
--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage/memory"
 	"github.com/google/trillian/testonly/integration"
 	"google.golang.org/grpc"
@@ -112,6 +113,7 @@ func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
 		AdminStorage:  memory.NewAdminStorage(ms),
 		SignerFactory: keys.PEMSignerFactory{},
 		LogStorage:    ms,
+		QuotaManager:  quota.Noop(),
 	}
 
 	env, err := integration.NewLogEnvWithRegistry(ctx, numSequencers, "TestInProcessLogIntegrationDuplicateLeaves", reggie)

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly"
@@ -136,6 +137,9 @@ type testParameters struct {
 	writeRevision int64
 
 	overrideDequeueTime *time.Time
+
+	// qm is the quota.Manager to be used. If nil, quota.Noop() is used instead.
+	qm quota.Manager
 }
 
 // Tests get their own mock context so they can be run in parallel safely
@@ -239,8 +243,11 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	}
 
 	signer := crypto.NewSHA256Signer(params.signer)
-	sequencer := NewSequencer(testonly.Hasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil)
-
+	qm := params.qm
+	if qm == nil {
+		qm = quota.Noop()
+	}
+	sequencer := NewSequencer(testonly.Hasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil, qm)
 	return testContext{mockTx: mockTx, mockStorage: mockStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 
@@ -527,8 +534,20 @@ func TestSequenceBatch(t *testing.T) {
 		t.Fatalf("Failed to create test signer (%v)", err)
 	}
 
+	treeID := int64(154035)
+	wantLeafCount := 1
+
+	specs := []quota.Spec{
+		{Group: quota.Tree, Kind: quota.Read, TreeID: treeID},
+		{Group: quota.Tree, Kind: quota.Write, TreeID: treeID},
+		{Group: quota.Global, Kind: quota.Read},
+		{Group: quota.Global, Kind: quota.Write},
+	}
+	qm := quota.NewMockManager(ctrl)
+	qm.EXPECT().PutTokens(gomock.Any(), wantLeafCount, specs).Return(nil)
+
 	params := testParameters{
-		logID:            154035,
+		logID:            treeID,
 		writeRevision:    testRoot16.TreeRevision + 1,
 		dequeueLimit:     1,
 		shouldCommit:     true,
@@ -538,6 +557,7 @@ func TestSequenceBatch(t *testing.T) {
 		merkleNodesSet:   &updatedNodes,
 		storeSignedRoot:  &expectedSignedRoot,
 		signer:           signer,
+		qm:               qm,
 	}
 	c, ctx := createTestContext(ctrl, params)
 
@@ -545,7 +565,7 @@ func TestSequenceBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected sequencing to succeed, but got err: %v", err)
 	}
-	if got, want := leafCount, 1; got != want {
+	if got, want := leafCount, wantLeafCount; got != want {
 		t.Fatalf("Sequenced %d leaf, expected %d", got, want)
 	}
 }

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -75,7 +75,8 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 		return 0, fmt.Errorf("error getting signer for log %v: %v", logID, err)
 	}
 
-	sequencer := log.NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer, s.registry.MetricFactory)
+	sequencer := log.NewSequencer(
+		hasher, info.TimeSource, s.registry.LogStorage, signer, s.registry.MetricFactory, s.registry.QuotaManager)
 	sequencer.SetGuardWindow(s.guardWindow)
 
 	leaves, err := sequencer.SequenceBatch(ctx, logID, info.BatchSize)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly"
@@ -122,6 +123,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 		AdminStorage:  mockAdmin,
 		LogStorage:    mockStorage,
 		SignerFactory: mockSf,
+		QuotaManager:  quota.Noop(),
 	}
 
 	sm := NewSequencerManager(registry, zeroDuration)
@@ -144,6 +146,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 		AdminStorage:  mockAdmin,
 		LogStorage:    mockStorage,
 		SignerFactory: mockSf,
+		QuotaManager:  quota.Noop(),
 	}
 	sm := NewSequencerManager(registry, zeroDuration)
 
@@ -200,6 +203,7 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 		AdminStorage:  mockAdmin,
 		LogStorage:    mockStorage,
 		SignerFactory: mockSf,
+		QuotaManager:  quota.Noop(),
 	}
 
 	sm := NewSequencerManager(registry, zeroDuration)
@@ -243,6 +247,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 		AdminStorage:  mockAdmin,
 		LogStorage:    mockStorage,
 		SignerFactory: mockSf,
+		QuotaManager:  quota.Noop(),
 	}
 
 	sm := NewSequencerManager(registry, zeroDuration)
@@ -280,6 +285,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 		AdminStorage:  mockAdmin,
 		LogStorage:    mockStorage,
 		SignerFactory: mockSf,
+		QuotaManager:  quota.Noop(),
 	}
 
 	sm := NewSequencerManager(registry, time.Second*5)

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
 	stestonly "github.com/google/trillian/storage/testonly"
@@ -95,6 +96,7 @@ func NewLogEnv(ctx context.Context, numSequencers int, testID string) (*LogEnv, 
 		AdminStorage:  mysql.NewAdminStorage(db),
 		SignerFactory: keys.PEMSignerFactory{},
 		LogStorage:    mysql.NewLogStorage(db, nil),
+		QuotaManager:  quota.Noop(),
 	}
 
 	ret, err := NewLogEnvWithRegistry(ctx, numSequencers, testID, registry)


### PR DESCRIPTION
Sequencing-based quotas need a signal to be able to replenish tokens based on
the sequencer progress. Different quota implementations may simply choose to
ignore the signal.