### PR TITLE
Upgrade logging of ExecutePass() failure from warning to error

### DIFF
--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -341,7 +341,7 @@ func (l *LogOperationManager) getLogsAndExecutePass(ctx context.Context) error {
 				start := time.Now()
 				count, err := l.logOperation.ExecutePass(ctx, logID, &l.info)
 				if err != nil {
-					glog.Warningf("ExecutePass(%v) failed: %v", logID, err)
+					glog.Errorf("ExecutePass(%v) failed: %v", logID, err)
 					continue
 				}
 


### PR DESCRIPTION
This is particularly helpful for the integration tests, as they will show error logging but not warning logging. Since the err is swallowed, the integration tests will never end (until they timeout), and this is surprising if no errors are logged.

Helped with diagnosing #733.