### PR TITLE
Verify index length from hasher

### DIFF
--- a/merkle/common.go
+++ b/merkle/common.go
@@ -26,6 +26,7 @@ func isRightChild(leafIndex int64) bool {
 }
 
 // bit returns the i'th bit of index from the right.
+// eg. bit(0x80000000, 31) -> 1
 func bit(index []byte, i int) uint {
 	IndexBits := len(index) * 8
 	bIndex := (IndexBits - i - 1) / 8

--- a/merkle/common_test.go
+++ b/merkle/common_test.go
@@ -32,6 +32,9 @@ func TestBit(t *testing.T) {
 		{index: h2b("000b"), i: 3, want: 1},
 		{index: h2b("0001"), i: 0, want: 1},
 		{index: h2b("8000"), i: 15, want: 1},
+		{index: h2b("0000000000000001"), i: 0, want: 1},
+		{index: h2b("0000000000010000"), i: 16, want: 1},
+		{index: h2b("8000000000000000"), i: 63, want: 1},
 	} {
 		if got, want := bit(tc.index, tc.i), tc.want; got != want {
 			t.Errorf("bit(%x, %d): %v, want %v", tc.index, tc.i, got, want)

--- a/merkle/common_test.go
+++ b/merkle/common_test.go
@@ -12,22 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package merkle provides Merkle tree manipulation functions.
 package merkle
 
-// parent returns the index of the parent node in the parent level of the tree.
-func parent(leafIndex int64) int64 {
-	return leafIndex >> 1
-}
+import (
+	"testing"
+)
 
-// isRightChild returns true if the node is a right child.
-func isRightChild(leafIndex int64) bool {
-	return leafIndex&1 == 1
-}
-
-// bit returns the i'th bit of index from the right.
-func bit(index []byte, i int) uint {
-	IndexBits := len(index) * 8
-	bIndex := (IndexBits - i - 1) / 8
-	return uint((index[bIndex] >> uint(i%8)) & 0x01)
+func TestBit(t *testing.T) {
+	for _, tc := range []struct {
+		index []byte
+		i     int
+		want  uint
+	}{
+		{index: h2b("00"), i: 0, want: 0},
+		{index: h2b("00"), i: 7, want: 0},
+		{index: h2b("000b"), i: 0, want: 1},
+		{index: h2b("000b"), i: 1, want: 1},
+		{index: h2b("000b"), i: 2, want: 0},
+		{index: h2b("000b"), i: 3, want: 1},
+		{index: h2b("0001"), i: 0, want: 1},
+		{index: h2b("8000"), i: 15, want: 1},
+	} {
+		if got, want := bit(tc.index, tc.i), tc.want; got != want {
+			t.Errorf("bit(%x, %d): %v, want %v", tc.index, tc.i, got, want)
+		}
+	}
 }

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -17,7 +17,6 @@ package merkle
 import (
 	"bytes"
 	"fmt"
-	"math/big"
 
 	"github.com/google/trillian/merkle/hashers"
 )
@@ -45,14 +44,13 @@ func VerifyMapInclusionProof(treeID int64, index, leafHash, expectedRoot []byte,
 	runningHash := make([]byte, len(leafHash))
 	copy(runningHash, leafHash)
 
-	fmtString := fmt.Sprintf("%%0%db", h.BitLen())
-	bits := fmt.Sprintf(fmtString, new(big.Int).SetBytes(index))
-	for height, bit := range reverse(bits) {
+	for height := 0; height < h.BitLen(); height++ {
+		proofIsRightHandElement := bit(index, height) == 0
 		pElement := proof[height]
 		if len(pElement) == 0 {
 			pElement = h.HashEmpty(treeID, index, height)
 		}
-		if bit == '0' {
+		if proofIsRightHandElement {
 			runningHash = h.HashChildren(runningHash, pElement)
 		} else {
 			runningHash = h.HashChildren(pElement, runningHash)

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -44,11 +44,11 @@ func VerifyMapInclusionProof(treeID int64, index, leafHash, expectedRoot []byte,
 	runningHash := make([]byte, len(leafHash))
 	copy(runningHash, leafHash)
 
-	for height := 0; height < h.BitLen(); height++ {
-		proofIsRightHandElement := bit(index, height) == 0
-		pElement := proof[height]
+	for level := 0; level < h.BitLen(); level++ {
+		proofIsRightHandElement := bit(index, level) == 0
+		pElement := proof[level]
 		if len(pElement) == 0 {
-			pElement = h.HashEmpty(treeID, index, height)
+			pElement = h.HashEmpty(treeID, index, level)
 		}
 		if proofIsRightHandElement {
 			runningHash = h.HashChildren(runningHash, pElement)

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -62,12 +62,3 @@ func VerifyMapInclusionProof(treeID int64, index, leafHash, expectedRoot []byte,
 	}
 	return nil
 }
-
-// reverse returns its argument string reversed rune-wise left to right.
-func reverse(s string) string {
-	r := []rune(s)
-	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
-		r[i], r[j] = r[j], r[i]
-	}
-	return string(r)
-}

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -21,21 +21,6 @@ import (
 	"github.com/google/trillian/testonly"
 )
 
-func TestReverse(t *testing.T) {
-
-	for _, tc := range []struct {
-		s, want string
-	}{
-		{s: "abc", want: "cba"},
-		{s: "1234", want: "4321"},
-		{s: "", want: ""},
-	} {
-		if got, want := reverse(tc.s), tc.want; got != want {
-			t.Errorf("reverse(%v): %v, want %v", tc.s, got, want)
-		}
-	}
-}
-
 func TestVerifyMap(t *testing.T) {
 	h := maphasher.Default
 	tv := mapInclusionTestVector[0]

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -21,6 +21,21 @@ import (
 	"github.com/google/trillian/testonly"
 )
 
+func TestReverse(t *testing.T) {
+
+	for _, tc := range []struct {
+		s, want string
+	}{
+		{s: "abc", want: "cba"},
+		{s: "1234", want: "4321"},
+		{s: "", want: ""},
+	} {
+		if got, want := reverse(tc.s), tc.want; got != want {
+			t.Errorf("reverse(%v): %v, want %v", tc.s, got, want)
+		}
+	}
+}
+
 func TestVerifyMap(t *testing.T) {
 	h := maphasher.Default
 	tv := mapInclusionTestVector[0]

--- a/server/trillian_map_server.go
+++ b/server/trillian_map_server.go
@@ -31,12 +31,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	// indexSize is the number of bytes all indexes should be.
-	// TODO(gdbelvin): specify the index length in the tree specification.
-	indexSize = 32
-)
-
 // TODO(codingllama): There is no access control in the server yet and clients could easily modify
 // any tree.
 
@@ -95,7 +89,7 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 	found := 0
 	for _, index := range req.Index {
 		// TODO(gdbelvin): specify the index length in the tree specification.
-		if got, want := len(index), indexSize; got != want {
+		if got, want := len(index), hasher.Size(); got != want {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"index len(%x): %v, want %v", index, got, want)
 		}
@@ -168,7 +162,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 	}
 
 	for _, l := range req.Leaves {
-		if got, want := len(l.Index), indexSize; got != want {
+		if got, want := len(l.Index), hasher.Size(); got != want {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"len(%x): %v, want %v", l.Index, got, want)
 		}


### PR DESCRIPTION
Fixes `// TODO(gdbelvin): specify the index length in the tree specification.`