### PR TITLE
Disable certificate-transparency-go integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ install:
   - go get -u github.com/golang/protobuf/protoc-gen-go
   - go get -u github.com/kisielk/errcheck
   - go get -u golang.org/x/tools/cmd/stringer
-  - go get -u github.com/google/certificate-transparency-go
-  - go get -d -t github.com/google/certificate-transparency-go/...
   - go install github.com/golang/{mock/mockgen,protobuf/protoc-gen-go}
   # install vendored protoc-gen-grpc-gateway binary
   - go install ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
@@ -82,8 +80,6 @@ script:
         export ETCD_DIR="${GOPATH}/bin"
       fi
   - ./integration/integration_test.sh
-  - cd $HOME/gopath/src/github.com/google/certificate-transparency-go
-  - ./trillian/integration/integration_test.sh
   - set +e
 
 services: mysql


### PR DESCRIPTION
Temporary until certificate-transparency-go vendors its dependencies, at
which point Travis should work again