### PR TITLE
Replenish tokens for bad requests / duplicate leaves

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -138,6 +138,10 @@ func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, handle
 		}
 	}
 	if tokens > 0 && len(tp.info.specs) > 0 {
+		// TODO(codingllama): If PutTokens turns out to be unreliable we can still leak tokens. In
+		// this case, we may want to keep tabs on how many tokens we failed to replenish and bundle
+		// them up in the next PutTokens call (possibly as a QuotaManager decorator, or internally
+		// in its impl).
 		if err := tp.parent.QuotaManager.PutTokens(ctx, tokens, tp.info.specs); err != nil {
 			glog.Warningf("Failed to replenish %v tokens: %v", tokens, err)
 		}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -113,12 +113,12 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 }
 
 func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, handlerErr error) {
-	// Decide if we have to replenish tokens. There are a few situations that require tokens to be
-	// replenished:
-	// * Invalid requests (a bad request shouldn't spend sequencing-based tokens, as it won't cause
-	//   a corresponding sequencing to happen)
-	// * Requests that filter out duplicates (eg, QueueLeaf and QueueLeaves, for the same reason
-	//   above: duplicates aren't queued for sequencing)
+	// Decide if we have to replenish tokens. There are a few situations that require tokens to
+	// be replenished:
+	// * Invalid requests (a bad request shouldn't spend sequencing-based tokens, as it won't
+	//   cause a corresponding sequencing to happen)
+	// * Requests that filter out duplicates (e.g., QueueLeaf and QueueLeaves, for the same
+	//   reason as above: duplicates aren't queued for sequencing)
 	tokens := 0
 	if handlerErr != nil {
 		// Return the tokens spent by invalid requests


### PR DESCRIPTION
Bad requests and, more importantly, duplicate leaves, may be a major source of token leakage for sequencing-based quotas (as tokens are taken when the request goes in, but never replenished via sequencing). Interceptors are changed to now return tokens in those scenarios.

This change introduces the first block of genuine after-handler logic. To allow for easy ports to non-gRPC environments, the concepts of a RequestProcessor and Before/After have been added.