### PR TITLE
Rename PEMSignerFactory to DefaultSignerFactory

### DIFF
--- a/crypto/keys/default_signer_factory_test.go
+++ b/crypto/keys/default_signer_factory_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 )
 
-func TestPEMSignerFactory(t *testing.T) {
+func TestDefaultSignerFactory(t *testing.T) {
 	tester := SignerFactoryTester{
-		NewSignerFactory: func() SignerFactory { return &PEMSignerFactory{} },
+		NewSignerFactory: func() SignerFactory { return &DefaultSignerFactory{} },
 		NewSignerTests: []NewSignerTest{
 			{
 				Name: "PEMKeyFile",

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -111,7 +111,7 @@ func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
 
 	reggie := extension.Registry{
 		AdminStorage:  memory.NewAdminStorage(ms),
-		SignerFactory: &keys.PEMSignerFactory{},
+		SignerFactory: &keys.DefaultSignerFactory{},
 		LogStorage:    ms,
 		QuotaManager:  quota.Noop(),
 	}

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mf := prometheus.MetricFactory{}
 
-	sf := &keys.PEMSignerFactory{}
+	sf := &keys.DefaultSignerFactory{}
 	if *pkcs11ModulePath != "" {
 		sf.SetPKCS11Module(*pkcs11ModulePath)
 	}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	mf := prometheus.MetricFactory{}
 
-	sf := &keys.PEMSignerFactory{}
+	sf := &keys.DefaultSignerFactory{}
 	if *pkcs11ModulePath != "" {
 		sf.SetPKCS11Module(*pkcs11ModulePath)
 	}

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	registry := extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
-		SignerFactory: &keys.PEMSignerFactory{},
+		SignerFactory: &keys.DefaultSignerFactory{},
 		MapStorage:    mysql.NewMapStorage(db),
 		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: *maxUnsequencedRows},
 		MetricFactory: prometheus.MetricFactory{},

--- a/testonly/integration/clientserver.go
+++ b/testonly/integration/clientserver.go
@@ -97,7 +97,7 @@ func NewLogEnv(ctx context.Context, numSequencers int, testID string) (*LogEnv, 
 		AdminStorage:  mysql.NewAdminStorage(db),
 		LogStorage:    mysql.NewLogStorage(db, nil),
 		QuotaManager:  quota.Noop(),
-		SignerFactory: &keys.PEMSignerFactory{},
+		SignerFactory: &keys.DefaultSignerFactory{},
 	}
 
 	ret, err := NewLogEnvWithRegistry(ctx, numSequencers, testID, registry)

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -32,7 +32,7 @@ func NewRegistryForTests(testID string) (extension.Registry, error) {
 	return extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
 		LogStorage:    mysql.NewLogStorage(db, nil),
-		SignerFactory: &keys.PEMSignerFactory{},
+		SignerFactory: &keys.DefaultSignerFactory{},
 		MapStorage:    mysql.NewMapStorage(db),
 		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: mysqlq.DefaultMaxUnsequenced},
 	}, nil


### PR DESCRIPTION
There is nothing PEM-specific about this SignerFactory implementation now.
It supports PEM files, DER and PKCS#11.