### PR TITLE
Revert "Disable certificate-transparency-go integration tests (#822)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ install:
   - go get -u github.com/golang/protobuf/protoc-gen-go
   - go get -u github.com/kisielk/errcheck
   - go get -u golang.org/x/tools/cmd/stringer
+  - go get -u github.com/google/certificate-transparency-go
+  - go get -d -t github.com/google/certificate-transparency-go/...
   - go install github.com/golang/{mock/mockgen,protobuf/protoc-gen-go}
   # install vendored protoc-gen-grpc-gateway binary
   - go install ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
@@ -80,6 +82,8 @@ script:
         export ETCD_DIR="${GOPATH}/bin"
       fi
   - ./integration/integration_test.sh
+  - cd $HOME/gopath/src/github.com/google/certificate-transparency-go
+  - ./trillian/integration/integration_test.sh
   - set +e
 
 services: mysql


### PR DESCRIPTION
This reverts commit 0a7397dad3eef54ff931cda55614af6ce5e8ed46.