### PR TITLE
Move code for marshaling PEM to DER into crypto/keys/testonly package

### DIFF
--- a/crypto/keys/testonly/doc.go
+++ b/crypto/keys/testonly/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package testonly contains code and data that should only be used by tests.
+Production code MUST NOT depend on anything in this package. This will be
+enforced by tools where possible.
+*/
+package testonly

--- a/crypto/keys/testonly/keys.go
+++ b/crypto/keys/testonly/keys.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"crypto/x509"
+
+	"github.com/google/trillian/crypto/keys"
+)
+
+// MustMarshalPublicPEMToDER reads a PEM-encoded public key and returns it in DER encoding.
+// If an error occurs, it panics.
+func MustMarshalPublicPEMToDER(pem string) []byte {
+	key, err := keys.NewFromPublicPEM(pem)
+	if err != nil {
+		panic(err)
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		panic(err)
+	}
+	return der
+}
+
+// MustMarshalPrivatePEMToDER decrypts a PEM-encoded private key and returns it in DER encoding.
+// If an error occurs, it panics.
+func MustMarshalPrivatePEMToDER(pem, password string) []byte {
+	key, err := keys.NewFromPrivatePEM(pem, password)
+	if err != nil {
+		panic(err)
+	}
+
+	der, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		panic(err)
+	}
+	return der
+}

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -16,7 +16,6 @@ package testonly
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"testing"
 
@@ -24,7 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keys"
+	ktestonly "github.com/google/trillian/crypto/keys/testonly"
 	"github.com/google/trillian/crypto/keyspb"
 	spb "github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
@@ -41,37 +40,6 @@ func mustMarshalAny(pb proto.Message) *any.Any {
 	return value
 }
 
-// publicPEMToDER reads a PEM-encoded public key and returns it in DER encoding.
-// If an error occurs, it panics.
-func publicPEMToDER(pem string) []byte {
-	key, err := keys.NewFromPublicPEM(pem)
-	if err != nil {
-		panic(err)
-	}
-
-	der, err := x509.MarshalPKIXPublicKey(key)
-	if err != nil {
-		panic(err)
-	}
-	return der
-}
-
-// privatePEMToDER reads a PEM-encoded private key and returns it in DER encoding.
-// The PEM must be encrypted, and the password must be provided in order to decrypt it.
-// If an error occurs, it panics.
-func privatePEMToDER(pem, password string) []byte {
-	key, err := keys.NewFromPrivatePEM(pem, password)
-	if err != nil {
-		panic(err)
-	}
-
-	der, err := keys.MarshalPrivateKey(key)
-	if err != nil {
-		panic(err)
-	}
-	return der
-}
-
 var (
 	// LogTree is a valid, LOG-type trillian.Tree for tests.
 	LogTree = &trillian.Tree{
@@ -83,10 +51,10 @@ var (
 		DisplayName:        "Llamas Log",
 		Description:        "Registry of publicly-owned llamas",
 		PrivateKey: mustMarshalAny(&keyspb.PrivateKey{
-			Der: privatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
+			Der: ktestonly.MustMarshalPrivatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
 		}),
 		PublicKey: &keyspb.PublicKey{
-			Der: publicPEMToDER(ttestonly.DemoPublicKey),
+			Der: ktestonly.MustMarshalPublicPEMToDER(ttestonly.DemoPublicKey),
 		},
 	}
 
@@ -100,10 +68,10 @@ var (
 		DisplayName:        "Llamas Map",
 		Description:        "Key Transparency map for all your digital llama needs.",
 		PrivateKey: mustMarshalAny(&keyspb.PrivateKey{
-			Der: privatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
+			Der: ktestonly.MustMarshalPrivatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
 		}),
 		PublicKey: &keyspb.PublicKey{
-			Der: publicPEMToDER(ttestonly.DemoPublicKey),
+			Der: ktestonly.MustMarshalPublicPEMToDER(ttestonly.DemoPublicKey),
 		},
 	}
 )

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -29,7 +29,9 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
+	ktestonly "github.com/google/trillian/crypto/keys/testonly"
 	"github.com/google/trillian/crypto/keyspb"
+
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server"
@@ -48,22 +50,9 @@ var (
 	timeSource        = util.SystemTimeSource{}
 	publicKey         = testonly.DemoPublicKey
 	privateKeyInfo    = &keyspb.PrivateKey{
-		Der: privatePEMToDER(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass),
+		Der: ktestonly.MustMarshalPrivatePEMToDER(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass),
 	}
 )
-
-func privatePEMToDER(pem, password string) []byte {
-	key, err := keys.NewFromPrivatePEM(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass)
-	if err != nil {
-		panic(err)
-	}
-
-	der, err := keys.MarshalPrivateKey(key)
-	if err != nil {
-		panic(err)
-	}
-	return der
-}
 
 // LogEnv is a test environment that contains both a log server and a connection to it.
 type LogEnv struct {


### PR DESCRIPTION
PrivatePEMToDER() is used in a couple of different tests, so this eliminates some duplication.

As requested in PR #680.