### PR TITLE
Removes GetActiveLogIDs() from LogTreeTX.

### DIFF
--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -57,7 +57,6 @@ type LogTreeTX interface {
 	LeafReader
 	LeafQueuer
 	LeafDequeuer
-	LogMetadata
 }
 
 // ReadOnlyLogStorage represents a narrowed read-only view into a LogStorage.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -341,19 +341,6 @@ func (_mr *MockLogTreeTXMockRecorder) DequeueLeaves(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DequeueLeaves", arg0, arg1, arg2)
 }
 
-// GetActiveLogIDs mocks base method
-func (_m *MockLogTreeTX) GetActiveLogIDs(_param0 context.Context) ([]int64, error) {
-	ret := _m.ctrl.Call(_m, "GetActiveLogIDs", _param0)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActiveLogIDs indicates an expected call of GetActiveLogIDs
-func (_mr *MockLogTreeTXMockRecorder) GetActiveLogIDs(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetActiveLogIDs", arg0)
-}
-
 // GetLeavesByHash mocks base method
 func (_m *MockLogTreeTX) GetLeavesByHash(_param0 context.Context, _param1 [][]byte, _param2 bool) ([]*trillian.LogLeaf, error) {
 	ret := _m.ctrl.Call(_m, "GetLeavesByHash", _param0, _param1, _param2)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -684,11 +684,6 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 	return ret, nil
 }
 
-// GetActiveLogIDs returns a list of the IDs of all configured logs
-func (t *logTreeTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
-	return getActiveLogIDs(ctx, t.tx)
-}
-
 // byLeafIdentityHash allows sorting of leaves by their identity hash, so DB
 // operations always happen in a consistent order.
 type byLeafIdentityHash []*trillian.LogLeaf

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -921,21 +921,6 @@ func runTestGetActiveLogIDs(ctx context.Context, t *testing.T, test getActiveIDs
 }
 
 func TestGetActiveLogIDs(t *testing.T) {
-	getActiveIDsBegin := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
-		tx, err := s.BeginForTree(ctx, logID)
-		if err != nil {
-			return nil, err
-		}
-		defer tx.Close()
-		ids, err := tx.GetActiveLogIDs(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if err := tx.Commit(); err != nil {
-			return nil, err
-		}
-		return ids, nil
-	}
 	getActiveIDsSnapshot := func(ctx context.Context, s storage.LogStorage, logID int64) ([]int64, error) {
 		tx, err := s.Snapshot(ctx)
 		if err != nil {
@@ -952,15 +937,9 @@ func TestGetActiveLogIDs(t *testing.T) {
 		return ids, nil
 	}
 
-	tests := []getActiveIDsTest{
-		{name: "getActiveIDsBegin", fn: getActiveIDsBegin},
-		{name: "getActiveIDsSnapshot", fn: getActiveIDsSnapshot},
-	}
-
+	test := getActiveIDsTest{name: "getActiveIDsSnapshot", fn: getActiveIDsSnapshot}
 	ctx := context.Background()
-	for _, test := range tests {
-		runTestGetActiveLogIDs(ctx, t, test)
-	}
+	runTestGetActiveLogIDs(ctx, t, test)
 }
 
 func TestGetActiveLogIDsEmpty(t *testing.T) {


### PR DESCRIPTION
This is a meta-data operation, and shouldn't be part of a per-tree TX.