### PR TITLE
Remove testonly.Hasher

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
@@ -39,7 +40,7 @@ var (
 	// These can be shared between tests as they're never modified
 	testLeaf16Data = []byte("testdataforleaf")
 	testLeaf16     = &trillian.LogLeaf{
-		MerkleLeafHash: testonly.Hasher.HashLeaf(testLeaf16Data),
+		MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf(testLeaf16Data),
 		LeafValue:      testLeaf16Data,
 		ExtraData:      nil,
 		LeafIndex:      16,
@@ -160,7 +161,7 @@ type testContext struct {
 // This gets modified so tests need their own copies
 func getLeaf42() *trillian.LogLeaf {
 	return &trillian.LogLeaf{
-		MerkleLeafHash: testonly.Hasher.HashLeaf(testLeaf16Data),
+		MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf(testLeaf16Data),
 		LeafValue:      testLeaf16Data,
 		ExtraData:      nil,
 		LeafIndex:      42,
@@ -254,7 +255,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	if qm == nil {
 		qm = quota.Noop()
 	}
-	sequencer := NewSequencer(testonly.Hasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil, qm)
+	sequencer := NewSequencer(rfc6962.DefaultHasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil, qm)
 	return testContext{mockTx: mockTx, mockStorage: mockStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
@@ -71,7 +72,7 @@ func TestAddingLeaves(t *testing.T) {
 	// api-visible calculation of root & size.
 	{
 		// First tree, add nodes one-by-one
-		tree := NewCompactMerkleTree(testonly.Hasher)
+		tree := NewCompactMerkleTree(rfc6962.DefaultHasher)
 		if got, want := tree.Size(), int64(0); got != want {
 			t.Errorf("Size()=%d, want %d", got, want)
 		}
@@ -100,7 +101,7 @@ func TestAddingLeaves(t *testing.T) {
 
 	{
 		// Second tree, add nodes all at once
-		tree := NewCompactMerkleTree(testonly.Hasher)
+		tree := NewCompactMerkleTree(rfc6962.DefaultHasher)
 		for i := 0; i < 8; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
 				return nil
@@ -122,7 +123,7 @@ func TestAddingLeaves(t *testing.T) {
 
 	{
 		// Third tree, add nodes in two chunks
-		tree := NewCompactMerkleTree(testonly.Hasher)
+		tree := NewCompactMerkleTree(rfc6962.DefaultHasher)
 		for i := 0; i < 3; i++ {
 			tree.AddLeaf(inputs[i], func(int, int64, []byte) error {
 				return nil
@@ -172,7 +173,7 @@ func fixedHashGetNodeFunc(int, int64) ([]byte, error) {
 }
 
 func TestLoadingTreeFailsNodeFetch(t *testing.T) {
-	_, err := NewCompactMerkleTreeWithState(testonly.Hasher, 237, failingGetNodeFunc, []byte("notimportant"))
+	_, err := NewCompactMerkleTreeWithState(rfc6962.DefaultHasher, 237, failingGetNodeFunc, []byte("notimportant"))
 
 	if err == nil || !strings.Contains(err.Error(), "bang") {
 		t.Errorf("Did not return correctly on failed node fetch: %v", err)
@@ -182,7 +183,7 @@ func TestLoadingTreeFailsNodeFetch(t *testing.T) {
 func TestLoadingTreeFailsBadRootHash(t *testing.T) {
 	// Supply a root hash that can't possibly match the result of the SHA 256 hashing on our dummy
 	// data
-	_, err := NewCompactMerkleTreeWithState(testonly.Hasher, 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
+	_, err := NewCompactMerkleTreeWithState(rfc6962.DefaultHasher, 237, fixedHashGetNodeFunc, []byte("nomatch!nomatch!nomatch!nomatch!"))
 	_, ok := err.(RootHashMismatchError)
 
 	if err == nil || !ok {
@@ -199,12 +200,12 @@ func nodeKey(d int, i int64) (string, error) {
 }
 
 func TestCompactVsFullTree(t *testing.T) {
-	imt := NewInMemoryMerkleTree(testonly.Hasher)
+	imt := NewInMemoryMerkleTree(rfc6962.DefaultHasher)
 	nodes := make(map[string][]byte)
 
 	for i := int64(0); i < 1024; i++ {
 		cmt, err := NewCompactMerkleTreeWithState(
-			testonly.Hasher,
+			rfc6962.DefaultHasher,
 			imt.LeafCount(),
 			func(depth int, index int64) ([]byte, error) {
 				k, err := nodeKey(depth, index)
@@ -277,7 +278,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 	b64e := func(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
 
 	for _, test := range tests {
-		tree := NewCompactMerkleTree(testonly.Hasher)
+		tree := NewCompactMerkleTree(rfc6962.DefaultHasher)
 		for i := int64(0); i < test.size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
 			tree.AddLeaf(l, func(int, int64, []byte) error {

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
 type logProofTestVector struct {
@@ -297,7 +297,7 @@ func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1,
 }
 
 func TestVerifyInclusionProof(t *testing.T) {
-	v := NewLogVerifier(testonly.Hasher)
+	v := NewLogVerifier(rfc6962.DefaultHasher)
 	path := [][]byte{}
 	// Various invalid paths
 	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{1}); err == nil {
@@ -333,7 +333,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
 			proof = append(proof, inclusionProofs[i].proof[j].h)
 		}
-		leafHash := testonly.Hasher.HashLeaf(leaves[inclusionProofs[i].leaf-1].h)
+		leafHash := rfc6962.DefaultHasher.HashLeaf(leaves[inclusionProofs[i].leaf-1].h)
 		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
 			roots[inclusionProofs[i].snapshot-1].h, leafHash)
 		if err != nil {
@@ -344,7 +344,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 }
 
 func TestVerifyConsistencyProof(t *testing.T) {
-	v := NewLogVerifier(testonly.Hasher)
+	v := NewLogVerifier(rfc6962.DefaultHasher)
 
 	proof := [][]byte{}
 	root1 := []byte("don't care")

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/trillian/merkle/hashers"
-	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
 // Note test inputs came from the values used by the C++ code. The original
@@ -121,7 +121,7 @@ func decodeHexStringOrPanic(hs string) []byte {
 }
 
 func makeEmptyTree() *InMemoryMerkleTree {
-	return NewInMemoryMerkleTree(testonly.Hasher)
+	return NewInMemoryMerkleTree(rfc6962.DefaultHasher)
 }
 
 func makeFuzzTestData() [][]byte {

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -24,15 +24,15 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
-	"github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
 
 var (
-	th                 = testonly.Hasher
+	th                 = rfc6962.DefaultHasher
 	logID1             = int64(1)
 	logID2             = int64(2)
 	leaf0Request       = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0}}

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
@@ -41,7 +42,7 @@ var fakeTimeSource = util.NewFakeTimeSource(fakeTime)
 // We use a size zero tree for testing, Merkle tree state restore is tested elsewhere
 var testLogID1 = int64(1)
 var testLeaf0 = &trillian.LogLeaf{
-	MerkleLeafHash: testonly.Hasher.HashLeaf([]byte{}),
+	MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf([]byte{}),
 	LeafValue:      nil,
 	ExtraData:      nil,
 	LeafIndex:      0,

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/maphasher"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
 	stestonly "github.com/google/trillian/storage/testonly"
-	"github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -251,8 +251,8 @@ func TestSuffixSerializeFormat(t *testing.T) {
 }
 
 func TestRepopulateLogSubtree(t *testing.T) {
-	populateTheThing := PopulateLogSubtreeNodes(testonly.Hasher)
-	cmt := merkle.NewCompactMerkleTree(testonly.Hasher)
+	populateTheThing := PopulateLogSubtreeNodes(rfc6962.DefaultHasher)
+	cmt := merkle.NewCompactMerkleTree(rfc6962.DefaultHasher)
 	cmtStorage := storagepb.SubtreeProto{
 		Leaves:        make(map[string][]byte),
 		InternalNodes: make(map[string][]byte),
@@ -262,13 +262,13 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		Leaves: make(map[string][]byte),
 		Depth:  int32(defaultLogStrata[0]),
 	}
-	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(testonly.Hasher), PrepareLogSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, PopulateLogSubtreeNodes(rfc6962.DefaultHasher), PrepareLogSubtreeWrite())
 	for numLeaves := int64(1); numLeaves <= 256; numLeaves++ {
 		// clear internal nodes
 		s.InternalNodes = make(map[string][]byte)
 
 		leaf := []byte(fmt.Sprintf("this is leaf %d", numLeaves))
-		leafHash := testonly.Hasher.HashLeaf(leaf)
+		leafHash := rfc6962.DefaultHasher.HashLeaf(leaf)
 		_, err := cmt.AddLeafHash(leafHash, func(depth int, index int64, h []byte) error {
 			n, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 8)
 			if err != nil {

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/testonly"
 )
 
 // This is a fake implementation of a NodeReader intended for use in testing Merkle path code.
@@ -128,7 +128,7 @@ func NewMultiFakeNodeReader(readers []FakeNodeReader) *MultiFakeNodeReader {
 // code. To help guard against this we check the tree root hash after each batch has been
 // processed. The supplied batches should be in ascending order of tree revision.
 func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader {
-	tree := merkle.NewCompactMerkleTree(testonly.Hasher)
+	tree := merkle.NewCompactMerkleTree(rfc6962.DefaultHasher)
 	readers := make([]FakeNodeReader, 0, len(batches))
 
 	lastBatchRevision := int64(0)

--- a/testonly/hasher.go
+++ b/testonly/hasher.go
@@ -19,13 +19,7 @@ package testonly
 
 import (
 	"crypto/sha256"
-
-	"github.com/google/trillian/merkle/rfc6962"
 )
-
-// Hasher is the default hasher for tests.
-// TODO: Make this a custom algorithm to decouple hashing from coded defaults.
-var Hasher = rfc6962.DefaultHasher
 
 // HashKey converts a map key into a map index using SHA256.
 // This preserves tests that precomputed indexes based on SHA256.


### PR DESCRIPTION
General cleanup

Removes testonly.Hasher in favor of having tests explicitly depend on a particular hasher.  Many of the tests contain hasher specific test vectors which makes an explicit dependency appropriate. 

Removing the testonly.Hasher reference also cleans up an unneeded dependency in some cases, avoiding future problems with import cycles. 