### PR TITLE
Use testonly.MustDecode* functions

### DIFF
--- a/merkle/coniks/coniks_test.go
+++ b/merkle/coniks/coniks_test.go
@@ -17,18 +17,12 @@ package coniks
 import (
 	"bytes"
 	"crypto"
-	"encoding/hex"
 	"testing"
+
+	"github.com/google/trillian/testonly"
 )
 
-// h2b converts a hex string into a bytes string
-func h2b(h string) []byte {
-	b, err := hex.DecodeString(h)
-	if err != nil {
-		panic("invalid hex string")
-	}
-	return b
-}
+var h2b = testonly.MustHexDecode
 
 func TestVectors(t *testing.T) {
 	for _, tc := range []struct {

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -16,8 +16,6 @@ package merkle
 
 import (
 	"bytes"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"testing"
@@ -28,6 +26,11 @@ import (
 )
 
 const treeID = int64(0)
+
+var (
+	h2b   = testonly.MustHexDecode
+	deB64 = testonly.MustDecodeBase64
+)
 
 // Some known answers for incrementally adding index/value pairs to a sparse tree.
 // rootB64 is the incremental root after adding the corresponding i/v pair, and
@@ -200,22 +203,4 @@ func TestPaddedBytes(t *testing.T) {
 			t.Errorf("PaddedBytes(%d): %x, want %x", tc.i, got, want)
 		}
 	}
-}
-
-// deB64 converts a base64 string into []byte.
-func deB64(b64 string) []byte {
-	b, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil {
-		panic("invalid base64 string")
-	}
-	return b
-}
-
-// h2b converts a hex string into []byte.
-func h2b(h string) []byte {
-	b, err := hex.DecodeString(h)
-	if err != nil {
-		panic("invalid hex string")
-	}
-	return b
 }

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -16,7 +16,6 @@ package cache
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
+	"github.com/google/trillian/testonly"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kylelemons/godebug/pretty"
@@ -33,8 +33,11 @@ import (
 	stestonly "github.com/google/trillian/storage/testonly"
 )
 
-var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
-var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
+var (
+	defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8}
+	defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
+	h2b              = testonly.MustHexDecode
+)
 
 const treeID = int64(0)
 
@@ -341,13 +344,4 @@ func TestGetStratumInfo(t *testing.T) {
 			t.Errorf("(test %d for depth %d) diff:\n%v", i, tv.depth, diff)
 		}
 	}
-}
-
-// h2b converts a hex string into []byte.
-func h2b(h string) []byte {
-	b, err := hex.DecodeString(h)
-	if err != nil {
-		panic("invalid hex string")
-	}
-	return b
 }

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -16,12 +16,15 @@ package storage
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
+
+	"github.com/google/trillian/testonly"
 )
+
+var h2b = testonly.MustHexDecode
 
 func TestNewNodeIDFromBigInt(t *testing.T) {
 	for _, tc := range []struct {
@@ -461,13 +464,4 @@ func h26(h string) uint64 {
 		panic(err)
 	}
 	return i
-}
-
-// h2b converts a hex string into []byte.
-func h2b(h string) []byte {
-	b, err := hex.DecodeString(h)
-	if err != nil {
-		panic("invalid hex string")
-	}
-	return b
 }


### PR DESCRIPTION
Al helpfully pointed out that functions can be renamed.
Commence the removal of duplicate code!