### PR TITLE
Refactor createtree command

### DIFF
--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -55,7 +55,7 @@ var (
 	treeType           = flag.String("tree_type", trillian.TreeType_LOG.String(), "Type of the new tree")
 	hashStrategy       = flag.String("hash_strategy", trillian.HashStrategy_RFC6962_SHA256.String(), "Hash strategy (aka preimage protection) of the new tree")
 	hashAlgorithm      = flag.String("hash_algorithm", sigpb.DigitallySigned_SHA256.String(), "Hash algorithm of the new tree")
-	signatureAlgorithm = flag.String("signature_algorithm", sigpb.DigitallySigned_RSA.String(), "Signature algorithm of the new tree")
+	signatureAlgorithm = flag.String("signature_algorithm", sigpb.DigitallySigned_ECDSA.String(), "Signature algorithm of the new tree")
 	displayName        = flag.String("display_name", "", "Display name of the new tree")
 	description        = flag.String("description", "", "Description of the new tree")
 	maxRootDuration    = flag.Duration("max_root_duration", 0, "Interval after which a new signed root is produced despite no submissions; zero means never")

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -16,9 +16,9 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -27,15 +27,34 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/util/flagsaver"
 	"github.com/kylelemons/godebug/pretty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
-func marshalAny(p proto.Message) *any.Any {
+// defaultTree reflects all flag defaults with the addition of a valid private key.
+var defaultTree = &trillian.Tree{
+	TreeState:          trillian.TreeState_ACTIVE,
+	TreeType:           trillian.TreeType_LOG,
+	HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
+	HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+	SignatureAlgorithm: sigpb.DigitallySigned_RSA,
+	PrivateKey:         mustMarshalAny(&empty.Empty{}),
+	MaxRootDuration:    ptypes.DurationProto(0 * time.Millisecond),
+}
+
+type testCase struct {
+	desc      string
+	setFlags  func()
+	createErr error
+	wantErr   bool
+	wantTree  *trillian.Tree
+}
+
+func mustMarshalAny(p proto.Message) *any.Any {
 	anyKey, err := ptypes.MarshalAny(p)
 	if err != nil {
 		panic(err)
@@ -43,155 +62,95 @@ func marshalAny(p proto.Message) *any.Any {
 	return anyKey
 }
 
-func TestRun(t *testing.T) {
-	err := os.Chdir("../..")
-	if err != nil {
-		t.Fatalf("Unable to change working directory to ../..: %s", err)
-	}
-
-	pemPath, pemPassword := "testdata/log-rpc-server.privkey.pem", "towel"
-	pemSigner, err := keys.NewFromPrivatePEMFile(pemPath, pemPassword)
-	if err != nil {
-		t.Fatalf("NewFromPrivatePEM(): %v", err)
-	}
-	pemDer, err := keys.MarshalPrivateKey(pemSigner)
-	if err != nil {
-		t.Fatalf("MarshalPrivateKey(): %v", err)
-	}
-	anyPrivKey, err := ptypes.MarshalAny(&keyspb.PrivateKey{Der: pemDer})
-	if err != nil {
-		t.Fatalf("MarshalAny(%v): %v", pemDer, err)
-	}
-
-	// defaultTree reflects all flag defaults with the addition of a valid pk
-	defaultTree := &trillian.Tree{
-		TreeState:          trillian.TreeState_ACTIVE,
-		TreeType:           trillian.TreeType_LOG,
-		HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
-		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
-		SignatureAlgorithm: sigpb.DigitallySigned_RSA,
-		PrivateKey:         anyPrivKey,
-		MaxRootDuration:    ptypes.DurationProto(0 * time.Millisecond),
-	}
-
-	server, lis, stopFn, err := startFakeServer()
-	if err != nil {
-		t.Fatalf("Error starting fake server: %v", err)
-	}
-	defer stopFn()
-	server.generatedKey = anyPrivKey
-
-	validOpts := newOptsFromFlags()
-	validOpts.addr = lis.Addr().String()
-
+func TestCreateTree(t *testing.T) {
 	nonDefaultTree := *defaultTree
 	nonDefaultTree.TreeType = trillian.TreeType_MAP
 	nonDefaultTree.SignatureAlgorithm = sigpb.DigitallySigned_ECDSA
 	nonDefaultTree.DisplayName = "Llamas Map"
 	nonDefaultTree.Description = "For all your digital llama needs!"
 
-	nonDefaultOpts := *validOpts
-	nonDefaultOpts.treeType = nonDefaultTree.TreeType.String()
-	nonDefaultOpts.sigAlgorithm = nonDefaultTree.SignatureAlgorithm.String()
-	nonDefaultOpts.displayName = nonDefaultTree.DisplayName
-	nonDefaultOpts.description = nonDefaultTree.Description
-
-	emptyAddr := *validOpts
-	emptyAddr.addr = ""
-
-	invalidEnumOpts := *validOpts
-	invalidEnumOpts.treeType = "LLAMA!"
-
-	privateKeyOpts := *validOpts
-	privateKeyOpts.privateKeyType = "PrivateKey"
-	privateKeyOpts.pemKeyPath = pemPath
-	privateKeyOpts.pemKeyPass = pemPassword
-
-	emptyKeyTypeOpts := privateKeyOpts
-	emptyKeyTypeOpts.privateKeyType = ""
-
-	invalidKeyTypeOpts := privateKeyOpts
-	invalidKeyTypeOpts.privateKeyType = "LLAMA!!"
-
-	emptyPEMPath := privateKeyOpts
-	emptyPEMPath.pemKeyPath = ""
-
-	emptyPEMPass := privateKeyOpts
-	emptyPEMPass.pemKeyPass = ""
-
-	pemKeyOpts := privateKeyOpts
-	pemKeyOpts.privateKeyType = "PEMKeyFile"
-	pemKeyTree := *defaultTree
-	pemKeyTree.PrivateKey, err = ptypes.MarshalAny(&keyspb.PEMKeyFile{
-		Path:     pemPath,
-		Password: pemPassword,
+	runTest(t, []*testCase{
+		{
+			desc:     "validOpts",
+			wantTree: defaultTree,
+		},
+		{
+			desc: "nonDefaultOpts",
+			setFlags: func() {
+				*treeType = nonDefaultTree.TreeType.String()
+				*signatureAlgorithm = nonDefaultTree.SignatureAlgorithm.String()
+				*displayName = nonDefaultTree.DisplayName
+				*description = nonDefaultTree.Description
+			},
+			wantTree: &nonDefaultTree,
+		},
+		{
+			desc:     "defaultOptsOnly",
+			setFlags: resetFlags,
+			wantErr:  true,
+		},
+		{
+			desc:     "emptyAddr",
+			setFlags: func() { *adminServerAddr = "" },
+			wantErr:  true,
+		},
+		{
+			desc:     "invalidEnumOpts",
+			setFlags: func() { *treeType = "LLAMA!" },
+			wantErr:  true,
+		},
+		{
+			desc:     "invalidKeyTypeOpts",
+			setFlags: func() { *privateKeyFormat = "LLAMA!!" },
+			wantErr:  true,
+		},
+		{
+			desc:      "createErr",
+			createErr: errors.New("create tree failed"),
+			wantErr:   true,
+		},
 	})
+}
+
+func runTest(t *testing.T, tests []*testCase) {
+	server, lis, stopFn, err := startFakeServer()
 	if err != nil {
-		t.Fatalf("MarshalAny(PEMKeyFile): %v", err)
+		t.Fatalf("Error starting fake server: %v", err)
 	}
-
-	pkcs11Opts := *validOpts
-	pkcs11Opts.privateKeyType = "PKCS11ConfigFile"
-	pkcs11Opts.pkcs11ConfigPath = "testdata/pkcs11-conf.json"
-	pkcs11Tree := *defaultTree
-	pkcs11Tree.PrivateKey, err = ptypes.MarshalAny(&keyspb.PKCS11Config{
-		TokenLabel: "log",
-		Pin:        "1234",
-		PublicKey: `-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7/tWwqUXZJaNfnpvnqiaeNMkn
-hKusCsyAidrHxvuL+t54XFCHJwsB3wIlQZ4mMwb8mC/KRYhCqECBEoCAf/b0m3j/
-ASuEPLyYOrz/aEs3wP02IZQLGmihmjMk7T/ouNCuX7y1fTjX3GeVQ06U/EePwZFC
-xToc6NWBri0N3VVsswIDAQAB
------END PUBLIC KEY-----
-`,
-	})
-	if err != nil {
-		t.Fatalf("MarshalAny(PKCS11Config): %v", err)
-	}
-
-	emptyPKCS11Path := pkcs11Opts
-	emptyPKCS11Path.pkcs11ConfigPath = ""
-
-	tests := []struct {
-		desc      string
-		opts      *createOpts
-		createErr error
-		wantErr   bool
-		wantTree  *trillian.Tree
-	}{
-		{desc: "validOpts", opts: validOpts, wantTree: defaultTree},
-		{desc: "nonDefaultOpts", opts: &nonDefaultOpts, wantTree: &nonDefaultTree},
-		{desc: "defaultOptsOnly", opts: newOptsFromFlags(), wantErr: true}, // No mandatory opts provided
-		{desc: "emptyAddr", opts: &emptyAddr, wantErr: true},
-		{desc: "invalidEnumOpts", opts: &invalidEnumOpts, wantErr: true},
-		{desc: "emptyKeyTypeOpts", opts: &emptyKeyTypeOpts, wantErr: true},
-		{desc: "invalidKeyTypeOpts", opts: &invalidKeyTypeOpts, wantErr: true},
-		{desc: "emptyPEMPath", opts: &emptyPEMPath, wantErr: true},
-		{desc: "emptyPEMPass", opts: &emptyPEMPass, wantErr: true},
-		{desc: "PrivateKey", opts: &privateKeyOpts, wantTree: defaultTree},
-		{desc: "PEMKeyFile", opts: &pemKeyOpts, wantTree: &pemKeyTree},
-		{desc: "createErr", opts: validOpts, createErr: errors.New("create tree failed"), wantErr: true},
-		{desc: "PKCS11Config", opts: &pkcs11Opts, wantTree: &pkcs11Tree},
-		{desc: "emptyPKCS11Path", opts: &emptyPKCS11Path, wantErr: true},
-	}
+	defer stopFn()
+	server.generatedKey = defaultTree.PrivateKey
 
 	ctx := context.Background()
 	for _, test := range tests {
-		server.err = test.createErr
+		t.Run(test.desc, func(t *testing.T) {
+			defer flagsaver.Save().Restore()
+			*adminServerAddr = lis.Addr().String()
+			if test.setFlags != nil {
+				test.setFlags()
+			}
 
-		tree, err := createTree(ctx, test.opts)
-		switch hasErr := err != nil; {
-		case hasErr != test.wantErr:
-			t.Errorf("%v: createTree() returned err = '%v', wantErr = %v", test.desc, err, test.wantErr)
-			continue
-		case hasErr:
-			continue
-		}
+			server.err = test.createErr
 
-		if !proto.Equal(tree, test.wantTree) {
-			t.Errorf("%v: post-createTree diff -got +want:\n%v", test.desc, pretty.Compare(tree, test.wantTree))
-		}
+			tree, err := createTree(ctx)
+			switch hasErr := err != nil; {
+			case hasErr != test.wantErr:
+				t.Errorf("createTree() returned err = '%v', wantErr = %v", err, test.wantErr)
+				return
+			case hasErr:
+				return
+			}
+
+			if !proto.Equal(tree, test.wantTree) {
+				t.Errorf("post-createTree diff -got +want:\n%v", pretty.Compare(tree, test.wantTree))
+			}
+		})
 	}
+}
+
+func resetFlags() {
+	flag.Visit(func(f *flag.Flag) {
+		f.Value.Set(f.DefValue)
+	})
 }
 
 // fakeAdminServer that implements CreateTree.

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -38,7 +38,7 @@ var defaultTree = &trillian.Tree{
 	TreeType:           trillian.TreeType_LOG,
 	HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
 	HashAlgorithm:      sigpb.DigitallySigned_SHA256,
-	SignatureAlgorithm: sigpb.DigitallySigned_RSA,
+	SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
 	PrivateKey:         mustMarshalAny(&empty.Empty{}),
 	MaxRootDuration:    ptypes.DurationProto(0 * time.Millisecond),
 }
@@ -62,7 +62,7 @@ func mustMarshalAny(p proto.Message) *any.Any {
 func TestCreateTree(t *testing.T) {
 	nonDefaultTree := *defaultTree
 	nonDefaultTree.TreeType = trillian.TreeType_MAP
-	nonDefaultTree.SignatureAlgorithm = sigpb.DigitallySigned_ECDSA
+	nonDefaultTree.SignatureAlgorithm = sigpb.DigitallySigned_RSA
 	nonDefaultTree.DisplayName = "Llamas Map"
 	nonDefaultTree.Description = "For all your digital llama needs!"
 

--- a/cmd/createtree/pem_test.go
+++ b/cmd/createtree/pem_test.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/trillian/crypto/keys"
+	"github.com/google/trillian/crypto/keyspb"
+)
+
+func TestWithPEMKeyFile(t *testing.T) {
+	pemPath, pemPassword := "../../testdata/log-rpc-server.privkey.pem", "towel"
+
+	wantTree := *defaultTree
+	wantTree.PrivateKey = mustMarshalAny(&keyspb.PEMKeyFile{
+		Path:     pemPath,
+		Password: pemPassword,
+	})
+
+	runTest(t, []*testCase{
+		{
+			desc: "empty pemKeyPath",
+			setFlags: func() {
+				*privateKeyFormat = "PEMKeyFile"
+				*pemKeyPath = ""
+				*pemKeyPassword = pemPassword
+			},
+			wantErr: true,
+		},
+		{
+			desc: "empty pemKeyPass",
+			setFlags: func() {
+				*privateKeyFormat = "PEMKeyFile"
+				*pemKeyPath = pemPath
+				*pemKeyPassword = ""
+			},
+			wantErr: true,
+		},
+		{
+			desc: "valid pemKeyPath and pemKeyPass",
+			setFlags: func() {
+				*privateKeyFormat = "PEMKeyFile"
+				*pemKeyPath = pemPath
+				*pemKeyPassword = pemPassword
+			},
+			wantTree: &wantTree,
+		},
+	})
+}
+
+func TestWithPrivateKey(t *testing.T) {
+	pemPath, pemPassword := "../../testdata/log-rpc-server.privkey.pem", "towel"
+
+	key, err := keys.NewFromPrivatePEMFile(pemPath, pemPassword)
+	if err != nil {
+		t.Fatalf("Error reading test private key file: %v", err)
+	}
+
+	keyDER, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		t.Fatalf("Error marshaling test private key to DER: %v", err)
+	}
+
+	wantTree := *defaultTree
+	wantTree.PrivateKey = mustMarshalAny(&keyspb.PrivateKey{
+		Der: keyDER,
+	})
+
+	runTest(t, []*testCase{
+		{
+			desc: "empty pemKeyPath",
+			setFlags: func() {
+				*privateKeyFormat = "PrivateKey"
+				*pemKeyPath = ""
+				*pemKeyPassword = pemPassword
+			},
+			wantErr: true,
+		},
+		{
+			desc: "empty pemKeyPass",
+			setFlags: func() {
+				*privateKeyFormat = "PrivateKey"
+				*pemKeyPath = pemPath
+				*pemKeyPassword = ""
+			},
+			wantErr: true,
+		},
+		{
+			desc: "valid pemKeyPath and pemKeyPass",
+			setFlags: func() {
+				*privateKeyFormat = "PrivateKey"
+				*pemKeyPath = pemPath
+				*pemKeyPassword = pemPassword
+			},
+			wantTree: &wantTree,
+		},
+	})
+}

--- a/cmd/createtree/pkcs11_test.go
+++ b/cmd/createtree/pkcs11_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/trillian/crypto/keyspb"
+)
+
+func TestRunPkcs11(t *testing.T) {
+	err := os.Chdir("../..")
+	if err != nil {
+		t.Fatalf("Unable to change working directory to ../..: %s", err)
+	}
+	defer os.Chdir("cmd/createtree")
+
+	pkcs11Tree := *defaultTree
+	pkcs11Tree.PrivateKey = mustMarshalAny(&keyspb.PKCS11Config{
+		TokenLabel: "log",
+		Pin:        "1234",
+		PublicKey: `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7/tWwqUXZJaNfnpvnqiaeNMkn
+hKusCsyAidrHxvuL+t54XFCHJwsB3wIlQZ4mMwb8mC/KRYhCqECBEoCAf/b0m3j/
+ASuEPLyYOrz/aEs3wP02IZQLGmihmjMk7T/ouNCuX7y1fTjX3GeVQ06U/EePwZFC
+xToc6NWBri0N3VVsswIDAQAB
+-----END PUBLIC KEY-----
+`,
+	})
+
+	runTest(t, []*testCase{
+		{
+			desc: "PKCS11Config",
+			setFlags: func() {
+				*privateKeyFormat = "PKCS11ConfigFile"
+				*pkcs11ConfigPath = "testdata/pkcs11-conf.json"
+			},
+			wantErr:  false,
+			wantTree: &pkcs11Tree,
+		},
+		{
+			desc: "emptyPKCS11Path",
+			setFlags: func() {
+				*privateKeyFormat = "PKCS11ConfigFile"
+				*pkcs11ConfigPath = ""
+			},
+			wantErr: true,
+		},
+	})
+}

--- a/cmd/createtree/testonly/fake_server.go
+++ b/cmd/createtree/testonly/fake_server.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keyspb"
+	"github.com/google/trillian/crypto/sigpb"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// FakeAdminServer implements the TrillianAdminServer CreateTree RPC.
+// The remaining RPCs are not implemented.
+type FakeAdminServer struct {
+	trillian.TrillianAdminServer
+
+	// Err will be returned by CreateTree if not nil.
+	Err error
+	// GeneratedKey will be used to set a tree's PrivateKey if a CreateTree request has a KeySpec.
+	// This is for simulating key generation.
+	GeneratedKey *any.Any
+}
+
+// StartFakeAdminServer starts a FakeAdminServer on a random port.
+// Returns the started server, the listener it's using for connection and a
+// close function that must be defer-called on the scope the server is meant to
+// stop.
+func StartFakeAdminServer(server *FakeAdminServer) (net.Listener, func(), error) {
+	grpcServer := grpc.NewServer()
+	trillian.RegisterTrillianAdminServer(grpcServer, server)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	go grpcServer.Serve(lis)
+
+	stopFn := func() {
+		grpcServer.Stop()
+		lis.Close()
+	}
+
+	return lis, stopFn, nil
+}
+
+// CreateTree returns req.Tree, unless s.Err is not nil, in which case it
+// returns s.Err. This allows tests to examine the requested tree and check
+// behavior under error conditions.
+// If s.GeneratedKey and req.KeySpec are not nil, the returned tree will have
+// its PrivateKey field set to s.GeneratedKey.
+func (s *FakeAdminServer) CreateTree(ctx context.Context, req *trillian.CreateTreeRequest) (*trillian.Tree, error) {
+	if s.Err != nil {
+		return nil, s.Err
+	}
+	resp := *req.Tree
+	if req.KeySpec != nil {
+		if s.GeneratedKey == nil {
+			panic("fakeAdminServer.GeneratedKey == nil but CreateTreeRequest requests generated key")
+		}
+
+		var keySigAlgo sigpb.DigitallySigned_SignatureAlgorithm
+		switch req.KeySpec.Params.(type) {
+		case *keyspb.Specification_EcdsaParams:
+			keySigAlgo = sigpb.DigitallySigned_ECDSA
+		case *keyspb.Specification_RsaParams:
+			keySigAlgo = sigpb.DigitallySigned_RSA
+		default:
+			return nil, fmt.Errorf("got unsupported type of key_spec.params: %T", req.KeySpec.Params)
+		}
+		if treeSigAlgo := req.Tree.GetSignatureAlgorithm(); treeSigAlgo != keySigAlgo {
+			return nil, fmt.Errorf("got tree.SignatureAlgorithm = %v but key_spec.Params of type %T", treeSigAlgo, req.KeySpec.Params)
+		}
+
+		resp.PrivateKey = s.GeneratedKey
+	}
+	return &resp, nil
+}

--- a/util/flagsaver/flagsaver.go
+++ b/util/flagsaver/flagsaver.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flagsaver provides a simple way to save and restore flag values.
+// TODO(RJPercival): Move this to its own GitHub project.
+//
+// Example:
+//   func TestFoo(t *testing.T) {
+//     defer flagsaver.Save().Restore()
+//     // Test code that changes flags
+//   } // flags are reset to their original values here.
+package flagsaver
+
+import "flag"
+
+// Stash holds flag values so that they can be restored at the end of a test.
+type Stash struct {
+	flags map[string]string
+}
+
+// Restore sets all non-hidden flags to the values they had when the Stash was created.
+func (s *Stash) Restore() {
+	for name, value := range s.flags {
+		flag.Set(name, value)
+	}
+}
+
+// Save returns a Stash that captures the current value of all non-hidden flags.
+func Save() *Stash {
+	s := Stash{
+		flags: make(map[string]string, flag.NFlag()),
+	}
+
+	flag.VisitAll(func(f *flag.Flag) {
+		s.flags[f.Name] = f.Value.String()
+	})
+
+	return &s
+}

--- a/util/flagsaver/flagsaver_test.go
+++ b/util/flagsaver/flagsaver_test.go
@@ -1,0 +1,106 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flagsaver
+
+import (
+	"flag"
+	"testing"
+	"time"
+)
+
+var (
+	intFlag      = flag.Int("int_flag", 123, "test integer flag")
+	strFlag      = flag.String("str_flag", "foo", "test string flag")
+	durationFlag = flag.Duration("duration_flag", 5*time.Second, "test duration flag")
+)
+
+// TestRestore checks that flags are saved and restore correctly.
+// Checks are performed on flags with both their default values and with explicit values set.
+// Only a subset of the possible flag types are currently tested.
+func TestRestore(t *testing.T) {
+	tests := []struct {
+		desc string
+		// flag is the name of the flag to save and restore.
+		flag string
+		// oldValue is the value the flag should have when saved. If empty, this indicates the flag should have its default value.
+		oldValue string
+		// newValue ist he value the flag should have just before being restored to oldValue.
+		newValue string
+	}{
+		{
+			desc:     "RestoreDefaultIntValue",
+			flag:     "int_flag",
+			newValue: "666",
+		},
+		{
+			desc:     "RestoreDefaultStrValue",
+			flag:     "str_flag",
+			newValue: "baz",
+		},
+		{
+			desc:     "RestoreDefaultDurationValue",
+			flag:     "duration_flag",
+			newValue: "1m0s",
+		},
+		{
+			desc:     "RestoreSetIntValue",
+			flag:     "int_flag",
+			oldValue: "555",
+			newValue: "666",
+		},
+		{
+			desc:     "RestoreSetStrValue",
+			flag:     "str_flag",
+			oldValue: "bar",
+			newValue: "baz",
+		},
+		{
+			desc:     "RestoreSetDurationValue",
+			flag:     "duration_flag",
+			oldValue: "10s",
+			newValue: "1m0s",
+		},
+	}
+
+	for _, test := range tests {
+		f := flag.Lookup(test.flag)
+		if f == nil {
+			t.Errorf("%v: flag.Lookup(%q) = nil, want not nil", test.desc, test.flag)
+			continue
+		}
+
+		if test.oldValue != "" {
+			if err := flag.Set(test.flag, test.oldValue); err != nil {
+				t.Errorf("%v: flag.Set(%q, %q) = %q, want nil", test.desc, test.flag, test.oldValue, err)
+				continue
+			}
+		} else {
+			// Use the default value of the flag as the oldValue if none was set.
+			test.oldValue = f.DefValue
+		}
+
+		func() {
+			defer Save().Restore()
+			flag.Set(test.flag, test.newValue)
+			if gotValue := f.Value.String(); gotValue != test.newValue {
+				t.Errorf("%v: flag.Lookup(%q).Value.String() = %q, want %q", test.desc, test.flag, gotValue, test.newValue)
+			}
+		}()
+
+		if gotValue := f.Value.String(); gotValue != test.oldValue {
+			t.Errorf("%v: flag.Lookup(%q).Value.String() = %q, want %q", test.desc, test.flag, gotValue, test.oldValue)
+		}
+	}
+}


### PR DESCRIPTION
This simplifies PR #734, which requires putting the PKCS#11 flag used by createtree behind a build tag.