### PR TITLE
Save MapRoots when no leaves are changed

### DIFF
--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -61,7 +61,7 @@ func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				return nil, nil
 			},
 			func(depth int, index *big.Int, h []byte) error {
-				if depth == 0 {
+				if depth == 0 && len(st.Prefix) > 0 {
 					// no space for the root in the node cache
 					return nil
 				}


### PR DESCRIPTION
*Observed behavior*
When `SetMapLeaves` is called with no leaves in order to advance the revision number without changing the map, the map root is reset to the empty root hash. 

*Desired behavior* 
When `SetMapLeaves` is called with no leaves in order to advance the revision number without changing the map, the map root remains the same as it was in the previous revision. 

This adds a unit test to detect this behavior, and a small change to enforce it. 