### PR TITLE
Fix memory storage issue where only latest revision was retained.

### DIFF
--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/storagepb"
+	"github.com/golang/protobuf/proto"
 )
 
 const degree = 8
@@ -185,7 +186,10 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []
 			if s == nil {
 				continue
 			}
-			ret = append(ret, s.(*kv).v.(*storagepb.SubtreeProto))
+			// Return a copy of the proto to protect against the caller modifying the stored one.
+			p := s.(*kv).v.(*storagepb.SubtreeProto)
+			v := proto.Clone(p).(*storagepb.SubtreeProto)
+			ret = append(ret, v)
 			break
 		}
 	}

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -22,12 +22,12 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/storagepb"
-	"github.com/golang/protobuf/proto"
 )
 
 const degree = 8


### PR DESCRIPTION
getSubtrees() needs to return a copy of the stored proto as the caller modifies it and then uses it to write the new revision.