### PR TITLE
Improve dequeuing performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ go:
 env:
   - GOFLAGS=''
   - GOFLAGS='-race'
-  - GOFLAGS=''                    WITH_ETCD=true
-  - GOFLAGS='-race'               WITH_ETCD=true
-  - GOFLAGS='--tags pkcs11'       WITH_PKCS11=true
-  - GOFLAGS='-race --tags pkcs11' WITH_PKCS11=true
+  - GOFLAGS='--tags batched_queue'
+  - GOFLAGS='-race --tags batched_queue'
+  - GOFLAGS=''                           WITH_ETCD=true
+  - GOFLAGS='-race'                      WITH_ETCD=true
+  - GOFLAGS='--tags pkcs11'              WITH_PKCS11=true
+  - GOFLAGS='-race --tags pkcs11'        WITH_PKCS11=true
 
 matrix:
   fast_finish: true

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -308,7 +308,7 @@ func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime tim
 		}
 
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
-			return nil, errors.New("Dequeued a leaf with incorrect hash size")
+			return nil, errors.New("dequeued a leaf with incorrect hash size")
 		}
 
 		leaves = append(leaves, leaf)

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -59,7 +59,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 	for _, leaf := range leaves {
 		// This should fail on insert but catch it early
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
-			return errors.New("Sequenced leaf has incorrect hash size")
+			return errors.New("sequenced leaf has incorrect hash size")
 		}
 
 		_, err := t.tx.ExecContext(

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -1,0 +1,124 @@
+// +build !batched_queue
+
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+)
+
+const (
+	// If this statement ORDER BY clause is changed refer to the comment in removeSequencedLeaves
+	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos
+			FROM Unsequenced
+			WHERE TreeID=?
+			AND Bucket=0
+			AND QueueTimestampNanos<=?
+			ORDER BY QueueTimestampNanos,LeafIdentityHash ASC LIMIT ?`
+	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos)
+			VALUES(?,0,?,?,?)`
+	insertSequencedLeafSQL = `INSERT INTO SequencedLeafData(TreeId,LeafIdentityHash,MerkleLeafHash,SequenceNumber)
+			VALUES(?,?,?,?)`
+	deleteUnsequencedSQL = "DELETE FROM Unsequenced WHERE TreeId=? AND Bucket=0 AND QueueTimestampNanos=? AND LeafIdentityHash=?"
+)
+
+// dequeuedLeaf is used internally and contains some data that is not part of the client API.
+type dequeuedLeaf struct {
+	queueTimestampNanos int64
+	leafIdentityHash    []byte
+}
+
+func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, interface{}, error) {
+	var leafIDHash []byte
+	var merkleHash []byte
+	var queueTimeNanos int64
+
+	err := rows.Scan(&leafIDHash, &merkleHash, &queueTimeNanos)
+	if err != nil {
+		glog.Warningf("Error scanning work rows: %s", err)
+		return nil, nil, err
+	}
+
+	// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
+	// sequencer. The sequencer only writes to the SequencedLeafData table and the client
+	// supplied data was already written to LeafData as part of queueing the leaf.
+	leaf := &trillian.LogLeaf{
+		LeafIdentityHash: leafIDHash,
+		MerkleLeafHash:   merkleHash,
+	}
+	return leaf, &dequeuedLeaf{queueTimestampNanos: queueTimeNanos, leafIdentityHash: leafIDHash}, nil
+}
+
+func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []interface{} {
+	return []interface{}{queueTimestamp.UnixNano()}
+}
+
+func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
+	// TODO: In theory we can do this with CASE / WHEN in one SQL statement but it's more fiddly
+	// and can be implemented later if necessary
+	for _, leaf := range leaves {
+		// This should fail on insert but catch it early
+		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
+			return errors.New("Sequenced leaf has incorrect hash size")
+		}
+
+		_, err := t.tx.ExecContext(
+			ctx,
+			insertSequencedLeafSQL,
+			t.treeID,
+			leaf.LeafIdentityHash,
+			leaf.MerkleLeafHash,
+			leaf.LeafIndex)
+		if err != nil {
+			glog.Warningf("Failed to update sequenced leaves: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// removeSequencedLeaves removes the passed in leaves slice (which may be
+// modified as part of the operation).
+func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, leaves []interface{}) error {
+	// Don't need to re-sort because the query ordered by leaf hash. If that changes because
+	// the query is expensive then the sort will need to be done here. See comment in
+	// QueueLeaves.
+	stx, err := t.tx.PrepareContext(ctx, deleteUnsequencedSQL)
+	if err != nil {
+		glog.Warningf("Failed to prep delete statement for sequenced work: %v", err)
+		return err
+	}
+	for _, obj := range leaves {
+		dql, ok := obj.(*dequeuedLeaf)
+		if !ok {
+			return errors.New("non-dequeuedLeaf passed to removeSequencedLeaves")
+		}
+		result, err := stx.ExecContext(ctx, t.treeID, dql.queueTimestampNanos, dql.leafIdentityHash)
+		err = checkResultOkAndRowCountIs(result, err, int64(1))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -1,0 +1,125 @@
+// +build batched_queue
+
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+)
+
+const (
+	// If this statement ORDER BY clause is changed refer to the comment in removeSequencedLeaves
+	selectQueuedLeavesSQL = `SELECT LeafIdentityHash,MerkleLeafHash,QueueID
+			FROM Unsequenced
+			WHERE TreeID=?
+			AND Bucket=0
+			AND QueueTimestampNanos<=?
+			ORDER BY QueueTimestampNanos,LeafIdentityHash ASC LIMIT ?`
+	insertUnsequencedEntrySQL = `INSERT INTO Unsequenced(TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos,QueueID) VALUES(?,0,?,?,?,?)`
+	insertSequencedLeafSQL    = `INSERT INTO SequencedLeafData(TreeId,LeafIdentityHash,MerkleLeafHash,SequenceNumber) VALUES`
+	deleteUnsequencedSQL      = "DELETE FROM Unsequenced WHERE QueueID IN (<placeholder>)"
+)
+
+func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, interface{}, error) {
+	var leafIDHash []byte
+	var merkleHash []byte
+	var queueID []byte
+
+	err := rows.Scan(&leafIDHash, &merkleHash, &queueID)
+	if err != nil {
+		glog.Warningf("Error scanning work rows: %s", err)
+		return nil, nil, err
+	}
+
+	// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
+	// sequencer. The sequencer only writes to the SequencedLeafData table and the client
+	// supplied data was already written to LeafData as part of queueing the leaf.
+	leaf := &trillian.LogLeaf{
+		LeafIdentityHash: leafIDHash,
+		MerkleLeafHash:   merkleHash,
+	}
+	return leaf, queueID, nil
+}
+
+func generateQueueID(treeID int64, leafIdentityHash []byte, timestamp int64) []byte {
+	h := sha256.New()
+	b := make([]byte, 10)
+	binary.PutVarint(b, treeID)
+	h.Write(b)
+	b = make([]byte, 10)
+	binary.PutVarint(b, timestamp)
+	h.Write(b)
+	h.Write(leafIdentityHash)
+	return h.Sum(nil)
+}
+
+func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []interface{} {
+	timestamp := queueTimestamp.UnixNano()
+	return []interface{}{timestamp, generateQueueID(treeID, identityHash, timestamp)}
+}
+
+func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
+	querySuffix := []string{}
+	args := []interface{}{}
+	for _, leaf := range leaves {
+		querySuffix = append(querySuffix, "(?,?,?,?)")
+		args = append(args, t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex)
+	}
+	result, err := t.tx.ExecContext(ctx, insertSequencedLeafSQL+strings.Join(querySuffix, ","), args...)
+	if err != nil {
+		glog.Warningf("Failed to update sequenced leaves: %s", err)
+	}
+	if err := checkResultOkAndRowCountIs(result, err, int64(len(leaves))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *mySQLLogStorage) getDeleteUnsequencedStmt(ctx context.Context, num int) (*sql.Stmt, error) {
+	return m.getStmt(ctx, deleteUnsequencedSQL, num, "?", "?")
+}
+
+// removeSequencedLeaves removes the passed in leaves slice (which may be
+// modified as part of the operation).
+func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, queueIDs []interface{}) error {
+	// Don't need to re-sort because the query ordered by leaf hash. If that changes because
+	// the query is expensive then the sort will need to be done here. See comment in
+	// QueueLeaves.
+	tmpl, err := t.ls.getDeleteUnsequencedStmt(ctx, len(queueIDs))
+	if err != nil {
+		glog.Warningf("Failed to get delete statement for sequenced work: %s", err)
+		return err
+	}
+	stx := t.tx.StmtContext(ctx, tmpl)
+	result, err := stx.ExecContext(ctx, queueIDs...)
+	if err != nil {
+		// Error is handled by checkResultOkAndRowCountIs() below
+		glog.Warningf("Failed to delete sequenced work: %s", err)
+	}
+	if err := checkResultOkAndRowCountIs(result, err, int64(len(queueIDs))); err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -118,6 +118,10 @@ CREATE TABLE IF NOT EXISTS Unsequenced(
   -- CT this hash will include the leaf prefix byte as well as the leaf data.
   MerkleLeafHash       VARBINARY(255) NOT NULL,
   QueueTimestampNanos  BIGINT NOT NULL,
+  -- This is a SHA256 hash of the TreeID, LeafIdentityHash and QueueTimestampNanos. It is used
+  -- for batched deletes from the table when trillian_log_server and trillian_log_signer are
+  -- built with the batched_queue tag.
+  QueueID VARBINARY(32) DEFAULT NULL UNIQUE,
   PRIMARY KEY (TreeId, Bucket, QueueTimestampNanos, LeafIdentityHash)
 );
 


### PR DESCRIPTION
These changes significantly increase the performance of sequencing by batching the deletes from the `Unsequenced` table and inserts into the `SequencedLeafData` table. This undoes some of the work done in #603.

This is a breaking change as it requires adding a new field to the `Unsequenced` table. It would be possible to do a similar thing without making this change but then requires some slightly hacky uses of the existing indexes to avoid removing rows with duplicate `LeafIdentityHash`s. That said I think the changes are worth the short term pain as they significantly improve performance and reduce load on the database.

As I have yet to put together a god Prometheus dashboard I don't have any good charts to illustrate the speed up so here is some log output from a unpatched and patched `trillian_log_signer` using a batch size of `1000` while using `ct_hammer` with `-max_parallel_chains 50 -invalid_chance 0` and an empty tree. This shows (at least as far as I can tell) that this isn't re-introducing any of the previous locking problems on the `Unsequenced` and `SequencedLeafData` tables that were constraining sequencing performance. Note these numbers are from my laptop so the boost should actually be a bit better on real machines.

```
# master
5487756799089772688: processed 1000 items in 0.84 seconds (1190.85 qps)
5487756799089772688: processed 1000 items in 0.84 seconds (1192.62 qps)
5487756799089772688: processed 1000 items in 0.95 seconds (1052.98 qps)
5487756799089772688: processed 1000 items in 0.95 seconds (1047.63 qps)
5487756799089772688: processed 1000 items in 1.03 seconds (972.74 qps)
5487756799089772688: processed 1000 items in 1.00 seconds (1001.31 qps)
5487756799089772688: processed 1000 items in 1.05 seconds (949.57 qps)
5487756799089772688: processed 1000 items in 1.13 seconds (887.82 qps)
5487756799089772688: processed 1000 items in 1.22 seconds (817.28 qps)
5487756799089772688: processed 1000 items in 1.06 seconds (944.25 qps)

# patched
5487756799089772688: processed 1000 items in 0.14 seconds (7335.50 qps)
5487756799089772688: processed 1000 items in 0.16 seconds (6397.87 qps)
5487756799089772688: processed 1000 items in 0.14 seconds (6920.55 qps)
5487756799089772688: processed 1000 items in 0.17 seconds (5918.10 qps)
5487756799089772688: processed 1000 items in 0.21 seconds (4784.84 qps)
5487756799089772688: processed 1000 items in 0.11 seconds (9004.58 qps)
5487756799089772688: processed 1000 items in 0.13 seconds (7871.44 qps)
5487756799089772688: processed 1000 items in 0.17 seconds (5987.53 qps)
5487756799089772688: processed 1000 items in 0.12 seconds (8514.92 qps)
5487756799089772688: processed 1000 items in 0.10 seconds (10255.44 qps)
```