### PR TITLE
Remove libtool dependency from Docker files

### DIFF
--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -14,7 +14,6 @@ ENV DUMP_METRICS 0s
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN apt-get update && apt-get install -y libtool libltdl-dev
 RUN go get -v ./server/trillian_log_server
 
 ENTRYPOINT /go/bin/trillian_log_server \

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -18,7 +18,6 @@ ENV SEQUENCER_GUARD_WINDOW=0s \
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN apt-get update && apt-get install -y libtool libltdl-dev
 RUN go get ./server/trillian_log_signer
 
 # Run the outyet command by default when the container starts.

--- a/server/trillian_log_server/Dockerfile
+++ b/server/trillian_log_server/Dockerfile
@@ -3,9 +3,6 @@ FROM golang:1.8
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN apt-get update && \
-    apt-get install -y libtool libltdl-dev
-
 RUN go get ./server/trillian_log_server
 
 ENTRYPOINT ["/go/bin/trillian_log_server"]

--- a/server/trillian_log_signer/Dockerfile
+++ b/server/trillian_log_signer/Dockerfile
@@ -3,9 +3,6 @@ FROM golang:1.8
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN apt-get update && \
-    apt-get install -y libtool libltdl-dev
-
 RUN go get ./server/trillian_log_signer
 
 ENTRYPOINT ["/go/bin/trillian_log_signer"]

--- a/server/trillian_map_server/Dockerfile
+++ b/server/trillian_map_server/Dockerfile
@@ -3,9 +3,6 @@ FROM golang:1.8
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN apt-get update && \
-    apt-get install -y libtool libltdl-dev
-
 RUN go get ./server/trillian_map_server
 
 ENTRYPOINT ["/go/bin/trillian_map_server"]


### PR DESCRIPTION
This removes the libtool dependency from all trillian Docker files. The dependency was introduced with pkcs11 support which isn't build by default now.