### PR TITLE
Add --generate-key flag to createtree command

### DIFF
--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -154,10 +154,19 @@ func newRequest(opts *createOpts) (*trillian.CreateTreeRequest, error) {
 		}
 
 		// If no key flags were provided at all, get Trillian to generate a key.
-		ctr.KeySpec = &keyspb.Specification{
-			Params: &keyspb.Specification_EcdsaParams{
+		ctr.KeySpec = &keyspb.Specification{}
+
+		switch sigpb.DigitallySigned_SignatureAlgorithm(sa) {
+		case sigpb.DigitallySigned_ECDSA:
+			ctr.KeySpec.Params = &keyspb.Specification_EcdsaParams{
 				EcdsaParams: &keyspb.Specification_ECDSA{},
-			},
+			}
+		case sigpb.DigitallySigned_RSA:
+			ctr.KeySpec.Params = &keyspb.Specification_RsaParams{
+				RsaParams: &keyspb.Specification_RSA{},
+			}
+		default:
+			return nil, fmt.Errorf("unsupported signature algorithm: %v", sa)
 		}
 	}
 

--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -16,10 +16,7 @@
 // command.
 //
 // Example usage:
-// $ ./createtree \
-//     --admin_server=host:port \
-//     --pem_key_path=/path/to/pem/file \
-//     --pem_key_password=mypassword
+// $ ./createtree --admin_server=host:port
 //
 // The command outputs the tree ID of the created tree to stdout, or an error to
 // stderr in case of failure. The output is minimal to allow for easy usage in

--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -65,7 +65,7 @@ var (
 	description        = flag.String("description", "", "Description of the new tree")
 	maxRootDuration    = flag.Duration("max_root_duration", 0, "Interval after which a new signed root is produced despite no submissions; zero means never")
 
-	privateKeyFormat = flag.String("private_key_format", "PrivateKey", "Type of private key to be used (PrivateKey, PEMKeyFile, or PKCS11ConfigFile)")
+	privateKeyFormat = flag.String("private_key_format", "", "Type of protobuf message to send the key as (PrivateKey, PEMKeyFile, or PKCS11ConfigFile). If empty, a key will be generated for you by Trillian.")
 	pemKeyPath       = flag.String("pem_key_path", "", "Path to the private key PEM file")
 	pemKeyPassword   = flag.String("pem_key_password", "", "Password of the private key PEM file")
 	pkcs11ConfigPath = flag.String("pkcs11_config_path", "", "Path to the PKCS #11 key configuration file")
@@ -131,11 +131,6 @@ func newRequest(opts *createOpts) (*trillian.CreateTreeRequest, error) {
 		return nil, fmt.Errorf("unknown SignatureAlgorithm: %v", opts.sigAlgorithm)
 	}
 
-	pk, err := newPK(opts)
-	if err != nil {
-		return nil, err
-	}
-
 	ctr := &trillian.CreateTreeRequest{Tree: &trillian.Tree{
 		TreeState:          trillian.TreeState(ts),
 		TreeType:           trillian.TreeType(tt),
@@ -144,9 +139,31 @@ func newRequest(opts *createOpts) (*trillian.CreateTreeRequest, error) {
 		SignatureAlgorithm: sigpb.DigitallySigned_SignatureAlgorithm(sa),
 		DisplayName:        opts.displayName,
 		Description:        opts.description,
-		PrivateKey:         pk,
 		MaxRootDuration:    ptypes.DurationProto(opts.maxRootDuration),
 	}}
+
+	if opts.privateKeyType != "" {
+		pk, err := newPK(opts)
+		if err != nil {
+			return nil, err
+		}
+		ctr.Tree.PrivateKey = pk
+	} else {
+		// Cannot continue if options specifying a key were provided but
+		// privateKeyType is not set, as there's no way to know what protobuf
+		// message type was intended.
+		if opts.pemKeyPath != "" || opts.pemKeyPass != "" || opts.pkcs11ConfigPath != "" {
+			return nil, errors.New("must specify private key format")
+		}
+
+		// If no key flags were provided at all, get Trillian to generate a key.
+		ctr.KeySpec = &keyspb.Specification{
+			Params: &keyspb.Specification_EcdsaParams{
+				EcdsaParams: &keyspb.Specification_ECDSA{},
+			},
+		}
+	}
+
 	return ctr, nil
 }
 

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -232,7 +232,10 @@ func (s *fakeAdminServer) CreateTree(ctx context.Context, req *trillian.CreateTr
 		return nil, s.err
 	}
 	resp := *req.Tree
-	if req.KeySpec != nil && s.generatedKey != nil {
+	if req.KeySpec != nil {
+		if s.generatedKey == nil {
+			panic("fakeAdminServer.generatedKey == nil but CreateTreeRequest requests generated key")
+		}
 		resp.PrivateKey = s.generatedKey
 	}
 	return &resp, nil

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -78,11 +78,10 @@ func TestRun(t *testing.T) {
 		t.Fatalf("Error starting fake server: %v", err)
 	}
 	defer stopFn()
+	server.generatedKey = anyPrivKey
 
 	validOpts := newOptsFromFlags()
 	validOpts.addr = lis.Addr().String()
-	validOpts.pemKeyPath = pemPath
-	validOpts.pemKeyPass = pemPassword
 
 	nonDefaultTree := *defaultTree
 	nonDefaultTree.TreeType = trillian.TreeType_MAP
@@ -102,16 +101,24 @@ func TestRun(t *testing.T) {
 	invalidEnumOpts := *validOpts
 	invalidEnumOpts.treeType = "LLAMA!"
 
-	invalidKeyTypeOpts := *validOpts
+	privateKeyOpts := *validOpts
+	privateKeyOpts.privateKeyType = "PrivateKey"
+	privateKeyOpts.pemKeyPath = pemPath
+	privateKeyOpts.pemKeyPass = pemPassword
+
+	emptyKeyTypeOpts := privateKeyOpts
+	emptyKeyTypeOpts.privateKeyType = ""
+
+	invalidKeyTypeOpts := privateKeyOpts
 	invalidKeyTypeOpts.privateKeyType = "LLAMA!!"
 
-	emptyPEMPath := *validOpts
+	emptyPEMPath := privateKeyOpts
 	emptyPEMPath.pemKeyPath = ""
 
-	emptyPEMPass := *validOpts
+	emptyPEMPass := privateKeyOpts
 	emptyPEMPass.pemKeyPass = ""
 
-	pemKeyOpts := *validOpts
+	pemKeyOpts := privateKeyOpts
 	pemKeyOpts.privateKeyType = "PEMKeyFile"
 	pemKeyTree := *defaultTree
 	pemKeyTree.PrivateKey, err = ptypes.MarshalAny(&keyspb.PEMKeyFile{
@@ -141,8 +148,8 @@ xToc6NWBri0N3VVsswIDAQAB
 		t.Fatalf("MarshalAny(PKCS11Config): %v", err)
 	}
 
-	emptyPKCS11Path := *validOpts
-	emptyPKCS11Path.privateKeyType = "PKCS11ConfigFile"
+	emptyPKCS11Path := pkcs11Opts
+	emptyPKCS11Path.pkcs11ConfigPath = ""
 
 	tests := []struct {
 		desc      string
@@ -156,12 +163,14 @@ xToc6NWBri0N3VVsswIDAQAB
 		{desc: "defaultOptsOnly", opts: newOptsFromFlags(), wantErr: true}, // No mandatory opts provided
 		{desc: "emptyAddr", opts: &emptyAddr, wantErr: true},
 		{desc: "invalidEnumOpts", opts: &invalidEnumOpts, wantErr: true},
+		{desc: "emptyKeyTypeOpts", opts: &emptyKeyTypeOpts, wantErr: true},
 		{desc: "invalidKeyTypeOpts", opts: &invalidKeyTypeOpts, wantErr: true},
 		{desc: "emptyPEMPath", opts: &emptyPEMPath, wantErr: true},
 		{desc: "emptyPEMPass", opts: &emptyPEMPass, wantErr: true},
-		{desc: "PEMKeyFile", opts: &pemKeyOpts, wantErr: false, wantTree: &pemKeyTree},
+		{desc: "PrivateKey", opts: &privateKeyOpts, wantTree: defaultTree},
+		{desc: "PEMKeyFile", opts: &pemKeyOpts, wantTree: &pemKeyTree},
 		{desc: "createErr", opts: validOpts, createErr: errors.New("create tree failed"), wantErr: true},
-		{desc: "PKCS11Config", opts: &pkcs11Opts, wantErr: false, wantTree: &pkcs11Tree},
+		{desc: "PKCS11Config", opts: &pkcs11Opts, wantTree: &pkcs11Tree},
 		{desc: "emptyPKCS11Path", opts: &emptyPKCS11Path, wantErr: true},
 	}
 
@@ -178,17 +187,22 @@ xToc6NWBri0N3VVsswIDAQAB
 			continue
 		}
 
-		if diff := pretty.Compare(tree, test.wantTree); diff != "" {
-			t.Errorf("%v: post-createTree diff:\n%v", test.desc, diff)
+		if !proto.Equal(tree, test.wantTree) {
+			t.Errorf("%v: post-createTree diff -got +want:\n%v", test.desc, pretty.Compare(tree, test.wantTree))
 		}
 	}
 }
 
-// fakeAdminServer that implements CreateTree. If err is nil, the CreateTree
-// input is echoed as the output, otherwise err is returned instead.
+// fakeAdminServer that implements CreateTree.
+// If err is not nil, it will be returned in response to CreateTree requests.
+// If generatedKey is not nil, and a request has a KeySpec set, the response
+// will contain generatedKey.
+// The response to a CreateTree request will otherwise contain an identical copy
+// of the tree sent in the request.
 // The remaining methods are not implemented.
 type fakeAdminServer struct {
-	err error
+	err          error
+	generatedKey *any.Any
 }
 
 // startFakeServer starts a fakeAdminServer on a random port.
@@ -218,6 +232,9 @@ func (s *fakeAdminServer) CreateTree(ctx context.Context, req *trillian.CreateTr
 		return nil, s.err
 	}
 	resp := *req.Tree
+	if req.KeySpec != nil && s.generatedKey != nil {
+		resp.PrivateKey = s.generatedKey
+	}
 	return &resp, nil
 }
 

--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -25,8 +25,6 @@ go build ./examples/ct/ctmapper/lookup
 go build ./cmd/createtree/
 tree_id=$(./createtree \
     --admin_server=localhost:8090 \
-    --pem_key_path=testdata/log-rpc-server.privkey.pem \
-    --pem_key_password=towel \
     --signature_algorithm=ECDSA)
 ./mapper \
     -source http://ct.googleapis.com/pilot \

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -16,9 +16,9 @@ if [[ "${WITH_PKCS11}" == "true" ]]; then
   echo 0:${TMPDIR}/softhsm-slot0.db > ${SOFTHSM_CONF}
   softhsm --slot 0 --init-token --label log --pin 1234 --so-pin 5678
   softhsm --slot 0 --import testdata/log-rpc-server-pkcs11.privkey.pem --label log_key --pin 1234 --id BEEF
-  KEY_ARGS="--private_key_format PKCS11ConfigFile --pkcs11_config_path testdata/pkcs11-conf.json --signature_algorithm=RSA"
+  KEY_ARGS="--private_key_format=PKCS11ConfigFile --pkcs11_config_path=testdata/pkcs11-conf.json --signature_algorithm=RSA"
 else
-  KEY_ARGS="--pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel --signature_algorithm=ECDSA"
+  KEY_ARGS="--private_key_format=PrivateKey --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password=towel --signature_algorithm=ECDSA"
 fi
 
 echo "Provision log"


### PR DESCRIPTION
Makes the Trillian admin server generate the private key, rather than requiring the user to provide one. This may be more secure, depending on how the server stores the generated key.

It is hard-coded to generate a key using the default parameters. Users that require more control over the key specification should communicate with the admin server directly.