### PR TITLE
Remove interceptor's reliance on grpc.UnaryServerInfo

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -17,6 +17,7 @@ package interceptor
 
 import (
 	"fmt"
+
 	"github.com/google/trillian"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server/errors"
@@ -26,11 +27,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-)
-
-const (
-	// requestTypePrefix is the expected prefix for all request protos.
-	requestTypePrefix = "*trillian."
 )
 
 // TrillianInterceptor checks that:
@@ -154,12 +150,12 @@ func getAdminRequestInfo(req interface{}) (bool, bool) {
 	isAdmin := true
 	readonly := false
 	switch req.(type) {
-	case *trillian.CreateTreeRequest,
-		*trillian.DeleteTreeRequest,
-		*trillian.UpdateTreeRequest:
 	case *trillian.GetTreeRequest,
 		*trillian.ListTreesRequest:
 		readonly = true
+	case *trillian.CreateTreeRequest,
+		*trillian.DeleteTreeRequest,
+		*trillian.UpdateTreeRequest:
 	default:
 		isAdmin = false
 	}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -47,7 +47,7 @@ type TrillianInterceptor struct {
 // UnaryInterceptor executes the TrillianInterceptor logic for unary RPCs.
 func (i *TrillianInterceptor) UnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	// IMPORTANT: Do not rely on grpc.UnaryServerInfo in this filter. It makes life a lot harder
-	// when adapting the code to our internal branch.
+	// when adapting the code to other environments.
 
 	quotaUser := i.QuotaManager.GetUser(ctx, req)
 	rpcInfo, err := getRPCInfo(req, quotaUser)


### PR DESCRIPTION
All data required for interception is now extracted from the request message.
This makes tests simpler (no need to specify the RPC's FullMethod) and makes it
easier to adapt interceptors to other environments.