### PR TITLE
Fix sequencer_latency metric

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -216,7 +216,7 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int, gu
 	}
 	defer tx.Close()
 	defer seqBatches.Inc(label)
-	defer seqLatency.Observe(s.sinceMillis(start), label)
+	defer func() { seqLatency.Observe(s.sinceMillis(start), label) }()
 
 	// Very recent leaves inside the guard window will not be available for sequencing
 	guardCutoffTime := s.timeSource.Now().Add(-guardWindow)


### PR DESCRIPTION
When calling `defer` the arguments to a function are saved at the call site for later use when the function returns (per the [spec](https://golang.org/ref/spec#Defer_statements)) so using `start := time.Now(); defer metric.Observe(time.Since(start))` will always return basically `0s` (really some very small number of nanoseconds but w/e). Instead you should use `defer func() { ... }()` as the function is saved and the closure is evaluated at call time which gets the proper result from `time.Since(start)`.

A quick look didn't turn up any other instances of this.