### PR TITLE
Wire etcd quotas on log and map servers and logsigner

### DIFF
--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/quota/etcd/etcdqm"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
+	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/admin"
 	"github.com/google/trillian/server/interceptor"
@@ -39,8 +40,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	mysqlqm "github.com/google/trillian/quota/mysql"
 )
 
 func TestEtcdRateLimiting(t *testing.T) {

--- a/quota/etcd/etcdqm/etcdqm.go
+++ b/quota/etcd/etcdqm/etcdqm.go
@@ -34,7 +34,7 @@ func New(client *clientv3.Client) quota.Manager {
 }
 
 func (m *manager) GetUser(ctx context.Context, req interface{}) string {
-	return "" // Unused
+	return "default" // Unused
 }
 
 func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {

--- a/quota/mysql/mysql_quota.go
+++ b/quota/mysql/mysql_quota.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Package mysql defines a MySQL-based quota.Manager implementation.
+// TODO(codingllama): Rename to mysqlqm
 package mysql
 
 import (

--- a/quota/mysqlqm/mysql_quota.go
+++ b/quota/mysqlqm/mysql_quota.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package mysql defines a MySQL-based quota.Manager implementation.
-// TODO(codingllama): Rename to mysqlqm
-package mysql
+// Package mysqlqm defines a MySQL-based quota.Manager implementation.
+package mysqlqm
 
 import (
 	"context"

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mysql_test
+package mysqlqm_test
 
 import (
 	"context"
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/quota"
-	mysqlq "github.com/google/trillian/quota/mysql"
+	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly/integration"
@@ -42,7 +42,7 @@ func TestQuotaManager_GetTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTree() returned err = %v", err)
 	}
-	user := (&mysqlq.QuotaManager{}).GetUser(ctx, nil /* req */)
+	user := (&mysqlqm.QuotaManager{}).GetUser(ctx, nil /* req */)
 
 	tests := []struct {
 		desc                                           string
@@ -102,9 +102,9 @@ func TestQuotaManager_GetTokens(t *testing.T) {
 		// Test general cases using select count(*) to avoid flakiness / allow for more
 		// precise assertions.
 		// See TestQuotaManager_GetTokens_InformationSchema for information schema tests.
-		qm := &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: test.maxUnsequencedRows, UseSelectCount: true}
+		qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: test.maxUnsequencedRows, UseSelectCount: true}
 		err := qm.GetTokens(ctx, test.numTokens, test.specs)
-		if hasErr := err == mysqlq.ErrTooManyUnsequencedRows; hasErr != test.wantErr {
+		if hasErr := err == mysqlqm.ErrTooManyUnsequencedRows; hasErr != test.wantErr {
 			t.Errorf("%v: GetTokens() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
 		}
 	}
@@ -138,7 +138,7 @@ func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
 			continue
 		}
 
-		qm := &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequenced, UseSelectCount: test.useSelectCount}
+		qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequenced, UseSelectCount: test.useSelectCount}
 
 		// All GetTokens() calls where leaves < maxUnsequenced should succeed:
 		// information_schema may be outdated, but it should refer to a valid point in the
@@ -168,7 +168,7 @@ func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
 				stop = true
 			default:
 				// An error means that GetTokens is working correctly
-				stop = qm.GetTokens(ctx, 1 /* numTokens */, globalWriteSpec) == mysqlq.ErrTooManyUnsequencedRows
+				stop = qm.GetTokens(ctx, 1 /* numTokens */, globalWriteSpec) == mysqlqm.ErrTooManyUnsequencedRows
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func TestQuotaManager_PeekTokens(t *testing.T) {
 	}
 
 	// Test using select count(*) to allow for precise assertions without flakiness.
-	qm := &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequencedRows, UseSelectCount: true}
+	qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequencedRows, UseSelectCount: true}
 	specs := allSpecs(ctx, qm, tree.TreeId)
 	tokens, err := qm.PeekTokens(ctx, specs)
 	if err != nil {
@@ -220,7 +220,7 @@ func TestQuotaManager_Noops(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	qm := &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: 1000}
+	qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: 1000}
 	specs := allSpecs(ctx, qm, 10 /* treeID */)
 
 	tests := []struct {

--- a/server/quota.go
+++ b/server/quota.go
@@ -21,8 +21,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd/etcdqm"
-
-	mysqlq "github.com/google/trillian/quota/mysql"
+	"github.com/google/trillian/quota/mysqlqm"
 )
 
 const (
@@ -67,7 +66,7 @@ func NewQuotaManager(params *QuotaParams) (quota.Manager, error) {
 	case QuotaNoop:
 		qm = quota.Noop()
 	case QuotaMySQL:
-		qm = &mysqlq.QuotaManager{DB: params.DB, MaxUnsequencedRows: params.MaxUnsequencedRows}
+		qm = &mysqlqm.QuotaManager{DB: params.DB, MaxUnsequencedRows: params.MaxUnsequencedRows}
 	case QuotaEtcd:
 		// Client is more likely to be nil than all other params, due to etcd being an optional
 		// dependency in some cases.

--- a/server/quota.go
+++ b/server/quota.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/google/trillian/quota"
+	"github.com/google/trillian/quota/etcd/etcdqm"
+
+	mysqlq "github.com/google/trillian/quota/mysql"
+)
+
+const (
+	// QuotaNoop represents the noop quota implementation.
+	QuotaNoop = "noop"
+
+	// QuotaMySQL represents the MySQL quota implementation.
+	QuotaMySQL = "mysql"
+
+	// QuotaEtcd represents the etcd quota implementation.
+	QuotaEtcd = "etcd"
+)
+
+// QuotaParams represents all parameters required to initialize a quota.Manager.
+//
+// Depending on the supplied QuotaSystem, the actual quota.Manager implementation, as returned by
+// NewQuotaManager, may differ.
+//
+// See fields for details.
+type QuotaParams struct {
+	// QuotaSystem represents the underlying quota implementation used.
+	// Valid values are "noop", "mysql" and "etcd".
+	QuotaSystem string
+
+	// DB is the database used by MySQL quotas.
+	DB *sql.DB
+
+	// MaxUnsequencedRows is the max number of rows that may be in Unsequenced before new write
+	// requests are blocked.
+	// Used by MySQL quotas.
+	MaxUnsequencedRows int
+
+	// Client is used by etcd quotas.
+	Client *clientv3.Client
+}
+
+// NewQuotaManager returns a quota.Manager implementation according to params.
+// See QuotaParams for details.
+func NewQuotaManager(params *QuotaParams) (quota.Manager, error) {
+	var qm quota.Manager
+	switch params.QuotaSystem {
+	case QuotaNoop:
+		qm = quota.Noop()
+	case QuotaMySQL:
+		qm = &mysqlq.QuotaManager{DB: params.DB, MaxUnsequencedRows: params.MaxUnsequencedRows}
+	case QuotaEtcd:
+		// Client is more likely to be nil than all other params, due to etcd being an optional
+		// dependency in some cases.
+		// As such, let's fail fast here if that's the case.
+		if params.Client == nil {
+			return nil, fmt.Errorf("etcd servers required for %v quota", params.QuotaSystem)
+		}
+		qm = etcdqm.New(params.Client)
+	default:
+		return nil, fmt.Errorf("unknown quota system: %v", params.QuotaSystem)
+	}
+
+	return qm, nil
+}

--- a/server/quota.go
+++ b/server/quota.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/golang/glog"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd/etcdqm"
 	"github.com/google/trillian/quota/mysqlqm"
@@ -79,5 +80,6 @@ func NewQuotaManager(params *QuotaParams) (quota.Manager, error) {
 		return nil, fmt.Errorf("unknown quota system: %v", params.QuotaSystem)
 	}
 
+	glog.Infof("Using QuotaManager %T", qm)
 	return qm, nil
 }

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -29,14 +29,18 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota/etcd/quotaapi"
+	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/etcd"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
 	mysqlq "github.com/google/trillian/quota/mysql"
+	netcontext "golang.org/x/net/context"
 
 	// Register pprof HTTP handlers
 	_ "net/http/pprof"
@@ -52,14 +56,17 @@ import (
 )
 
 var (
-	mySQLURI           = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
-	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
-	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
-	etcdServers        = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
-	etcdService        = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
-	etcdHTTPService    = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in")
+	mySQLURI        = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	rpcEndpoint     = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
+	httpEndpoint    = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
+	etcdServers     = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+	etcdService     = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
+	etcdHTTPService = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
+
 	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
+	quotaSystem        = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+		"Only effective for quota_system=mysql.")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
@@ -95,12 +102,22 @@ func main() {
 		defer unannounceHTTP()
 	}
 
+	qm, err := server.NewQuotaManager(&server.QuotaParams{
+		QuotaSystem:        *quotaSystem,
+		DB:                 db,
+		MaxUnsequencedRows: *maxUnsequencedRows,
+		Client:             client,
+	})
+	if err != nil {
+		glog.Exitf("Error creating quota manager: %v", err)
+	}
+
 	mf := prometheus.MetricFactory{}
 
 	registry := extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
 		LogStorage:    mysql.NewLogStorage(db, mf),
-		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: *maxUnsequencedRows},
+		QuotaManager:  qm,
 		MetricFactory: mf,
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)
@@ -116,19 +133,30 @@ func main() {
 	// No defer: server ownership is delegated to server.Main
 
 	m := server.Main{
-		RPCEndpoint:       *rpcEndpoint,
-		HTTPEndpoint:      *httpEndpoint,
-		DB:                db,
-		Registry:          registry,
-		Server:            s,
-		RegisterHandlerFn: trillian.RegisterTrillianLogHandlerFromEndpoint,
+		RPCEndpoint:  *rpcEndpoint,
+		HTTPEndpoint: *httpEndpoint,
+		DB:           db,
+		Registry:     registry,
+		Server:       s,
+		RegisterHandlerFn: func(ctx netcontext.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+			if err := trillian.RegisterTrillianLogHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+				return err
+			}
+			if *quotaSystem == server.QuotaEtcd {
+				return quotapb.RegisterQuotaHandlerFromEndpoint(ctx, mux, endpoint, opts)
+			}
+			return nil
+		},
 		RegisterServerFn: func(s *grpc.Server, registry extension.Registry) error {
 			logServer := server.NewTrillianLogRPCServer(registry, ts)
 			if err := logServer.IsHealthy(); err != nil {
 				return err
 			}
 			trillian.RegisterTrillianLogServer(s, logServer)
-			return err
+			if *quotaSystem == server.QuotaEtcd {
+				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
+			}
+			return nil
 		},
 	}
 

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
+	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage/mysql"
@@ -39,7 +40,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
-	mysqlq "github.com/google/trillian/quota/mysql"
 	netcontext "golang.org/x/net/context"
 
 	// Register pprof HTTP handlers
@@ -65,7 +65,7 @@ var (
 
 	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 	quotaSystem        = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
 		"Only effective for quota_system=mysql.")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/monitoring/prometheus"
-	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
@@ -57,8 +56,11 @@ var (
 	etcdServers              = flag.String("etcd_servers", "", "A comma-separated list of etcd servers")
 	etcdHTTPService          = flag.String("etcd_http_service", "trillian-logsigner-http", "Service name to announce our HTTP endpoint under")
 	lockDir                  = flag.String("lock_file_path", "/test/multimaster", "etcd lock file directory path")
-	quotaIncreaseFactor      = flag.Float64("quota_increase_factor", log.QuotaIncreaseFactor,
-		"Increase factor for tokens replenished by sequencing-based quotas (1 means a 1:1 relationship between sequenced leaves and replenished tokens).")
+
+	quotaSystem         = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
+	quotaIncreaseFactor = flag.Float64("quota_increase_factor", log.QuotaIncreaseFactor,
+		"Increase factor for tokens replenished by sequencing-based quotas (1 means a 1:1 relationship between sequenced leaves and replenished tokens)."+
+			"Only effective for --quota_system=etcd.")
 
 	preElectionPause    = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	masterCheckInterval = flag.Duration("master_check_interval", 5*time.Second, "Interval between checking mastership still held")
@@ -108,13 +110,22 @@ func main() {
 		glog.Exit("Either --force_master or --etcd_servers must be supplied")
 	}
 
+	qm, err := server.NewQuotaManager(&server.QuotaParams{
+		QuotaSystem: *quotaSystem,
+		DB:          db,
+		Client:      client,
+	})
+	if err != nil {
+		glog.Exitf("Error creating quota manager: %v", err)
+	}
+
 	mf := prometheus.MetricFactory{}
 
 	registry := extension.Registry{
 		AdminStorage:    mysql.NewAdminStorage(db),
 		LogStorage:      mysql.NewLogStorage(db, mf),
 		ElectionFactory: electionFactory,
-		QuotaManager:    quota.Noop(),
+		QuotaManager:    qm,
 		MetricFactory:   mf,
 	}
 

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -27,13 +27,18 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota/etcd/quotaapi"
+	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/etcd"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
 	mysqlq "github.com/google/trillian/quota/mysql"
+	netcontext "golang.org/x/net/context"
 
 	// Register pprof HTTP handlers
 	_ "net/http/pprof"
@@ -49,11 +54,15 @@ import (
 )
 
 var (
-	mySQLURI           = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
-	rpcEndpoint        = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
-	httpEndpoint       = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in")
+	mySQLURI     = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	rpcEndpoint  = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
+	httpEndpoint = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
+	etcdServers  = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+
 	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
+	quotaSystem        = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+		"Only effective for quota_system=mysql.")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
@@ -73,10 +82,25 @@ func main() {
 	}
 	// No defer: database ownership is delegated to server.Main
 
+	client, err := etcd.NewClient(*etcdServers)
+	if err != nil {
+		glog.Exitf("Failed to connect to etcd at %v: %v", etcdServers, err)
+	}
+
+	qm, err := server.NewQuotaManager(&server.QuotaParams{
+		QuotaSystem:        *quotaSystem,
+		DB:                 db,
+		MaxUnsequencedRows: *maxUnsequencedRows,
+		Client:             client,
+	})
+	if err != nil {
+		glog.Exitf("Error creating quota manager: %v", err)
+	}
+
 	registry := extension.Registry{
 		AdminStorage:  mysql.NewAdminStorage(db),
 		MapStorage:    mysql.NewMapStorage(db),
-		QuotaManager:  &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: *maxUnsequencedRows},
+		QuotaManager:  qm,
 		MetricFactory: prometheus.MetricFactory{},
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)
@@ -92,19 +116,30 @@ func main() {
 	// No defer: server ownership is delegated to server.Main
 
 	m := server.Main{
-		RPCEndpoint:       *rpcEndpoint,
-		HTTPEndpoint:      *httpEndpoint,
-		DB:                db,
-		Registry:          registry,
-		Server:            s,
-		RegisterHandlerFn: trillian.RegisterTrillianMapHandlerFromEndpoint,
+		RPCEndpoint:  *rpcEndpoint,
+		HTTPEndpoint: *httpEndpoint,
+		DB:           db,
+		Registry:     registry,
+		Server:       s,
+		RegisterHandlerFn: func(ctx netcontext.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+			if err := trillian.RegisterTrillianMapHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+				return err
+			}
+			if *quotaSystem == server.QuotaEtcd {
+				return quotapb.RegisterQuotaHandlerFromEndpoint(ctx, mux, endpoint, opts)
+			}
+			return nil
+		},
 		RegisterServerFn: func(s *grpc.Server, registry extension.Registry) error {
 			mapServer := server.NewTrillianMapServer(registry)
 			if err := mapServer.IsHealthy(); err != nil {
 				return err
 			}
 			trillian.RegisterTrillianMapServer(s, mapServer)
-			return err
+			if *quotaSystem == server.QuotaEtcd {
+				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
+			}
+			return nil
 		},
 	}
 

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
+	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage/mysql"
@@ -37,7 +38,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
-	mysqlq "github.com/google/trillian/quota/mysql"
 	netcontext "golang.org/x/net/context"
 
 	// Register pprof HTTP handlers
@@ -61,7 +61,7 @@ var (
 
 	quotaDryRun        = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 	quotaSystem        = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlq.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
 		"Only effective for quota_system=mysql.")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -16,7 +16,7 @@ package integration
 
 import (
 	"github.com/google/trillian/extension"
-	mysqlq "github.com/google/trillian/quota/mysql"
+	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/storage/mysql"
 )
 
@@ -32,6 +32,6 @@ func NewRegistryForTests(testID string) (extension.Registry, error) {
 		AdminStorage: mysql.NewAdminStorage(db),
 		LogStorage:   mysql.NewLogStorage(db, nil),
 		MapStorage:   mysql.NewMapStorage(db),
-		QuotaManager: &mysqlq.QuotaManager{DB: db, MaxUnsequencedRows: mysqlq.DefaultMaxUnsequenced},
+		QuotaManager: &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: mysqlqm.DefaultMaxUnsequenced},
 	}, nil
 }

--- a/util/etcd/client.go
+++ b/util/etcd/client.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+// NewClient returns an etcd client, or nil if servers is empty.
+// The servers parameter should be a comma-separated list of etcd server URIs.
+func NewClient(servers string) (*clientv3.Client, error) {
+	if servers == "" {
+		return nil, nil
+	}
+	return clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(servers, ","),
+		DialTimeout: 5 * time.Second,
+	})
+}


### PR DESCRIPTION
Etcd-based quotas may now be used with Log and Map servers.

A few refactors went into the PR, such as:
* Etcd clients are created by main and passed to other packages. This ensures the same client and configurations are used.
* Log integration test (the bash-driven one) uses etcd quotas when etcd is available
* Package quota/mysql renamed to quota/mysqlqm (in order to avoid import aliasing)

A quota-focused integration test for etcd has been added as well.