### PR TITLE
Map test cleanup

### DIFF
--- a/integration/map.go
+++ b/integration/map.go
@@ -32,6 +32,8 @@ import (
 
 const treeID = int64(0)
 
+var hasher = maphasher.Default
+
 // RunMapIntegration runs a map integration test using the given map ID and client.
 func RunMapIntegration(ctx context.Context, mapID int64, pubKey crypto.PublicKey, client trillian.TrillianMapClient) error {
 	{
@@ -90,7 +92,6 @@ func RunMapIntegration(ctx context.Context, mapID int64, pubKey crypto.PublicKey
 
 	// Check values
 	// Mix up the ordering of requests
-	h := maphasher.Default
 	randIndexes := make([][]byte, len(tests))
 	for i, r := range rand.Perm(len(tests)) {
 		randIndexes[i] = tests[r].Index
@@ -129,8 +130,8 @@ func RunMapIntegration(ctx context.Context, mapID int64, pubKey crypto.PublicKey
 			if got, want := leaf.LeafValue, ev.LeafValue; !bytes.Equal(got, want) {
 				return fmt.Errorf("got value %s, want %s", got, want)
 			}
-			leafHash := h.HashLeaf(treeID, leaf.Index, h.BitLen(), leaf.LeafValue)
-			if err := merkle.VerifyMapInclusionProof(treeID, leaf.Index, leafHash, r.GetMapRoot().GetRootHash(), incl.Inclusion, h); err != nil {
+			leafHash := hasher.HashLeaf(treeID, leaf.Index, hasher.BitLen(), leaf.LeafValue)
+			if err := merkle.VerifyMapInclusionProof(treeID, leaf.Index, leafHash, r.GetMapRoot().GetRootHash(), incl.Inclusion, hasher); err != nil {
 				return fmt.Errorf("verifyMapInclusionProof(%x): %v", leaf.Index, err)
 			}
 		}
@@ -144,7 +145,6 @@ func RunMapIntegration(ctx context.Context, mapID int64, pubKey crypto.PublicKey
 // Ensure that a query for a leaf that does not exist results in a valid inclusion proof.
 func testForNonExistentLeaf(ctx context.Context, mapID int64,
 	client trillian.TrillianMapClient, latestRoot trillian.SignedMapRoot) error {
-	h := maphasher.Default
 	index1 := []byte("doesnotexist....................")
 	r, err := client.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
 		MapId:    mapID,
@@ -159,8 +159,8 @@ func testForNonExistentLeaf(ctx context.Context, mapID int64,
 		if got, want := len(leaf.LeafValue), 0; got != want {
 			return fmt.Errorf("len(GetLeaves(%s).LeafValue): %v, want, %v", index1, got, want)
 		}
-		leafHash := h.HashLeaf(treeID, leaf.Index, h.BitLen(), leaf.LeafValue)
-		if err := merkle.VerifyMapInclusionProof(treeID, leaf.Index, leafHash, latestRoot.RootHash, incl.Inclusion, h); err != nil {
+		leafHash := hasher.HashLeaf(treeID, leaf.Index, hasher.BitLen(), leaf.LeafValue)
+		if err := merkle.VerifyMapInclusionProof(treeID, leaf.Index, leafHash, latestRoot.RootHash, incl.Inclusion, hasher); err != nil {
 			return fmt.Errorf("VerifyMapInclusionProof(%x): %v", leaf.Index, err)
 		}
 	}

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -29,17 +29,17 @@ import (
 
 const treeID = int64(0)
 
-// This root was calculated with the C++/Python sparse Merkle tree code in the
-// github.com/google/certificate-transparency repo.
-// TODO(alcutter): replace with hash-dependent computation. How is this computed?
-var sparseEmptyRootHashB64 = b64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")
-
 // Some known answers for incrementally adding index/value pairs to a sparse tree.
 // rootB64 is the incremental root after adding the corresponding i/v pair, and
 // all i/v pairs which come before it.
+//
+// Values were calculated with the C++/Python sparse Merkle tree code in the
+// github.com/google/certificate-transparency repo.
+// TODO(alcutter): replace with hash-dependent computation. How is this computed?
 var simpleTestVector = []struct {
 	index, value, root []byte
 }{
+	{nil, nil, b64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")}, // Empty tree.
 	{testonly.HashKey("a"), []byte("0"), b64("nP1psZp1bu3jrY5Yv89rI+w5ywe9lLqI2qZi5ibTSF0=")},
 	{testonly.HashKey("b"), []byte("1"), b64("EJ1Rw6DQT9bDn2Zbn7u+9/j799PSdqT9gfBymS9MBZY=")},
 	{testonly.HashKey("a"), []byte("2"), b64("2rAZz4HJAMJqJ5c8ClS4wEzTP71GTdjMZMe1rKWPA5o=")},
@@ -69,17 +69,6 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []
 		r = append(r, v)
 	}
 	return r
-}
-
-func TestHStar2EmptyRootKAT(t *testing.T) {
-	s := NewHStar2(treeID, maphasher.Default)
-	root, err := s.HStar2Root(s.hasher.BitLen(), []HStar2LeafHash{})
-	if err != nil {
-		t.Fatalf("Failed to calculate root: %v", err)
-	}
-	if got, want := root, sparseEmptyRootHashB64; !bytes.Equal(got, want) {
-		t.Fatalf("Expected empty root. Got: \n%x\nWant:\n%x", got, want)
-	}
 }
 
 func TestHStar2SimpleDataSetKAT(t *testing.T) {
@@ -129,24 +118,6 @@ func TestHStar2GetSet(t *testing.T) {
 		}
 		if got, want := root, x.root; !bytes.Equal(got, want) {
 			t.Errorf("Root:\n%x, want:\n%x", got, want)
-		}
-	}
-}
-
-// Checks that we calculate the same empty root hash as a 256-level tree has
-// when calculating top subtrees using an appropriate offset.
-func TestHStar2OffsetEmptyRootKAT(t *testing.T) {
-	s := NewHStar2(treeID, maphasher.Default)
-
-	for size := 1; size < 255; size++ {
-		root, err := s.HStar2Nodes(size, s.hasher.BitLen()-size, []HStar2LeafHash{},
-			func(int, *big.Int) ([]byte, error) { return nil, nil },
-			func(int, *big.Int, []byte) error { return nil })
-		if err != nil {
-			t.Fatalf("Failed to calculate root %v", err)
-		}
-		if got, want := root, sparseEmptyRootHashB64; !bytes.Equal(got, want) {
-			t.Fatalf("Got root:\n%x, want:\n%x", got, want)
 		}
 	}
 }

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -39,10 +39,10 @@ const treeID = int64(0)
 var simpleTestVector = []struct {
 	index, value, root []byte
 }{
-	{nil, nil, b64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")}, // Empty tree.
-	{testonly.HashKey("a"), []byte("0"), b64("nP1psZp1bu3jrY5Yv89rI+w5ywe9lLqI2qZi5ibTSF0=")},
-	{testonly.HashKey("b"), []byte("1"), b64("EJ1Rw6DQT9bDn2Zbn7u+9/j799PSdqT9gfBymS9MBZY=")},
-	{testonly.HashKey("a"), []byte("2"), b64("2rAZz4HJAMJqJ5c8ClS4wEzTP71GTdjMZMe1rKWPA5o=")},
+	{nil, nil, deB64("xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=")}, // Empty tree.
+	{testonly.HashKey("a"), []byte("0"), deB64("nP1psZp1bu3jrY5Yv89rI+w5ywe9lLqI2qZi5ibTSF0=")},
+	{testonly.HashKey("b"), []byte("1"), deB64("EJ1Rw6DQT9bDn2Zbn7u+9/j799PSdqT9gfBymS9MBZY=")},
+	{testonly.HashKey("a"), []byte("2"), deB64("2rAZz4HJAMJqJ5c8ClS4wEzTP71GTdjMZMe1rKWPA5o=")},
 }
 
 // createHStar2Leaves returns a []HStar2LeafHash formed by the mapping of index, value ...
@@ -202,8 +202,8 @@ func TestPaddedBytes(t *testing.T) {
 	}
 }
 
-// b64 converts a base64 string into []byte.
-func b64(b64 string) []byte {
+// deB64 converts a base64 string into []byte.
+func deB64(b64 string) []byte {
 	b, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
 		panic("invalid base64 string")

--- a/merkle/map_verifier_test.go
+++ b/merkle/map_verifier_test.go
@@ -21,71 +21,42 @@ import (
 	"github.com/google/trillian/testonly"
 )
 
-func TestVerifyMap(t *testing.T) {
+func TestMapHasherTestVectors(t *testing.T) {
 	h := maphasher.Default
-	tv := mapInclusionTestVector[0]
-
-	// Copy the bad proof so we don't mess up the good proof.
-	badProof := make([][]byte, len(tv.Proof))
-	for i := range badProof {
-		badProof[i] = make([]byte, len(tv.Proof[i]))
-		copy(badProof[i], tv.Proof[i])
-	}
-	badProof[250][15] ^= 0x10
-
-	for _, test := range []struct {
-		desc  string
-		key   string
-		leaf  []byte
-		root  []byte
-		proof [][]byte
-		want  bool
+	tv := struct {
+		Index        []byte
+		Value        []byte
+		Proof        [][]byte
+		ExpectedRoot []byte
 	}{
-		{"correct", tv.Key, tv.Value, tv.ExpectedRoot, tv.Proof, true},
-		{"incorrect key", "w", tv.Value, tv.ExpectedRoot, tv.Proof, false},
-		{"incorrect value", tv.Key, []byte("w"), tv.ExpectedRoot, tv.Proof, false},
-		{"incorrect root", tv.Key, tv.Value, []byte("w"), tv.Proof, false},
-		{"incorrect proof", tv.Key, tv.Value, tv.ExpectedRoot, badProof, false},
-		{"short proof", tv.Key, tv.Value, tv.ExpectedRoot, [][]byte{[]byte("shorty")}, false},
-		{"excess proof", tv.Key, tv.Value, tv.ExpectedRoot, make([][]byte, h.Size()*8+1), false},
-	} {
-		index := testonly.HashKey(test.key)
-		leafHash := h.HashLeaf(treeID, index, h.BitLen(), test.leaf)
-		err := VerifyMapInclusionProof(treeID, index, leafHash, test.root, test.proof, h)
-		if got := err == nil; got != test.want {
-			t.Errorf("%v: VerifyMapInclusionProof(): %v, want %v", test.desc, err, test.want)
-		}
-	}
-}
 
-// Testdata produced with python
-var mapInclusionTestVector = []struct {
-	Key          string
-	Value        []byte
-	Proof        [][]byte
-	ExpectedRoot []byte
-}{
-	{
-		"key-0-848",
+		testonly.HashKey("key-0-848"),
 		[]byte("value-0-848"),
 		[][]byte{
 			// 246 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil,
 			testonly.MustDecodeBase64("vMWPHFclXXchQbAGJr6pcB002vQZYHnJTfOC42E1iT8="),
 			nil,
 			testonly.MustDecodeBase64("C3VKkaOliXmuHXM0zrkSulYX6ORaNG8qWHez/dyQkQs="),
@@ -98,182 +69,34 @@ var mapInclusionTestVector = []struct {
 			testonly.MustDecodeBase64("CtC2GCsc3/zFn1DNkoUThUnn7k+DMotaNXvmceKIL4Y="),
 		},
 		testonly.MustDecodeBase64("U6ANU1en3BSbbnWqhV2nTGtQ+scBlaZf9kRPEEDZsHM="),
-	}, {
-		"key-1-848",
-		[]byte("value-1-848"),
-		[][]byte{
-			// 246 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil,
-			testonly.MustDecodeBase64("bKUeTeIo5yNgZOJvU+MpfTQQlgOCasII6lglAg9BKXY="),
-			testonly.MustDecodeBase64("H35adeuKvGi/1cTAu1bxMFfFXwItLiKhggRdHE/uyro="),
-			testonly.MustDecodeBase64("rUKL1gJQQZVwYrQBxjxrYO/3P/Q6FDSetGqNwRxyk5A="),
-			testonly.MustDecodeBase64("8dg2BbkzWzeNBB0JSHuf6x5XcTyW2x2/b4KapNdYACc="),
-			testonly.MustDecodeBase64("jm1Z2OcD+n6eHcMDx73qWKZsT/LhzKTsdU1TCGfGaIY="),
-			testonly.MustDecodeBase64("9O6P4cOx1OqmHAg/tiAbdA/0x/bBFtovW5BfoRcrY5o="),
-			testonly.MustDecodeBase64("z55TNrWY+8Wgv4a4u4NEqwdCytwp8/HjT3D0BNIEFTI="),
-			testonly.MustDecodeBase64("xQzWi9r+QBAjMNpE+gN+l5GtIhHlYP2NXrBC8kUU/EY="),
-			testonly.MustDecodeBase64("zY5ONepiFwzAo102WU6DzMRApJKAe/dwOhns+guFAkg="),
-			testonly.MustDecodeBase64("9KJS1KgpfzbiVyaKKFFzLuKROQ/hAPsPvii0+/Us8+I="),
-		},
-		testonly.MustDecodeBase64("gdpe8FlS2bUYksxb392j+v/qxyYwUZC9uj1Lm62r3d0="),
-	}, {
-		"key-2-848",
-		[]byte("value-2-848"),
-		[][]byte{
-			// 244 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil,
-			testonly.MustDecodeBase64("t1OxaGjUkK+5sBsbgx5magZdh4VShTzSNvI4N925vFs="),
-			nil,
-			testonly.MustDecodeBase64("caC5J6720XiPfIcha76Os2x27TKw3OiGgu7vHc1SFuk="),
-			testonly.MustDecodeBase64("9fNicrw1ROQi2f/Ltcvbgj6vfz+TTdWM378cDR8WWxg="),
-			testonly.MustDecodeBase64("f+hTbDmbASIMv6DljlYjvBJ7m8rla5Z8T6zxkTasv/M="),
-			testonly.MustDecodeBase64("GBODQoymwvfJAJSLvxCrS27gOPtrVLfJJVYNfxmPknE="),
-			testonly.MustDecodeBase64("LqSHvjmOrF2Cf1aFXCYN3kMqWbu7aNo1C15qDXKwfFU="),
-			testonly.MustDecodeBase64("nj+mho3MS9RZq29+QWcHlCJLMGi1IAMPnWXopf8QoKw="),
-			testonly.MustDecodeBase64("QDsAIhiw3+GASUAdNMTW/fVRbv67fwiNrtzFKm4cpGU="),
-			testonly.MustDecodeBase64("aTqVP3hCyRHNUaP7hemCQ46oS1qfwAuRCWQnqwR3RsU="),
-			testonly.MustDecodeBase64("2jpxzwUIUeOpBbIMFmOXGCGA54kB/pvcO+kok2cqiKM="),
-			testonly.MustDecodeBase64("aeyl7vP9KXhfLo0GoIULaKsXDqEDb7HhKYJBTc+JW4I="),
-		},
-		testonly.MustDecodeBase64("vfV8k7xAvSNHvDp7lmKjppWlXlYh3ftq801B1QmFMA8="),
-	}, {
-		"key-3-848",
-		[]byte("value-3-848"),
-		[][]byte{
-			// 236 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			testonly.MustDecodeBase64("TCoz0L9ZdVAfXzB5DYi7JkvgSu41TJHFk1z4z+aRrYM="),
-			nil, nil, nil, nil, nil, nil,
-			testonly.MustDecodeBase64("H/5CFPaHvNYyq2vvbgwgUnpRjbvPFgoQMh+0lwKyWmE="),
-			testonly.MustDecodeBase64("Q0DymzR94JVkVb3djyW5e6lSN4ZF5yRHFKVHQJ8abFE="),
-			testonly.MustDecodeBase64("hCsLGJGsNOtD17I5wTfhMgVXXg9PplDuYHohEX0uvZI="),
-			testonly.MustDecodeBase64("IMQmP0/VI+2jNh1sQtSotTtIRjHmWrXABSyXZ9U9vUo="),
-			testonly.MustDecodeBase64("KnIt+BwTybVh6GhYqnh2tGeGvseXUoZtvR3YP5fBF6s="),
-			testonly.MustDecodeBase64("Hth6J7YLf+4WL6XKX+sRkKTj9ME/2gmrkB3CWCV3HSY="),
-			testonly.MustDecodeBase64("tGbuTo30YPbdgaU0614qRofiO9hMNh/jsTai9/HicMk="),
-			testonly.MustDecodeBase64("uujeGLnv42VsXWm4xR1iNGFi0LazL81V2zuhoCV+xwE="),
-			testonly.MustDecodeBase64("HEq0JbLal4nVVYeK8jgzVxO75uRoJ7hMQUZLy8snkig="),
-			testonly.MustDecodeBase64("PmccqijdN1j6S25Tn22HNiysdaNwhX4aPG8x7JSRfc4="),
-			testonly.MustDecodeBase64("t6UeSSZj9dEov5Vhll2x8b/266IQngg5XgyTHjPbsPQ="),
-			testonly.MustDecodeBase64("U2nveNA/h2WQZ7mEmeWknn6phAIlJ4pxYw+U+1ZXSmQ="),
-			testonly.MustDecodeBase64("wDB5KKmLMkH4eWtv9HHb8SmatjP4kjYuKW14nQI+yAk="),
-		},
-		testonly.MustDecodeBase64("7LkdcssuSGAv+6BrLXhUXZbuxWepuGy6ZaJe2JcHy2w="),
-	}, {
-		"key-4-848",
-		[]byte("value-4-848"),
-		[][]byte{
-			// 243 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil,
-			testonly.MustDecodeBase64("RMUW9pcA1aAv4UgU8P5m7SrD0b3CCcO+Bhc0T/AfYsc="),
-			testonly.MustDecodeBase64("r+tZ2h/t75Ef1KXh1NaEAx7K2WDrhOHwoa4qJIcsYCw="),
-			testonly.MustDecodeBase64("lytZmQPjKcQ6ylWru5U/j6TPq9OtEgBO7UAkEeJt8+s="),
-			testonly.MustDecodeBase64("UDbur6hehAiic3ov1VXWWafqdwGD35gSEhC1OD8t8YE="),
-			testonly.MustDecodeBase64("BgD8awFsMcQJYZfIe1PhqkiEDH1fo/WCDcsoZ3szVNE="),
-			testonly.MustDecodeBase64("QJCGI/QhjajxLJdEEqR9JBylBa65AuN2ppvY+6qFmX0="),
-			testonly.MustDecodeBase64("Baws8Zc/6ql08L7m4alVJqo7bske1EhRteNVEUEEaZA="),
-			testonly.MustDecodeBase64("us0ShL/Ly3Jp5Vxx6jutAHEWVl1H2MKYkUNyeJjOg4Q="),
-			testonly.MustDecodeBase64("aDtxuuyTm/u1BgLvVzCQt5rYY7of9o2l5ovLc5Lp4rA="),
-			testonly.MustDecodeBase64("Eb3b6jxsqEjO2YKcsWE7exMDP15QVohkwRDaNO7QOwo="),
-			testonly.MustDecodeBase64("M/Q7RQtMDsE2bok/JxYwc4Rco3H0Juil1XfmRWtbbUw="),
-			testonly.MustDecodeBase64("QLSisPLWbV8FjwrFnUJxqyMKDnof//Djjrq082btVsQ="),
-			testonly.MustDecodeBase64("UoDpJ8sv0EymM0xNz/gUHB1icfS67wE5m+lUDGVI6Ic="),
-		},
-		testonly.MustDecodeBase64("bEapbZbXfyhAZqLAFPpbx2KMX/m9FvHenwFJFIn2LHs="),
-	}, {
-		"key-4-848",
-		[]byte("value-4-848"),
-		[][]byte{
-			// 243 x nil
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil,
-			testonly.MustDecodeBase64("RMUW9pcA1aAv4UgU8P5m7SrD0b3CCcO+Bhc0T/AfYsc="),
-			testonly.MustDecodeBase64("r+tZ2h/t75Ef1KXh1NaEAx7K2WDrhOHwoa4qJIcsYCw="),
-			testonly.MustDecodeBase64("lytZmQPjKcQ6ylWru5U/j6TPq9OtEgBO7UAkEeJt8+s="),
-			testonly.MustDecodeBase64("UDbur6hehAiic3ov1VXWWafqdwGD35gSEhC1OD8t8YE="),
-			testonly.MustDecodeBase64("BgD8awFsMcQJYZfIe1PhqkiEDH1fo/WCDcsoZ3szVNE="),
-			testonly.MustDecodeBase64("QJCGI/QhjajxLJdEEqR9JBylBa65AuN2ppvY+6qFmX0="),
-			testonly.MustDecodeBase64("Baws8Zc/6ql08L7m4alVJqo7bske1EhRteNVEUEEaZA="),
-			testonly.MustDecodeBase64("us0ShL/Ly3Jp5Vxx6jutAHEWVl1H2MKYkUNyeJjOg4Q="),
-			testonly.MustDecodeBase64("aDtxuuyTm/u1BgLvVzCQt5rYY7of9o2l5ovLc5Lp4rA="),
-			testonly.MustDecodeBase64("Eb3b6jxsqEjO2YKcsWE7exMDP15QVohkwRDaNO7QOwo="),
-			testonly.MustDecodeBase64("M/Q7RQtMDsE2bok/JxYwc4Rco3H0Juil1XfmRWtbbUw="),
-			testonly.MustDecodeBase64("QLSisPLWbV8FjwrFnUJxqyMKDnof//Djjrq082btVsQ="),
-			testonly.MustDecodeBase64("UoDpJ8sv0EymM0xNz/gUHB1icfS67wE5m+lUDGVI6Ic="),
-		},
-		testonly.MustDecodeBase64("bEapbZbXfyhAZqLAFPpbx2KMX/m9FvHenwFJFIn2LHs="),
-	},
+	}
+
+	// Copy the bad proof so we don't mess up the good proof.
+	badProof := make([][]byte, len(tv.Proof))
+	for i := range badProof {
+		badProof[i] = make([]byte, len(tv.Proof[i]))
+		copy(badProof[i], tv.Proof[i])
+	}
+	badProof[250][15] ^= 0x10
+
+	for _, tc := range []struct {
+		desc              string
+		index, leaf, root []byte
+		proof             [][]byte
+		want              bool
+	}{
+		{"correct", tv.Index, tv.Value, tv.ExpectedRoot, tv.Proof, true},
+		{"incorrect key", []byte("w"), tv.Value, tv.ExpectedRoot, tv.Proof, false},
+		{"incorrect value", tv.Index, []byte("w"), tv.ExpectedRoot, tv.Proof, false},
+		{"incorrect root", tv.Index, tv.Value, []byte("w"), tv.Proof, false},
+		{"incorrect proof", tv.Index, tv.Value, tv.ExpectedRoot, badProof, false},
+		{"short proof", tv.Index, tv.Value, tv.ExpectedRoot, [][]byte{[]byte("shorty")}, false},
+		{"excess proof", tv.Index, tv.Value, tv.ExpectedRoot, make([][]byte, h.Size()*8+1), false},
+	} {
+		leafHash := h.HashLeaf(treeID, tc.index, h.BitLen(), tc.leaf)
+		err := VerifyMapInclusionProof(treeID, tc.index, leafHash, tc.root, tc.proof, h)
+		if got := err == nil; got != tc.want {
+			t.Errorf("%v: VerifyMapInclusionProof(): %v, want %v", tc.desc, err, tc.want)
+		}
+	}
 }


### PR DESCRIPTION
In order to facilitate easier debugging and prepare for the needed changes to support #691, I did some preliminary code cleanup: 

- Use canonical sort functions in HStar2
- Use `hasher.BitLen()` in place of `hasher.Size()*8`
- Use index ([]byte)/ value pairs in tests instead of  key (string)/value pairs.
   - This removed a dependency on `testonly.HashKey` 
   - `map[key]value` -> `[][]byte` of alternating index / value pairs.  
- Removed unused test vectors
- Combined `EmptyRoot*` tests into `simpleTestVector`