### PR TITLE
Convert consistency proof tests to be table driven

### DIFF
--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1132,20 +1132,6 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	}
 }
 
-func TestGetConsistencyProofBeginTXFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	test := newParameterizedTest(ctrl, "GetConsistencyProof", readOnly,
-		func(t *storage.MockLogTreeTX) {},
-		func(s *TrillianLogRPCServer) error {
-			_, err := s.GetConsistencyProof(context.Background(), &getConsistencyProofRequest25)
-			return err
-		})
-
-	test.executeBeginFailsTest(t, getConsistencyProofRequest25.LogId)
-}
-
 type consistProofTest struct {
 	req         trillian.GetConsistencyProofRequest
 	wantErr     bool

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1279,11 +1279,11 @@ func TestGetConsistencyProof(t *testing.T) {
 
 		if test.wantErr {
 			if err == nil {
-				t.Errorf("TestGetConsistencyProof(%+v)=nil, want: err", test.req)
+				t.Errorf("GetConsistencyProof(%+v)=nil, want: err", test.req)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("TestGetConsistencyProof(%+v)=%v, want: nil", test.req, err)
+				t.Errorf("GetConsistencyProof(%+v)=%v, want: nil", test.req, err)
 			}
 			// Ensure we got the expected proof.
 			wantProof := trillian.Proof{
@@ -1291,7 +1291,7 @@ func TestGetConsistencyProof(t *testing.T) {
 				Hashes:    test.wantHashes,
 			}
 			if got, want := response.Proof, &wantProof; !proto.Equal(got, want) {
-				t.Errorf("TestGetConsistencyProof got: %v, want: %v", got, want)
+				t.Errorf("GetConsistencyProof(%+v)=%v, want: %v", test.req, got, want)
 			}
 		}
 	}


### PR DESCRIPTION
Add a couple of extra test cases where storage can return an error.