### PR TITLE
Refactor: NodeID.Equivalent -> storge.Equal

### DIFF
--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -36,7 +36,8 @@ type NodeFetch struct {
 
 // Equivalent return true iff the other represents the same rehash state and NodeID as the other.
 func (n NodeFetch) Equivalent(other NodeFetch) bool {
-	return n.Rehash == other.Rehash && n.NodeID.Equivalent(other.NodeID)
+	return n.Rehash == other.Rehash &&
+		storage.Equal(&n.NodeID, &other.NodeID)
 }
 
 // checkSnapshot performs a couple of simple sanity checks on ss and treeSize

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -370,7 +370,7 @@ func (s SparseMerkleTreeReader) RootAtRevision(ctx context.Context, rev int64) (
 		return nil, fmt.Errorf("expected 1 node, but got %d", len(nodes))
 	}
 	// Sanity check the nodeID
-	if !nodes[0].NodeID.Equivalent(rootNodeID) {
+	if !storage.Equal(&nodes[0].NodeID, &rootNodeID) {
 		return nil, fmt.Errorf("unexpected node returned with ID: %v", nodes[0].NodeID)
 	}
 	// Sanity check the revision

--- a/storage/testonly/matchers.go
+++ b/storage/testonly/matchers.go
@@ -34,7 +34,7 @@ func (s subtreeHasPrefix) Matches(x interface{}) bool {
 		return false
 	}
 	subID := storage.NewNodeIDFromHash(st.Prefix)
-	return subID.Equivalent(s.expectedID)
+	return storage.Equal(&subID, &s.expectedID)
 }
 
 func (s subtreeHasPrefix) String() string {
@@ -50,7 +50,7 @@ func (m nodeIDEq) Matches(x interface{}) bool {
 	if !ok {
 		return false
 	}
-	return n.Equivalent(m.expectedID)
+	return storage.Equal(&n, &m.expectedID)
 }
 
 func (m nodeIDEq) String() string {

--- a/storage/types.go
+++ b/storage/types.go
@@ -361,9 +361,9 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	return a[:prefixBytes], sfx
 }
 
-// Equivalent return true iff the other represents the same path prefix as this NodeID.
-func (n *NodeID) Equivalent(other NodeID) bool {
-	return n.String() == other.String()
+// Equal returns true iff a and b have the same string representation.
+func Equal(a, b *NodeID) bool {
+	return a.String() == b.String()
 }
 
 // PopulateSubtreeFunc is a function which knows how to re-populate a subtree

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -471,9 +471,8 @@ func TestNodeEquivalent(t *testing.T) {
 			want: true,
 		},
 	} {
-		if got, want := tc.n1.Equivalent(tc.n2), tc.want; got != want {
-			t.Errorf("Equivalent(%v, %v): %v, want %v",
-				tc.n1, tc.n2, got, want)
+		if got, want := Equal(&tc.n1, &tc.n2), tc.want; got != want {
+			t.Errorf("Equal(%v, %v): %v, want %v", tc.n1, tc.n2, got, want)
 		}
 	}
 }


### PR DESCRIPTION
This is a simple style change from 

`NodeID.Equivilant(other)`
to
`storage.Equal(a, b *NodeID)`

This better matches `bytes.Equal(a, b []byte)` 