### PR TITLE
Stash coverage reports in /tmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,4 +92,5 @@ before_script:
   - yes | ./scripts/resetdb.sh
 
 after_success:
+  - cp /tmp/coverage.txt .
   - bash <(curl -s https://codecov.io/bash)

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -102,6 +102,7 @@ main() {
         rm profile.out
       fi
     done
+    cp coverage.txt /tmp
   fi
 
   if [[ "${run_linters}" -eq 1 ]]; then


### PR DESCRIPTION
This should fix report uploads to codecov as it seemed that that this file was getting removed during the rest of the build.