### PR TITLE
Fix trillian-map Dockerfile with respect to #611

### DIFF
--- a/server/trillian_map_server/Dockerfile
+++ b/server/trillian_map_server/Dockerfile
@@ -12,6 +12,7 @@ ENV HOST=0.0.0.0 \
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian 
 
+RUN apt-get update && apt-get install -y libtool libltdl-dev
 RUN go get ./server/trillian_map_server
 
 ENTRYPOINT /go/bin/trillian_map_server \


### PR DESCRIPTION
Related #714: map-server also needs libltdl header to build