### PR TITLE
Record quota and interceptor related metrics

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -381,15 +381,17 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int, gu
 	// where the tokens come from.
 	if numLeaves > 0 {
 		tokens := int(float64(numLeaves) * quotaIncreaseFactor())
-		glog.V(2).Infof("Replenishing %v tokens for tree %v (numLeaves = %v)", tokens, logID, leaves)
-		if err := s.qm.PutTokens(ctx, tokens, []quota.Spec{
+		specs := []quota.Spec{
 			{Group: quota.Tree, Kind: quota.Read, TreeID: logID},
 			{Group: quota.Tree, Kind: quota.Write, TreeID: logID},
 			{Group: quota.Global, Kind: quota.Read},
 			{Group: quota.Global, Kind: quota.Write},
-		}); err != nil {
+		}
+		glog.V(2).Infof("Replenishing %v tokens for tree %v (numLeaves = %v)", tokens, logID, leaves)
+		if err := s.qm.PutTokens(ctx, tokens, specs); err != nil {
 			glog.Warningf("Failed to replenish %v tokens for tree %v: %v", tokens, logID, err)
 		}
+		quota.Metrics.IncReplenished(tokens, specs)
 	}
 
 	seqCounter.Add(float64(numLeaves), label)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -388,10 +388,11 @@ func (s Sequencer) SequenceBatch(ctx context.Context, logID int64, limit int, gu
 			{Group: quota.Global, Kind: quota.Write},
 		}
 		glog.V(2).Infof("Replenishing %v tokens for tree %v (numLeaves = %v)", tokens, logID, leaves)
-		if err := s.qm.PutTokens(ctx, tokens, specs); err != nil {
+		err := s.qm.PutTokens(ctx, tokens, specs)
+		if err != nil {
 			glog.Warningf("Failed to replenish %v tokens for tree %v: %v", tokens, logID, err)
 		}
-		quota.Metrics.IncReplenished(tokens, specs)
+		quota.Metrics.IncReplenished(tokens, specs, err != nil)
 	}
 
 	seqCounter.Add(float64(numLeaves), label)

--- a/monitoring/labels.go
+++ b/monitoring/labels.go
@@ -17,5 +17,5 @@ package monitoring
 const (
 	// TreeIDLabel is the monitoring label used to represent a tree ID.
 	// TODO(codingllama): Consider using TreeIDLabel in place of log ID.
-	TreeIDLabel = "tree-id"
+	TreeIDLabel = "tree_id"
 )

--- a/monitoring/labels.go
+++ b/monitoring/labels.go
@@ -1,0 +1,21 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+const (
+	// TreeIDLabel is the monitoring label used to represent a tree ID.
+	// TODO(codingllama): Consider using TreeIDLabel in place of log ID.
+	TreeIDLabel = "tree-id"
+)

--- a/quota/metrics.go
+++ b/quota/metrics.go
@@ -14,7 +14,11 @@
 
 package quota
 
-import "github.com/google/trillian/monitoring"
+import (
+	"fmt"
+
+	"github.com/google/trillian/monitoring"
+)
 
 // Metrics groups all quota-related metrics.
 // The metrics represented here are not meant to be maintained by the quota subsystem
@@ -30,32 +34,32 @@ type m struct {
 }
 
 // IncAcquired increments the AcquiredTokens metric.
-func (m *m) IncAcquired(tokens int, specs []Spec) {
-	m.add(m.AcquiredTokens, tokens, specs)
+func (m *m) IncAcquired(tokens int, specs []Spec, success bool) {
+	m.add(m.AcquiredTokens, tokens, specs, success)
 }
 
 // IncReturned increments the ReturnedTokens metric.
-func (m *m) IncReturned(tokens int, specs []Spec) {
-	m.add(m.ReturnedTokens, tokens, specs)
+func (m *m) IncReturned(tokens int, specs []Spec, success bool) {
+	m.add(m.ReturnedTokens, tokens, specs, success)
 }
 
 // IncReplenished increments the ReplenishedTokens metric.
-func (m *m) IncReplenished(tokens int, specs []Spec) {
-	m.add(m.ReplenishedTokens, tokens, specs)
+func (m *m) IncReplenished(tokens int, specs []Spec, success bool) {
+	m.add(m.ReplenishedTokens, tokens, specs, success)
 }
 
-func (m *m) add(c monitoring.Counter, tokens int, specs []Spec) {
+func (m *m) add(c monitoring.Counter, tokens int, specs []Spec, success bool) {
 	if c == nil {
 		return
 	}
 	for _, spec := range specs {
-		c.Add(float64(tokens), spec.Name())
+		c.Add(float64(tokens), spec.Name(), fmt.Sprint(success))
 	}
 }
 
 // InitMetrics initializes Metrics using mf to create the monitoring objects.
 func InitMetrics(mf monitoring.MetricFactory) {
-	Metrics.AcquiredTokens = mf.NewCounter("quota_acquired_tokens", "Number of acquired quota tokens", "spec")
-	Metrics.ReturnedTokens = mf.NewCounter("quota_returned_tokens", "Number of quota tokens returned due to overcharging (bad requests, duplicates, etc)", "spec")
-	Metrics.ReplenishedTokens = mf.NewCounter("quota_replenished_tokens", "Number of quota tokens replenished due to sequencer progress", "spec")
+	Metrics.AcquiredTokens = mf.NewCounter("quota_acquired_tokens", "Number of acquired quota tokens", "spec", "success")
+	Metrics.ReturnedTokens = mf.NewCounter("quota_returned_tokens", "Number of quota tokens returned due to overcharging (bad requests, duplicates, etc)", "spec", "success")
+	Metrics.ReplenishedTokens = mf.NewCounter("quota_replenished_tokens", "Number of quota tokens replenished due to sequencer progress", "spec", "success")
 }

--- a/quota/metrics.go
+++ b/quota/metrics.go
@@ -1,0 +1,61 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import "github.com/google/trillian/monitoring"
+
+// Metrics groups all quota-related metrics.
+// The metrics represented here are not meant to be maintained by the quota subsystem
+// implementation.  Instead, they're meant to be updated by the quota's callers, in order to record
+// their interactions with quotas.
+// The quota implementation is encouraged to define its own metrics to monitor its internal state.
+var Metrics = &m{}
+
+type m struct {
+	AcquiredTokens    monitoring.Counter
+	ReturnedTokens    monitoring.Counter
+	ReplenishedTokens monitoring.Counter
+}
+
+// IncAcquired increments the AcquiredTokens metric.
+func (m *m) IncAcquired(tokens int, specs []Spec) {
+	m.add(m.AcquiredTokens, tokens, specs)
+}
+
+// IncReturned increments the ReturnedTokens metric.
+func (m *m) IncReturned(tokens int, specs []Spec) {
+	m.add(m.ReturnedTokens, tokens, specs)
+}
+
+// IncReplenished increments the ReplenishedTokens metric.
+func (m *m) IncReplenished(tokens int, specs []Spec) {
+	m.add(m.ReplenishedTokens, tokens, specs)
+}
+
+func (m *m) add(c monitoring.Counter, tokens int, specs []Spec) {
+	if c == nil {
+		return
+	}
+	for _, spec := range specs {
+		c.Add(float64(tokens), spec.Name())
+	}
+}
+
+// InitMetrics initializes Metrics using mf to create the monitoring objects.
+func InitMetrics(mf monitoring.MetricFactory) {
+	Metrics.AcquiredTokens = mf.NewCounter("quota_acquired_tokens", "Number of acquired quota tokens", "spec")
+	Metrics.ReturnedTokens = mf.NewCounter("quota_returned_tokens", "Number of quota tokens returned due to overcharging (bad requests, duplicates, etc)", "spec")
+	Metrics.ReplenishedTokens = mf.NewCounter("quota_replenished_tokens", "Number of quota tokens replenished due to sequencer progress", "spec")
+}

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -69,16 +69,16 @@ type Spec struct {
 	User string
 }
 
-// Name returns a textual representation of the Spec. Names are constant and may be relied not to
-// change in the future.
+// Name returns a textual representation of the Spec. Names are constant and may be relied upon to
+// not change in the future.
 //
 // Names are created as follows:
 // * Global quotas are mapped to "global/read" or "global/write"
 // * Tree quotas are mapped to "trees/$TreeID/$Kind". E.g., "trees/10/read".
 // * User quotas are mapped to "users/$User/$Kind". E.g., "trees/10/read".
 func (s Spec) Name() string {
-	group := strings.ToLower(s.Group.String())
-	kind := strings.ToLower(s.Kind.String())
+	group := strings.ToLower(fmt.Sprint(s.Group))
+	kind := strings.ToLower(fmt.Sprint(s.Kind))
 	if s.Group == Global {
 		return fmt.Sprintf("%v/%v", group, kind)
 	}

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -16,6 +16,8 @@ package quota
 
 import (
 	"context"
+	"fmt"
+	"strings"
 )
 
 // MaxTokens is the maximum number of available tokens a quota may have.
@@ -65,6 +67,34 @@ type Spec struct {
 	// User identifies the user for specs of the User group.
 	// Not used for other specs.
 	User string
+}
+
+// Name returns a textual representation of the Spec. Names are constant and may be relied not to
+// change in the future.
+//
+// Names are created as follows:
+// * Global quotas are mapped to "global/read" or "global/write"
+// * Tree quotas are mapped to "trees/$TreeID/$Kind". E.g., "trees/10/read".
+// * User quotas are mapped to "users/$User/$Kind". E.g., "trees/10/read".
+func (s Spec) Name() string {
+	group := strings.ToLower(s.Group.String())
+	kind := strings.ToLower(s.Kind.String())
+	if s.Group == Global {
+		return fmt.Sprintf("%v/%v", group, kind)
+	}
+	var user string
+	switch s.Group {
+	case Tree:
+		user = fmt.Sprint(s.TreeID)
+	case User:
+		user = s.User
+	}
+	return fmt.Sprintf("%vs/%v/%v", group, user, kind)
+}
+
+// String returns a description of Spec.
+func (s Spec) String() string {
+	return s.Name()
 }
 
 // Manager is the component responsible for the management of tokens.

--- a/quota/quota_test.go
+++ b/quota/quota_test.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import "testing"
+
+func TestSpec_Name(t *testing.T) {
+	tests := []struct {
+		spec Spec
+		want string
+	}{
+		{spec: Spec{Group: Global, Kind: Read}, want: "global/read"},
+		{spec: Spec{Group: Global, Kind: Write}, want: "global/write"},
+		{spec: Spec{Group: Tree, Kind: Read, TreeID: 11}, want: "trees/11/read"},
+		{spec: Spec{Group: Tree, Kind: Write, TreeID: 10}, want: "trees/10/write"},
+		{spec: Spec{Group: User, Kind: Read, User: "alpaca"}, want: "users/alpaca/read"},
+		{spec: Spec{Group: User, Kind: Write, User: "llama"}, want: "users/llama/write"},
+	}
+	for _, test := range tests {
+		if got := test.spec.Name(); got != test.want {
+			t.Errorf("%#v.Name() = %v, want = %v", test.spec, got, test.want)
+		}
+	}
+}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server/errors"
 	"github.com/google/trillian/storage"
@@ -29,6 +30,32 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const (
+	badInfoLabel            = "bad-info"
+	badTreeLabel            = "bad-tree"
+	insufficientTokensLabel = "insufficient-tokens"
+)
+
+var (
+	requestCounter       monitoring.Counter
+	requestDeniedCounter monitoring.Counter
+)
+
+// InitMetrics initializes the metrics on the interceptor package.
+func InitMetrics(mf monitoring.MetricFactory) {
+	requestCounter = mf.NewCounter("interceptor_request_count", "Total number of intercepted requests")
+	requestDeniedCounter = mf.NewCounter(
+		"interceptor_request_denied_count",
+		"Number of requests by denied, labeled according to the reason for denial",
+		badInfoLabel, badTreeLabel, insufficientTokensLabel)
+}
+
+func increment(c monitoring.Counter, labels ...string) {
+	if c != nil {
+		c.Inc(labels...)
+	}
+}
 
 // RequestProcessor encapsulates the logic to intercept a request, split into separate stages:
 // before and after the handler is invoked.
@@ -84,9 +111,12 @@ type trillianProcessor struct {
 }
 
 func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (context.Context, error) {
+	increment(requestCounter)
+
 	quotaUser := tp.parent.QuotaManager.GetUser(ctx, req)
 	info, err := getRPCInfo(req, quotaUser)
 	if err != nil {
+		increment(requestDeniedCounter, badInfoLabel)
 		return ctx, err
 	}
 	tp.info = info
@@ -94,6 +124,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 	if info.treeID != 0 {
 		tree, err := trees.GetTree(ctx, tp.parent.Admin, info.treeID, info.opts)
 		if err != nil {
+			increment(requestDeniedCounter, badTreeLabel)
 			return ctx, err
 		}
 		ctx = trees.NewContext(ctx, tree)
@@ -104,12 +135,12 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 		quota.Metrics.IncAcquired(info.tokens, info.specs)
 		if err := tp.parent.QuotaManager.GetTokens(ctx, info.tokens, info.specs); err != nil {
 			if !tp.parent.QuotaDryRun {
+				increment(requestDeniedCounter, insufficientTokensLabel)
 				return ctx, status.Errorf(codes.ResourceExhausted, "quota exhausted: %v", err)
 			}
 			glog.Warningf("(QuotaDryRun) Request %+v not denied due to dry run mode: %v", req, err)
 		}
 	}
-
 	return ctx, nil
 }
 

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -101,6 +101,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 	}
 
 	if len(info.specs) > 0 && info.tokens > 0 {
+		quota.Metrics.IncAcquired(info.tokens, info.specs)
 		if err := tp.parent.QuotaManager.GetTokens(ctx, info.tokens, info.specs); err != nil {
 			if !tp.parent.QuotaDryRun {
 				return ctx, status.Errorf(codes.ResourceExhausted, "quota exhausted: %v", err)
@@ -145,6 +146,7 @@ func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, handle
 		if err := tp.parent.QuotaManager.PutTokens(ctx, tokens, tp.info.specs); err != nil {
 			glog.Warningf("Failed to replenish %v tokens: %v", tokens, err)
 		}
+		quota.Metrics.IncReturned(tokens, tp.info.specs)
 	}
 }
 

--- a/server/interceptor/metrics.go
+++ b/server/interceptor/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptor
+
+import (
+	"fmt"
+
+	"github.com/google/trillian/monitoring"
+)
+
+const (
+	badInfoReason            = "bad-info"
+	badTreeReason            = "bad-tree"
+	insufficientTokensReason = "insufficient-tokens"
+)
+
+var (
+	requestCounter       monitoring.Counter
+	requestDeniedCounter monitoring.Counter
+)
+
+// InitMetrics initializes the metrics on the interceptor package.
+func InitMetrics(mf monitoring.MetricFactory) {
+	requestCounter = mf.NewCounter("interceptor_request_count", "Total number of intercepted requests")
+	requestDeniedCounter = mf.NewCounter(
+		"interceptor_request_denied_count",
+		"Number of requests by denied, labeled according to the reason for denial",
+		"reason", monitoring.TreeIDLabel, "quota-user")
+}
+
+func incRequestCounter() {
+	if requestCounter != nil {
+		requestCounter.Inc()
+	}
+}
+
+func incRequestDeniedCounter(reason string, treeID int64, quotaUser string) {
+	if requestDeniedCounter != nil {
+		requestDeniedCounter.Inc(reason, fmt.Sprint(treeID), quotaUser)
+	}
+}

--- a/server/interceptor/metrics.go
+++ b/server/interceptor/metrics.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	badInfoReason            = "bad-info"
-	badTreeReason            = "bad-tree"
-	insufficientTokensReason = "insufficient-tokens"
+	badInfoReason            = "bad_info"
+	badTreeReason            = "bad_tree"
+	insufficientTokensReason = "insufficient_tokens"
 )
 
 var (
@@ -37,7 +37,7 @@ func InitMetrics(mf monitoring.MetricFactory) {
 	requestDeniedCounter = mf.NewCounter(
 		"interceptor_request_denied_count",
 		"Number of requests by denied, labeled according to the reason for denial",
-		"reason", monitoring.TreeIDLabel, "quota-user")
+		"reason", monitoring.TreeIDLabel, "quota_user")
 }
 
 func incRequestCounter() {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/google/trillian/merkle/rfc6962"   // Load hashers
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota"
 	mysqlq "github.com/google/trillian/quota/mysql"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
@@ -86,6 +87,7 @@ func main() {
 	}
 
 	mf := prometheus.MetricFactory{}
+	quota.InitMetrics(mf)
 
 	sf := &keys.DefaultSignerFactory{}
 	if *pkcs11ModulePath != "" {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -87,6 +87,7 @@ func main() {
 	}
 
 	mf := prometheus.MetricFactory{}
+	interceptor.InitMetrics(mf)
 	quota.InitMetrics(mf)
 
 	sf := &keys.DefaultSignerFactory{}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -98,6 +98,7 @@ func main() {
 	}
 
 	mf := prometheus.MetricFactory{}
+	quota.InitMetrics(mf)
 
 	sf := &keys.DefaultSignerFactory{}
 	if *pkcs11ModulePath != "" {

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -71,6 +71,7 @@ func main() {
 		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: *maxUnsequencedRows},
 		MetricFactory: prometheus.MetricFactory{},
 	}
+	interceptor.InitMetrics(registry.MetricFactory)
 	quota.InitMetrics(registry.MetricFactory)
 
 	ts := util.SystemTimeSource{}

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota"
 	mysqlq "github.com/google/trillian/quota/mysql"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
@@ -70,6 +71,7 @@ func main() {
 		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: *maxUnsequencedRows},
 		MetricFactory: prometheus.MetricFactory{},
 	}
+	quota.InitMetrics(registry.MetricFactory)
 
 	ts := util.SystemTimeSource{}
 	stats := monitoring.NewRPCStatsInterceptor(ts, "map", registry.MetricFactory)


### PR DESCRIPTION
The following metrics are now recorded:

Quotas
* Tokens acquired (per spec)
* Tokens replenished (per spec)
* Tokens returned (per spec)

The distinction between replenished and returned is that the former is sequencing-related, whereas the latter indicates tokens were incorrectly charged (errors requests, duplicate leaves queued, etc)

Interceptor
* Total number of intercepted requests
* Denied requests (per type of denial)