### PR TITLE
Travis should let tests timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
 script:
   - set -e
   - cd $HOME/gopath/src/github.com/google/trillian
-  - travis_wait ./scripts/presubmit.sh
+  - ./scripts/presubmit.sh
   - |
       # Check re-generation didn't change anything
       # Skip protoc-generated files (.pb.go) because protoc is not deterministic

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
 script:
   - set -e
   - cd $HOME/gopath/src/github.com/google/trillian
-  - ./scripts/presubmit.sh
+  - travis_wait ./scripts/presubmit.sh
   - |
       # Check re-generation didn't change anything
       # Skip protoc-generated files (.pb.go) because protoc is not deterministic

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -93,7 +93,7 @@ main() {
     go build ${go_dirs}
 
     echo 'running go test'
-    go test -cover ${goflags} ${go_dirs}
+    go test -cover -timeout=1m ${goflags} ${go_dirs}
   fi
 
   if [[ "${run_linters}" -eq 1 ]]; then


### PR DESCRIPTION
Travis will kill a build if there is no output for 10 minutes. 10 minutes is also the duration that `go test` will wait before a test times out. By reducing the test timeout, `go test` will get the chance to timeout a test and continue, rather than the build being killing right there. This allows it to print stack traces and detect any other test issues. Reducing the timeout also guarantees that no slow tests will be added in the future.