### PR TITLE
Replace makeSuffixKey with NewNodeID().Split() 

### DIFF
--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"math/big"
 	"os"
 	"runtime/pprof"
 	"strings"
@@ -620,33 +619,4 @@ func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 		t.Errorf("Expected root %s, got root: %s", base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(got))
 	}
 	maybeProfileMemory(t)
-}
-
-func bigIntFromString(dec string) *big.Int {
-	r, ok := new(big.Int).SetString(dec, 10)
-	if !ok {
-		panic(fmt.Errorf("Couldn't parse %s as base10", dec))
-	}
-	return r
-}
-
-func TestNodeIDFromAddress(t *testing.T) {
-	testVec := []struct {
-		size           int
-		prefix         []byte
-		index          *big.Int
-		depth          int
-		expectedString string
-	}{
-		{1, []byte{}, big.NewInt(0xaa), 8, "10101010"},
-		{3, []byte{0x12}, big.NewInt(0xaaaa), 16, "000100101010101010101010"},
-		{2, []byte{0x12}, big.NewInt(0x05), 8, "0001001000000101"},
-		{32, []byte{0xd1}, bigIntFromString("1180198625301186407651343252449371352369139634241136100932791642269679616"), 16, "110100010000000010101011"},
-	}
-	for i, vec := range testVec {
-		nID := nodeIDFromAddress(vec.size, vec.prefix, vec.index, vec.depth)
-		if expected, got := vec.expectedString, nID.String(); expected != got {
-			t.Errorf("(test %d) expected %s, got %s (path: %x)", i, expected, got, nID.Path)
-		}
-	}
 }

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -58,6 +58,8 @@ const (
 	depthQuantum = 8
 	// logStrataDepth is the strata that must be used for all log subtrees.
 	logStrataDepth = 8
+	// maxLogDepth is the number of bits in a log path.
+	maxLogDepth = 64
 )
 
 // SubtreeCache provides a caching access to Subtree storage. Currently there are assumptions
@@ -130,23 +132,9 @@ func (s *SubtreeCache) stratumInfoForPrefixLength(numBits int) stratumInfo {
 
 // splitNodeID breaks a NodeID out into its prefix and suffix parts.
 // unless ID is 0 bits long, Suffix must always contain at least one bit.
-func (s *SubtreeCache) splitNodeID(id storage.NodeID) ([]byte, Suffix) {
-	if id.PrefixLenBits == 0 {
-		return []byte{}, Suffix{bits: 0, path: []byte{0}}
-	}
-	a := make([]byte, len(id.Path))
-	copy(a, id.Path)
+func (s *SubtreeCache) splitNodeID(id storage.NodeID) ([]byte, storage.Suffix) {
 	sInfo := s.stratumInfoForPrefixLength(id.PrefixLenBits - 1)
-	prefixSplit := sInfo.prefixBytes
-	sfx := Suffix{
-		bits: byte((id.PrefixLenBits-1)%sInfo.depth) + 1,
-		path: a[prefixSplit : prefixSplit+sInfo.depth/depthQuantum],
-	}
-	maskIndex := int((sfx.bits - 1) / depthQuantum)
-	maskLowBits := (sfx.bits-1)%depthQuantum + 1
-	sfx.path[maskIndex] &= ((0x01 << maskLowBits) - 1) << uint(depthQuantum-maskLowBits)
-
-	return a[:prefixSplit], sfx
+	return id.Split(sInfo.prefixBytes, sInfo.depth)
 }
 
 // preload calculates the set of subtrees required to know the hashes of the
@@ -414,12 +402,10 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				return nil, nil
 			},
 			func(depth int, index *big.Int, h []byte) error {
-				i := index.Int64()
-				sfx, err := makeSuffixKey(depth, i)
-				if err != nil {
-					return err
-				}
-				st.InternalNodes[sfx] = h
+				nodeID := storage.NewNodeIDFromRelativeBigInt(st.Prefix, depth, index, hasher.BitLen())
+				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+				sfxKey := sfx.Serialize()
+				st.InternalNodes[sfxKey] = h
 				return nil
 			})
 		if err != nil {
@@ -456,30 +442,27 @@ func PopulateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 
 		// We need to update the subtree root hash regardless of whether it's fully populated
 		for leafIndex := int64(0); leafIndex < int64(len(st.Leaves)); leafIndex++ {
-			sfx, err := makeSuffixKey(logStrataDepth, leafIndex)
-			if err != nil {
-				return err
-			}
-			h := st.Leaves[sfx]
+			nodeID := storage.NewNodeIDFromPrefix(st.Prefix, logStrataDepth, leafIndex, logStrataDepth, maxLogDepth)
+			_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+			sfxKey := sfx.Serialize()
+			h := st.Leaves[sfxKey]
 			if h == nil {
 				return fmt.Errorf("unexpectedly got nil for subtree leaf suffix %s", sfx)
 			}
-			seq, err := cmt.AddLeafHash(h, func(depth int, index int64, h []byte) error {
-				if depth == 8 && index == 0 {
+			seq, err := cmt.AddLeafHash(h, func(height int, index int64, h []byte) error {
+				if height == logStrataDepth && index == 0 {
 					// no space for the root in the node cache
 					return nil
 				}
-				key, err := makeSuffixKey(logStrataDepth-depth, index<<uint(depth))
-				if err != nil {
-					// This can only happen if we somehow ended up outside of the subtree. For example
-					// if more leaves were added to the CMT than the fully populated count for the strata
-					// depth.
-					return fmt.Errorf("bad suffix key in log repop: %v", err)
-				}
+
+				subDepth := logStrataDepth - height
+				nodeID := storage.NewNodeIDFromPrefix(st.Prefix, subDepth, index, logStrataDepth, maxLogDepth)
+				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+				sfxKey := sfx.Serialize()
 				// Don't put leaves into the internal map and only update if we're rebuilding internal
 				// nodes. If the subtree was saved with internal nodes then we don't touch the map.
-				if depth > 0 && len(st.Leaves) == maxLeaves {
-					st.InternalNodes[key] = h
+				if height > 0 && len(st.Leaves) == maxLeaves {
+					st.InternalNodes[sfxKey] = h
 				}
 				return nil
 			})

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -278,7 +278,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 	// have a fixed depth if the suffix has the same number of significant bits as the
 	// subtree depth then this is a leaf. For example if the subtree is depth 8 its leaves
 	// have 8 significant suffix bits.
-	sfxKey := sx.Serialize()
+	sfxKey := sx.String()
 	if int32(sx.Bits) == c.Depth {
 		nh = c.Leaves[sfxKey]
 	} else {
@@ -319,7 +319,7 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 	s.dirtyPrefixes[prefixKey] = true
 	// Determine whether we're being asked to store a leaf node, or an internal
 	// node, and store it accordingly.
-	sfxKey := sx.Serialize()
+	sfxKey := sx.String()
 	if int32(sx.Bits) == c.Depth {
 		c.Leaves[sfxKey] = h
 	} else {
@@ -404,7 +404,7 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 			func(depth int, index *big.Int, h []byte) error {
 				nodeID := storage.NewNodeIDFromRelativeBigInt(st.Prefix, depth, index, hasher.BitLen())
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
-				sfxKey := sfx.Serialize()
+				sfxKey := sfx.String()
 				st.InternalNodes[sfxKey] = h
 				return nil
 			})
@@ -444,7 +444,7 @@ func PopulateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 		for leafIndex := int64(0); leafIndex < int64(len(st.Leaves)); leafIndex++ {
 			nodeID := storage.NewNodeIDFromPrefix(st.Prefix, logStrataDepth, leafIndex, logStrataDepth, maxLogDepth)
 			_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
-			sfxKey := sfx.Serialize()
+			sfxKey := sfx.String()
 			h := st.Leaves[sfxKey]
 			if h == nil {
 				return fmt.Errorf("unexpectedly got nil for subtree leaf suffix %s", sfx)
@@ -458,7 +458,7 @@ func PopulateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 				subDepth := logStrataDepth - height
 				nodeID := storage.NewNodeIDFromPrefix(st.Prefix, subDepth, index, logStrataDepth, maxLogDepth)
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
-				sfxKey := sfx.Serialize()
+				sfxKey := sfx.String()
 				// Don't put leaves into the internal map and only update if we're rebuilding internal
 				// nodes. If the subtree was saved with internal nodes then we don't touch the map.
 				if height > 0 && len(st.Leaves) == maxLeaves {

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -398,10 +398,11 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 		hs2 := merkle.NewHStar2(treeID, hasher)
 		offset := hasher.BitLen() - rootID.PrefixLenBits - int(st.Depth)
 		root, err := hs2.HStar2Nodes(int(st.Depth), offset, leaves,
-			func(depth int, index *big.Int) ([]byte, error) {
+			func(height int, index *big.Int) ([]byte, error) {
 				return nil, nil
 			},
-			func(depth int, index *big.Int, h []byte) error {
+			func(height int, index *big.Int, h []byte) error {
+				depth := int(st.Depth) - height
 				nodeID := storage.NewNodeIDFromRelativeBigInt(st.Prefix, depth, index, hasher.BitLen())
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.Serialize()

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -398,11 +398,10 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 		hs2 := merkle.NewHStar2(treeID, hasher)
 		offset := hasher.BitLen() - rootID.PrefixLenBits - int(st.Depth)
 		root, err := hs2.HStar2Nodes(int(st.Depth), offset, leaves,
-			func(height int, index *big.Int) ([]byte, error) {
+			func(depth int, index *big.Int) ([]byte, error) {
 				return nil, nil
 			},
-			func(height int, index *big.Int, h []byte) error {
-				depth := int(st.Depth) - height
+			func(depth int, index *big.Int, h []byte) error {
 				nodeID := storage.NewNodeIDFromRelativeBigInt(st.Prefix, depth, index, hasher.BitLen())
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.Serialize()

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -271,7 +271,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			// Don't store leaves or the subtree root in InternalNodes
 			if depth > 0 && depth < 8 {
 				_, sfx := c.splitNodeID(n)
-				cmtStorage.InternalNodes[sfx.Serialize()] = h
+				cmtStorage.InternalNodes[sfx.String()] = h
 			}
 			return nil
 		})
@@ -281,7 +281,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 
 		nodeID := storage.NewNodeIDFromPrefix(s.Prefix, logStrataDepth, numLeaves-1, logStrataDepth, maxLogDepth)
 		_, sfx := nodeID.Split(len(s.Prefix), int(s.Depth))
-		sfxKey := sfx.Serialize()
+		sfxKey := sfx.String()
 		s.Leaves[sfxKey] = leafHash
 		if numLeaves == 1<<uint(defaultLogStrata[0]) {
 			s.InternalNodeCount = uint32(len(cmtStorage.InternalNodes))

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -16,21 +16,21 @@ package cache
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/maphasher"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
-	stestonly "github.com/google/trillian/storage/testonly"
+
+	"github.com/golang/mock/gomock"
 	"github.com/kylelemons/godebug/pretty"
+
+	stestonly "github.com/google/trillian/storage/testonly"
 )
 
 var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
@@ -241,55 +241,6 @@ func TestCacheFlush(t *testing.T) {
 		default:
 			t.Errorf("Unknown state for subtree %s: %s", k, v)
 		}
-	}
-}
-
-func TestSuffixKey(t *testing.T) {
-	for _, tc := range []struct {
-		depth   int
-		index   int64
-		want    []byte
-		wantErr bool
-	}{
-		{depth: 0, index: 0x00, want: h2b("0000"), wantErr: false},
-		{depth: 8, index: 0x00, want: h2b("0800"), wantErr: false},
-		// TODO(gdbelvin): want: "0fabcd"?
-		{depth: 8, index: 0xabcd, want: h2b("08cd"), wantErr: false},
-		// TODO(gdbelvin): want "0240"
-		{
-			depth:   2,
-			index:   new(big.Int).SetBytes(h2b("4000000000000000000000000000000000000000000000000000000000000000")).Int64(),
-			want:    h2b("0200"),
-			wantErr: false,
-		},
-		{depth: 15, index: 0xab, want: h2b("0fab"), wantErr: false},
-		{depth: 16, index: 0x00, want: h2b("1000"), wantErr: false},
-	} {
-		suffixKey, err := makeSuffixKey(tc.depth, tc.index)
-		if got, want := err != nil, tc.wantErr; got != want {
-			t.Errorf("makeSuffixKey(%v, %v): %v, want err: %v",
-				tc.depth, tc.index, err, want)
-			continue
-		}
-		if err != nil {
-			continue
-		}
-		b, err := base64.StdEncoding.DecodeString(suffixKey)
-		if err != nil {
-			t.Errorf("DecodeString(%v): %v", suffixKey, err)
-			continue
-		}
-		if got, want := b, tc.want; !bytes.Equal(got, want) {
-			t.Errorf("makeSuffixKey(%v, %x): %x, want %x",
-				tc.depth, tc.index, got, want)
-		}
-	}
-}
-
-func TestSuffixSerializeFormat(t *testing.T) {
-	s := Suffix{5, []byte{0xae}}
-	if got, want := s.serialize(), "Ba4="; got != want {
-		t.Fatalf("Got serialized suffix of %s, expected %s", got, want)
 	}
 }
 

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Suffix represents the tail of a NodeID, indexing into the Subtree which
+// corresponds to the prefix of the NodeID.
+type Suffix struct {
+	// bits is the number of bits in the node ID suffix.
+	// TODO(gdbelvin): make bits an integer.
+	Bits byte
+	// path is the suffix itself.
+	Path []byte
+}
+
+// Serialize returns a base64 encoding of a byte array with the following format:
+// [ 1 byte for depth || path bytes ]
+func (s Suffix) Serialize() string {
+	r := make([]byte, 1, 1+(len(s.Path)))
+	r[0] = s.Bits
+	r = append(r, s.Path...)
+	return base64.StdEncoding.EncodeToString(r)
+}
+
+// makeSuffixKey creates a suffix key for indexing into the subtree's Leaves and
+// InternalNodes maps.
+// TODO(gdbelvin): deprecate in favor of nodeID.Split()
+func makeSuffixKey(depth int, index int64) (string, error) {
+	if depth < 0 {
+		return "", fmt.Errorf("invalid negative depth of %d", depth)
+	}
+	if index < 0 {
+		return "", fmt.Errorf("invalid negative index %d", index)
+	}
+	sfx := Suffix{byte(depth), []byte{byte(index)}}
+	return sfx.Serialize(), nil
+}

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 )
 
-// Suffix represents the tail of a NodeID, indexing into the Subtree which
-// corresponds to the prefix of the NodeID.
+// Suffix represents the tail of a NodeID. It is the path within the subtree.
+// The portion of the path that extends beyond the subtree is not part of this suffix.
 type Suffix struct {
 	// bits is the number of bits in the node ID suffix.
 	// TODO(gdbelvin): make bits an integer.
@@ -29,9 +29,9 @@ type Suffix struct {
 	Path []byte
 }
 
-// Serialize returns a base64 encoding of a byte array with the following format:
+// String returns a base64 encoding of a byte array with the following format:
 // [ 1 byte for depth || path bytes ]
-func (s Suffix) Serialize() string {
+func (s Suffix) String() string {
 	r := make([]byte, 1, 1+(len(s.Path)))
 	r[0] = s.Bits
 	r = append(r, s.Path...)
@@ -49,5 +49,5 @@ func makeSuffixKey(depth int, index int64) (string, error) {
 		return "", fmt.Errorf("invalid negative index %d", index)
 	}
 	sfx := Suffix{byte(depth), []byte{byte(index)}}
-	return sfx.Serialize(), nil
+	return sfx.String(), nil
 }

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"encoding/base64"
-	"fmt"
 )
 
 // Suffix represents the tail of a NodeID. It is the path within the subtree.
@@ -37,18 +36,4 @@ func (s Suffix) String() string {
 	r[0] = s.Bits
 	r = append(r, s.Path...)
 	return base64.StdEncoding.EncodeToString(r)
-}
-
-// makeSuffixKey creates a suffix key for indexing into the subtree's Leaves and
-// InternalNodes maps.
-// TODO(gdbelvin): deprecate in favor of nodeID.Split()
-func makeSuffixKey(depth int, index int64) (string, error) {
-	if depth < 0 {
-		return "", fmt.Errorf("invalid negative depth of %d", depth)
-	}
-	if index < 0 {
-		return "", fmt.Errorf("invalid negative index %d", index)
-	}
-	sfx := Suffix{byte(depth), []byte{byte(index)}}
-	return sfx.String(), nil
 }

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -29,7 +29,8 @@ type Suffix struct {
 	Path []byte
 }
 
-// String returns a base64 encoding of a byte array with the following format:
+// String returns a string that represents Suffix.
+// This is a base64 encoding of the following format:
 // [ 1 byte for depth || path bytes ]
 func (s Suffix) String() string {
 	r := make([]byte, 1, 1+(len(s.Path)))

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -115,7 +115,7 @@ func TestSuffixSerialize(t *testing.T) {
 		s    Suffix
 		want string
 	}{
-		// Prexisting format. This test vector must NOT change or existing data will be inaccessable.
+		// Prexisting format. This test vector must NOT change or existing data will be inaccessible.
 		{s: Suffix{5, []byte{0xae}}, want: "Ba4="},
 	} {
 		if got, want := tc.s.Serialize(), tc.want; got != want {

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"encoding/base64"
+	"math/big"
+	"testing"
+)
+
+const (
+	logStrataDepth = 8
+	maxLogDepth    = 64
+)
+
+func TestSuffixKeyEquals(t *testing.T) {
+	for _, tc := range []struct {
+		prefix    []byte
+		leafIndex int64
+		want      []byte
+	}{
+		{h2b(""), 1, h2b("0801")},
+		{h2b("00"), 1, h2b("0801")},
+	} {
+		sfxA, err := makeSuffixKey(logStrataDepth, tc.leafIndex)
+		if err != nil {
+			t.Errorf("makeSuffixKey(%v, %v): %v", logStrataDepth, tc.leafIndex, err)
+			continue
+		}
+
+		sfxABytes, err := base64.StdEncoding.DecodeString(sfxA)
+		if err != nil {
+			t.Errorf("makeSuffixKey(%v, %v): %v", logStrataDepth, tc.leafIndex, err)
+			continue
+		}
+
+		if got, want := sfxABytes, tc.want; !bytes.Equal(got, want) {
+			t.Errorf("makeSuffixKey(%v, %v): %x, want %x", logStrataDepth, tc.leafIndex, got, want)
+			continue
+		}
+
+		nodeID := NewNodeIDFromPrefix(tc.prefix, logStrataDepth, tc.leafIndex, logStrataDepth, maxLogDepth)
+		_, sfxB := nodeID.Split(len(tc.prefix), logStrataDepth)
+		sfxBKey := sfxB.Serialize()
+		sfxBBytes, err := base64.StdEncoding.DecodeString(sfxBKey)
+		if err != nil {
+			t.Errorf("splitNodeID(%v): _, %v", nodeID, err)
+			continue
+		}
+
+		if got, want := sfxBBytes, tc.want; !bytes.Equal(got, want) {
+			t.Errorf("[%x, %v].splitNodeID(%v, %v): %v.Serialize(): %x, want %x", nodeID.Path, nodeID.PrefixLenBits, len(tc.prefix), logStrataDepth, sfxB, got, want)
+			continue
+		}
+	}
+}
+
+func TestSuffixKey(t *testing.T) {
+	for _, tc := range []struct {
+		depth   int
+		index   int64
+		want    []byte
+		wantErr bool
+	}{
+		{depth: 0, index: 0x00, want: h2b("0000"), wantErr: false},
+		{depth: 8, index: 0x00, want: h2b("0800"), wantErr: false},
+		// TODO(gdbelvin): want: "0fabcd"?
+		{depth: 8, index: 0xabcd, want: h2b("08cd"), wantErr: false},
+		// TODO(gdbelvin): want "0240"
+		{
+			depth:   2,
+			index:   new(big.Int).SetBytes(h2b("4000000000000000000000000000000000000000000000000000000000000000")).Int64(),
+			want:    h2b("0200"),
+			wantErr: false,
+		},
+		{depth: 15, index: 0xab, want: h2b("0fab"), wantErr: false},
+		{depth: 16, index: 0x00, want: h2b("1000"), wantErr: false},
+	} {
+		suffixKey, err := makeSuffixKey(tc.depth, tc.index)
+		if got, want := err != nil, tc.wantErr; got != want {
+			t.Errorf("makeSuffixKey(%v, %v): %v, want err: %v",
+				tc.depth, tc.index, err, want)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		b, err := base64.StdEncoding.DecodeString(suffixKey)
+		if err != nil {
+			t.Errorf("DecodeString(%v): %v", suffixKey, err)
+			continue
+		}
+		if got, want := b, tc.want; !bytes.Equal(got, want) {
+			t.Errorf("makeSuffixKey(%v, %x): %x, want %x",
+				tc.depth, tc.index, got, want)
+		}
+	}
+}
+
+func TestSuffixSerialize(t *testing.T) {
+	for _, tc := range []struct {
+		s    Suffix
+		want string
+	}{
+		// Prexisting format. This test vector must NOT change or existing data will be inaccessable.
+		{s: Suffix{5, []byte{0xae}}, want: "Ba4="},
+	} {
+		if got, want := tc.s.Serialize(), tc.want; got != want {
+			t.Errorf("%v.serialize(): %v, want %v", tc.s, got, want)
+		}
+	}
+}

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -54,7 +54,7 @@ func TestSuffixKeyEquals(t *testing.T) {
 
 		nodeID := NewNodeIDFromPrefix(tc.prefix, logStrataDepth, tc.leafIndex, logStrataDepth, maxLogDepth)
 		_, sfxB := nodeID.Split(len(tc.prefix), logStrataDepth)
-		sfxBKey := sfxB.Serialize()
+		sfxBKey := sfxB.String()
 		sfxBBytes, err := base64.StdEncoding.DecodeString(sfxBKey)
 		if err != nil {
 			t.Errorf("splitNodeID(%v): _, %v", nodeID, err)
@@ -118,7 +118,7 @@ func TestSuffixSerialize(t *testing.T) {
 		// Prexisting format. This test vector must NOT change or existing data will be inaccessible.
 		{s: Suffix{5, []byte{0xae}}, want: "Ba4="},
 	} {
-		if got, want := tc.s.Serialize(), tc.want; got != want {
+		if got, want := tc.s.String(), tc.want; got != want {
 			t.Errorf("%v.serialize(): %v, want %v", tc.s, got, want)
 		}
 	}

--- a/storage/types.go
+++ b/storage/types.go
@@ -16,7 +16,9 @@ package storage
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"math/big"
 
 	"github.com/google/trillian/storage/storagepb"
 )
@@ -82,6 +84,75 @@ func NewEmptyNodeID(maxLenBits int) NodeID {
 		Path:          make([]byte, bytesForBits(maxLenBits)),
 		PrefixLenBits: 0,
 		PathLenBits:   maxLenBits,
+	}
+}
+
+// NewNodeIDFromPrefix returns a nodeID for a particular node within a subtree.
+// Prefix is the prefix of the subtree.
+// depth is the depth of index from the root of the subtree.
+// index is the horizontal location of the subtree leaf.
+// subDepth is the total number of levels in the subtree.
+// totalDepth is the number of levels in the whole tree.
+func NewNodeIDFromPrefix(prefix []byte, depth int, index int64, subDepth, totalDepth int) NodeID {
+	if got, want := totalDepth%8, 0; got != want || got < want {
+		panic(fmt.Sprintf("storage NewNodeFromPrefix(): totalDepth mod 8: %v, want %v", got, want))
+	}
+	if got, want := subDepth%8, 0; got != want || got < want {
+		panic(fmt.Sprintf("storage NewNodeFromPrefix(): subDepth mod 8: %v, want %v", got, want))
+	}
+	if got, want := depth, 0; got < want {
+		panic(fmt.Sprintf("storage NewNodeFromPrefix(): depth: %v, want >= %v", got, want))
+	}
+
+	// Put prefix in the MSB bits of path.
+	path := make([]byte, totalDepth/8)
+	copy(path, prefix)
+
+	// Convert index into absolute coordinates for subtree.
+	height := subDepth - depth
+	subIndex := index << uint(height) // index is the horizontal index at the given height.
+
+	// Copy subDepth/8 bytes of subIndex into path.
+	subPath := new(bytes.Buffer)
+	binary.Write(subPath, binary.BigEndian, uint64(subIndex))
+	unusedHighBytes := 64/8 - subDepth/8
+	copy(path[len(prefix):], subPath.Bytes()[unusedHighBytes:])
+
+	return NodeID{
+		Path:          path,
+		PrefixLenBits: len(prefix)*8 + depth,
+		PathLenBits:   len(path) * 8,
+	}
+}
+
+// NewNodeIDFromRelativeBigInt returns a NodeID given by a prefix and a subtree index.
+func NewNodeIDFromRelativeBigInt(prefix []byte, subDepth int, subIndex *big.Int, totalDepth int) NodeID {
+	if got, want := subIndex.BitLen(), 64; got > want {
+		panic(fmt.Sprintf("storage NewNodeFromRelativeBigInt(): subIndex.BitLen():  %v, want <= %v", got, want))
+	}
+
+	return NewNodeIDFromPrefix(prefix, subDepth, subIndex.Int64(), subDepth, totalDepth)
+}
+
+// NewNodeIDFromBigInt returns a NodeID of a big.Int with no prefix.
+// index contains the path's least significant bits.
+// depth indicates the number of bits from the most significant bit to treat as part of the path.
+func NewNodeIDFromBigInt(depth int, index *big.Int, totalDepth int) NodeID {
+	if got, want := totalDepth%8, 0; got != want || got < want {
+		panic(fmt.Sprintf("storage NewNodeFromBitInt(): totalDepth mod 8: %v, want %v", got, want))
+	}
+
+	// Put index in the LSB bits of path.
+	path := make([]byte, totalDepth/8)
+	unusedHighBytes := len(path) - len(index.Bytes())
+	copy(path[unusedHighBytes:], index.Bytes())
+
+	// TODO(gdbelvin): consider masking off insignificant bits past depth.
+
+	return NodeID{
+		Path:          path,
+		PrefixLenBits: depth,
+		PathLenBits:   len(path) * 8,
 	}
 }
 
@@ -208,6 +279,25 @@ func (n *NodeID) Siblings() []NodeID {
 		bi++
 	}
 	return r
+}
+
+// Split splits a NodeID into a prefix and a suffix at prefixSplit
+func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
+	if n.PrefixLenBits == 0 {
+		return []byte{}, Suffix{Bits: 0, Path: []byte{0}}
+	}
+	a := make([]byte, len(n.Path))
+	copy(a, n.Path)
+
+	sfx := Suffix{
+		Bits: byte((n.PrefixLenBits-1)%suffixBits) + 1,
+		Path: a[prefixBytes : prefixBytes+suffixBits/8],
+	}
+	maskIndex := int((sfx.Bits - 1) / 8)
+	maskLowBits := (sfx.Bits-1)%8 + 1
+	sfx.Path[maskIndex] &= ((0x01 << maskLowBits) - 1) << uint(8-maskLowBits)
+
+	return a[:prefixBytes], sfx
 }
 
 // Equivalent return true iff the other represents the same path prefix as this NodeID.

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -146,6 +146,26 @@ func TestNewNodeIDWithPrefix(t *testing.T) {
 	}
 }
 
+var nodeIDForTreeCoordsVec = []struct {
+	depth      int64
+	index      int64
+	maxBits    int
+	shouldFail bool
+	expected   string
+}{
+	{0, 0x00, 8, false, "00000000"},
+	{0, 0x01, 8, false, "00000001"},
+	{0, 0x01, 15, false, "000000000000001"},
+	{1, 0x01, 8, false, "0000001"},
+	{2, 0x04, 8, false, "000100"},
+	{8, 0x01, 16, false, "00000001"},
+	{8, 0x01, 9, false, "1"},
+	{0, 0x80, 8, false, "10000000"},
+	{0, 0x01, 64, false, "0000000000000000000000000000000000000000000000000000000000000001"},
+	{63, 0x01, 64, false, "1"},
+	{63, 0x02, 64, true, "index of 0x02 is too large for given depth"},
+}
+
 func TestNewNodeIDForTreeCoords(t *testing.T) {
 	for _, v := range []struct {
 		height     int64

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -95,6 +95,36 @@ func TestSplit(t *testing.T) {
 	}
 }
 
+func TestNewNodeIDFromRelativeBigInt(t *testing.T) {
+	for _, tc := range []struct {
+		prefix     []byte
+		depth      int
+		index      int64
+		subDepth   int
+		totalDepth int
+		wantPath   []byte
+		wantDepth  int
+	}{
+		{prefix: h2b(""), depth: 8, index: 0, subDepth: 8, totalDepth: 64, wantPath: h2b("0000000000000000"), wantDepth: 8},
+		{prefix: h2b(""), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0100000000000000"), wantDepth: 8},
+		{prefix: h2b("00"), depth: 7, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0001000000000000"), wantDepth: 15},
+		{prefix: h2b("00"), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0001000000000000"), wantDepth: 16},
+		{prefix: h2b("00"), depth: 16, index: 257, subDepth: 16, totalDepth: 64, wantPath: h2b("0001010000000000"), wantDepth: 24},
+		{prefix: h2b("12345678"), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("1234567801000000"), wantDepth: 40},
+	} {
+		i := big.NewInt(tc.index)
+		n := NewNodeIDFromRelativeBigInt(tc.prefix, tc.depth, i, tc.totalDepth)
+		if got, want := n.Path, tc.wantPath; !bytes.Equal(got, want) {
+			t.Errorf("NewNodeIDFromRelativeBigInt(%x, %v, %v, %v, %v).Path: %x, want %x",
+				tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth, got, want)
+		}
+		if got, want := n.PrefixLenBits, tc.wantDepth; got != want {
+			t.Errorf("NewNodeIDFromRelativeBigInt(%x, %v, %v, %v, %v).Depth: %v, want %v",
+				tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth, got, want)
+		}
+	}
+}
+
 func TestNewNodeIDFromPrefix(t *testing.T) {
 	for _, tc := range []struct {
 		prefix     []byte
@@ -122,7 +152,6 @@ func TestNewNodeIDFromPrefix(t *testing.T) {
 				tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth, got, want)
 		}
 	}
-
 }
 
 func TestNewNodeIDWithPrefix(t *testing.T) {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -18,9 +18,112 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strconv"
 	"testing"
 )
+
+func TestNewNodeIDFromBigInt(t *testing.T) {
+	for _, tc := range []struct {
+		depth      int
+		index      *big.Int
+		totalDepth int
+		wantPath   []byte
+		wantDepth  int
+	}{
+		{256, new(big.Int).SetBytes(h2b("00")), 256, h2b("0000000000000000000000000000000000000000000000000000000000000000"), 256},
+		{256, new(big.Int).SetBytes(h2b("01")), 256, h2b("0000000000000000000000000000000000000000000000000000000000000001"), 256},
+		{8, new(big.Int).SetBytes(h2b("4100000000000000000000000000000000000000000000000000000000000000")), 256,
+			h2b("4100000000000000000000000000000000000000000000000000000000000000"), 8},
+	} {
+		n := NewNodeIDFromBigInt(tc.depth, tc.index, tc.totalDepth)
+		if got, want := n.Path, tc.wantPath; !bytes.Equal(got, want) {
+			t.Errorf("NewNodeIDFromBigInt(%v, %x, %v): %x, want %x",
+				tc.depth, tc.index.Bytes(), tc.totalDepth, got, want)
+		}
+		if got, want := n.PrefixLenBits, tc.wantDepth; got != want {
+			t.Errorf("NewNodeIDFromBigInt(%v, %x, %v): depth %v, want %v",
+				tc.depth, tc.index.Bytes(), tc.totalDepth, got, want)
+		}
+	}
+}
+
+func TestSplit(t *testing.T) {
+	for _, tc := range []struct {
+		inPath                 []byte
+		inPathLenBits          int
+		splitBytes, suffixBits int
+		outPrefix              []byte
+		outSuffixBits          int
+		outSuffix              []byte
+	}{
+		{h2b("1234567f"), 32, 3, 8, h2b("123456"), 8, h2b("7f")},
+		{h2b("123456ff"), 29, 3, 8, h2b("123456"), 5, h2b("f8")},
+		{h2b("123456ff"), 25, 3, 8, h2b("123456"), 1, h2b("80")},
+		{h2b("12345678"), 16, 1, 8, h2b("12"), 8, h2b("34")},
+		{h2b("12345678"), 9, 1, 8, h2b("12"), 1, h2b("00")},
+		{h2b("12345678"), 8, 0, 8, h2b(""), 8, h2b("12")},
+		{h2b("12345678"), 7, 0, 8, h2b(""), 7, h2b("12")},
+		{h2b("12345678"), 0, 0, 8, h2b(""), 0, h2b("00")},
+		{h2b("70"), 2, 0, 8, h2b(""), 2, h2b("40")},
+		{h2b("70"), 3, 0, 8, h2b(""), 3, h2b("60")},
+		{h2b("70"), 4, 0, 8, h2b(""), 4, h2b("70")},
+		{h2b("70"), 5, 0, 8, h2b(""), 5, h2b("70")},
+		{h2b("0003"), 16, 1, 8, h2b("00"), 8, h2b("03")},
+		{h2b("0003"), 15, 1, 8, h2b("00"), 7, h2b("02")},
+		{h2b("0001000000000000"), 8, 1, 8, h2b("00"), 8, h2b("01")},
+		{h2b("0100000000000000"), 8, 0, 8, h2b(""), 8, h2b("01")},
+	} {
+		n := NewNodeIDFromHash(tc.inPath)
+		n.PrefixLenBits = tc.inPathLenBits
+
+		p, s := n.Split(tc.splitBytes, tc.suffixBits)
+		if got, want := p, tc.outPrefix; !bytes.Equal(got, want) {
+			t.Errorf("%x.Split(%v, %v): prefix %x, want %x",
+				tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
+			continue
+		}
+		if got, want := int(s.Bits), tc.outSuffixBits; got != want {
+			t.Errorf("%x.Split(%v, %v): suffix.Bits %v, want %d",
+				tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
+			continue
+		}
+		if got, want := s.Path, tc.outSuffix; !bytes.Equal(got, want) {
+			t.Errorf("%x.Split(%v, %v).Path: %x, want %x",
+				tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
+		}
+	}
+}
+
+func TestNewNodeIDFromPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		prefix     []byte
+		depth      int
+		index      int64
+		subDepth   int
+		totalDepth int
+		wantPath   []byte
+		wantDepth  int
+	}{
+		{prefix: h2b(""), depth: 8, index: 0, subDepth: 8, totalDepth: 64, wantPath: h2b("0000000000000000"), wantDepth: 8},
+		{prefix: h2b(""), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0100000000000000"), wantDepth: 8},
+		{prefix: h2b("00"), depth: 7, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0002000000000000"), wantDepth: 15},
+		{prefix: h2b("00"), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("0001000000000000"), wantDepth: 16},
+		{prefix: h2b("00"), depth: 16, index: 257, subDepth: 16, totalDepth: 64, wantPath: h2b("0001010000000000"), wantDepth: 24},
+		{prefix: h2b("12345678"), depth: 8, index: 1, subDepth: 8, totalDepth: 64, wantPath: h2b("1234567801000000"), wantDepth: 40},
+	} {
+		n := NewNodeIDFromPrefix(tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth)
+		if got, want := n.Path, tc.wantPath; !bytes.Equal(got, want) {
+			t.Errorf("NewNodeIDFromPrefix(%x, %v, %v, %v, %v).Path: %x, want %x",
+				tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth, got, want)
+		}
+		if got, want := n.PrefixLenBits, tc.wantDepth; got != want {
+			t.Errorf("NewNodeIDFromPrefix(%x, %v, %v, %v, %v).Depth: %v, want %v",
+				tc.prefix, tc.depth, tc.index, tc.subDepth, tc.totalDepth, got, want)
+		}
+	}
+
+}
 
 func TestNewNodeIDWithPrefix(t *testing.T) {
 	for _, tc := range []struct {
@@ -30,27 +133,10 @@ func TestNewNodeIDWithPrefix(t *testing.T) {
 		maxLen   int
 		want     []byte
 	}{
-		{
-			input:    h26("00"),
-			inputLen: 0,
-			pathLen:  0,
-			maxLen:   64,
-			want:     h2b("0000000000000000"),
-		},
-		{
-			input:    h26("12345678"),
-			inputLen: 32,
-			pathLen:  32,
-			maxLen:   64,
-			want:     h2b("1234567800000000"),
-		},
-		{
-			input:    h26("345678"),
-			inputLen: 15,
-			pathLen:  16,
-			maxLen:   24,
-			want:     h2b("acf000"), // top 15 bits of 0x345678 are: 0101 0110 0111 1000
-		},
+		{input: h26("00"), inputLen: 0, pathLen: 0, maxLen: 64, want: h2b("0000000000000000")},
+		{input: h26("12345678"), inputLen: 32, pathLen: 32, maxLen: 64, want: h2b("1234567800000000")},
+		// top 15 bits of 0x345678 are: 0101 0110 0111 1000
+		{input: h26("345678"), inputLen: 15, pathLen: 16, maxLen: 24, want: h2b("acf000")},
 	} {
 		n := NewNodeIDWithPrefix(tc.input, tc.inputLen, tc.pathLen, tc.maxLen)
 		if got, want := n.Path, tc.want; !bytes.Equal(got, want) {
@@ -58,7 +144,6 @@ func TestNewNodeIDWithPrefix(t *testing.T) {
 				tc.input, tc.inputLen, tc.pathLen, tc.maxLen, got, want)
 		}
 	}
-
 }
 
 func TestNewNodeIDForTreeCoords(t *testing.T) {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -73,6 +73,9 @@ func TestSplit(t *testing.T) {
 		{h2b("0003"), 15, 1, 8, h2b("00"), 7, h2b("02")},
 		{h2b("0001000000000000"), 8, 1, 8, h2b("00"), 8, h2b("01")},
 		{h2b("0100000000000000"), 8, 0, 8, h2b(""), 8, h2b("01")},
+		// Map subtree scenarios
+		{h2b("0100000000000000"), 8, 0, 16, h2b(""), 8, h2b("0100")},
+		{h2b("0100000000000000"), 8, 0, 32, h2b(""), 8, h2b("01000000")},
 	} {
 		n := NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits


### PR DESCRIPTION
In order for Trillian to retrieve the nodes it stores, `makeSuffixKey` must produce exactly the same output as`splitNodeID`. Rather than trying to keep multiple functions in-sync, this PR opts to generate all suffixKeys through `splitNodeID`.  As a result, the code becomes self-documenting. The code declares the exact location of the node that it is operating on, and the rest is handled automatically. 

`NodeID`s are created in several different ways throughout the codebase.  This PR gathers the various methods for node creation in a central place with several new `NewNodeID` functions:
- `NewNodeIDFromPrefix` creates `NodeIDs` from within `PopulateLogSubtreeNodes`
- `NewNodeIDFromRelativeBigInt` creates `NodeIDs` from within `PopulateMapSubtreeNodes`
- `NewNodeIDFromBigInt` creates `NodeIDs` from a future version of `PopulateMapSubtreeNodes`
