### PR TITLE
Fix printf argument type in commit_log/signer/signer.go

### DIFF
--- a/docs/storage/commit_log/signer/signer.go
+++ b/docs/storage/commit_log/signer/signer.go
@@ -113,7 +113,7 @@ func (s *Signer) Run() {
 			continue
 		}
 		if nextSTH.TimeStamp < dbSTHInfo.sth.TimeStamp || nextSTH.TreeSize < dbSTHInfo.sth.TreeSize {
-			glog.Errorf("%s: next STH %s has earlier timestamp than in local DB (%s)!!", s.Name, nextSTH.String(), dbSTHInfo.sth)
+			glog.Errorf("%s: next STH %s has earlier timestamp than in local DB (%s)!!", s.Name, nextSTH.String(), dbSTHInfo.sth.String())
 			return
 		}
 		break


### PR DESCRIPTION
go vet reports:
```
error: arg dbSTHInfo.sth for printf verb %s of wrong type: signer.STH (vet)
```