### PR TITLE
Drop support for SignerFactory.NewSigner() accepting protobuf "Any" messages

### DIFF
--- a/crypto/keys/pem_signer_factory.go
+++ b/crypto/keys/pem_signer_factory.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
@@ -34,14 +32,6 @@ type PEMSignerFactory struct{}
 // - keyspb.PEMKeyFile
 // - keyspb.PrivateKey
 func (f PEMSignerFactory) NewSigner(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
-	if anyPB, ok := pb.(*any.Any); ok {
-		var unmarshaledPB ptypes.DynamicAny
-		if err := ptypes.UnmarshalAny(anyPB, &unmarshaledPB); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal private key protobuf: %v", err)
-		}
-		pb = unmarshaledPB.Message
-	}
-
 	switch privateKey := pb.(type) {
 	case *keyspb.PEMKeyFile:
 		return NewFromPrivatePEMFile(privateKey.GetPath(), privateKey.GetPassword())

--- a/crypto/keys/private_keys.go
+++ b/crypto/keys/private_keys.go
@@ -37,16 +37,16 @@ const defaultRsaKeySizeInBits = 2048
 // MinRsaKeySizeInBits is the smallest RSA key that this package will generate.
 const MinRsaKeySizeInBits = 2048
 
-// SignerFactory creates signers for Trillian trees.
-// A signers may be created by loading a private key, interfacing with a HSM,
-// or sending network requests to a remote key management service, to give a few
-// examples.
+// SignerFactory gets and creates cryptographic signers.
+// This may be done by loading a key from a file, interfacing with a HSM, or
+// sending requests to a remote key management service, to give a few examples.
 type SignerFactory interface {
 	// NewSigner uses the information in the provided protobuf message to obtain and return a crypto.Signer.
 	NewSigner(context.Context, proto.Message) (crypto.Signer, error)
 
 	// Generate creates a new private key based on a key specification.
-	// It returns a proto that can be used as the value of tree.PrivateKey.
+	// It returns a proto that describes how to access that key.
+	// This proto can be passed to NewSigner() to get a crypto.Signer.
 	Generate(context.Context, *keyspb.Specification) (proto.Message, error)
 }
 

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -65,6 +65,10 @@ func (tester *SignerFactoryTester) TestNewSigner(t *testing.T) {
 			KeyProto: &empty.Empty{},
 			WantErr:  true,
 		},
+		{
+			Name:    "Nil KeyProto",
+			WantErr: true,
+		},
 	}...) {
 		signer, err := tester.NewSignerFactory().NewSigner(context.Background(), test.KeyProto)
 		switch gotErr := err != nil; {
@@ -121,6 +125,10 @@ func (tester *SignerFactoryTester) TestGenerate(t *testing.T) {
 					},
 				},
 			},
+			WantErr: true,
+		},
+		{
+			Name:    "Nil KeySpec",
 			WantErr: true,
 		},
 	} {

--- a/crypto/keys/signer_factory_tester.go
+++ b/crypto/keys/signer_factory_tester.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian/crypto/keyspb"
 )
@@ -37,7 +36,7 @@ import (
 type NewSignerTest struct {
 	// Name describes the test.
 	Name string
-	// KeyProto is marshaled as a protobuf "Any" and passed to SignerFactory.NewSigner().
+	// KeyProto is passed to SignerFactory.NewSigner().
 	KeyProto proto.Message
 	// WantErr should be true if SignerFactory.NewSigner() is expected to return an error.
 	WantErr bool
@@ -67,46 +66,25 @@ func (tester *SignerFactoryTester) TestNewSigner(t *testing.T) {
 			WantErr:  true,
 		},
 	}...) {
-		sf := tester.NewSignerFactory()
-
-		anyKeyProto, err := ptypes.MarshalAny(test.KeyProto)
-		if err != nil {
-			t.Errorf("%v: Could not marshal test.KeyProto as protobuf Any: %v", test.Name, err)
+		signer, err := tester.NewSignerFactory().NewSigner(context.Background(), test.KeyProto)
+		switch gotErr := err != nil; {
+		case gotErr != test.WantErr:
+			t.Errorf("%v: Signer() = (%v, %v), want err? %v", test.Name, signer, err, test.WantErr)
+			continue
+		case gotErr:
+			continue
 		}
 
-		for _, subtest := range []struct {
-			desc     string
-			keyProto proto.Message
-		}{
-			{
-				desc:     "unmodified",
-				keyProto: test.KeyProto,
-			},
-			{
-				desc:     "marshaled as protobuf Any",
-				keyProto: anyKeyProto,
-			},
-		} {
-			signer, err := sf.NewSigner(context.Background(), subtest.keyProto)
-			switch gotErr := err != nil; {
-			case gotErr != test.WantErr:
-				t.Errorf("%v (%v): Signer() = (%v, %v), want err? %v", test.Name, subtest.desc, signer, err, test.WantErr)
-				continue
-			case gotErr:
-				continue
-			}
+		// Check that the returned signer can produce signatures successfully.
+		hasher := crypto.SHA256
+		digest := sha256.Sum256([]byte("test"))
+		signature, err := signer.Sign(rand.Reader, digest[:], hasher)
+		if err != nil {
+			t.Errorf("%v: Signer().Sign() = (_, %v), want (_, nil)", test.Name, err)
+		}
 
-			// Check that the returned signer can produce signatures successfully.
-			hasher := crypto.SHA256
-			digest := sha256.Sum256([]byte("test"))
-			signature, err := signer.Sign(rand.Reader, digest[:], hasher)
-			if err != nil {
-				t.Errorf("%v (%v): Signer().Sign() = (_, %v), want (_, nil)", test.Name, subtest.desc, err)
-			}
-
-			if err := verify(signer.Public(), digest[:], signature, hasher, hasher); err != nil {
-				t.Errorf("%v (%v): %v", test.Name, subtest.desc, err)
-			}
+		if err := verify(signer.Public(), digest[:], signature, hasher, hasher); err != nil {
+			t.Errorf("%v: %v", test.Name, err)
 		}
 	}
 }

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -443,14 +443,8 @@ func TestServer_CreateTree(t *testing.T) {
 			}
 
 			keyProto := &keyspb.PrivateKey{Der: keyDER}
-			marshaledKeyProto, err := ptypes.MarshalAny(keyProto)
-			if err != nil {
-				t.Errorf("%v: failed to marshal test private key as proto: %v", test.desc, err)
-				continue
-			}
-
 			sf.EXPECT().Generate(gomock.Any(), test.req.GetKeySpec()).Return(keyProto, nil)
-			sf.EXPECT().NewSigner(gomock.Any(), marshaledKeyProto).Return(privateKey, nil)
+			sf.EXPECT().NewSigner(gomock.Any(), keyProto).Return(privateKey, nil)
 
 			publicKeyDER, err = x509.MarshalPKIXPublicKey(privateKey.Public())
 			if err != nil {
@@ -458,7 +452,12 @@ func TestServer_CreateTree(t *testing.T) {
 				continue
 			}
 		} else if test.req.Tree.GetPrivateKey() != nil {
-			sf.EXPECT().NewSigner(gomock.Any(), test.req.Tree.GetPrivateKey()).MaxTimes(1).Return(privateKey, nil)
+			var keyProto ptypes.DynamicAny
+			if err := ptypes.UnmarshalAny(test.req.Tree.GetPrivateKey(), &keyProto); err != nil {
+				t.Errorf("%v: failed to unmarshal test.req.Tree.PrivateKey: %v", test.desc, err)
+			}
+
+			sf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).MaxTimes(1).Return(privateKey, nil)
 		}
 
 		setup := setupAdminServer(ctrl, sf, false /* snapshot */, test.wantCommit, test.commitErr)

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -455,6 +455,7 @@ func TestServer_CreateTree(t *testing.T) {
 			var keyProto ptypes.DynamicAny
 			if err := ptypes.UnmarshalAny(test.req.Tree.GetPrivateKey(), &keyProto); err != nil {
 				t.Errorf("%v: failed to unmarshal test.req.Tree.PrivateKey: %v", test.desc, err)
+				continue
 			}
 
 			sf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).MaxTimes(1).Return(privateKey, nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
@@ -105,7 +106,12 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
+		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+	}
+
+	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
@@ -150,9 +156,14 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 	}
 	sm := NewSequencerManager(registry, zeroDuration)
 
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
+		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+	}
+
 	// Expect only one call to SignerFactory.NewSigner, as the returned signer should be cached by SequencerManager
 	// and re-used for the second sequencing pass.
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	// Expect two sequencing passes.
 	for i := 0; i < 2; i++ {
@@ -190,7 +201,12 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(nil, errors.New("no signer for this tree"))
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
+		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+	}
+
+	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(nil, errors.New("no signer for this tree"))
 
 	gomock.InOrder(
 		mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil),
@@ -224,7 +240,12 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
+		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+	}
+
+	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	// Set up enough mockery to be able to sequence. We don't test all the error paths
 	// through sequencer as other tests cover this
@@ -266,7 +287,12 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	mockSf.EXPECT().NewSigner(gomock.Any(), stestonly.LogTree.PrivateKey).Return(newSignerWithFixedSig(updatedRoot.Signature))
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
+		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+	}
+
+	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
 
 	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -108,7 +108,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
-		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+		t.Fatalf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
 	}
 
 	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
@@ -158,7 +158,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
-		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+		t.Fatalf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
 	}
 
 	// Expect only one call to SignerFactory.NewSigner, as the returned signer should be cached by SequencerManager
@@ -201,12 +201,7 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	mockStorage := storage.NewMockLogStorage(mockCtrl)
 	mockSf := keys.NewMockSignerFactory(mockCtrl)
 
-	var keyProto ptypes.DynamicAny
-	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
-		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
-	}
-
-	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(nil, errors.New("no signer for this tree"))
+	mockSf.EXPECT().NewSigner(gomock.Any(), gomock.Any()).Return(nil, errors.New("no signer for this tree"))
 
 	gomock.InOrder(
 		mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil),
@@ -242,7 +237,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
-		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+		t.Fatalf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
 	}
 
 	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))
@@ -289,7 +284,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
-		t.Errorf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
+		t.Fatalf("Failed to unmarshal stestonly.LogTree.PrivateKey: %v", err)
 	}
 
 	mockSf.EXPECT().NewSigner(gomock.Any(), keyProto.Message).Return(newSignerWithFixedSig(updatedRoot.Signature))

--- a/trees/trees.go
+++ b/trees/trees.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
@@ -147,7 +148,12 @@ func Signer(ctx context.Context, sf keys.SignerFactory, tree *trillian.Tree) (*t
 		return nil, err
 	}
 
-	signer, err := sf.NewSigner(ctx, tree.PrivateKey)
+	var keyProto ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(tree.PrivateKey, &keyProto); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tree.PrivateKey: %v", err)
+	}
+
+	signer, err := sf.NewSigner(ctx, keyProto.Message)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The narrower interface is simpler to use and implement.