### PR TITLE
Map: remove storage dependency in verifier

### DIFF
--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -21,6 +21,21 @@ import (
 	"github.com/google/trillian/testonly"
 )
 
+func TestReverse(t *testing.T) {
+
+	for _, tc := range []struct {
+		s, want string
+	}{
+		{s: "abc", want: "cba"},
+		{s: "1234", want: "4321"},
+		{s: "", want: ""},
+	} {
+		if got, want := reverse(tc.s), tc.want; got != want {
+			t.Errorf("reverse(%v): %v, want %v", tc.s, got, want)
+		}
+	}
+}
+
 func TestVerifyMap(t *testing.T) {
 	h := maphasher.Default
 	tv := mapInclusionTestVector[0]


### PR DESCRIPTION
This PR cleans up map_verifier so that it does not depend on the storage layer.

Fixes:
```
// TODO(al): Remove this dep on storage, since clients will want to use this code.
```