### PR TITLE
Quota increase factor and other minor adjustments

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -48,6 +48,7 @@ var (
 	etcdService        = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
 	etcdHTTPService    = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in")
+	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 
 	pkcs11ModulePath = flag.String("pkcs11_module_path", "", "Path to the PKCS#11 module to use for keys that use the PKCS#11 interface")
 
@@ -104,6 +105,7 @@ func main() {
 	ti := &interceptor.TrillianInterceptor{
 		Admin:        registry.AdminStorage,
 		QuotaManager: registry.QuotaManager,
+		QuotaDryRun:  *quotaDryRun,
 	}
 	netInterceptor := interceptor.Combine(stats.Interceptor(), interceptor.ErrorWrapper, ti.UnaryInterceptor)
 	s := grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -43,6 +43,7 @@ var (
 	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in")
+	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
@@ -75,6 +76,7 @@ func main() {
 	ti := &interceptor.TrillianInterceptor{
 		Admin:        registry.AdminStorage,
 		QuotaManager: registry.QuotaManager,
+		QuotaDryRun:  *quotaDryRun,
 	}
 	netInterceptor := interceptor.Combine(stats.Interceptor(), interceptor.ErrorWrapper, ti.UnaryInterceptor)
 	s := grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))


### PR DESCRIPTION
Added a quota_increase_factor flag that multiplies the number of replenished
tokens. A value slightly higher than 1 adds resilience to leakages, without too
much impact on legitimate "token outages".

A few minor adjustments have been performed, like not calling Get/Put if tokens
= 0, correctly charging quota of batch write requests and not charging Admin
RPCs.