### PR TITLE
Add a caching quota.Manager decorator

### DIFF
--- a/quota/cache/cache.go
+++ b/quota/cache/cache.go
@@ -1,0 +1,200 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache contains a caching quota.Manager implementation.
+package cache
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/quota"
+)
+
+// now is used in place of time.Now to allow tests to take control of time.
+var now = time.Now
+
+type manager struct {
+	qm                    quota.Manager
+	batchSize, maxEntries int
+
+	// mu guards cache
+	mu    sync.Mutex
+	cache map[quota.Spec]*bucket
+
+	// evictWg tracks evict() goroutines.
+	evictWg sync.WaitGroup
+}
+
+type bucket struct {
+	tokens       int
+	lastModified time.Time
+}
+
+// NewCachedManager wraps a quota.Manager with an implementation that caches tokens locally.
+//
+// batchSize determines the minimum number of tokens requested from qm for each GetTokens() request.
+// More tokens than batchSize may be requested in order to fulfill the present request.
+//
+// maxEntries determines the maximum number of cache entries, apart from global quotas. The oldest
+// entries are evicted as necessary, their tokens replenished via PutTokens() to avoid excessive
+// leakage.
+func NewCachedManager(qm quota.Manager, batchSize, maxEntries int) quota.Manager {
+	return &manager{
+		qm:         qm,
+		batchSize:  batchSize,
+		maxEntries: maxEntries,
+		cache:      make(map[quota.Spec]*bucket),
+	}
+}
+
+func (m *manager) GetUser(ctx context.Context, req interface{}) string {
+	return m.qm.GetUser(ctx, req)
+}
+
+func (m *manager) PeekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
+	return m.qm.PeekTokens(ctx, specs)
+}
+
+func (m *manager) PutTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
+	return m.qm.PutTokens(ctx, numTokens, specs)
+}
+
+func (m *manager) ResetQuota(ctx context.Context, specs []quota.Spec) error {
+	return m.qm.ResetQuota(ctx, specs)
+}
+
+func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Verify which buckets need more tokens, if any
+	specsToRefill := []quota.Spec{}
+	for _, spec := range specs {
+		bucket, ok := m.cache[spec]
+		if !ok || bucket.tokens < numTokens {
+			specsToRefill = append(specsToRefill, spec)
+		}
+	}
+
+	// Request the required number of tokens and add them to buckets
+	if len(specsToRefill) != 0 {
+		defer func() {
+			// Do not hold GetTokens on eviction, it won't change the result.
+			m.evictWg.Add(1)
+			go func() {
+				m.evict(ctx)
+				m.evictWg.Done()
+			}()
+		}()
+
+		// A more accurate count would be numTokens+m.batchSize-bucket.tokens, but that might force
+		// us to make a GetTokens call for each spec. A single call is likely to be more efficient.
+		tokens := numTokens + m.batchSize
+		if err := m.qm.GetTokens(ctx, tokens, specsToRefill); err != nil {
+			return err
+		}
+		for _, spec := range specsToRefill {
+			b, ok := m.cache[spec]
+			if !ok {
+				b = &bucket{}
+				m.cache[spec] = b
+			}
+			b.tokens += tokens
+		}
+	}
+
+	// Subtract tokens from cache
+	lastModified := now()
+	for _, spec := range specs {
+		bucket, ok := m.cache[spec]
+		// Sanity check
+		if !ok || bucket.tokens < 0 || bucket.tokens < numTokens {
+			glog.Warningf("Bucket invariants failed for spec %+v: ok = %v, bucket = %+v", spec, ok, bucket)
+			return nil // Something is wrong with the implementation, let requests go through.
+		}
+		bucket.tokens -= numTokens
+		bucket.lastModified = lastModified
+	}
+	return nil
+}
+
+func (m *manager) evict(ctx context.Context) {
+	m.mu.Lock()
+	// m.mu is explicitly unlocked, so we don't have to hold it while we wait for goroutines to
+	// complete.
+
+	if len(m.cache) <= m.maxEntries {
+		m.mu.Unlock()
+		return
+	}
+
+	// Find and evict the oldest entries. To avoid excessive token leakage, let's try and
+	// replenish the tokens held for the evicted entries.
+	var buckets bucketsByTime = make([]specBucket, 0, len(m.cache))
+	for spec, b := range m.cache {
+		if spec.Group != quota.Global {
+			buckets = append(buckets, specBucket{bucket: b, spec: spec})
+		}
+	}
+	sort.Sort(buckets)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < len(m.cache)-m.maxEntries; i++ {
+		b := buckets[i]
+		glog.Infof("Evicting bucket for spec %+v (%v tokens held)", b.spec, b.tokens)
+		delete(m.cache, b.spec)
+
+		// goroutines must not access the cache, the lock is released before they complete.
+		wg.Add(1)
+		go func() {
+			if err := m.qm.PutTokens(ctx, b.tokens, []quota.Spec{b.spec}); err != nil {
+				glog.Warningf("Error replenishing tokens from evicted bucket (spec = %+v, bucket = %+v): %v", b.spec, b.bucket, err)
+			}
+			wg.Done()
+		}()
+	}
+
+	m.mu.Unlock()
+	wg.Wait()
+}
+
+// wait waits for spawned goroutines to complete. Used by eviction tests.
+func (m *manager) wait() {
+	m.evictWg.Wait()
+}
+
+// specBucket is a bucket with the corresponding spec.
+type specBucket struct {
+	*bucket
+	spec quota.Spec
+}
+
+// bucketsByTime is a sortable slice of specBuckets.
+type bucketsByTime []specBucket
+
+func (b bucketsByTime) Len() int {
+	return len(b)
+}
+
+func (b bucketsByTime) Less(i, j int) bool {
+	return b[i].lastModified.Before(b[j].lastModified)
+}
+
+func (b bucketsByTime) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}

--- a/quota/cache/cache.go
+++ b/quota/cache/cache.go
@@ -154,7 +154,8 @@ func (m *manager) evict(ctx context.Context) {
 	sort.Sort(buckets)
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < len(m.cache)-m.maxEntries; i++ {
+	evicts := len(m.cache) - m.maxEntries
+	for i := 0; i < evicts; i++ {
 		b := buckets[i]
 		glog.Infof("Too many tokens cached, returning least recently used (%v tokens for %+v)", b.tokens, b.spec)
 		delete(m.cache, b.spec)

--- a/quota/cache/cache_test.go
+++ b/quota/cache/cache_test.go
@@ -1,0 +1,205 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/trillian/quota"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+const (
+	batchSize  = 20
+	maxEntries = 10
+)
+
+var (
+	specs = []quota.Spec{
+		{Group: quota.Global, Kind: quota.Read},
+		{Group: quota.Global, Kind: quota.Write},
+	}
+)
+
+func TestCachedManager_GetUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	want := "llama"
+	mock := quota.NewMockManager(ctrl)
+	mock.EXPECT().GetUser(ctx, nil).Return(want)
+
+	qm := NewCachedManager(mock, batchSize, maxEntries)
+	if got := qm.GetUser(ctx, nil /* req */); got != want {
+		t.Errorf("GetUser() = %v, want = %v", got, want)
+	}
+}
+
+func TestCachedManager_PeekTokens(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		desc       string
+		wantTokens map[quota.Spec]int
+		wantErr    error
+	}{
+		{
+			desc: "success",
+			wantTokens: map[quota.Spec]int{
+				{Group: quota.Global, Kind: quota.Read}: 10,
+				{Group: quota.Global, Kind: quota.Read}: 11,
+			},
+		},
+		{
+			desc:    "error",
+			wantErr: errors.New("llama ate all tokens"),
+		},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		mock := quota.NewMockManager(ctrl)
+		mock.EXPECT().PeekTokens(ctx, specs).Return(test.wantTokens, test.wantErr)
+
+		qm := NewCachedManager(mock, batchSize, maxEntries)
+		tokens, err := qm.PeekTokens(ctx, specs)
+		if diff := pretty.Compare(tokens, test.wantTokens); diff != "" {
+			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
+		}
+		if err != test.wantErr {
+			t.Errorf("%v: PeekTokens() returned err = %v, want = %v", test.desc, err, test.wantErr)
+		}
+	}
+}
+
+// TestCachedManager_DelegatedMethods tests all delegated methods that have a single error return.
+func TestCachedManager_DelegatedMethods(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	tokens := 5
+	for _, want := range []error{nil, errors.New("llama ate all tokens")} {
+		mock := quota.NewMockManager(ctrl)
+		qm := NewCachedManager(mock, batchSize, maxEntries)
+
+		mock.EXPECT().PutTokens(ctx, tokens, specs).Return(want)
+		if err := qm.PutTokens(ctx, tokens, specs); err != want {
+			t.Errorf("PutTokens() returned err = %v, want = %v", err, want)
+		}
+
+		mock.EXPECT().ResetQuota(ctx, specs).Return(want)
+		if err := qm.ResetQuota(ctx, specs); err != want {
+			t.Errorf("ResetQuota() returned err = %v, want = %v", err, want)
+		}
+	}
+}
+
+func TestCachedManager_GetTokens_CachesTokens(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	tokens := 3
+	mock := quota.NewMockManager(ctrl)
+	mock.EXPECT().GetTokens(ctx, tokens+batchSize, specs).Times(2).Return(nil)
+
+	qm := NewCachedManager(mock, batchSize, maxEntries)
+
+	// Quota requests happen in tokens+batchSize steps, so that batchSize tokens get cached after
+	// the the request is satisfied.
+	// Therefore, the call pattern below is satisfied by just 2 underlying GetTokens() calls.
+	calls := []int{tokens, batchSize, tokens, batchSize / 2, batchSize / 2}
+	for i, call := range calls {
+		if err := qm.GetTokens(ctx, call, specs); err != nil {
+			t.Fatalf("GetTokens() returned err = %v (call #%v)", err, i+1)
+		}
+	}
+}
+
+func TestCachedManager_GetTokens_EvictsCache(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := quota.NewMockManager(ctrl)
+	mock.EXPECT().GetTokens(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+
+	ctx := context.Background()
+	qm := NewCachedManager(mock, batchSize, maxEntries)
+
+	originalNow := now
+	defer func() { now = originalNow }()
+	currentTime := time.Time{}
+	now = func() time.Time {
+		currentTime = currentTime.Add(1 * time.Second)
+		return currentTime
+	}
+
+	// Ensure Global quotas are the oldest, we don't want those to get evicted regardless of age.
+	tokens := 5
+	if err := qm.GetTokens(ctx, tokens, []quota.Spec{
+		{Group: quota.Global, Kind: quota.Read},
+		{Group: quota.Global, Kind: quota.Write},
+	}); err != nil {
+		t.Fatalf("GetTokens() returned err = %v", err)
+	}
+
+	// Fill the cache up to maxEntries
+	firstTree := int64(10)
+	tree := firstTree
+	for i := 0; i < maxEntries-2; i++ {
+		if err := qm.GetTokens(ctx, tokens, specForTree(tree)); err != nil {
+			t.Fatalf("GetTokens() returned err = %v (i = %v)", err, i)
+		}
+		tree++
+	}
+
+	// All entries added now must cause eviction of the oldest entries
+	evicts := 5
+	for i := 0; i < evicts; i++ {
+		mock.EXPECT().PutTokens(ctx, batchSize, specForTree(firstTree+int64(i))).Return(nil)
+		if err := qm.GetTokens(ctx, tokens, specForTree(tree)); err != nil {
+			t.Fatalf("GetTokens() returned err = %v (i = %v)", err, i)
+		}
+		tree++
+	}
+
+	qm.(*manager).wait()
+}
+
+func TestManager_GetTokensErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	want := errors.New("llama ate all tokens")
+	mock := quota.NewMockManager(ctrl)
+	mock.EXPECT().GetTokens(ctx, gomock.Any(), specs).Return(want)
+
+	qm := NewCachedManager(mock, batchSize, maxEntries)
+	if err := qm.GetTokens(ctx, 5 /* numTokens */, specs); err != want {
+		t.Errorf("GetTokens() returned err = %v, want = %v", err, want)
+	}
+}
+
+func specForTree(treeID int64) []quota.Spec {
+	return []quota.Spec{{Group: quota.Tree, Kind: quota.Write, TreeID: treeID}}
+}

--- a/testonly/matchers/matchers.go
+++ b/testonly/matchers/matchers.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package matchers contains additional gomock matchers.
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+)
+
+// AtLeast returns a matcher that requires a number >= n.
+func AtLeast(n int) gomock.Matcher {
+	return &atLeastMatcher{n}
+}
+
+type atLeastMatcher struct {
+	num int
+}
+
+func (m atLeastMatcher) Matches(x interface{}) bool {
+	if x, ok := x.(int); ok {
+		return x >= m.num
+	}
+	return false
+}
+
+func (m atLeastMatcher) String() string {
+	return fmt.Sprintf("at least %v", m.num)
+}

--- a/testonly/matchers/matchers_test.go
+++ b/testonly/matchers/matchers_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import "testing"
+
+func TestAtLeast(t *testing.T) {
+	tests := []struct {
+		num, actual int
+		want        bool
+	}{
+		{num: 5, actual: 3},
+		{num: 5, actual: 5, want: true},
+		{num: 5, actual: 10, want: true},
+	}
+	for _, test := range tests {
+		if got := AtLeast(test.num).Matches(test.actual); got != test.want {
+			t.Errorf("AtLeast(%v).Matches(%v) = %v, want = %v", test.num, test.actual, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
The cached quota.Manager keeps an in-memory count of tokens per quota.Spec. It
may be used together with any quota.Manager implementation that is friendly to
token caching.