### PR TITLE
Allow "static" initialization of metrics

### DIFF
--- a/client/verifier_test.go
+++ b/client/verifier_test.go
@@ -65,7 +65,7 @@ func TestVerifyRootErrors(t *testing.T) {
 func TestVerifyInclusionAtIndexErrors(t *testing.T) {
 	logVerifier := NewLogVerifier(nil, nil)
 	// An error is expected because the first parameter (trusted) is nil
-	err := logVerifier.VerifyInclusionAtIndex(nil, []byte{0,0,0}, 1, [][]byte{[]byte{0,0}})
+	err := logVerifier.VerifyInclusionAtIndex(nil, []byte{0, 0, 0}, 1, [][]byte{{0, 0}})
 	if err == nil {
 		t.Errorf("VerifyInclusionAtIndex() error expected, but got nil")
 	}

--- a/extension/registry.go
+++ b/extension/registry.go
@@ -18,7 +18,6 @@ package extension
 
 import (
 	"github.com/google/trillian/crypto/keys"
-	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
@@ -40,6 +39,4 @@ type Registry struct {
 	util.ElectionFactory
 	// QuotaManager provides rate limiting capabilities for Trillian.
 	QuotaManager quota.Manager
-	// MetricFactory provides metrics for monitoring.
-	monitoring.MetricFactory
 }

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -347,8 +347,7 @@ func setupAdminServer() (trillian.TrillianAdminClient, func(), error) {
 		return nil, nil, err
 	}
 
-	ti := interceptor.New(
-		registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */, registry.MetricFactory)
+	ti := interceptor.New(registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */)
 	netInterceptor := interceptor.Combine(interceptor.ErrorWrapper, ti.UnaryInterceptor)
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))
 	// grpcServer is stopped via returned func

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -107,7 +107,7 @@ func TestInProcessLogIntegration(t *testing.T) {
 func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
 	ctx := context.Background()
 	const numSequencers = 2
-	ms := memory.NewLogStorage(nil)
+	ms := memory.NewLogStorage()
 
 	reggie := extension.Registry{
 		AdminStorage:  memory.NewAdminStorage(ms),

--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -114,8 +114,7 @@ func setupLogServer(maxUnsequenced int) (trillian.TrillianAdminClient, trillian.
 	}
 	qm.MaxUnsequencedRows = maxUnsequenced
 
-	intercept := interceptor.New(
-		registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */, registry.MetricFactory)
+	intercept := interceptor.New(registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */)
 	netInterceptor := interceptor.Combine(interceptor.ErrorWrapper, intercept.UnaryInterceptor)
 	s = grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))
 	trillian.RegisterTrillianAdminServer(s, admin.New(registry))

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -255,7 +255,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	if qm == nil {
 		qm = quota.Noop()
 	}
-	sequencer := NewSequencer(rfc6962.DefaultHasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil, qm)
+	sequencer := NewSequencer(rfc6962.DefaultHasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, qm)
 	return testContext{mockTx: mockTx, mockStorage: mockStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 
@@ -636,7 +636,7 @@ func TestSequenceBatch_PutTokens(t *testing.T) {
 				qm.EXPECT().PutTokens(any, test.wantTokens, specs)
 			}
 
-			sequencer := NewSequencer(hasher, ts, logStorage, signer, nil /* mf */, qm)
+			sequencer := NewSequencer(hasher, ts, logStorage, signer, qm)
 			leaves, err := sequencer.SequenceBatch(ctx, treeID, limit, guardWindow, maxRootDuration)
 			if err != nil {
 				t.Errorf("%v: SequenceBatch() returned err = %v", test.desc, err)

--- a/monitoring/global.go
+++ b/monitoring/global.go
@@ -1,0 +1,145 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+var globalMF MetricFactory = &fwdMF{createChan: make(chan func(MetricFactory), 100)}
+
+// MF returns the globally registered MetricFactory.
+func MF() MetricFactory {
+	return globalMF
+}
+
+// SetMF sets the global MetricFactory.
+// The newly-assigned factory will be prompted to create all requested metrics so far.
+func SetMF(mf MetricFactory) {
+	if f, ok := globalMF.(*fwdMF); ok {
+		go f.processCreates(mf)
+	}
+	globalMF = mf
+}
+
+// fwdMF plays the part of the global MF until a proper implementation is assigned (by calling
+// SetMF).
+// Proxy, noop metrics are created until SetMF() is called, at that point processCreates() is
+// triggered and calls are forwarded to the underlying, "real" MetricFactory.
+type fwdMF struct {
+	createChan chan func(MetricFactory)
+}
+
+func (f *fwdMF) processCreates(mf MetricFactory) {
+	for true {
+		fn := <-f.createChan
+		fn(mf)
+	}
+}
+
+func (f *fwdMF) NewCounter(name, help string, labelNames ...string) Counter {
+	c := &fwdCounter{}
+	f.createChan <- func(mf MetricFactory) {
+		c.impl = mf.NewCounter(name, help, labelNames...)
+	}
+	return c
+}
+
+func (f *fwdMF) NewGauge(name, help string, labelNames ...string) Gauge {
+	g := &fwdGauge{}
+	f.createChan <- func(mf MetricFactory) {
+		g.impl = mf.NewGauge(name, help, labelNames...)
+	}
+	return g
+}
+
+func (f *fwdMF) NewHistogram(name, help string, labelNames ...string) Histogram {
+	h := &fwdHistogram{}
+	f.createChan <- func(mf MetricFactory) {
+		h.impl = mf.NewHistogram(name, help, labelNames...)
+	}
+	return h
+}
+
+type fwdCounter struct {
+	impl Counter
+}
+
+func (c *fwdCounter) Inc(labelVals ...string) {
+	if c.impl != nil {
+		c.impl.Inc(labelVals...)
+	}
+}
+
+func (c *fwdCounter) Add(val float64, labelVals ...string) {
+	if c.impl != nil {
+		c.impl.Add(val, labelVals...)
+	}
+}
+
+func (c *fwdCounter) Value(labelVals ...string) float64 {
+	if c.impl != nil {
+		return c.impl.Value(labelVals...)
+	}
+	return 0
+}
+
+type fwdGauge struct {
+	impl Gauge
+}
+
+func (g *fwdGauge) Inc(labelVals ...string) {
+	if g.impl != nil {
+		g.Inc(labelVals...)
+	}
+}
+
+func (g *fwdGauge) Dec(labelVals ...string) {
+	if g.impl != nil {
+		g.Dec(labelVals...)
+	}
+}
+
+func (g *fwdGauge) Add(val float64, labelVals ...string) {
+	if g.impl != nil {
+		g.Add(val, labelVals...)
+	}
+}
+
+func (g *fwdGauge) Set(val float64, labelVals ...string) {
+	if g.impl != nil {
+		g.Set(val, labelVals...)
+	}
+}
+
+func (g *fwdGauge) Value(labelVals ...string) float64 {
+	if g.impl != nil {
+		g.Value(labelVals...)
+	}
+	return 0
+}
+
+type fwdHistogram struct {
+	impl Histogram
+}
+
+func (h *fwdHistogram) Observe(val float64, labelVals ...string) {
+	if h.impl != nil {
+		h.impl.Observe(val, labelVals...)
+	}
+}
+
+func (h *fwdHistogram) Info(labelVals ...string) (uint64, float64) {
+	if h.impl != nil {
+		return h.impl.Info(labelVals...)
+	}
+	return 0, 0
+}

--- a/quota/mysql/mysql_quota_test.go
+++ b/quota/mysql/mysql_quota_test.go
@@ -314,7 +314,7 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 		})
 	}
 
-	ls := mysql.NewLogStorage(db, nil)
+	ls := mysql.NewLogStorage(db)
 	tx, err := ls.BeginForTree(ctx, tree.TreeId)
 	if err != nil {
 		return err

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -93,7 +93,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	intercept := New(admin, quota.Noop(), false /* quotaDryRun */, nil /* mf */)
+	intercept := New(admin, quota.Noop(), false /* quotaDryRun */)
 	for _, test := range tests {
 		handler := &fakeHandler{resp: "handler response", err: test.handlerErr}
 
@@ -262,7 +262,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		}
 
 		handler := &fakeHandler{resp: "ok"}
-		intercept := New(admin, qm, test.dryRun, nil /* mf */)
+		intercept := New(admin, qm, test.dryRun)
 
 		// resp and handler assertions are done by TestTrillianInterceptor_TreeInterception,
 		// we're only concerned with the quota logic here.
@@ -400,7 +400,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 		}
 
 		handler := &fakeHandler{resp: test.resp, err: test.handlerErr}
-		intercept := New(admin, qm, false /* quotaDryRun */, nil /* mf */)
+		intercept := New(admin, qm, false /* quotaDryRun */)
 
 		if _, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run); err != test.handlerErr {
 			t.Errorf("%v: UnaryInterceptor() returned err = [%v], want = [%v]", test.desc, err, test.handlerErr)
@@ -449,7 +449,7 @@ func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		intercept := New(admin, qm, false /* quotaDryRun */, nil /* mf */)
+		intercept := New(admin, qm, false /* quotaDryRun */)
 		p := intercept.NewProcessor()
 
 		_, err := p.Before(ctx, test.req)

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -78,7 +78,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 		return 0, fmt.Errorf("error getting signer for log %v: %v", logID, err)
 	}
 
-	sequencer := log.NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer, s.registry.MetricFactory, s.registry.QuotaManager)
+	sequencer := log.NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer, s.registry.QuotaManager)
 
 	maxRootDuration, err := ptypes.Duration(tree.MaxRootDuration)
 	if err != nil {

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/log"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server"
@@ -98,6 +99,8 @@ func main() {
 	}
 
 	mf := prometheus.MetricFactory{}
+	monitoring.SetMF(mf)
+
 	sf := &keys.DefaultSignerFactory{}
 	if *pkcs11ModulePath != "" {
 		sf.SetPKCS11Module(*pkcs11ModulePath)
@@ -105,11 +108,10 @@ func main() {
 
 	registry := extension.Registry{
 		AdminStorage:    mysql.NewAdminStorage(db),
-		LogStorage:      mysql.NewLogStorage(db, mf),
+		LogStorage:      mysql.NewLogStorage(db),
 		SignerFactory:   sf,
 		ElectionFactory: electionFactory,
 		QuotaManager:    quota.Noop(),
-		MetricFactory:   mf,
 	}
 
 	// Start HTTP server (optional)

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -99,7 +99,7 @@ func checkLeafContents(leaf *trillian.LogLeaf, seq int64, rawHash, hash, data, e
 
 func TestMySQLLogStorage_CheckDatabaseAccessible(t *testing.T) {
 	cleanTestDB(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	if err := s.CheckDatabaseAccessible(context.Background()); err != nil {
 		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
 	}
@@ -168,7 +168,7 @@ func TestBeginSnapshot(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	for _, test := range tests {
 		func() {
 			var tx rootReaderLogTX
@@ -213,7 +213,7 @@ type rootReaderLogTX interface {
 func TestIsOpenCommitRollbackClosed(t *testing.T) {
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tests := []struct {
 		commit, rollback, close bool
@@ -254,7 +254,7 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	count := 15
 	leaves := createTestLeaves(int64(count), 10)
 	leaves2 := createTestLeaves(int64(count), 12)
@@ -319,7 +319,7 @@ func TestQueueLeaves(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -354,7 +354,7 @@ func TestDequeueLeavesNoneQueued(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -374,7 +374,7 @@ func TestDequeueLeaves(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	{
 		tx := beginLogTx(s, logID, t)
@@ -421,7 +421,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	leavesToDequeue1 := 3
 	leavesToDequeue2 := 2
@@ -491,7 +491,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	{
 		tx := beginLogTx(s, logID, t)
@@ -536,7 +536,7 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 	// queue.
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	batchSize := 2
 	leaves := createTestLeaves(int64(batchSize), 0)
@@ -600,7 +600,7 @@ func TestGetLeavesByHashNotPresent(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -621,7 +621,7 @@ func TestGetLeavesByIndexNotPresent(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -638,7 +638,7 @@ func TestGetLeavesByHash(t *testing.T) {
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	data := []byte("some data")
 	createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
@@ -664,7 +664,7 @@ func TestGetLeafDataByIdentityHash(t *testing.T) {
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	data := []byte("some data")
 	leaf := createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
 	leaf.LeafIndex = -1
@@ -726,7 +726,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	// Create fake leaf as if it had been sequenced, read it back and check contents
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	data := []byte("some data")
 	createFakeLeaf(ctx, DB, logID, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
@@ -750,7 +750,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -770,7 +770,7 @@ func TestLatestSignedLogRoot(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -807,7 +807,7 @@ func TestDuplicateSignedLogRoot(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -836,7 +836,7 @@ func TestLogRootUpdate(t *testing.T) {
 	// Write two roots for a log and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx := beginLogTx(s, logID, t)
 	defer tx.Close()
@@ -913,7 +913,7 @@ func TestGetActiveLogIDs(t *testing.T) {
 		*tree = *updatedTree
 	}
 
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	tx, err := s.Snapshot(ctx)
 	if err != nil {
 		t.Fatalf("Snapshot() returns err = %v", err)
@@ -939,7 +939,7 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 	ctx := context.Background()
 
 	cleanTestDB(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	tx, err := s.Snapshot(context.Background())
 	if err != nil {
@@ -966,7 +966,7 @@ func TestGetUnsequencedCounts(t *testing.T) {
 	for i := 0; i < numLogs; i++ {
 		logIDs = append(logIDs, createLogForTests(DB))
 	}
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	ctx := context.Background()
 	expectedCount := make(map[int64]int64)
@@ -1005,7 +1005,7 @@ func TestGetUnsequencedCounts(t *testing.T) {
 func TestReadOnlyLogTX_Rollback(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 	tx, err := s.Snapshot(ctx)
 	if err != nil {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
@@ -1027,7 +1027,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	cleanTestDB(DB)
 	logID1 := createLogForTests(DB)
 	logID2 := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	{
 		// Create fake leaf as if it had been sequenced

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -38,7 +38,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	const writeRevision = int64(100)
 	nodesToStore := createSomeNodes()
@@ -86,7 +86,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 
 	cleanTestDB(DB)
 	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB)
 
 	const writeRevision = int64(100)
 	nodesToStore, err := createLogNodesForTreeAtSize(871, writeRevision)

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -34,20 +34,20 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
-	tc "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/memory"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/util"
+
+	tc "github.com/google/trillian/crypto"
 )
 
 var (
@@ -217,7 +217,7 @@ func Main(args Options) string {
 	leafHashesFlag = args.LeafHashes
 
 	glog.Info("Initializing memory log storage")
-	ls := memory.NewLogStorage(monitoring.InertMetricFactory{})
+	ls := memory.NewLogStorage()
 	as := memory.NewAdminStorage(ls)
 	tree, cSigner := createTree(as)
 
@@ -225,7 +225,6 @@ func Main(args Options) string {
 		util.SystemTimeSource{},
 		ls,
 		&tc.Signer{Signer: cSigner, Hash: crypto.SHA256},
-		nil,
 		quota.Noop())
 
 	// Create the initial tree head at size 0, which is required. And then sequence the leaves.

--- a/storage/tools/fetch_leaves/main.go
+++ b/storage/tools/fetch_leaves/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 	defer db.Close()
 
-	storage := mysql.NewLogStorage(db, nil)
+	storage := mysql.NewLogStorage(db)
 	ctx := context.Background()
 	tx, err := storage.SnapshotForTree(ctx, *treeIDFlag)
 	if err != nil {

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -61,7 +61,7 @@ func main() {
 	}
 	defer db.Close()
 
-	storage := mysql.NewLogStorage(db, nil)
+	storage := mysql.NewLogStorage(db)
 	ctx := context.Background()
 	tx, err := storage.BeginForTree(ctx, *treeIDFlag)
 	if err != nil {

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -81,7 +81,7 @@ func NewLogEnv(ctx context.Context, numSequencers int, testID string) (*LogEnv, 
 
 	registry := extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
-		LogStorage:    mysql.NewLogStorage(db, nil),
+		LogStorage:    mysql.NewLogStorage(db),
 		QuotaManager:  quota.Noop(),
 		SignerFactory: &keys.DefaultSignerFactory{},
 	}

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -31,7 +31,7 @@ func NewRegistryForTests(testID string) (extension.Registry, error) {
 
 	return extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
-		LogStorage:    mysql.NewLogStorage(db, nil),
+		LogStorage:    mysql.NewLogStorage(db),
 		SignerFactory: &keys.DefaultSignerFactory{},
 		MapStorage:    mysql.NewMapStorage(db),
 		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: mysqlq.DefaultMaxUnsequenced},


### PR DESCRIPTION
Usually, metric initialization is performed in a "static" manner, ie:

```go
var myCounter = prometheus.NewCounter(...)
```

Because Trillian allows for flexible monitoring systems we have the MetricFactory abstraction. As a consequence, we've developed a convention of passing in MetricFactory and initializing metrics with the assistence of sync.Once.

I spent some time looking for a solution that would allow us to initialize metrics statically, without losing the flexibility we gain by MetricFactory. The result is a global "metric proxy" implementation that returns forwarding metrics until an implementation is available. Once an implementation is available, all metrics get created and the forwards pass on the calls to the underlying metric system. This scheme greatly simplifies metric creation and usage, both of which look "natural" now, at the cost of a simple delegate class.

The final results looks like:

```go
// Metric declaration:
var myMetric = monitoring.MF().NewCounter(...)

// Entry point:
func main() {
  mf := MetricFactoryImpl{}
  monitoring.SetMF(mf)
}
```

As it stands, this PR is a suggestion / PoC. If people like it, I can add some tests and clean up a bit. (It does work as-is, though.)