### PR TITLE
Common function to produce keypb.PublicKey

### DIFF
--- a/crypto/keys/der/der.go
+++ b/crypto/keys/der/der.go
@@ -29,6 +29,11 @@ func FromProto(pb *keyspb.PrivateKey) (crypto.Signer, error) {
 	return UnmarshalPrivateKey(pb.GetDer())
 }
 
+// FromPublicProto takes a PublicKey protobuf message and returns the public key contained within.
+func FromPublicProto(pb *keyspb.PublicKey) (crypto.PublicKey, error) {
+	return UnmarshalPublicKey(pb.GetDer())
+}
+
 // UnmarshalPrivateKey reads a DER-encoded private key.
 func UnmarshalPrivateKey(keyDER []byte) (crypto.Signer, error) {
 	key1, err1 := x509.ParseECPrivateKey(keyDER)


### PR DESCRIPTION
This PR creates a common function to convert `crypto.PublicKey` into
`keyspb.PublicKey`. This code is currently spread throughout a few
locations.

This also makes it easier for all the `keys.NewFrom*` functions, which
all produce `crypto.PublicKey`, and then convert it back into a
protobuf.