### PR TITLE
Simplify MaxRootDuration validation

### DIFF
--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -143,14 +143,6 @@ func (s *Server) CreateTree(ctx context.Context, request *trillian.CreateTreeReq
 		tree.PublicKey = &keyspb.PublicKey{Der: publicKeyDER}
 	}
 
-	duration, err := ptypes.Duration(tree.MaxRootDuration)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "failed to convert max root duration")
-	}
-	if duration < 0 {
-		return nil, status.Error(codes.InvalidArgument, "the max root duration must be >= 0")
-	}
-
 	tx, err := s.registry.AdminStorage.Begin(ctx)
 	if err != nil {
 		return nil, err

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -316,12 +316,6 @@ func TestServer_CreateTree(t *testing.T) {
 	keySignatureMismatch := validTree
 	keySignatureMismatch.SignatureAlgorithm = sigpb.DigitallySigned_RSA
 
-	negRootDuration := validTree
-	negRootDuration.MaxRootDuration = ptypes.DurationProto(-1 * time.Millisecond)
-
-	malformedRootDuration := validTree
-	malformedRootDuration.MaxRootDuration = nil
-
 	tests := []struct {
 		desc                           string
 		req                            *trillian.CreateTreeRequest
@@ -346,16 +340,6 @@ func TestServer_CreateTree(t *testing.T) {
 		{
 			desc:    "omittedPrivateKey",
 			req:     &trillian.CreateTreeRequest{Tree: &omittedPrivateKey},
-			wantErr: true,
-		},
-		{
-			desc:    "negativeMaxRootDuration",
-			req:     &trillian.CreateTreeRequest{Tree: &negRootDuration},
-			wantErr: true,
-		},
-		{
-			desc:    "malformedMaxRootDuration",
-			req:     &trillian.CreateTreeRequest{Tree: &malformedRootDuration},
 			wantErr: true,
 		},
 		{

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -90,6 +90,9 @@ func TestValidateTreeForCreation(t *testing.T) {
 	validSettings := newTree()
 	validSettings.StorageSettings = settings
 
+	nilRootDuration := newTree()
+	nilRootDuration.MaxRootDuration = nil
+
 	invalidRootDuration := newTree()
 	invalidRootDuration.MaxRootDuration = ptypes.DurationProto(-1 * time.Second)
 
@@ -194,6 +197,11 @@ func TestValidateTreeForCreation(t *testing.T) {
 		{
 			desc: "validSettings",
 			tree: validSettings,
+		},
+		{
+			desc:    "nilRootDuration",
+			tree:    nilRootDuration,
+			wantErr: true,
 		},
 		{
 			desc:    "invalidRootDuration",


### PR DESCRIPTION
Removed validation from admin_server, as it's already performed by
tree_validation.