### PR TITLE
Add --mysql_max_conns flag to Trillian binaries

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -53,8 +53,8 @@ import (
 var (
 	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	// MySQL supports 151 connections by default (https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_connections).
-	// Default to a maximum of ~1/2 of this, because other Trillian binaries will also need to make connections.
-	mySQLMaxConns = flag.Int("mysql_max_conns", 75, "Maximum number of connections that may be made to the MySQL database")
+	// Default to a maximum of ~1/3 of this, because other Trillian binaries will also need to make connections.
+	mySQLMaxConns = flag.Int("mysql_max_conns", 50, "Maximum number of connections that may be made to the MySQL database")
 
 	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -49,8 +49,8 @@ import (
 var (
 	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	// MySQL supports 151 connections by default (https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_connections).
-	// Default to a maximum of ~1/2 of this, because other Trillian binaries will also need to make connections.
-	mySQLMaxConns = flag.Int("mysql_max_conns", 75, "Maximum number of connections that may be made to the MySQL database")
+	// Default to a maximum of ~1/3 of this, because other Trillian binaries will also need to make connections.
+	mySQLMaxConns = flag.Int("mysql_max_conns", 50, "Maximum number of connections that may be made to the MySQL database")
 
 	httpEndpoint             = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP (host:port, empty means disabled)")
 	sequencerIntervalFlag    = flag.Duration("sequencer_interval", time.Second*10, "Time between each sequencing pass through all logs")

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -47,7 +47,11 @@ import (
 )
 
 var (
-	mySQLURI                 = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	// MySQL supports 151 connections by default (https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_connections).
+	// Default to a maximum of ~1/2 of this, because other Trillian binaries will also need to make connections.
+	mySQLMaxConns = flag.Int("mysql_max_conns", 75, "Maximum number of connections that may be made to the MySQL database")
+
 	httpEndpoint             = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP (host:port, empty means disabled)")
 	sequencerIntervalFlag    = flag.Duration("sequencer_interval", time.Second*10, "Time between each sequencing pass through all logs")
 	batchSizeFlag            = flag.Int("batch_size", 50, "Max number of leaves to process per batch")
@@ -86,6 +90,9 @@ func main() {
 		glog.Exitf("Failed to open MySQL database: %v", err)
 	}
 	defer db.Close()
+
+	// Limit the number of connections to the MySQL database, to avoid a "too many connections" error under heavy load.
+	db.SetMaxOpenConns(*mySQLMaxConns)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go util.AwaitSignal(cancel)

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -51,8 +51,8 @@ import (
 var (
 	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	// MySQL supports 151 connections by default (https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_connections).
-	// Default to a maximum of ~1/2 of this, because other Trillian binaries will also need to make connections.
-	mySQLMaxConns = flag.Int("mysql_max_conns", 75, "Maximum number of connections that may be made to the MySQL database")
+	// Default to a maximum of ~1/3 of this, because other Trillian binaries will also need to make connections.
+	mySQLMaxConns = flag.Int("mysql_max_conns", 50, "Maximum number of connections that may be made to the MySQL database")
 
 	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -49,7 +49,11 @@ import (
 )
 
 var (
-	mySQLURI           = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	// MySQL supports 151 connections by default (https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_connections).
+	// Default to a maximum of ~1/2 of this, because other Trillian binaries will also need to make connections.
+	mySQLMaxConns = flag.Int("mysql_max_conns", 75, "Maximum number of connections that may be made to the MySQL database")
+
 	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in")
@@ -72,6 +76,9 @@ func main() {
 		glog.Exitf("Failed to open database: %v", err)
 	}
 	// No defer: database ownership is delegated to server.Main
+
+	// Limit the number of connections to the MySQL database, to avoid a "too many connections" error under heavy load.
+	db.SetMaxOpenConns(*mySQLMaxConns)
 
 	registry := extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),


### PR DESCRIPTION
Controls the maximum number of connections each binary can make to the MySQL database. Defaults to approximately one third of the default limit imposed by MySQL. This could be increased if using a MySQL cluster, or if the max_connections setting on the MySQL server has been increased.

This avoids a "[too many connections](https://dev.mysql.com/doc/refman/en/too-many-connections.html)" error under heavy load.