### PR TITLE
Add gLogging for debugging

### DIFF
--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -361,7 +361,7 @@ func TestNonExistentLeaf(t *testing.T) {
 			}
 			if err := merkle.VerifyMapInclusionProof(tree.TreeId, index,
 				leafHash, rootHash, proof, hasher); err != nil {
-				t.Errorf("verifyMapInclusionProof(%x): %v", index, err)
+				t.Errorf("%v: VerifyMapInclusionProof(%x): %v", tc.desc, index, err)
 			}
 		}
 	}

--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
 )
@@ -63,7 +64,9 @@ func (m *hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 	binary.Write(h, binary.BigEndian, uint64(treeID))
 	h.Write(m.maskIndex(index, depth))
 	binary.Write(h, binary.BigEndian, uint32(depth))
-	return h.Sum(nil)
+	r := h.Sum(nil)
+	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	return r
 }
 
 // HashLeaf calculate the merkle tree leaf value:
@@ -77,7 +80,9 @@ func (m *hasher) HashLeaf(treeID int64, index []byte, height int, leaf []byte) [
 	h.Write(m.maskIndex(index, depth))
 	binary.Write(h, binary.BigEndian, uint32(depth))
 	h.Write(leaf)
-	return h.Sum(nil)
+	p := h.Sum(nil)
+	glog.V(5).Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
+	return p
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
@@ -86,7 +91,9 @@ func (m *hasher) HashChildren(l, r []byte) []byte {
 	h := m.New()
 	h.Write(l)
 	h.Write(r)
-	return h.Sum(nil)
+	p := h.Sum(nil)
+	glog.V(5).Infof("HashChildren(%x, %x): %x", l, r, p)
+	return p
 }
 
 // BitLen returns the number of bits in the hash function.

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -34,7 +34,6 @@ type LogHasher interface {
 }
 
 // MapHasher provides the hash functions needed to compute sparse merkle trees.
-// TODO(gbelvin): Update interface to match #670
 type MapHasher interface {
 	// HashEmpty returns the hash of an empty branch at a given depth.
 	// A height of 0 indicates an empty leaf. The maximum height is Size*8.
@@ -44,11 +43,11 @@ type MapHasher interface {
 	HashLeaf(treeID int64, index []byte, height int, leaf []byte) []byte
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
-	// Size is the number of bits in the underlying hash function.
-	// It is also the height of the merkle tree.
+	// Size is the number of bytes in the underlying hash function.
 	// TODO(gbelvin): Replace Size() with BitLength().
 	Size() int
 	// BitLen returns the number of bits in the underlying hash function.
+	// It is also the height of the merkle tree.
 	BitLen() int
 }
 

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian/merkle/hashers"
 )
 
@@ -84,6 +85,12 @@ type SparseSetNodeFunc func(depth int, index *big.Int, hash []byte) error
 // levels of a 256-level tree).  To do this, you'd set treeDepth=8, and
 // treeLevelOffset=248 (256-8).
 func (s *HStar2) HStar2Nodes(treeDepth, treeLevelOffset int, values []HStar2LeafHash, get SparseGetNodeFunc, set SparseSetNodeFunc) ([]byte, error) {
+	if glog.V(3) {
+		glog.Infof("HStar2Nodes(%v, %v, %v)", treeDepth, treeLevelOffset, len(values))
+		for _, v := range values {
+			glog.Infof("  %x: %x", v.Index.Bytes(), v.LeafHash)
+		}
+	}
 	if treeLevelOffset < 0 {
 		return nil, ErrNegativeTreeLevelOffset
 	}

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -77,7 +77,7 @@ func (m *MapHasher) HashLeaf(treeID int64, index []byte, height int, leaf []byte
 	h.Write(leaf)
 	r := h.Sum(nil)
 	depth := m.BitLen() - height
-	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	glog.V(5).Infof("HashLeaf(%x, %d): %x", index, depth, r)
 	return r
 }
 

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
 )
@@ -63,6 +64,8 @@ func (m *MapHasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 	if height < 0 || height >= len(m.nullHashes) {
 		panic(fmt.Sprintf("HashEmpty(%v) out of bounds", height))
 	}
+	depth := m.BitLen() - height
+	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, m.nullHashes[height])
 	return m.nullHashes[height]
 }
 
@@ -72,7 +75,10 @@ func (m *MapHasher) HashLeaf(treeID int64, index []byte, height int, leaf []byte
 	h := m.New()
 	h.Write([]byte{leafHashPrefix})
 	h.Write(leaf)
-	return h.Sum(nil)
+	r := h.Sum(nil)
+	depth := m.BitLen() - height
+	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	return r
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
@@ -82,7 +88,9 @@ func (m *MapHasher) HashChildren(l, r []byte) []byte {
 	h.Write([]byte{nodeHashPrefix})
 	h.Write(l)
 	h.Write(r)
-	return h.Sum(nil)
+	p := h.Sum(nil)
+	glog.V(5).Infof("HashChildren(%x, %x): %x", l, r, p)
+	return p
 }
 
 // BitLen returns the number of bits in the hash function.

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/storage"
 )
@@ -225,6 +226,8 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context) {
 	root, err := hs2.HStar2Nodes(s.subtreeDepth, treeDepthOffset, leaves,
 		func(height int, index *big.Int) ([]byte, error) {
 			nodeID := storage.NewNodeIDFromRelativeBigInt(s.prefix, height, index, totalDepth)
+			glog.V(4).Infof("buildSubtree.get(%x, %d) nid: %x, %v",
+				index.Bytes(), height, nodeID.Path, nodeID.PrefixLenBits)
 			nodes, err := s.tx.GetMerkleNodes(ctx, s.treeRevision, []storage.NodeID{nodeID})
 			if err != nil {
 				return nil, err
@@ -247,6 +250,8 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context) {
 				return nil
 			}
 			nodeID := storage.NewNodeIDFromRelativeBigInt(s.prefix, height, index, totalDepth)
+			glog.V(4).Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
+				index.Bytes(), height, nodeID.Path, nodeID.PrefixLenBits, h)
 			nodesToStore = append(nodesToStore,
 				storage.Node{
 					NodeID:       nodeID,

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -88,7 +88,6 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 	inclusions := make([]*trillian.MapLeafInclusion, 0, len(req.Index))
 	found := 0
 	for _, index := range req.Index {
-		// TODO(gdbelvin): specify the index length in the tree specification.
 		if got, want := len(index), hasher.Size(); got != want {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"index len(%x): %v, want %v", index, got, want)

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -292,7 +292,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 	}
 	if glog.V(4) {
 		b, _ := base64.StdEncoding.DecodeString(sfxKey)
-		glog.Infof("getNodeHashUnderLock(%s | %x): %x", prefixKey, b, nh)
+		glog.Infof("getNodeHashUnderLock(%x | %x): %x", prefixKey, b, nh)
 	}
 	if nh == nil {
 		return nil, nil
@@ -421,7 +421,7 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				sfxKey := sfx.String()
 				if glog.V(4) {
 					b, _ := base64.StdEncoding.DecodeString(sfxKey)
-					glog.Infof("PopulateMapSubtreeNodes.Get(%x, %d) suffix: %x: %x", index.Bytes(), depth, b, h)
+					glog.Infof("PopulateMapSubtreeNodes.Set(%x, %d) suffix: %x: %x", index.Bytes(), depth, b, h)
 				}
 				st.InternalNodes[sfxKey] = h
 				return nil

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -251,7 +251,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 	prefixKey := string(px)
 	c := s.subtrees[prefixKey]
 	if c == nil {
-		glog.Warningf("Cache miss for %x so we'll try to fetch from storage", prefixKey)
+		glog.Infof("Cache miss for %x so we'll try to fetch from storage", prefixKey)
 		// Cache miss, so we'll try to fetch from storage.
 		subID := id
 		subID.PrefixLenBits = len(px) * depthQuantum // this won't work if depthQuantum changes
@@ -291,7 +291,10 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 		nh = c.InternalNodes[sfxKey]
 	}
 	if glog.V(4) {
-		b, _ := base64.StdEncoding.DecodeString(sfxKey)
+		b, err := base64.StdEncoding.DecodeString(sfxKey)
+		if err != nil {
+			glog.Errorf("base64.DecodeString(%v): %v", sfxKey, err)
+		}
 		glog.Infof("getNodeHashUnderLock(%x | %x): %x", prefixKey, b, nh)
 	}
 	if nh == nil {
@@ -336,7 +339,10 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 		c.InternalNodes[sfxKey] = h
 	}
 	if glog.V(4) {
-		b, _ := base64.StdEncoding.DecodeString(sfxKey)
+		b, err := base64.StdEncoding.DecodeString(sfxKey)
+		if err != nil {
+			glog.Errorf("base64.DecodeString(%v): %v", sfxKey, err)
+		}
 		glog.Infof("SetNodeHash(pfx: %s, sfx: %x): %x", prefixKey, b, h)
 	}
 	return nil
@@ -420,7 +426,10 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.String()
 				if glog.V(4) {
-					b, _ := base64.StdEncoding.DecodeString(sfxKey)
+					b, err := base64.StdEncoding.DecodeString(sfxKey)
+					if err != nil {
+						glog.Errorf("base64.DecodeString(%v): %v", sfxKey, err)
+					}
 					glog.Infof("PopulateMapSubtreeNodes.Set(%x, %d) suffix: %x: %x", index.Bytes(), depth, b, h)
 				}
 				st.InternalNodes[sfxKey] = h

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -198,6 +198,11 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 // GetNodes returns the requested nodes, calling the getSubtrees function if
 // they are not already cached.
 func (s *SubtreeCache) GetNodes(ids []storage.NodeID, getSubtrees GetSubtreesFunc) ([]storage.Node, error) {
+	if glog.V(4) {
+		for _, n := range ids {
+			glog.Infof("cache: GetNodes(%x, %d", n.Path, n.PrefixLenBits)
+		}
+	}
 	if err := s.preload(ids, getSubtrees); err != nil {
 		return nil, err
 	}
@@ -246,6 +251,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 	prefixKey := string(px)
 	c := s.subtrees[prefixKey]
 	if c == nil {
+		glog.Warningf("Cache miss for %x so we'll try to fetch from storage", prefixKey)
 		// Cache miss, so we'll try to fetch from storage.
 		subID := id
 		subID.PrefixLenBits = len(px) * depthQuantum // this won't work if depthQuantum changes
@@ -283,6 +289,10 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 		nh = c.Leaves[sfxKey]
 	} else {
 		nh = c.InternalNodes[sfxKey]
+	}
+	if glog.V(4) {
+		b, _ := base64.StdEncoding.DecodeString(sfxKey)
+		glog.Infof("getNodeHashUnderLock(%s | %x): %x", prefixKey, b, nh)
 	}
 	if nh == nil {
 		return nil, nil
@@ -324,6 +334,10 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 		c.Leaves[sfxKey] = h
 	} else {
 		c.InternalNodes[sfxKey] = h
+	}
+	if glog.V(4) {
+		b, _ := base64.StdEncoding.DecodeString(sfxKey)
+		glog.Infof("SetNodeHash(pfx: %s, sfx: %x): %x", prefixKey, b, h)
 	}
 	return nil
 }
@@ -405,6 +419,10 @@ func PopulateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				nodeID := storage.NewNodeIDFromRelativeBigInt(st.Prefix, depth, index, hasher.BitLen())
 				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.String()
+				if glog.V(4) {
+					b, _ := base64.StdEncoding.DecodeString(sfxKey)
+					glog.Infof("PopulateMapSubtreeNodes.Get(%x, %d) suffix: %x: %x", index.Bytes(), depth, b, h)
+				}
 				st.InternalNodes[sfxKey] = h
 				return nil
 			})

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -253,7 +253,7 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []
 				subtreeIDBytes, subtree.Prefix, subtree.Depth)
 			for k, v := range subtree.Leaves {
 				b, _ := base64.StdEncoding.DecodeString(k)
-				glog.Infof("     %s: %x", b, v)
+				glog.Infof("     %x: %x", b, v)
 			}
 		}
 	}

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -252,7 +252,10 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []
 			glog.Infof("  subtree: NID: %x, prefix: %x, depth: %d",
 				subtreeIDBytes, subtree.Prefix, subtree.Depth)
 			for k, v := range subtree.Leaves {
-				b, _ := base64.StdEncoding.DecodeString(k)
+				b, err := base64.StdEncoding.DecodeString(k)
+				if err != nil {
+					glog.Errorf("base64.DecodeString(%v): %v", k, err)
+				}
 				glog.Infof("     %x: %x", b, v)
 			}
 		}
@@ -267,10 +270,13 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 	if glog.V(4) {
 		glog.Infof("storeSubtrees(")
 		for _, s := range subtrees {
-			glog.V(4).Infof("  prefix: %x, depth: %d", s.Prefix, s.Depth)
+			glog.Infof("  prefix: %x, depth: %d", s.Prefix, s.Depth)
 			for k, v := range s.Leaves {
-				b, _ := base64.StdEncoding.DecodeString(k)
-				glog.V(4).Infof("     %x: %x", b, v)
+				b, err := base64.StdEncoding.DecodeString(k)
+				if err != nil {
+					glog.Errorf("base64.DecodeString(%v): %v", k, err)
+				}
+				glog.Infof("     %x: %x", b, v)
 			}
 		}
 	}


### PR DESCRIPTION
There are the logging statements I added while debugging the merkle tree. 
These may be useful for others in the future.  They're relatively verbose, so they're hidden behind relatively high verbose glog numbers. 