### PR TITLE
Replace some uses of $GOPATH with `go list github.com/google/trillian`

### DIFF
--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -14,6 +14,7 @@ RPC_SERVERS=''
 ETCD_OPTS=''
 ETCD_PID=''
 ETCD_DB_DIR=''
+readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
 
 # run_test runs the given test with additional output messages.
 run_test() {
@@ -103,7 +104,7 @@ log_prep_test() {
   go build ${GOFLAGS} github.com/google/trillian/server/trillian_log_signer/
 
   # Wipe the test database
-  yes | "${GOPATH}"/src/github.com/google/trillian/scripts/resetdb.sh
+  yes | "${TRILLIAN_PATH}/scripts/resetdb.sh"
 
   # Start a local etcd instance (if configured).
   if [[ -x "${ETCD_DIR}/etcd" ]]; then

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -7,7 +7,7 @@ echo "Building code"
 go build ${GOFLAGS} github.com/google/trillian/cmd/createtree/
 go build ${GOFLAGS} github.com/google/trillian/server/trillian_map_server/
 
-yes | "${GOPATH}"/src/github.com/google/trillian/scripts/resetdb.sh
+yes | "${TRILLIAN_PATH}/scripts/resetdb.sh"
 
 RPC_PORT=$(pick_unused_port)
 
@@ -21,7 +21,7 @@ echo "Provision map"
 TEST_TREE_ID=$(./createtree \
   --admin_server="localhost:${RPC_PORT}" \
   --tree_type=MAP \
-  --pem_key_path=${GOPATH}/src/github.com/google/trillian/testdata/map-rpc-server.privkey.pem \
+  --pem_key_path=${TRILLIAN_PATH}/testdata/map-rpc-server.privkey.pem \
   --pem_key_password=towel \
   --signature_algorithm=ECDSA)
 echo "Created tree ${TEST_TREE_ID}"


### PR DESCRIPTION
$GOPATH may contain more than one directory path, separated by colons. If this was the case, the previous code would fail.