### PR TITLE
Allow log server to return consistency proofs where first=second

### DIFF
--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1289,7 +1289,7 @@ func TestGetConsistencyProof(t *testing.T) {
 	hashes := [][][]byte{{[]byte("nodehash")}, {}}
 	nodes := [][]storage.Node{{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}}, {}}
 
-	for i, _ := range testCases {
+	for i := range testCases {
 		mockStorage := storage.NewMockLogStorage(ctrl)
 		mockTx := storage.NewMockLogTreeTX(ctrl)
 		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), testCases[i].LogId).Return(mockTx, nil)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1283,7 +1283,7 @@ func TestGetConsistencyProof(t *testing.T) {
 
 	// getConsistencyProofRequest7 - tests a normal request which should succeed
 	// getConsistencyProofRequest44 - tests an edge condition we used to reject but now support
-	// for compatibilty with the older C++ log servers.
+	// for compatibility with the older C++ log servers.
 	testCases := []trillian.GetConsistencyProofRequest{getConsistencyProofRequest7, getConsistencyProofRequest44}
 	nodeIDs := [][]storage.NodeID{nodeIdsConsistencySize4ToSize7, {}}
 	hashes := [][][]byte{{[]byte("nodehash")}, {}}

--- a/server/validate.go
+++ b/server/validate.go
@@ -52,7 +52,7 @@ func validateGetConsistencyProofRequest(req *trillian.GetConsistencyProofRequest
 		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v, want > 0", req.SecondTreeSize)
 	}
 	if req.SecondTreeSize < req.FirstTreeSize {
-		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want > ", req.FirstTreeSize, req.SecondTreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want >= ", req.FirstTreeSize, req.SecondTreeSize)
 	}
 	return nil
 }

--- a/server/validate.go
+++ b/server/validate.go
@@ -51,7 +51,7 @@ func validateGetConsistencyProofRequest(req *trillian.GetConsistencyProofRequest
 	if req.SecondTreeSize <= 0 {
 		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v, want > 0", req.SecondTreeSize)
 	}
-	if req.SecondTreeSize <= req.FirstTreeSize {
+	if req.SecondTreeSize < req.FirstTreeSize {
 		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want > ", req.FirstTreeSize, req.SecondTreeSize)
 	}
 	return nil


### PR DESCRIPTION
This is for additional compatiblity with the older C++ log server code. Needs a corresponding change to CTFE, which will follow:

https://github.com/google/certificate-transparency-go/pull/74