### PR TITLE
Vendor in HEAD^ of ugoriji/go

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -470,12 +470,8 @@ func checkConsistencyProof(consistParams consistencyProofParams, treeID int64, t
 	verifier := merkle.NewLogVerifier(rfc6962.DefaultHasher)
 	root1 := tree.RootAtSnapshot(req.FirstTreeSize).Hash()
 	root2 := tree.RootAtSnapshot(req.SecondTreeSize).Hash()
-	if err := verifier.VerifyConsistencyProof(
-		req.FirstTreeSize, req.SecondTreeSize,
-		root1, root2, resp.Proof.Hashes); err != nil {
-		return err
-	}
-	return nil
+	return verifier.VerifyConsistencyProof(req.FirstTreeSize, req.SecondTreeSize,
+		root1, root2, resp.Proof.Hashes)
 }
 
 func makeGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *trillian.GetLeavesByIndexRequest {

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -323,11 +323,7 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 	if _, err := tx.QueueLeaves(ctx, leaves, time.Now()); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit()
 }
 
 func setUnsequencedRows(ctx context.Context, db *sql.DB, tree *trillian.Tree, wantRows int) error {

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -38,10 +38,7 @@ func (n noopManager) GetTokens(ctx context.Context, numTokens int, specs []Spec)
 	if err := validateNumTokens(numTokens); err != nil {
 		return err
 	}
-	if err := validateSpecs(specs); err != nil {
-		return err
-	}
-	return nil
+	return validateSpecs(specs)
 }
 
 func (n noopManager) PeekTokens(ctx context.Context, specs []Spec) (map[Spec]int, error) {
@@ -59,17 +56,11 @@ func (n noopManager) PutTokens(ctx context.Context, numTokens int, specs []Spec)
 	if err := validateNumTokens(numTokens); err != nil {
 		return err
 	}
-	if err := validateSpecs(specs); err != nil {
-		return err
-	}
-	return nil
+	return validateSpecs(specs)
 }
 
 func (n noopManager) ResetQuota(ctx context.Context, specs []Spec) error {
-	if err := validateSpecs(specs); err != nil {
-		return err
-	}
-	return nil
+	return validateSpecs(specs)
 }
 
 func (n noopManager) SetupInitialQuota(ctx context.Context, treeID int64) error {

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -98,11 +98,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 	if err != nil {
 		glog.Warningf("Failed to update sequenced leaves: %s", err)
 	}
-	if err := checkResultOkAndRowCountIs(result, err, int64(len(leaves))); err != nil {
-		return err
-	}
-
-	return nil
+	return checkResultOkAndRowCountIs(result, err, int64(len(leaves)))
 }
 
 func (m *mySQLLogStorage) getDeleteUnsequencedStmt(ctx context.Context, num int) (*sql.Stmt, error) {
@@ -130,8 +126,5 @@ func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, queueIDs []dequeu
 		// Error is handled by checkResultOkAndRowCountIs() below
 		glog.Warningf("Failed to delete sequenced work: %s", err)
 	}
-	if err := checkResultOkAndRowCountIs(result, err, int64(len(queueIDs))); err != nil {
-		return err
-	}
-	return nil
+	return checkResultOkAndRowCountIs(result, err, int64(len(queueIDs)))
 }

--- a/vendor/github.com/ugorji/go/LICENSE
+++ b/vendor/github.com/ugorji/go/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2015 Ugorji Nwoke.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ugorji/go/README.md
+++ b/vendor/github.com/ugorji/go/README.md
@@ -1,0 +1,20 @@
+# go/codec
+
+This repository contains the `go-codec` library,
+a High Performance and Feature-Rich Idiomatic encode/decode and rpc library for
+
+  - msgpack: https://github.com/msgpack/msgpack
+  - binc:    http://github.com/ugorji/binc
+  - cbor:    http://cbor.io http://tools.ietf.org/html/rfc7049
+  - json:    http://json.org http://tools.ietf.org/html/rfc7159 
+
+For more information:
+
+  - [see the codec/Readme for quick usage information](https://github.com/ugorji/go/tree/master/codec#readme)
+  - [view the API on godoc](http://godoc.org/github.com/ugorji/go/codec)
+  - [read the detailed usage/how-to primer](http://ugorji.net/blog/go-codec-primer)
+
+Install using:
+
+    go get github.com/ugorji/go/codec
+

--- a/vendor/github.com/ugorji/go/codec/0doc.go
+++ b/vendor/github.com/ugorji/go/codec/0doc.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+/*
+High Performance, Feature-Rich Idiomatic Go codec/encoding library for 
+binc, msgpack, cbor, json.
+
+Supported Serialization formats are:
+
+  - msgpack: https://github.com/msgpack/msgpack
+  - binc:    http://github.com/ugorji/binc
+  - cbor:    http://cbor.io http://tools.ietf.org/html/rfc7049
+  - json:    http://json.org http://tools.ietf.org/html/rfc7159
+  - simple: 
+
+To install:
+
+    go get github.com/ugorji/go/codec
+
+This package understands the 'unsafe' tag, to allow using unsafe semantics:
+
+  - When decoding into a struct, you need to read the field name as a string 
+    so you can find the struct field it is mapped to.
+    Using `unsafe` will bypass the allocation and copying overhead of []byte->string conversion.
+
+To install using unsafe, pass the 'unsafe' tag:
+
+    go get -tags=unsafe github.com/ugorji/go/codec
+
+For detailed usage information, read the primer at http://ugorji.net/blog/go-codec-primer .
+
+The idiomatic Go support is as seen in other encoding packages in
+the standard library (ie json, xml, gob, etc).
+
+Rich Feature Set includes:
+
+  - Simple but extremely powerful and feature-rich API
+  - Very High Performance.
+    Our extensive benchmarks show us outperforming Gob, Json, Bson, etc by 2-4X.
+  - Multiple conversions:
+    Package coerces types where appropriate 
+    e.g. decode an int in the stream into a float, etc.
+  - Corner Cases: 
+    Overflows, nil maps/slices, nil values in streams are handled correctly
+  - Standard field renaming via tags
+  - Support for omitting empty fields during an encoding
+  - Encoding from any value and decoding into pointer to any value
+    (struct, slice, map, primitives, pointers, interface{}, etc)
+  - Extensions to support efficient encoding/decoding of any named types
+  - Support encoding.(Binary|Text)(M|Unm)arshaler interfaces
+  - Decoding without a schema (into a interface{}).
+    Includes Options to configure what specific map or slice type to use
+    when decoding an encoded list or map into a nil interface{}
+  - Encode a struct as an array, and decode struct from an array in the data stream
+  - Comprehensive support for anonymous fields
+  - Fast (no-reflection) encoding/decoding of common maps and slices
+  - Code-generation for faster performance.
+  - Support binary (e.g. messagepack, cbor) and text (e.g. json) formats
+  - Support indefinite-length formats to enable true streaming 
+    (for formats which support it e.g. json, cbor)
+  - Support canonical encoding, where a value is ALWAYS encoded as same sequence of bytes.
+    This mostly applies to maps, where iteration order is non-deterministic.
+  - NIL in data stream decoded as zero value
+  - Never silently skip data when decoding.
+    User decides whether to return an error or silently skip data when keys or indexes
+    in the data stream do not map to fields in the struct.
+  - Detect and error when encoding a cyclic reference (instead of stack overflow shutdown)
+  - Encode/Decode from/to chan types (for iterative streaming support)
+  - Drop-in replacement for encoding/json. `json:` key in struct tag supported.
+  - Provides a RPC Server and Client Codec for net/rpc communication protocol.
+  - Handle unique idiosyncrasies of codecs e.g. 
+    - For messagepack, configure how ambiguities in handling raw bytes are resolved 
+    - For messagepack, provide rpc server/client codec to support 
+      msgpack-rpc protocol defined at:
+      https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md
+  
+Extension Support
+
+Users can register a function to handle the encoding or decoding of
+their custom types.
+
+There are no restrictions on what the custom type can be. Some examples:
+
+    type BisSet   []int
+    type BitSet64 uint64
+    type UUID     string
+    type MyStructWithUnexportedFields struct { a int; b bool; c []int; }
+    type GifImage struct { ... }
+
+As an illustration, MyStructWithUnexportedFields would normally be
+encoded as an empty map because it has no exported fields, while UUID
+would be encoded as a string. However, with extension support, you can
+encode any of these however you like.
+
+RPC
+
+RPC Client and Server Codecs are implemented, so the codecs can be used
+with the standard net/rpc package.
+
+Usage
+
+The Handle is SAFE for concurrent READ, but NOT SAFE for concurrent modification.
+
+The Encoder and Decoder are NOT safe for concurrent use.
+
+Consequently, the usage model is basically:
+
+    - Create and initialize the Handle before any use.
+      Once created, DO NOT modify it.
+    - Multiple Encoders or Decoders can now use the Handle concurrently.
+      They only read information off the Handle (never write).
+    - However, each Encoder or Decoder MUST not be used concurrently
+    - To re-use an Encoder/Decoder, call Reset(...) on it first.
+      This allows you use state maintained on the Encoder/Decoder.
+
+Sample usage model:
+
+    // create and configure Handle
+    var (
+      bh codec.BincHandle
+      mh codec.MsgpackHandle
+      ch codec.CborHandle
+    )
+
+    mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+
+    // configure extensions
+    // e.g. for msgpack, define functions and enable Time support for tag 1
+    // mh.SetExt(reflect.TypeOf(time.Time{}), 1, myExt)
+
+    // create and use decoder/encoder
+    var (
+      r io.Reader
+      w io.Writer
+      b []byte
+      h = &bh // or mh to use msgpack
+    )
+
+    dec = codec.NewDecoder(r, h)
+    dec = codec.NewDecoderBytes(b, h)
+    err = dec.Decode(&v)
+
+    enc = codec.NewEncoder(w, h)
+    enc = codec.NewEncoderBytes(&b, h)
+    err = enc.Encode(v)
+
+    //RPC Server
+    go func() {
+        for {
+            conn, err := listener.Accept()
+            rpcCodec := codec.GoRpc.ServerCodec(conn, h)
+            //OR rpcCodec := codec.MsgpackSpecRpc.ServerCodec(conn, h)
+            rpc.ServeCodec(rpcCodec)
+        }
+    }()
+
+    //RPC Communication (client side)
+    conn, err = net.Dial("tcp", "localhost:5555")
+    rpcCodec := codec.GoRpc.ClientCodec(conn, h)
+    //OR rpcCodec := codec.MsgpackSpecRpc.ClientCodec(conn, h)
+    client := rpc.NewClientWithCodec(rpcCodec)
+
+*/
+package codec
+
+// Benefits of go-codec:
+//
+//    - encoding/json always reads whole file into memory first.
+//      This makes it unsuitable for parsing very large files.
+//    - encoding/xml cannot parse into a map[string]interface{}
+//      I found this out on reading https://github.com/clbanning/mxj
+
+// TODO:
+//
+//   - optimization for codecgen:
+//     if len of entity is <= 3 words, then support a value receiver for encode.
+//   - (En|De)coder should store an error when it occurs.
+//     Until reset, subsequent calls return that error that was stored.
+//     This means that free panics must go away.
+//     All errors must be raised through errorf method.
+//   - Decoding using a chan is good, but incurs concurrency costs.
+//     This is because there's no fast way to use a channel without it
+//     having to switch goroutines constantly.
+//     Callback pattern is still the best. Maybe consider supporting something like:
+//        type X struct {
+//             Name string
+//             Ys []Y
+//             Ys chan <- Y
+//             Ys func(Y) -> call this function for each entry
+//        }
+//    - Consider adding a isZeroer interface { isZero() bool }
+//      It is used within isEmpty, for omitEmpty support.
+//    - Consider making Handle used AS-IS within the encoding/decoding session.
+//      This means that we don't cache Handle information within the (En|De)coder,
+//      except we really need it at Reset(...)
+//    - Consider adding math/big support
+//    - Consider reducing the size of the generated functions:
+//      Maybe use one loop, and put the conditionals in the loop.
+//      for ... { if cLen > 0 { if j == cLen { break } } else if dd.CheckBreak() { break } }

--- a/vendor/github.com/ugorji/go/codec/README.md
+++ b/vendor/github.com/ugorji/go/codec/README.md
@@ -1,0 +1,148 @@
+# Codec
+
+High Performance, Feature-Rich Idiomatic Go codec/encoding library for
+binc, msgpack, cbor, json.
+
+Supported Serialization formats are:
+
+  - msgpack: https://github.com/msgpack/msgpack
+  - binc:    http://github.com/ugorji/binc
+  - cbor:    http://cbor.io http://tools.ietf.org/html/rfc7049
+  - json:    http://json.org http://tools.ietf.org/html/rfc7159
+  - simple: 
+
+To install:
+
+    go get github.com/ugorji/go/codec
+
+This package understands the `unsafe` tag, to allow using unsafe semantics:
+
+  - When decoding into a struct, you need to read the field name as a string 
+    so you can find the struct field it is mapped to.
+    Using `unsafe` will bypass the allocation and copying overhead of `[]byte->string` conversion.
+
+To use it, you must pass the `unsafe` tag during install:
+
+```
+go install -tags=unsafe github.com/ugorji/go/codec 
+```
+
+Online documentation: http://godoc.org/github.com/ugorji/go/codec  
+Detailed Usage/How-to Primer: http://ugorji.net/blog/go-codec-primer
+
+The idiomatic Go support is as seen in other encoding packages in
+the standard library (ie json, xml, gob, etc).
+
+Rich Feature Set includes:
+
+  - Simple but extremely powerful and feature-rich API
+  - Very High Performance.
+    Our extensive benchmarks show us outperforming Gob, Json, Bson, etc by 2-4X.
+  - Multiple conversions:
+    Package coerces types where appropriate 
+    e.g. decode an int in the stream into a float, etc.
+  - Corner Cases: 
+    Overflows, nil maps/slices, nil values in streams are handled correctly
+  - Standard field renaming via tags
+  - Support for omitting empty fields during an encoding
+  - Encoding from any value and decoding into pointer to any value
+    (struct, slice, map, primitives, pointers, interface{}, etc)
+  - Extensions to support efficient encoding/decoding of any named types
+  - Support encoding.(Binary|Text)(M|Unm)arshaler interfaces
+  - Decoding without a schema (into a interface{}).
+    Includes Options to configure what specific map or slice type to use
+    when decoding an encoded list or map into a nil interface{}
+  - Encode a struct as an array, and decode struct from an array in the data stream
+  - Comprehensive support for anonymous fields
+  - Fast (no-reflection) encoding/decoding of common maps and slices
+  - Code-generation for faster performance.
+  - Support binary (e.g. messagepack, cbor) and text (e.g. json) formats
+  - Support indefinite-length formats to enable true streaming 
+    (for formats which support it e.g. json, cbor)
+  - Support canonical encoding, where a value is ALWAYS encoded as same sequence of bytes.
+    This mostly applies to maps, where iteration order is non-deterministic.
+  - NIL in data stream decoded as zero value
+  - Never silently skip data when decoding.
+    User decides whether to return an error or silently skip data when keys or indexes
+    in the data stream do not map to fields in the struct.
+  - Encode/Decode from/to chan types (for iterative streaming support)
+  - Drop-in replacement for encoding/json. `json:` key in struct tag supported.
+  - Provides a RPC Server and Client Codec for net/rpc communication protocol.
+  - Handle unique idiosyncrasies of codecs e.g. 
+    - For messagepack, configure how ambiguities in handling raw bytes are resolved 
+    - For messagepack, provide rpc server/client codec to support
+      msgpack-rpc protocol defined at:
+      https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md
+
+## Extension Support
+
+Users can register a function to handle the encoding or decoding of
+their custom types.
+
+There are no restrictions on what the custom type can be. Some examples:
+
+    type BisSet   []int
+    type BitSet64 uint64
+    type UUID     string
+    type MyStructWithUnexportedFields struct { a int; b bool; c []int; }
+    type GifImage struct { ... }
+
+As an illustration, MyStructWithUnexportedFields would normally be
+encoded as an empty map because it has no exported fields, while UUID
+would be encoded as a string. However, with extension support, you can
+encode any of these however you like.
+
+## RPC
+
+RPC Client and Server Codecs are implemented, so the codecs can be used
+with the standard net/rpc package.
+
+## Usage
+
+Typical usage model:
+
+    // create and configure Handle
+    var (
+      bh codec.BincHandle
+      mh codec.MsgpackHandle
+      ch codec.CborHandle
+    )
+
+    mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+
+    // configure extensions
+    // e.g. for msgpack, define functions and enable Time support for tag 1
+    // mh.SetExt(reflect.TypeOf(time.Time{}), 1, myExt)
+
+    // create and use decoder/encoder
+    var (
+      r io.Reader
+      w io.Writer
+      b []byte
+      h = &bh // or mh to use msgpack
+    )
+
+    dec = codec.NewDecoder(r, h)
+    dec = codec.NewDecoderBytes(b, h)
+    err = dec.Decode(&v)
+
+    enc = codec.NewEncoder(w, h)
+    enc = codec.NewEncoderBytes(&b, h)
+    err = enc.Encode(v)
+
+    //RPC Server
+    go func() {
+        for {
+            conn, err := listener.Accept()
+            rpcCodec := codec.GoRpc.ServerCodec(conn, h)
+            //OR rpcCodec := codec.MsgpackSpecRpc.ServerCodec(conn, h)
+            rpc.ServeCodec(rpcCodec)
+        }
+    }()
+
+    //RPC Communication (client side)
+    conn, err = net.Dial("tcp", "localhost:5555")
+    rpcCodec := codec.GoRpc.ClientCodec(conn, h)
+    //OR rpcCodec := codec.MsgpackSpecRpc.ClientCodec(conn, h)
+    client := rpc.NewClientWithCodec(rpcCodec)
+

--- a/vendor/github.com/ugorji/go/codec/binc.go
+++ b/vendor/github.com/ugorji/go/codec/binc.go
@@ -1,0 +1,938 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"math"
+	"reflect"
+	"time"
+)
+
+const bincDoPrune = true // No longer needed. Needed before as C lib did not support pruning.
+
+// vd as low 4 bits (there are 16 slots)
+const (
+	bincVdSpecial byte = iota
+	bincVdPosInt
+	bincVdNegInt
+	bincVdFloat
+
+	bincVdString
+	bincVdByteArray
+	bincVdArray
+	bincVdMap
+
+	bincVdTimestamp
+	bincVdSmallInt
+	bincVdUnicodeOther
+	bincVdSymbol
+
+	bincVdDecimal
+	_               // open slot
+	_               // open slot
+	bincVdCustomExt = 0x0f
+)
+
+const (
+	bincSpNil byte = iota
+	bincSpFalse
+	bincSpTrue
+	bincSpNan
+	bincSpPosInf
+	bincSpNegInf
+	bincSpZeroFloat
+	bincSpZero
+	bincSpNegOne
+)
+
+const (
+	bincFlBin16 byte = iota
+	bincFlBin32
+	_ // bincFlBin32e
+	bincFlBin64
+	_ // bincFlBin64e
+	// others not currently supported
+)
+
+type bincEncDriver struct {
+	e *Encoder
+	w encWriter
+	m map[string]uint16 // symbols
+	b [scratchByteArrayLen]byte
+	s uint16 // symbols sequencer
+	encNoSeparator
+}
+
+func (e *bincEncDriver) IsBuiltinType(rt uintptr) bool {
+	return rt == timeTypId
+}
+
+func (e *bincEncDriver) EncodeBuiltin(rt uintptr, v interface{}) {
+	if rt == timeTypId {
+		var bs []byte
+		switch x := v.(type) {
+		case time.Time:
+			bs = encodeTime(x)
+		case *time.Time:
+			bs = encodeTime(*x)
+		default:
+			e.e.errorf("binc error encoding builtin: expect time.Time, received %T", v)
+		}
+		e.w.writen1(bincVdTimestamp<<4 | uint8(len(bs)))
+		e.w.writeb(bs)
+	}
+}
+
+func (e *bincEncDriver) EncodeNil() {
+	e.w.writen1(bincVdSpecial<<4 | bincSpNil)
+}
+
+func (e *bincEncDriver) EncodeBool(b bool) {
+	if b {
+		e.w.writen1(bincVdSpecial<<4 | bincSpTrue)
+	} else {
+		e.w.writen1(bincVdSpecial<<4 | bincSpFalse)
+	}
+}
+
+func (e *bincEncDriver) EncodeFloat32(f float32) {
+	if f == 0 {
+		e.w.writen1(bincVdSpecial<<4 | bincSpZeroFloat)
+		return
+	}
+	e.w.writen1(bincVdFloat<<4 | bincFlBin32)
+	bigenHelper{e.b[:4], e.w}.writeUint32(math.Float32bits(f))
+}
+
+func (e *bincEncDriver) EncodeFloat64(f float64) {
+	if f == 0 {
+		e.w.writen1(bincVdSpecial<<4 | bincSpZeroFloat)
+		return
+	}
+	bigen.PutUint64(e.b[:8], math.Float64bits(f))
+	if bincDoPrune {
+		i := 7
+		for ; i >= 0 && (e.b[i] == 0); i-- {
+		}
+		i++
+		if i <= 6 {
+			e.w.writen1(bincVdFloat<<4 | 0x8 | bincFlBin64)
+			e.w.writen1(byte(i))
+			e.w.writeb(e.b[:i])
+			return
+		}
+	}
+	e.w.writen1(bincVdFloat<<4 | bincFlBin64)
+	e.w.writeb(e.b[:8])
+}
+
+func (e *bincEncDriver) encIntegerPrune(bd byte, pos bool, v uint64, lim uint8) {
+	if lim == 4 {
+		bigen.PutUint32(e.b[:lim], uint32(v))
+	} else {
+		bigen.PutUint64(e.b[:lim], v)
+	}
+	if bincDoPrune {
+		i := pruneSignExt(e.b[:lim], pos)
+		e.w.writen1(bd | lim - 1 - byte(i))
+		e.w.writeb(e.b[i:lim])
+	} else {
+		e.w.writen1(bd | lim - 1)
+		e.w.writeb(e.b[:lim])
+	}
+}
+
+func (e *bincEncDriver) EncodeInt(v int64) {
+	const nbd byte = bincVdNegInt << 4
+	if v >= 0 {
+		e.encUint(bincVdPosInt<<4, true, uint64(v))
+	} else if v == -1 {
+		e.w.writen1(bincVdSpecial<<4 | bincSpNegOne)
+	} else {
+		e.encUint(bincVdNegInt<<4, false, uint64(-v))
+	}
+}
+
+func (e *bincEncDriver) EncodeUint(v uint64) {
+	e.encUint(bincVdPosInt<<4, true, v)
+}
+
+func (e *bincEncDriver) encUint(bd byte, pos bool, v uint64) {
+	if v == 0 {
+		e.w.writen1(bincVdSpecial<<4 | bincSpZero)
+	} else if pos && v >= 1 && v <= 16 {
+		e.w.writen1(bincVdSmallInt<<4 | byte(v-1))
+	} else if v <= math.MaxUint8 {
+		e.w.writen2(bd|0x0, byte(v))
+	} else if v <= math.MaxUint16 {
+		e.w.writen1(bd | 0x01)
+		bigenHelper{e.b[:2], e.w}.writeUint16(uint16(v))
+	} else if v <= math.MaxUint32 {
+		e.encIntegerPrune(bd, pos, v, 4)
+	} else {
+		e.encIntegerPrune(bd, pos, v, 8)
+	}
+}
+
+func (e *bincEncDriver) EncodeExt(rv interface{}, xtag uint64, ext Ext, _ *Encoder) {
+	bs := ext.WriteExt(rv)
+	if bs == nil {
+		e.EncodeNil()
+		return
+	}
+	e.encodeExtPreamble(uint8(xtag), len(bs))
+	e.w.writeb(bs)
+}
+
+func (e *bincEncDriver) EncodeRawExt(re *RawExt, _ *Encoder) {
+	e.encodeExtPreamble(uint8(re.Tag), len(re.Data))
+	e.w.writeb(re.Data)
+}
+
+func (e *bincEncDriver) encodeExtPreamble(xtag byte, length int) {
+	e.encLen(bincVdCustomExt<<4, uint64(length))
+	e.w.writen1(xtag)
+}
+
+func (e *bincEncDriver) EncodeArrayStart(length int) {
+	e.encLen(bincVdArray<<4, uint64(length))
+}
+
+func (e *bincEncDriver) EncodeMapStart(length int) {
+	e.encLen(bincVdMap<<4, uint64(length))
+}
+
+func (e *bincEncDriver) EncodeString(c charEncoding, v string) {
+	l := uint64(len(v))
+	e.encBytesLen(c, l)
+	if l > 0 {
+		e.w.writestr(v)
+	}
+}
+
+func (e *bincEncDriver) EncodeSymbol(v string) {
+	// if WriteSymbolsNoRefs {
+	// 	e.encodeString(c_UTF8, v)
+	// 	return
+	// }
+
+	//symbols only offer benefit when string length > 1.
+	//This is because strings with length 1 take only 2 bytes to store
+	//(bd with embedded length, and single byte for string val).
+
+	l := len(v)
+	if l == 0 {
+		e.encBytesLen(c_UTF8, 0)
+		return
+	} else if l == 1 {
+		e.encBytesLen(c_UTF8, 1)
+		e.w.writen1(v[0])
+		return
+	}
+	if e.m == nil {
+		e.m = make(map[string]uint16, 16)
+	}
+	ui, ok := e.m[v]
+	if ok {
+		if ui <= math.MaxUint8 {
+			e.w.writen2(bincVdSymbol<<4, byte(ui))
+		} else {
+			e.w.writen1(bincVdSymbol<<4 | 0x8)
+			bigenHelper{e.b[:2], e.w}.writeUint16(ui)
+		}
+	} else {
+		e.s++
+		ui = e.s
+		//ui = uint16(atomic.AddUint32(&e.s, 1))
+		e.m[v] = ui
+		var lenprec uint8
+		if l <= math.MaxUint8 {
+			// lenprec = 0
+		} else if l <= math.MaxUint16 {
+			lenprec = 1
+		} else if int64(l) <= math.MaxUint32 {
+			lenprec = 2
+		} else {
+			lenprec = 3
+		}
+		if ui <= math.MaxUint8 {
+			e.w.writen2(bincVdSymbol<<4|0x0|0x4|lenprec, byte(ui))
+		} else {
+			e.w.writen1(bincVdSymbol<<4 | 0x8 | 0x4 | lenprec)
+			bigenHelper{e.b[:2], e.w}.writeUint16(ui)
+		}
+		if lenprec == 0 {
+			e.w.writen1(byte(l))
+		} else if lenprec == 1 {
+			bigenHelper{e.b[:2], e.w}.writeUint16(uint16(l))
+		} else if lenprec == 2 {
+			bigenHelper{e.b[:4], e.w}.writeUint32(uint32(l))
+		} else {
+			bigenHelper{e.b[:8], e.w}.writeUint64(uint64(l))
+		}
+		e.w.writestr(v)
+	}
+}
+
+func (e *bincEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
+	l := uint64(len(v))
+	e.encBytesLen(c, l)
+	if l > 0 {
+		e.w.writeb(v)
+	}
+}
+
+func (e *bincEncDriver) encBytesLen(c charEncoding, length uint64) {
+	//TODO: support bincUnicodeOther (for now, just use string or bytearray)
+	if c == c_RAW {
+		e.encLen(bincVdByteArray<<4, length)
+	} else {
+		e.encLen(bincVdString<<4, length)
+	}
+}
+
+func (e *bincEncDriver) encLen(bd byte, l uint64) {
+	if l < 12 {
+		e.w.writen1(bd | uint8(l+4))
+	} else {
+		e.encLenNumber(bd, l)
+	}
+}
+
+func (e *bincEncDriver) encLenNumber(bd byte, v uint64) {
+	if v <= math.MaxUint8 {
+		e.w.writen2(bd, byte(v))
+	} else if v <= math.MaxUint16 {
+		e.w.writen1(bd | 0x01)
+		bigenHelper{e.b[:2], e.w}.writeUint16(uint16(v))
+	} else if v <= math.MaxUint32 {
+		e.w.writen1(bd | 0x02)
+		bigenHelper{e.b[:4], e.w}.writeUint32(uint32(v))
+	} else {
+		e.w.writen1(bd | 0x03)
+		bigenHelper{e.b[:8], e.w}.writeUint64(uint64(v))
+	}
+}
+
+//------------------------------------
+
+type bincDecSymbol struct {
+	s string
+	b []byte
+	i uint16
+}
+
+type bincDecDriver struct {
+	d      *Decoder
+	h      *BincHandle
+	r      decReader
+	br     bool // bytes reader
+	bdRead bool
+	bd     byte
+	vd     byte
+	vs     byte
+	noStreamingCodec
+	decNoSeparator
+	b [scratchByteArrayLen]byte
+
+	// linear searching on this slice is ok,
+	// because we typically expect < 32 symbols in each stream.
+	s []bincDecSymbol
+}
+
+func (d *bincDecDriver) readNextBd() {
+	d.bd = d.r.readn1()
+	d.vd = d.bd >> 4
+	d.vs = d.bd & 0x0f
+	d.bdRead = true
+}
+
+func (d *bincDecDriver) uncacheRead() {
+	if d.bdRead {
+		d.r.unreadn1()
+		d.bdRead = false
+	}
+}
+
+func (d *bincDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.vd == bincVdSpecial && d.vs == bincSpNil {
+		return valueTypeNil
+	} else if d.vd == bincVdByteArray {
+		return valueTypeBytes
+	} else if d.vd == bincVdString {
+		return valueTypeString
+	} else if d.vd == bincVdArray {
+		return valueTypeArray
+	} else if d.vd == bincVdMap {
+		return valueTypeMap
+	} else {
+		// d.d.errorf("isContainerType: unsupported parameter: %v", vt)
+	}
+	return valueTypeUnset
+}
+
+func (d *bincDecDriver) TryDecodeAsNil() bool {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == bincVdSpecial<<4|bincSpNil {
+		d.bdRead = false
+		return true
+	}
+	return false
+}
+
+func (d *bincDecDriver) IsBuiltinType(rt uintptr) bool {
+	return rt == timeTypId
+}
+
+func (d *bincDecDriver) DecodeBuiltin(rt uintptr, v interface{}) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if rt == timeTypId {
+		if d.vd != bincVdTimestamp {
+			d.d.errorf("Invalid d.vd. Expecting 0x%x. Received: 0x%x", bincVdTimestamp, d.vd)
+			return
+		}
+		tt, err := decodeTime(d.r.readx(int(d.vs)))
+		if err != nil {
+			panic(err)
+		}
+		var vt *time.Time = v.(*time.Time)
+		*vt = tt
+		d.bdRead = false
+	}
+}
+
+func (d *bincDecDriver) decFloatPre(vs, defaultLen byte) {
+	if vs&0x8 == 0 {
+		d.r.readb(d.b[0:defaultLen])
+	} else {
+		l := d.r.readn1()
+		if l > 8 {
+			d.d.errorf("At most 8 bytes used to represent float. Received: %v bytes", l)
+			return
+		}
+		for i := l; i < 8; i++ {
+			d.b[i] = 0
+		}
+		d.r.readb(d.b[0:l])
+	}
+}
+
+func (d *bincDecDriver) decFloat() (f float64) {
+	//if true { f = math.Float64frombits(bigen.Uint64(d.r.readx(8))); break; }
+	if x := d.vs & 0x7; x == bincFlBin32 {
+		d.decFloatPre(d.vs, 4)
+		f = float64(math.Float32frombits(bigen.Uint32(d.b[0:4])))
+	} else if x == bincFlBin64 {
+		d.decFloatPre(d.vs, 8)
+		f = math.Float64frombits(bigen.Uint64(d.b[0:8]))
+	} else {
+		d.d.errorf("only float32 and float64 are supported. d.vd: 0x%x, d.vs: 0x%x", d.vd, d.vs)
+		return
+	}
+	return
+}
+
+func (d *bincDecDriver) decUint() (v uint64) {
+	// need to inline the code (interface conversion and type assertion expensive)
+	switch d.vs {
+	case 0:
+		v = uint64(d.r.readn1())
+	case 1:
+		d.r.readb(d.b[6:8])
+		v = uint64(bigen.Uint16(d.b[6:8]))
+	case 2:
+		d.b[4] = 0
+		d.r.readb(d.b[5:8])
+		v = uint64(bigen.Uint32(d.b[4:8]))
+	case 3:
+		d.r.readb(d.b[4:8])
+		v = uint64(bigen.Uint32(d.b[4:8]))
+	case 4, 5, 6:
+		lim := int(7 - d.vs)
+		d.r.readb(d.b[lim:8])
+		for i := 0; i < lim; i++ {
+			d.b[i] = 0
+		}
+		v = uint64(bigen.Uint64(d.b[:8]))
+	case 7:
+		d.r.readb(d.b[:8])
+		v = uint64(bigen.Uint64(d.b[:8]))
+	default:
+		d.d.errorf("unsigned integers with greater than 64 bits of precision not supported")
+		return
+	}
+	return
+}
+
+func (d *bincDecDriver) decCheckInteger() (ui uint64, neg bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	vd, vs := d.vd, d.vs
+	if vd == bincVdPosInt {
+		ui = d.decUint()
+	} else if vd == bincVdNegInt {
+		ui = d.decUint()
+		neg = true
+	} else if vd == bincVdSmallInt {
+		ui = uint64(d.vs) + 1
+	} else if vd == bincVdSpecial {
+		if vs == bincSpZero {
+			//i = 0
+		} else if vs == bincSpNegOne {
+			neg = true
+			ui = 1
+		} else {
+			d.d.errorf("numeric decode fails for special value: d.vs: 0x%x", d.vs)
+			return
+		}
+	} else {
+		d.d.errorf("number can only be decoded from uint or int values. d.bd: 0x%x, d.vd: 0x%x", d.bd, d.vd)
+		return
+	}
+	return
+}
+
+func (d *bincDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	ui, neg := d.decCheckInteger()
+	i, overflow := chkOvf.SignedInt(ui)
+	if overflow {
+		d.d.errorf("simple: overflow converting %v to signed integer", ui)
+		return
+	}
+	if neg {
+		i = -i
+	}
+	if chkOvf.Int(i, bitsize) {
+		d.d.errorf("binc: overflow integer: %v", i)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) DecodeUint(bitsize uint8) (ui uint64) {
+	ui, neg := d.decCheckInteger()
+	if neg {
+		d.d.errorf("Assigning negative signed value to unsigned type")
+		return
+	}
+	if chkOvf.Uint(ui, bitsize) {
+		d.d.errorf("binc: overflow integer: %v", ui)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	vd, vs := d.vd, d.vs
+	if vd == bincVdSpecial {
+		d.bdRead = false
+		if vs == bincSpNan {
+			return math.NaN()
+		} else if vs == bincSpPosInf {
+			return math.Inf(1)
+		} else if vs == bincSpZeroFloat || vs == bincSpZero {
+			return
+		} else if vs == bincSpNegInf {
+			return math.Inf(-1)
+		} else {
+			d.d.errorf("Invalid d.vs decoding float where d.vd=bincVdSpecial: %v", d.vs)
+			return
+		}
+	} else if vd == bincVdFloat {
+		f = d.decFloat()
+	} else {
+		f = float64(d.DecodeInt(64))
+	}
+	if chkOverflow32 && chkOvf.Float32(f) {
+		d.d.errorf("binc: float32 overflow: %v", f)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+// bool can be decoded from bool only (single byte).
+func (d *bincDecDriver) DecodeBool() (b bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if bd := d.bd; bd == (bincVdSpecial | bincSpFalse) {
+		// b = false
+	} else if bd == (bincVdSpecial | bincSpTrue) {
+		b = true
+	} else {
+		d.d.errorf("Invalid single-byte value for bool: %s: %x", msgBadDesc, d.bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) ReadMapStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.vd != bincVdMap {
+		d.d.errorf("Invalid d.vd for map. Expecting 0x%x. Got: 0x%x", bincVdMap, d.vd)
+		return
+	}
+	length = d.decLen()
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) ReadArrayStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.vd != bincVdArray {
+		d.d.errorf("Invalid d.vd for array. Expecting 0x%x. Got: 0x%x", bincVdArray, d.vd)
+		return
+	}
+	length = d.decLen()
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) decLen() int {
+	if d.vs > 3 {
+		return int(d.vs - 4)
+	}
+	return int(d.decLenNumber())
+}
+
+func (d *bincDecDriver) decLenNumber() (v uint64) {
+	if x := d.vs; x == 0 {
+		v = uint64(d.r.readn1())
+	} else if x == 1 {
+		d.r.readb(d.b[6:8])
+		v = uint64(bigen.Uint16(d.b[6:8]))
+	} else if x == 2 {
+		d.r.readb(d.b[4:8])
+		v = uint64(bigen.Uint32(d.b[4:8]))
+	} else {
+		d.r.readb(d.b[:8])
+		v = bigen.Uint64(d.b[:8])
+	}
+	return
+}
+
+func (d *bincDecDriver) decStringAndBytes(bs []byte, withString, zerocopy bool) (bs2 []byte, s string) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == bincVdSpecial<<4|bincSpNil {
+		d.bdRead = false
+		return
+	}
+	var slen int = -1
+	// var ok bool
+	switch d.vd {
+	case bincVdString, bincVdByteArray:
+		slen = d.decLen()
+		if zerocopy {
+			if d.br {
+				bs2 = d.r.readx(slen)
+			} else if len(bs) == 0 {
+				bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, d.b[:])
+			} else {
+				bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, bs)
+			}
+		} else {
+			bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, bs)
+		}
+		if withString {
+			s = string(bs2)
+		}
+	case bincVdSymbol:
+		// zerocopy doesn't apply for symbols,
+		// as the values must be stored in a table for later use.
+		//
+		//from vs: extract numSymbolBytes, containsStringVal, strLenPrecision,
+		//extract symbol
+		//if containsStringVal, read it and put in map
+		//else look in map for string value
+		var symbol uint16
+		vs := d.vs
+		if vs&0x8 == 0 {
+			symbol = uint16(d.r.readn1())
+		} else {
+			symbol = uint16(bigen.Uint16(d.r.readx(2)))
+		}
+		if d.s == nil {
+			d.s = make([]bincDecSymbol, 0, 16)
+		}
+
+		if vs&0x4 == 0 {
+			for i := range d.s {
+				j := &d.s[i]
+				if j.i == symbol {
+					bs2 = j.b
+					if withString {
+						if j.s == "" && bs2 != nil {
+							j.s = string(bs2)
+						}
+						s = j.s
+					}
+					break
+				}
+			}
+		} else {
+			switch vs & 0x3 {
+			case 0:
+				slen = int(d.r.readn1())
+			case 1:
+				slen = int(bigen.Uint16(d.r.readx(2)))
+			case 2:
+				slen = int(bigen.Uint32(d.r.readx(4)))
+			case 3:
+				slen = int(bigen.Uint64(d.r.readx(8)))
+			}
+			// since using symbols, do not store any part of
+			// the parameter bs in the map, as it might be a shared buffer.
+			// bs2 = decByteSlice(d.r, slen, bs)
+			bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, nil)
+			if withString {
+				s = string(bs2)
+			}
+			d.s = append(d.s, bincDecSymbol{i: symbol, s: s, b: bs2})
+		}
+	default:
+		d.d.errorf("Invalid d.vd. Expecting string:0x%x, bytearray:0x%x or symbol: 0x%x. Got: 0x%x",
+			bincVdString, bincVdByteArray, bincVdSymbol, d.vd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) DecodeString() (s string) {
+	// DecodeBytes does not accommodate symbols, whose impl stores string version in map.
+	// Use decStringAndBytes directly.
+	// return string(d.DecodeBytes(d.b[:], true, true))
+	_, s = d.decStringAndBytes(d.b[:], true, true)
+	return
+}
+
+func (d *bincDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+	if isstring {
+		bsOut, _ = d.decStringAndBytes(bs, false, zerocopy)
+		return
+	}
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == bincVdSpecial<<4|bincSpNil {
+		d.bdRead = false
+		return nil
+	}
+	var clen int
+	if d.vd == bincVdString || d.vd == bincVdByteArray {
+		clen = d.decLen()
+	} else {
+		d.d.errorf("Invalid d.vd for bytes. Expecting string:0x%x or bytearray:0x%x. Got: 0x%x",
+			bincVdString, bincVdByteArray, d.vd)
+		return
+	}
+	d.bdRead = false
+	if zerocopy {
+		if d.br {
+			return d.r.readx(clen)
+		} else if len(bs) == 0 {
+			bs = d.b[:]
+		}
+	}
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
+}
+
+func (d *bincDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	if xtag > 0xff {
+		d.d.errorf("decodeExt: tag must be <= 0xff; got: %v", xtag)
+		return
+	}
+	realxtag1, xbs := d.decodeExtV(ext != nil, uint8(xtag))
+	realxtag = uint64(realxtag1)
+	if ext == nil {
+		re := rv.(*RawExt)
+		re.Tag = realxtag
+		re.Data = detachZeroCopyBytes(d.br, re.Data, xbs)
+	} else {
+		ext.ReadExt(rv, xbs)
+	}
+	return
+}
+
+func (d *bincDecDriver) decodeExtV(verifyTag bool, tag byte) (xtag byte, xbs []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.vd == bincVdCustomExt {
+		l := d.decLen()
+		xtag = d.r.readn1()
+		if verifyTag && xtag != tag {
+			d.d.errorf("Wrong extension tag. Got %b. Expecting: %v", xtag, tag)
+			return
+		}
+		xbs = d.r.readx(l)
+	} else if d.vd == bincVdByteArray {
+		xbs = d.DecodeBytes(nil, false, true)
+	} else {
+		d.d.errorf("Invalid d.vd for extensions (Expecting extensions or byte array). Got: 0x%x", d.vd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *bincDecDriver) DecodeNaked() {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+
+	n := &d.d.n
+	var decodeFurther bool
+
+	switch d.vd {
+	case bincVdSpecial:
+		switch d.vs {
+		case bincSpNil:
+			n.v = valueTypeNil
+		case bincSpFalse:
+			n.v = valueTypeBool
+			n.b = false
+		case bincSpTrue:
+			n.v = valueTypeBool
+			n.b = true
+		case bincSpNan:
+			n.v = valueTypeFloat
+			n.f = math.NaN()
+		case bincSpPosInf:
+			n.v = valueTypeFloat
+			n.f = math.Inf(1)
+		case bincSpNegInf:
+			n.v = valueTypeFloat
+			n.f = math.Inf(-1)
+		case bincSpZeroFloat:
+			n.v = valueTypeFloat
+			n.f = float64(0)
+		case bincSpZero:
+			n.v = valueTypeUint
+			n.u = uint64(0) // int8(0)
+		case bincSpNegOne:
+			n.v = valueTypeInt
+			n.i = int64(-1) // int8(-1)
+		default:
+			d.d.errorf("decodeNaked: Unrecognized special value 0x%x", d.vs)
+		}
+	case bincVdSmallInt:
+		n.v = valueTypeUint
+		n.u = uint64(int8(d.vs)) + 1 // int8(d.vs) + 1
+	case bincVdPosInt:
+		n.v = valueTypeUint
+		n.u = d.decUint()
+	case bincVdNegInt:
+		n.v = valueTypeInt
+		n.i = -(int64(d.decUint()))
+	case bincVdFloat:
+		n.v = valueTypeFloat
+		n.f = d.decFloat()
+	case bincVdSymbol:
+		n.v = valueTypeSymbol
+		n.s = d.DecodeString()
+	case bincVdString:
+		n.v = valueTypeString
+		n.s = d.DecodeString()
+	case bincVdByteArray:
+		n.v = valueTypeBytes
+		n.l = d.DecodeBytes(nil, false, false)
+	case bincVdTimestamp:
+		n.v = valueTypeTimestamp
+		tt, err := decodeTime(d.r.readx(int(d.vs)))
+		if err != nil {
+			panic(err)
+		}
+		n.t = tt
+	case bincVdCustomExt:
+		n.v = valueTypeExt
+		l := d.decLen()
+		n.u = uint64(d.r.readn1())
+		n.l = d.r.readx(l)
+	case bincVdArray:
+		n.v = valueTypeArray
+		decodeFurther = true
+	case bincVdMap:
+		n.v = valueTypeMap
+		decodeFurther = true
+	default:
+		d.d.errorf("decodeNaked: Unrecognized d.vd: 0x%x", d.vd)
+	}
+
+	if !decodeFurther {
+		d.bdRead = false
+	}
+	if n.v == valueTypeUint && d.h.SignedInteger {
+		n.v = valueTypeInt
+		n.i = int64(n.u)
+	}
+	return
+}
+
+//------------------------------------
+
+//BincHandle is a Handle for the Binc Schema-Free Encoding Format
+//defined at https://github.com/ugorji/binc .
+//
+//BincHandle currently supports all Binc features with the following EXCEPTIONS:
+//  - only integers up to 64 bits of precision are supported.
+//    big integers are unsupported.
+//  - Only IEEE 754 binary32 and binary64 floats are supported (ie Go float32 and float64 types).
+//    extended precision and decimal IEEE 754 floats are unsupported.
+//  - Only UTF-8 strings supported.
+//    Unicode_Other Binc types (UTF16, UTF32) are currently unsupported.
+//
+//Note that these EXCEPTIONS are temporary and full support is possible and may happen soon.
+type BincHandle struct {
+	BasicHandle
+	binaryEncodingType
+}
+
+func (h *BincHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
+}
+
+func (h *BincHandle) newEncDriver(e *Encoder) encDriver {
+	return &bincEncDriver{e: e, w: e.w}
+}
+
+func (h *BincHandle) newDecDriver(d *Decoder) decDriver {
+	return &bincDecDriver{d: d, h: h, r: d.r, br: d.bytes}
+}
+
+func (e *bincEncDriver) reset() {
+	e.w = e.e.w
+	e.s = 0
+	e.m = nil
+}
+
+func (d *bincDecDriver) reset() {
+	d.r, d.br = d.d.r, d.d.bytes
+	d.s = nil
+	d.bd, d.bdRead, d.vd, d.vs = 0, false, 0, 0
+}
+
+var _ decDriver = (*bincDecDriver)(nil)
+var _ encDriver = (*bincEncDriver)(nil)

--- a/vendor/github.com/ugorji/go/codec/cbor.go
+++ b/vendor/github.com/ugorji/go/codec/cbor.go
@@ -1,0 +1,601 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"math"
+	"reflect"
+)
+
+const (
+	cborMajorUint byte = iota
+	cborMajorNegInt
+	cborMajorBytes
+	cborMajorText
+	cborMajorArray
+	cborMajorMap
+	cborMajorTag
+	cborMajorOther
+)
+
+const (
+	cborBdFalse byte = 0xf4 + iota
+	cborBdTrue
+	cborBdNil
+	cborBdUndefined
+	cborBdExt
+	cborBdFloat16
+	cborBdFloat32
+	cborBdFloat64
+)
+
+const (
+	cborBdIndefiniteBytes  byte = 0x5f
+	cborBdIndefiniteString      = 0x7f
+	cborBdIndefiniteArray       = 0x9f
+	cborBdIndefiniteMap         = 0xbf
+	cborBdBreak                 = 0xff
+)
+
+const (
+	CborStreamBytes  byte = 0x5f
+	CborStreamString      = 0x7f
+	CborStreamArray       = 0x9f
+	CborStreamMap         = 0xbf
+	CborStreamBreak       = 0xff
+)
+
+const (
+	cborBaseUint   byte = 0x00
+	cborBaseNegInt      = 0x20
+	cborBaseBytes       = 0x40
+	cborBaseString      = 0x60
+	cborBaseArray       = 0x80
+	cborBaseMap         = 0xa0
+	cborBaseTag         = 0xc0
+	cborBaseSimple      = 0xe0
+)
+
+// -------------------
+
+type cborEncDriver struct {
+	noBuiltInTypes
+	encNoSeparator
+	e *Encoder
+	w encWriter
+	h *CborHandle
+	x [8]byte
+}
+
+func (e *cborEncDriver) EncodeNil() {
+	e.w.writen1(cborBdNil)
+}
+
+func (e *cborEncDriver) EncodeBool(b bool) {
+	if b {
+		e.w.writen1(cborBdTrue)
+	} else {
+		e.w.writen1(cborBdFalse)
+	}
+}
+
+func (e *cborEncDriver) EncodeFloat32(f float32) {
+	e.w.writen1(cborBdFloat32)
+	bigenHelper{e.x[:4], e.w}.writeUint32(math.Float32bits(f))
+}
+
+func (e *cborEncDriver) EncodeFloat64(f float64) {
+	e.w.writen1(cborBdFloat64)
+	bigenHelper{e.x[:8], e.w}.writeUint64(math.Float64bits(f))
+}
+
+func (e *cborEncDriver) encUint(v uint64, bd byte) {
+	if v <= 0x17 {
+		e.w.writen1(byte(v) + bd)
+	} else if v <= math.MaxUint8 {
+		e.w.writen2(bd+0x18, uint8(v))
+	} else if v <= math.MaxUint16 {
+		e.w.writen1(bd + 0x19)
+		bigenHelper{e.x[:2], e.w}.writeUint16(uint16(v))
+	} else if v <= math.MaxUint32 {
+		e.w.writen1(bd + 0x1a)
+		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(v))
+	} else { // if v <= math.MaxUint64 {
+		e.w.writen1(bd + 0x1b)
+		bigenHelper{e.x[:8], e.w}.writeUint64(v)
+	}
+}
+
+func (e *cborEncDriver) EncodeInt(v int64) {
+	if v < 0 {
+		e.encUint(uint64(-1-v), cborBaseNegInt)
+	} else {
+		e.encUint(uint64(v), cborBaseUint)
+	}
+}
+
+func (e *cborEncDriver) EncodeUint(v uint64) {
+	e.encUint(v, cborBaseUint)
+}
+
+func (e *cborEncDriver) encLen(bd byte, length int) {
+	e.encUint(uint64(length), bd)
+}
+
+func (e *cborEncDriver) EncodeExt(rv interface{}, xtag uint64, ext Ext, en *Encoder) {
+	e.encUint(uint64(xtag), cborBaseTag)
+	if v := ext.ConvertExt(rv); v == nil {
+		e.EncodeNil()
+	} else {
+		en.encode(v)
+	}
+}
+
+func (e *cborEncDriver) EncodeRawExt(re *RawExt, en *Encoder) {
+	e.encUint(uint64(re.Tag), cborBaseTag)
+	if re.Data != nil {
+		en.encode(re.Data)
+	} else if re.Value == nil {
+		e.EncodeNil()
+	} else {
+		en.encode(re.Value)
+	}
+}
+
+func (e *cborEncDriver) EncodeArrayStart(length int) {
+	e.encLen(cborBaseArray, length)
+}
+
+func (e *cborEncDriver) EncodeMapStart(length int) {
+	e.encLen(cborBaseMap, length)
+}
+
+func (e *cborEncDriver) EncodeString(c charEncoding, v string) {
+	e.encLen(cborBaseString, len(v))
+	e.w.writestr(v)
+}
+
+func (e *cborEncDriver) EncodeSymbol(v string) {
+	e.EncodeString(c_UTF8, v)
+}
+
+func (e *cborEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
+	if c == c_RAW {
+		e.encLen(cborBaseBytes, len(v))
+	} else {
+		e.encLen(cborBaseString, len(v))
+	}
+	e.w.writeb(v)
+}
+
+// ----------------------
+
+type cborDecDriver struct {
+	d      *Decoder
+	h      *CborHandle
+	r      decReader
+	b      [scratchByteArrayLen]byte
+	br     bool // bytes reader
+	bdRead bool
+	bd     byte
+	noBuiltInTypes
+	decNoSeparator
+}
+
+func (d *cborDecDriver) readNextBd() {
+	d.bd = d.r.readn1()
+	d.bdRead = true
+}
+
+func (d *cborDecDriver) uncacheRead() {
+	if d.bdRead {
+		d.r.unreadn1()
+		d.bdRead = false
+	}
+}
+
+func (d *cborDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == cborBdNil {
+		return valueTypeNil
+	} else if d.bd == cborBdIndefiniteBytes || (d.bd >= cborBaseBytes && d.bd < cborBaseString) {
+		return valueTypeBytes
+	} else if d.bd == cborBdIndefiniteString || (d.bd >= cborBaseString && d.bd < cborBaseArray) {
+		return valueTypeString
+	} else if d.bd == cborBdIndefiniteArray || (d.bd >= cborBaseArray && d.bd < cborBaseMap) {
+		return valueTypeArray
+	} else if d.bd == cborBdIndefiniteMap || (d.bd >= cborBaseMap && d.bd < cborBaseTag) {
+		return valueTypeMap
+	} else {
+		// d.d.errorf("isContainerType: unsupported parameter: %v", vt)
+	}
+	return valueTypeUnset
+}
+
+func (d *cborDecDriver) TryDecodeAsNil() bool {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	// treat Nil and Undefined as nil values
+	if d.bd == cborBdNil || d.bd == cborBdUndefined {
+		d.bdRead = false
+		return true
+	}
+	return false
+}
+
+func (d *cborDecDriver) CheckBreak() bool {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == cborBdBreak {
+		d.bdRead = false
+		return true
+	}
+	return false
+}
+
+func (d *cborDecDriver) decUint() (ui uint64) {
+	v := d.bd & 0x1f
+	if v <= 0x17 {
+		ui = uint64(v)
+	} else {
+		if v == 0x18 {
+			ui = uint64(d.r.readn1())
+		} else if v == 0x19 {
+			ui = uint64(bigen.Uint16(d.r.readx(2)))
+		} else if v == 0x1a {
+			ui = uint64(bigen.Uint32(d.r.readx(4)))
+		} else if v == 0x1b {
+			ui = uint64(bigen.Uint64(d.r.readx(8)))
+		} else {
+			d.d.errorf("decUint: Invalid descriptor: %v", d.bd)
+			return
+		}
+	}
+	return
+}
+
+func (d *cborDecDriver) decCheckInteger() (neg bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	major := d.bd >> 5
+	if major == cborMajorUint {
+	} else if major == cborMajorNegInt {
+		neg = true
+	} else {
+		d.d.errorf("invalid major: %v (bd: %v)", major, d.bd)
+		return
+	}
+	return
+}
+
+func (d *cborDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	neg := d.decCheckInteger()
+	ui := d.decUint()
+	// check if this number can be converted to an int without overflow
+	var overflow bool
+	if neg {
+		if i, overflow = chkOvf.SignedInt(ui + 1); overflow {
+			d.d.errorf("cbor: overflow converting %v to signed integer", ui+1)
+			return
+		}
+		i = -i
+	} else {
+		if i, overflow = chkOvf.SignedInt(ui); overflow {
+			d.d.errorf("cbor: overflow converting %v to signed integer", ui)
+			return
+		}
+	}
+	if chkOvf.Int(i, bitsize) {
+		d.d.errorf("cbor: overflow integer: %v", i)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *cborDecDriver) DecodeUint(bitsize uint8) (ui uint64) {
+	if d.decCheckInteger() {
+		d.d.errorf("Assigning negative signed value to unsigned type")
+		return
+	}
+	ui = d.decUint()
+	if chkOvf.Uint(ui, bitsize) {
+		d.d.errorf("cbor: overflow integer: %v", ui)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *cborDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if bd := d.bd; bd == cborBdFloat16 {
+		f = float64(math.Float32frombits(halfFloatToFloatBits(bigen.Uint16(d.r.readx(2)))))
+	} else if bd == cborBdFloat32 {
+		f = float64(math.Float32frombits(bigen.Uint32(d.r.readx(4))))
+	} else if bd == cborBdFloat64 {
+		f = math.Float64frombits(bigen.Uint64(d.r.readx(8)))
+	} else if bd >= cborBaseUint && bd < cborBaseBytes {
+		f = float64(d.DecodeInt(64))
+	} else {
+		d.d.errorf("Float only valid from float16/32/64: Invalid descriptor: %v", bd)
+		return
+	}
+	if chkOverflow32 && chkOvf.Float32(f) {
+		d.d.errorf("cbor: float32 overflow: %v", f)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+// bool can be decoded from bool only (single byte).
+func (d *cborDecDriver) DecodeBool() (b bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if bd := d.bd; bd == cborBdTrue {
+		b = true
+	} else if bd == cborBdFalse {
+	} else {
+		d.d.errorf("Invalid single-byte value for bool: %s: %x", msgBadDesc, d.bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *cborDecDriver) ReadMapStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	d.bdRead = false
+	if d.bd == cborBdIndefiniteMap {
+		return -1
+	}
+	return d.decLen()
+}
+
+func (d *cborDecDriver) ReadArrayStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	d.bdRead = false
+	if d.bd == cborBdIndefiniteArray {
+		return -1
+	}
+	return d.decLen()
+}
+
+func (d *cborDecDriver) decLen() int {
+	return int(d.decUint())
+}
+
+func (d *cborDecDriver) decAppendIndefiniteBytes(bs []byte) []byte {
+	d.bdRead = false
+	for {
+		if d.CheckBreak() {
+			break
+		}
+		if major := d.bd >> 5; major != cborMajorBytes && major != cborMajorText {
+			d.d.errorf("cbor: expect bytes or string major type in indefinite string/bytes; got: %v, byte: %v", major, d.bd)
+			return nil
+		}
+		n := d.decLen()
+		oldLen := len(bs)
+		newLen := oldLen + n
+		if newLen > cap(bs) {
+			bs2 := make([]byte, newLen, 2*cap(bs)+n)
+			copy(bs2, bs)
+			bs = bs2
+		} else {
+			bs = bs[:newLen]
+		}
+		d.r.readb(bs[oldLen:newLen])
+		// bs = append(bs, d.r.readn()...)
+		d.bdRead = false
+	}
+	d.bdRead = false
+	return bs
+}
+
+func (d *cborDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == cborBdNil || d.bd == cborBdUndefined {
+		d.bdRead = false
+		return nil
+	}
+	if d.bd == cborBdIndefiniteBytes || d.bd == cborBdIndefiniteString {
+		if bs == nil {
+			return d.decAppendIndefiniteBytes(nil)
+		}
+		return d.decAppendIndefiniteBytes(bs[:0])
+	}
+	clen := d.decLen()
+	d.bdRead = false
+	if zerocopy {
+		if d.br {
+			return d.r.readx(clen)
+		} else if len(bs) == 0 {
+			bs = d.b[:]
+		}
+	}
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
+}
+
+func (d *cborDecDriver) DecodeString() (s string) {
+	return string(d.DecodeBytes(d.b[:], true, true))
+}
+
+func (d *cborDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	u := d.decUint()
+	d.bdRead = false
+	realxtag = u
+	if ext == nil {
+		re := rv.(*RawExt)
+		re.Tag = realxtag
+		d.d.decode(&re.Value)
+	} else if xtag != realxtag {
+		d.d.errorf("Wrong extension tag. Got %b. Expecting: %v", realxtag, xtag)
+		return
+	} else {
+		var v interface{}
+		d.d.decode(&v)
+		ext.UpdateExt(rv, v)
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *cborDecDriver) DecodeNaked() {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+
+	n := &d.d.n
+	var decodeFurther bool
+
+	switch d.bd {
+	case cborBdNil:
+		n.v = valueTypeNil
+	case cborBdFalse:
+		n.v = valueTypeBool
+		n.b = false
+	case cborBdTrue:
+		n.v = valueTypeBool
+		n.b = true
+	case cborBdFloat16, cborBdFloat32:
+		n.v = valueTypeFloat
+		n.f = d.DecodeFloat(true)
+	case cborBdFloat64:
+		n.v = valueTypeFloat
+		n.f = d.DecodeFloat(false)
+	case cborBdIndefiniteBytes:
+		n.v = valueTypeBytes
+		n.l = d.DecodeBytes(nil, false, false)
+	case cborBdIndefiniteString:
+		n.v = valueTypeString
+		n.s = d.DecodeString()
+	case cborBdIndefiniteArray:
+		n.v = valueTypeArray
+		decodeFurther = true
+	case cborBdIndefiniteMap:
+		n.v = valueTypeMap
+		decodeFurther = true
+	default:
+		switch {
+		case d.bd >= cborBaseUint && d.bd < cborBaseNegInt:
+			if d.h.SignedInteger {
+				n.v = valueTypeInt
+				n.i = d.DecodeInt(64)
+			} else {
+				n.v = valueTypeUint
+				n.u = d.DecodeUint(64)
+			}
+		case d.bd >= cborBaseNegInt && d.bd < cborBaseBytes:
+			n.v = valueTypeInt
+			n.i = d.DecodeInt(64)
+		case d.bd >= cborBaseBytes && d.bd < cborBaseString:
+			n.v = valueTypeBytes
+			n.l = d.DecodeBytes(nil, false, false)
+		case d.bd >= cborBaseString && d.bd < cborBaseArray:
+			n.v = valueTypeString
+			n.s = d.DecodeString()
+		case d.bd >= cborBaseArray && d.bd < cborBaseMap:
+			n.v = valueTypeArray
+			decodeFurther = true
+		case d.bd >= cborBaseMap && d.bd < cborBaseTag:
+			n.v = valueTypeMap
+			decodeFurther = true
+		case d.bd >= cborBaseTag && d.bd < cborBaseSimple:
+			n.v = valueTypeExt
+			n.u = d.decUint()
+			n.l = nil
+			// d.bdRead = false
+			// d.d.decode(&re.Value) // handled by decode itself.
+			// decodeFurther = true
+		default:
+			d.d.errorf("decodeNaked: Unrecognized d.bd: 0x%x", d.bd)
+			return
+		}
+	}
+
+	if !decodeFurther {
+		d.bdRead = false
+	}
+	return
+}
+
+// -------------------------
+
+// CborHandle is a Handle for the CBOR encoding format,
+// defined at http://tools.ietf.org/html/rfc7049 and documented further at http://cbor.io .
+//
+// CBOR is comprehensively supported, including support for:
+//   - indefinite-length arrays/maps/bytes/strings
+//   - (extension) tags in range 0..0xffff (0 .. 65535)
+//   - half, single and double-precision floats
+//   - all numbers (1, 2, 4 and 8-byte signed and unsigned integers)
+//   - nil, true, false, ...
+//   - arrays and maps, bytes and text strings
+//
+// None of the optional extensions (with tags) defined in the spec are supported out-of-the-box.
+// Users can implement them as needed (using SetExt), including spec-documented ones:
+//   - timestamp, BigNum, BigFloat, Decimals, Encoded Text (e.g. URL, regexp, base64, MIME Message), etc.
+//
+// To encode with indefinite lengths (streaming), users will use
+// (Must)Encode methods of *Encoder, along with writing CborStreamXXX constants.
+//
+// For example, to encode "one-byte" as an indefinite length string:
+//     var buf bytes.Buffer
+//     e := NewEncoder(&buf, new(CborHandle))
+//     buf.WriteByte(CborStreamString)
+//     e.MustEncode("one-")
+//     e.MustEncode("byte")
+//     buf.WriteByte(CborStreamBreak)
+//     encodedBytes := buf.Bytes()
+//     var vv interface{}
+//     NewDecoderBytes(buf.Bytes(), new(CborHandle)).MustDecode(&vv)
+//     // Now, vv contains the same string "one-byte"
+//
+type CborHandle struct {
+	binaryEncodingType
+	BasicHandle
+}
+
+func (h *CborHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{i: ext})
+}
+
+func (h *CborHandle) newEncDriver(e *Encoder) encDriver {
+	return &cborEncDriver{e: e, w: e.w, h: h}
+}
+
+func (h *CborHandle) newDecDriver(d *Decoder) decDriver {
+	return &cborDecDriver{d: d, h: h, r: d.r, br: d.bytes}
+}
+
+func (e *cborEncDriver) reset() {
+	e.w = e.e.w
+}
+
+func (d *cborDecDriver) reset() {
+	d.r, d.br = d.d.r, d.d.bytes
+	d.bd, d.bdRead = 0, false
+}
+
+var _ decDriver = (*cborDecDriver)(nil)
+var _ encDriver = (*cborEncDriver)(nil)

--- a/vendor/github.com/ugorji/go/codec/cbor_test.go
+++ b/vendor/github.com/ugorji/go/codec/cbor_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"math"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestCborIndefiniteLength(t *testing.T) {
+	oldMapType := testCborH.MapType
+	defer func() {
+		testCborH.MapType = oldMapType
+	}()
+	testCborH.MapType = testMapStrIntfTyp
+	// var (
+	// 	M1 map[string][]byte
+	// 	M2 map[uint64]bool
+	// 	L1 []interface{}
+	// 	S1 []string
+	// 	B1 []byte
+	// )
+	var v, vv interface{}
+	// define it (v), encode it using indefinite lengths, decode it (vv), compare v to vv
+	v = map[string]interface{}{
+		"one-byte-key":   []byte{1, 2, 3, 4, 5, 6},
+		"two-string-key": "two-value",
+		"three-list-key": []interface{}{true, false, uint64(1), int64(-1)},
+	}
+	var buf bytes.Buffer
+	// buf.Reset()
+	e := NewEncoder(&buf, testCborH)
+	buf.WriteByte(cborBdIndefiniteMap)
+	//----
+	buf.WriteByte(cborBdIndefiniteString)
+	e.MustEncode("one-")
+	e.MustEncode("byte-")
+	e.MustEncode("key")
+	buf.WriteByte(cborBdBreak)
+
+	buf.WriteByte(cborBdIndefiniteBytes)
+	e.MustEncode([]byte{1, 2, 3})
+	e.MustEncode([]byte{4, 5, 6})
+	buf.WriteByte(cborBdBreak)
+
+	//----
+	buf.WriteByte(cborBdIndefiniteString)
+	e.MustEncode("two-")
+	e.MustEncode("string-")
+	e.MustEncode("key")
+	buf.WriteByte(cborBdBreak)
+
+	buf.WriteByte(cborBdIndefiniteString)
+	e.MustEncode([]byte("two-")) // encode as bytes, to check robustness of code
+	e.MustEncode([]byte("value"))
+	buf.WriteByte(cborBdBreak)
+
+	//----
+	buf.WriteByte(cborBdIndefiniteString)
+	e.MustEncode("three-")
+	e.MustEncode("list-")
+	e.MustEncode("key")
+	buf.WriteByte(cborBdBreak)
+
+	buf.WriteByte(cborBdIndefiniteArray)
+	e.MustEncode(true)
+	e.MustEncode(false)
+	e.MustEncode(uint64(1))
+	e.MustEncode(int64(-1))
+	buf.WriteByte(cborBdBreak)
+
+	buf.WriteByte(cborBdBreak) // close map
+
+	NewDecoderBytes(buf.Bytes(), testCborH).MustDecode(&vv)
+	if err := deepEqual(v, vv); err != nil {
+		logT(t, "-------- Before and After marshal do not match: Error: %v", err)
+		logT(t, "    ....... GOLDEN:  (%T) %#v", v, v)
+		logT(t, "    ....... DECODED: (%T) %#v", vv, vv)
+		failT(t)
+	}
+}
+
+type testCborGolden struct {
+	Base64     string      `codec:"cbor"`
+	Hex        string      `codec:"hex"`
+	Roundtrip  bool        `codec:"roundtrip"`
+	Decoded    interface{} `codec:"decoded"`
+	Diagnostic string      `codec:"diagnostic"`
+	Skip       bool        `codec:"skip"`
+}
+
+// Some tests are skipped because they include numbers outside the range of int64/uint64
+func doTestCborGoldens(t *testing.T) {
+	oldMapType := testCborH.MapType
+	defer func() {
+		testCborH.MapType = oldMapType
+	}()
+	testCborH.MapType = testMapStrIntfTyp
+	// decode test-cbor-goldens.json into a list of []*testCborGolden
+	// for each one,
+	// - decode hex into []byte bs
+	// - decode bs into interface{} v
+	// - compare both using deepequal
+	// - for any miss, record it
+	var gs []*testCborGolden
+	f, err := os.Open("test-cbor-goldens.json")
+	if err != nil {
+		logT(t, "error opening test-cbor-goldens.json: %v", err)
+		failT(t)
+	}
+	defer f.Close()
+	jh := new(JsonHandle)
+	jh.MapType = testMapStrIntfTyp
+	// d := NewDecoder(f, jh)
+	d := NewDecoder(bufio.NewReader(f), jh)
+	// err = d.Decode(&gs)
+	d.MustDecode(&gs)
+	if err != nil {
+		logT(t, "error json decoding test-cbor-goldens.json: %v", err)
+		failT(t)
+	}
+
+	tagregex := regexp.MustCompile(`[\d]+\(.+?\)`)
+	hexregex := regexp.MustCompile(`h'([0-9a-fA-F]*)'`)
+	for i, g := range gs {
+		// fmt.Printf("%v, skip: %v, isTag: %v, %s\n", i, g.Skip, tagregex.MatchString(g.Diagnostic), g.Diagnostic)
+		// skip tags or simple or those with prefix, as we can't verify them.
+		if g.Skip || strings.HasPrefix(g.Diagnostic, "simple(") || tagregex.MatchString(g.Diagnostic) {
+			// fmt.Printf("%v: skipped\n", i)
+			logT(t, "[%v] skipping because skip=true OR unsupported simple value or Tag Value", i)
+			continue
+		}
+		// println("++++++++++++", i, "g.Diagnostic", g.Diagnostic)
+		if hexregex.MatchString(g.Diagnostic) {
+			// println(i, "g.Diagnostic matched hex")
+			if s2 := g.Diagnostic[2 : len(g.Diagnostic)-1]; s2 == "" {
+				g.Decoded = zeroByteSlice
+			} else if bs2, err2 := hex.DecodeString(s2); err2 == nil {
+				g.Decoded = bs2
+			}
+			// fmt.Printf("%v: hex: %v\n", i, g.Decoded)
+		}
+		bs, err := hex.DecodeString(g.Hex)
+		if err != nil {
+			logT(t, "[%v] error hex decoding %s [%v]: %v", i, g.Hex, err)
+			failT(t)
+		}
+		var v interface{}
+		NewDecoderBytes(bs, testCborH).MustDecode(&v)
+		if _, ok := v.(RawExt); ok {
+			continue
+		}
+		// check the diagnostics to compare
+		switch g.Diagnostic {
+		case "Infinity":
+			b := math.IsInf(v.(float64), 1)
+			testCborError(t, i, math.Inf(1), v, nil, &b)
+		case "-Infinity":
+			b := math.IsInf(v.(float64), -1)
+			testCborError(t, i, math.Inf(-1), v, nil, &b)
+		case "NaN":
+			// println(i, "checking NaN")
+			b := math.IsNaN(v.(float64))
+			testCborError(t, i, math.NaN(), v, nil, &b)
+		case "undefined":
+			b := v == nil
+			testCborError(t, i, nil, v, nil, &b)
+		default:
+			v0 := g.Decoded
+			// testCborCoerceJsonNumber(reflect.ValueOf(&v0))
+			testCborError(t, i, v0, v, deepEqual(v0, v), nil)
+		}
+	}
+}
+
+func testCborError(t *testing.T, i int, v0, v1 interface{}, err error, equal *bool) {
+	if err == nil && equal == nil {
+		// fmt.Printf("%v testCborError passed (err and equal nil)\n", i)
+		return
+	}
+	if err != nil {
+		logT(t, "[%v] deepEqual error: %v", i, err)
+		logT(t, "    ....... GOLDEN:  (%T) %#v", v0, v0)
+		logT(t, "    ....... DECODED: (%T) %#v", v1, v1)
+		failT(t)
+	}
+	if equal != nil && !*equal {
+		logT(t, "[%v] values not equal", i)
+		logT(t, "    ....... GOLDEN:  (%T) %#v", v0, v0)
+		logT(t, "    ....... DECODED: (%T) %#v", v1, v1)
+		failT(t)
+	}
+	// fmt.Printf("%v testCborError passed (checks passed)\n", i)
+}
+
+func TestCborGoldens(t *testing.T) {
+	doTestCborGoldens(t)
+}

--- a/vendor/github.com/ugorji/go/codec/codec_test.go
+++ b/vendor/github.com/ugorji/go/codec/codec_test.go
@@ -1,0 +1,1505 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// Test works by using a slice of interfaces.
+// It can test for encoding/decoding into/from a nil interface{}
+// or passing the object to encode/decode into.
+//
+// There are basically 2 main tests here.
+// First test internally encodes and decodes things and verifies that
+// the artifact was as expected.
+// Second test will use python msgpack to create a bunch of golden files,
+// read those files, and compare them to what it should be. It then
+// writes those files back out and compares the byte streams.
+//
+// Taken together, the tests are pretty extensive.
+//
+// The following manual tests must be done:
+//   - TestCodecUnderlyingType
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"net"
+	"net/rpc"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func init() {
+	testPreInitFns = append(testPreInitFns, testInit)
+}
+
+// make this a mapbyslice
+type testMbsT []interface{}
+
+func (_ testMbsT) MapBySlice() {}
+
+type testVerifyArg int
+
+const (
+	testVerifyMapTypeSame testVerifyArg = iota
+	testVerifyMapTypeStrIntf
+	testVerifyMapTypeIntfIntf
+	// testVerifySliceIntf
+	testVerifyForPython
+)
+
+const testSkipRPCTests = false
+
+var (
+	testTableNumPrimitives int
+	testTableIdxTime       int
+	testTableNumMaps       int
+)
+
+var (
+	skipVerifyVal interface{} = &(struct{}{})
+
+	testMapStrIntfTyp = reflect.TypeOf(map[string]interface{}(nil))
+
+	// For Go Time, do not use a descriptive timezone.
+	// It's unnecessary, and makes it harder to do a reflect.DeepEqual.
+	// The Offset already tells what the offset should be, if not on UTC and unknown zone name.
+	timeLoc        = time.FixedZone("", -8*60*60) // UTC-08:00 //time.UTC-8
+	timeToCompare1 = time.Date(2012, 2, 2, 2, 2, 2, 2000, timeLoc).UTC()
+	timeToCompare2 = time.Date(1900, 2, 2, 2, 2, 2, 2000, timeLoc).UTC()
+	timeToCompare3 = time.Unix(0, 270).UTC() // use value that must be encoded as uint64 for nanoseconds (for cbor/msgpack comparison)
+	//timeToCompare4 = time.Time{}.UTC() // does not work well with simple cbor time encoding (overflow)
+	timeToCompare4 = time.Unix(-2013855848, 4223).UTC()
+
+	table              []interface{} // main items we encode
+	tableVerify        []interface{} // we verify encoded things against this after decode
+	tableTestNilVerify []interface{} // for nil interface, use this to verify (rules are different)
+	tablePythonVerify  []interface{} // for verifying for python, since Python sometimes
+	// will encode a float32 as float64, or large int as uint
+	testRpcInt = new(TestRpcInt)
+)
+
+func testByteBuf(in []byte) *bytes.Buffer {
+	return bytes.NewBuffer(in)
+}
+
+type TestABC struct {
+	A, B, C string
+}
+
+func (x *TestABC) MarshalBinary() ([]byte, error) {
+	return []byte(fmt.Sprintf("%s %s %s", x.A, x.B, x.C)), nil
+}
+func (x *TestABC) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("%s %s %s", x.A, x.B, x.C)), nil
+}
+func (x *TestABC) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s %s %s"`, x.A, x.B, x.C)), nil
+}
+
+func (x *TestABC) UnmarshalBinary(data []byte) (err error) {
+	ss := strings.Split(string(data), " ")
+	x.A, x.B, x.C = ss[0], ss[1], ss[2]
+	return
+}
+func (x *TestABC) UnmarshalText(data []byte) (err error) {
+	return x.UnmarshalBinary(data)
+}
+func (x *TestABC) UnmarshalJSON(data []byte) (err error) {
+	return x.UnmarshalBinary(data[1 : len(data)-1])
+}
+
+type TestABC2 struct {
+	A, B, C string
+}
+
+func (x TestABC2) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("%s %s %s", x.A, x.B, x.C)), nil
+}
+func (x *TestABC2) UnmarshalText(data []byte) (err error) {
+	ss := strings.Split(string(data), " ")
+	x.A, x.B, x.C = ss[0], ss[1], ss[2]
+	return
+	// _, err = fmt.Sscanf(string(data), "%s %s %s", &x.A, &x.B, &x.C)
+}
+
+type TestRpcABC struct {
+	A, B, C string
+}
+
+type TestRpcInt struct {
+	i int
+}
+
+func (r *TestRpcInt) Update(n int, res *int) error      { r.i = n; *res = r.i; return nil }
+func (r *TestRpcInt) Square(ignore int, res *int) error { *res = r.i * r.i; return nil }
+func (r *TestRpcInt) Mult(n int, res *int) error        { *res = r.i * n; return nil }
+func (r *TestRpcInt) EchoStruct(arg TestRpcABC, res *string) error {
+	*res = fmt.Sprintf("%#v", arg)
+	return nil
+}
+func (r *TestRpcInt) Echo123(args []string, res *string) error {
+	*res = fmt.Sprintf("%#v", args)
+	return nil
+}
+
+type TestRawValue struct {
+	R Raw
+	I int
+}
+
+type testUnixNanoTimeExt struct {
+	// keep timestamp here, so that do not incur interface-conversion costs
+	ts int64
+}
+
+// func (x *testUnixNanoTimeExt) WriteExt(interface{}) []byte { panic("unsupported") }
+// func (x *testUnixNanoTimeExt) ReadExt(interface{}, []byte) { panic("unsupported") }
+func (x *testUnixNanoTimeExt) ConvertExt(v interface{}) interface{} {
+	switch v2 := v.(type) {
+	case time.Time:
+		x.ts = v2.UTC().UnixNano()
+	case *time.Time:
+		x.ts = v2.UTC().UnixNano()
+	default:
+		panic(fmt.Sprintf("unsupported format for time conversion: expecting time.Time; got %T", v))
+	}
+	return &x.ts
+}
+func (x *testUnixNanoTimeExt) UpdateExt(dest interface{}, v interface{}) {
+	// fmt.Printf("testUnixNanoTimeExt.UpdateExt: v: %v\n", v)
+	tt := dest.(*time.Time)
+	switch v2 := v.(type) {
+	case int64:
+		*tt = time.Unix(0, v2).UTC()
+	case *int64:
+		*tt = time.Unix(0, *v2).UTC()
+	case uint64:
+		*tt = time.Unix(0, int64(v2)).UTC()
+	case *uint64:
+		*tt = time.Unix(0, int64(*v2)).UTC()
+	//case float64:
+	//case string:
+	default:
+		panic(fmt.Sprintf("unsupported format for time conversion: expecting int64/uint64; got %T", v))
+	}
+	// fmt.Printf("testUnixNanoTimeExt.UpdateExt: v: %v, tt: %#v\n", v, tt)
+}
+
+func testVerifyVal(v interface{}, arg testVerifyArg) (v2 interface{}) {
+	//for python msgpack,
+	//  - all positive integers are unsigned 64-bit ints
+	//  - all floats are float64
+	switch iv := v.(type) {
+	case int8:
+		if iv >= 0 {
+			v2 = uint64(iv)
+		} else {
+			v2 = int64(iv)
+		}
+	case int16:
+		if iv >= 0 {
+			v2 = uint64(iv)
+		} else {
+			v2 = int64(iv)
+		}
+	case int32:
+		if iv >= 0 {
+			v2 = uint64(iv)
+		} else {
+			v2 = int64(iv)
+		}
+	case int64:
+		if iv >= 0 {
+			v2 = uint64(iv)
+		} else {
+			v2 = int64(iv)
+		}
+	case uint8:
+		v2 = uint64(iv)
+	case uint16:
+		v2 = uint64(iv)
+	case uint32:
+		v2 = uint64(iv)
+	case uint64:
+		v2 = uint64(iv)
+	case float32:
+		v2 = float64(iv)
+	case float64:
+		v2 = float64(iv)
+	case []interface{}:
+		m2 := make([]interface{}, len(iv))
+		for j, vj := range iv {
+			m2[j] = testVerifyVal(vj, arg)
+		}
+		v2 = m2
+	case testMbsT:
+		m2 := make([]interface{}, len(iv))
+		for j, vj := range iv {
+			m2[j] = testVerifyVal(vj, arg)
+		}
+		v2 = testMbsT(m2)
+	case map[string]bool:
+		switch arg {
+		case testVerifyMapTypeSame:
+			m2 := make(map[string]bool)
+			for kj, kv := range iv {
+				m2[kj] = kv
+			}
+			v2 = m2
+		case testVerifyMapTypeStrIntf, testVerifyForPython:
+			m2 := make(map[string]interface{})
+			for kj, kv := range iv {
+				m2[kj] = kv
+			}
+			v2 = m2
+		case testVerifyMapTypeIntfIntf:
+			m2 := make(map[interface{}]interface{})
+			for kj, kv := range iv {
+				m2[kj] = kv
+			}
+			v2 = m2
+		}
+	case map[string]interface{}:
+		switch arg {
+		case testVerifyMapTypeSame:
+			m2 := make(map[string]interface{})
+			for kj, kv := range iv {
+				m2[kj] = testVerifyVal(kv, arg)
+			}
+			v2 = m2
+		case testVerifyMapTypeStrIntf, testVerifyForPython:
+			m2 := make(map[string]interface{})
+			for kj, kv := range iv {
+				m2[kj] = testVerifyVal(kv, arg)
+			}
+			v2 = m2
+		case testVerifyMapTypeIntfIntf:
+			m2 := make(map[interface{}]interface{})
+			for kj, kv := range iv {
+				m2[kj] = testVerifyVal(kv, arg)
+			}
+			v2 = m2
+		}
+	case map[interface{}]interface{}:
+		m2 := make(map[interface{}]interface{})
+		for kj, kv := range iv {
+			m2[testVerifyVal(kj, arg)] = testVerifyVal(kv, arg)
+		}
+		v2 = m2
+	case time.Time:
+		switch arg {
+		case testVerifyForPython:
+			if iv2 := iv.UnixNano(); iv2 >= 0 {
+				v2 = uint64(iv2)
+			} else {
+				v2 = int64(iv2)
+			}
+		default:
+			v2 = v
+		}
+	default:
+		v2 = v
+	}
+	return
+}
+
+func testInit() {
+	gob.Register(new(TestStruc))
+	if testInitDebug {
+		ts0 := newTestStruc(2, false, !testSkipIntf, false)
+		fmt.Printf("====> depth: %v, ts: %#v\n", 2, ts0)
+	}
+
+	for _, v := range testHandles {
+		bh := v.getBasicHandle()
+		bh.InternString = testInternStr
+		bh.Canonical = testCanonical
+		bh.CheckCircularRef = testCheckCircRef
+		bh.StructToArray = testStructToArray
+		bh.MaxInitLen = testMaxInitLen
+		// mostly doing this for binc
+		if testWriteNoSymbols {
+			bh.AsSymbols = AsSymbolNone
+		} else {
+			bh.AsSymbols = AsSymbolAll
+		}
+	}
+
+	testJsonH.Indent = int8(testJsonIndent)
+	testJsonH.HTMLCharsAsIs = testJsonHTMLCharsAsIs
+	testMsgpackH.RawToString = true
+
+	// testMsgpackH.AddExt(byteSliceTyp, 0, testMsgpackH.BinaryEncodeExt, testMsgpackH.BinaryDecodeExt)
+	// testMsgpackH.AddExt(timeTyp, 1, testMsgpackH.TimeEncodeExt, testMsgpackH.TimeDecodeExt)
+
+	// add extensions for msgpack, simple for time.Time, so we can encode/decode same way.
+	// use different flavors of XXXExt calls, including deprecated ones.
+	// NOTE:
+	// DO NOT set extensions for JsonH, so we can test json(M|Unm)arshal support.
+	testSimpleH.AddExt(timeTyp, 1, timeExtEncFn, timeExtDecFn)
+	testMsgpackH.SetBytesExt(timeTyp, 1, timeExt{})
+	testCborH.SetInterfaceExt(timeTyp, 1, &testUnixNanoTimeExt{})
+	// testJsonH.SetInterfaceExt(timeTyp, 1, &testUnixNanoTimeExt{})
+
+	// primitives MUST be an even number, so it can be used as a mapBySlice also.
+	primitives := []interface{}{
+		int8(-8),
+		int16(-1616),
+		int32(-32323232),
+		int64(-6464646464646464),
+		uint8(192),
+		uint16(1616),
+		uint32(32323232),
+		uint64(6464646464646464),
+		byte(192),
+		float32(-3232.0),
+		float64(-6464646464.0),
+		float32(3232.0),
+		float64(6464.0),
+		float64(6464646464.0),
+		false,
+		true,
+		"null",
+		nil,
+		"some&day>some<day",
+		timeToCompare1,
+		"",
+		timeToCompare2,
+		"bytestring",
+		timeToCompare3,
+		"none",
+		timeToCompare4,
+	}
+
+	maps := []interface{}{
+		map[string]bool{
+			"true":  true,
+			"false": false,
+		},
+		map[string]interface{}{
+			"true":         "True",
+			"false":        false,
+			"uint16(1616)": uint16(1616),
+		},
+		//add a complex combo map in here. (map has list which has map)
+		//note that after the first thing, everything else should be generic.
+		map[string]interface{}{
+			"list": []interface{}{
+				int16(1616),
+				int32(32323232),
+				true,
+				float32(-3232.0),
+				map[string]interface{}{
+					"TRUE":  true,
+					"FALSE": false,
+				},
+				[]interface{}{true, false},
+			},
+			"int32":        int32(32323232),
+			"bool":         true,
+			"LONG STRING":  "123456789012345678901234567890123456789012345678901234567890",
+			"SHORT STRING": "1234567890",
+		},
+		map[interface{}]interface{}{
+			true:       "true",
+			uint8(138): false,
+			"false":    uint8(200),
+		},
+	}
+
+	testTableNumPrimitives = len(primitives)
+	testTableIdxTime = testTableNumPrimitives - 8
+	testTableNumMaps = len(maps)
+
+	table = []interface{}{}
+	table = append(table, primitives...)
+	table = append(table, primitives)
+	table = append(table, testMbsT(primitives))
+	table = append(table, maps...)
+	table = append(table, newTestStruc(0, false, !testSkipIntf, false))
+
+	tableVerify = make([]interface{}, len(table))
+	tableTestNilVerify = make([]interface{}, len(table))
+	tablePythonVerify = make([]interface{}, len(table))
+
+	lp := testTableNumPrimitives + 4
+	av := tableVerify
+	for i, v := range table {
+		if i == lp {
+			av[i] = skipVerifyVal
+			continue
+		}
+		//av[i] = testVerifyVal(v, testVerifyMapTypeSame)
+		switch v.(type) {
+		case []interface{}:
+			av[i] = testVerifyVal(v, testVerifyMapTypeSame)
+		case testMbsT:
+			av[i] = testVerifyVal(v, testVerifyMapTypeSame)
+		case map[string]interface{}:
+			av[i] = testVerifyVal(v, testVerifyMapTypeSame)
+		case map[interface{}]interface{}:
+			av[i] = testVerifyVal(v, testVerifyMapTypeSame)
+		default:
+			av[i] = v
+		}
+	}
+
+	av = tableTestNilVerify
+	for i, v := range table {
+		if i > lp {
+			av[i] = skipVerifyVal
+			continue
+		}
+		av[i] = testVerifyVal(v, testVerifyMapTypeStrIntf)
+	}
+
+	av = tablePythonVerify
+	for i, v := range table {
+		if i == testTableNumPrimitives+1 || i > lp { // testTableNumPrimitives+1 is the mapBySlice
+			av[i] = skipVerifyVal
+			continue
+		}
+		av[i] = testVerifyVal(v, testVerifyForPython)
+	}
+
+	// only do the python verify up to the maps, skipping the last 2 maps.
+	tablePythonVerify = tablePythonVerify[:testTableNumPrimitives+2+testTableNumMaps-2]
+}
+
+func testUnmarshal(v interface{}, data []byte, h Handle) (err error) {
+	return testCodecDecode(data, v, h)
+}
+
+func testMarshal(v interface{}, h Handle) (bs []byte, err error) {
+	return testCodecEncode(v, nil, testByteBuf, h)
+}
+
+func testMarshalErr(v interface{}, h Handle, t *testing.T, name string) (bs []byte, err error) {
+	if bs, err = testMarshal(v, h); err != nil {
+		logT(t, "Error encoding %s: %v, Err: %v", name, v, err)
+		t.FailNow()
+	}
+	return
+}
+
+func testUnmarshalErr(v interface{}, data []byte, h Handle, t *testing.T, name string) (err error) {
+	if err = testUnmarshal(v, data, h); err != nil {
+		logT(t, "Error Decoding into %s: %v, Err: %v", name, v, err)
+		t.FailNow()
+	}
+	return
+}
+
+// doTestCodecTableOne allows us test for different variations based on arguments passed.
+func doTestCodecTableOne(t *testing.T, testNil bool, h Handle,
+	vs []interface{}, vsVerify []interface{}) {
+	//if testNil, then just test for when a pointer to a nil interface{} is passed. It should work.
+	//Current setup allows us test (at least manually) the nil interface or typed interface.
+	logT(t, "================ TestNil: %v ================\n", testNil)
+	for i, v0 := range vs {
+		logT(t, "..............................................")
+		logT(t, "         Testing: #%d:, %T, %#v\n", i, v0, v0)
+		b0, err := testMarshalErr(v0, h, t, "v0")
+		if err != nil {
+			continue
+		}
+		if h.isBinary() {
+			logT(t, "         Encoded bytes: len: %v, %v\n", len(b0), b0)
+		} else {
+			logT(t, "         Encoded string: len: %v, %v\n", len(string(b0)), string(b0))
+			// println("########### encoded string: " + string(b0))
+		}
+		var v1 interface{}
+
+		if testNil {
+			err = testUnmarshal(&v1, b0, h)
+		} else {
+			if v0 != nil {
+				v0rt := reflect.TypeOf(v0) // ptr
+				rv1 := reflect.New(v0rt)
+				err = testUnmarshal(rv1.Interface(), b0, h)
+				v1 = rv1.Elem().Interface()
+				// v1 = reflect.Indirect(reflect.ValueOf(v1)).Interface()
+			}
+		}
+
+		logT(t, "         v1 returned: %T, %#v", v1, v1)
+		// if v1 != nil {
+		//	logT(t, "         v1 returned: %T, %#v", v1, v1)
+		//	//we always indirect, because ptr to typed value may be passed (if not testNil)
+		//	v1 = reflect.Indirect(reflect.ValueOf(v1)).Interface()
+		// }
+		if err != nil {
+			logT(t, "-------- Error: %v. Partial return: %v", err, v1)
+			failT(t)
+			continue
+		}
+		v0check := vsVerify[i]
+		if v0check == skipVerifyVal {
+			logT(t, "        Nil Check skipped: Decoded: %T, %#v\n", v1, v1)
+			continue
+		}
+
+		if err = deepEqual(v0check, v1); err == nil {
+			logT(t, "++++++++ Before and After marshal matched\n")
+		} else {
+			// logT(t, "-------- Before and After marshal do not match: Error: %v"+
+			// 	" ====> GOLDEN: (%T) %#v, DECODED: (%T) %#v\n", err, v0check, v0check, v1, v1)
+			logT(t, "-------- Before and After marshal do not match: Error: %v", err)
+			logT(t, "    ....... GOLDEN:  (%T) %#v", v0check, v0check)
+			logT(t, "    ....... DECODED: (%T) %#v", v1, v1)
+			failT(t)
+		}
+	}
+}
+
+func testCodecTableOne(t *testing.T, h Handle) {
+	testOnce.Do(testInitAll)
+	// func TestMsgpackAllExperimental(t *testing.T) {
+	// dopts := testDecOpts(nil, nil, false, true, true),
+
+	numPrim, numMap, idxTime, idxMap := testTableNumPrimitives, testTableNumMaps, testTableIdxTime, testTableNumPrimitives+2
+
+	//println("#################")
+	switch v := h.(type) {
+	case *MsgpackHandle:
+		var oldWriteExt, oldRawToString bool
+		oldWriteExt, v.WriteExt = v.WriteExt, true
+		oldRawToString, v.RawToString = v.RawToString, true
+		doTestCodecTableOne(t, false, h, table, tableVerify)
+		v.WriteExt, v.RawToString = oldWriteExt, oldRawToString
+	case *JsonHandle:
+		//skip []interface{} containing time.Time, as it encodes as a number, but cannot decode back to time.Time.
+		//As there is no real support for extension tags in json, this must be skipped.
+		doTestCodecTableOne(t, false, h, table[:numPrim], tableVerify[:numPrim])
+		doTestCodecTableOne(t, false, h, table[idxMap:], tableVerify[idxMap:])
+	default:
+		doTestCodecTableOne(t, false, h, table, tableVerify)
+	}
+	// func TestMsgpackAll(t *testing.T) {
+
+	// //skip []interface{} containing time.Time
+	// doTestCodecTableOne(t, false, h, table[:numPrim], tableVerify[:numPrim])
+	// doTestCodecTableOne(t, false, h, table[numPrim+1:], tableVerify[numPrim+1:])
+	// func TestMsgpackNilStringMap(t *testing.T) {
+	var oldMapType reflect.Type
+	v := h.getBasicHandle()
+
+	oldMapType, v.MapType = v.MapType, testMapStrIntfTyp
+
+	//skip time.Time, []interface{} containing time.Time, last map, and newStruc
+	doTestCodecTableOne(t, true, h, table[:idxTime], tableTestNilVerify[:idxTime])
+	doTestCodecTableOne(t, true, h, table[idxMap:idxMap+numMap-1], tableTestNilVerify[idxMap:idxMap+numMap-1])
+
+	v.MapType = oldMapType
+
+	// func TestMsgpackNilIntf(t *testing.T) {
+
+	//do last map and newStruc
+	idx2 := idxMap + numMap - 1
+	doTestCodecTableOne(t, true, h, table[idx2:], tableTestNilVerify[idx2:])
+	//TODO? What is this one?
+	//doTestCodecTableOne(t, true, h, table[17:18], tableTestNilVerify[17:18])
+}
+
+func testCodecMiscOne(t *testing.T, h Handle) {
+	testOnce.Do(testInitAll)
+	b, err := testMarshalErr(32, h, t, "32")
+	// Cannot do this nil one, because faster type assertion decoding will panic
+	// var i *int32
+	// if err = testUnmarshal(b, i, nil); err == nil {
+	// 	logT(t, "------- Expecting error because we cannot unmarshal to int32 nil ptr")
+	// 	t.FailNow()
+	// }
+	var i2 int32 = 0
+	err = testUnmarshalErr(&i2, b, h, t, "int32-ptr")
+	if i2 != int32(32) {
+		logT(t, "------- didn't unmarshal to 32: Received: %d", i2)
+		t.FailNow()
+	}
+
+	// func TestMsgpackDecodePtr(t *testing.T) {
+	ts := newTestStruc(0, false, !testSkipIntf, false)
+	b, err = testMarshalErr(ts, h, t, "pointer-to-struct")
+	if len(b) < 40 {
+		logT(t, "------- Size must be > 40. Size: %d", len(b))
+		t.FailNow()
+	}
+	if h.isBinary() {
+		logT(t, "------- b: %v", b)
+	} else {
+		logT(t, "------- b: %s", b)
+	}
+	ts2 := new(TestStruc)
+	err = testUnmarshalErr(ts2, b, h, t, "pointer-to-struct")
+	if ts2.I64 != math.MaxInt64*2/3 {
+		logT(t, "------- Unmarshal wrong. Expect I64 = 64. Got: %v", ts2.I64)
+		t.FailNow()
+	}
+
+	// func TestMsgpackIntfDecode(t *testing.T) {
+	m := map[string]int{"A": 2, "B": 3}
+	p := []interface{}{m}
+	bs, err := testMarshalErr(p, h, t, "p")
+
+	m2 := map[string]int{}
+	p2 := []interface{}{m2}
+	err = testUnmarshalErr(&p2, bs, h, t, "&p2")
+
+	if m2["A"] != 2 || m2["B"] != 3 {
+		logT(t, "m2 not as expected: expecting: %v, got: %v", m, m2)
+		t.FailNow()
+	}
+	// log("m: %v, m2: %v, p: %v, p2: %v", m, m2, p, p2)
+	checkEqualT(t, p, p2, "p=p2")
+	checkEqualT(t, m, m2, "m=m2")
+	if err = deepEqual(p, p2); err == nil {
+		logT(t, "p and p2 match")
+	} else {
+		logT(t, "Not Equal: %v. p: %v, p2: %v", err, p, p2)
+		t.FailNow()
+	}
+	if err = deepEqual(m, m2); err == nil {
+		logT(t, "m and m2 match")
+	} else {
+		logT(t, "Not Equal: %v. m: %v, m2: %v", err, m, m2)
+		t.FailNow()
+	}
+
+	// func TestMsgpackDecodeStructSubset(t *testing.T) {
+	// test that we can decode a subset of the stream
+	mm := map[string]interface{}{"A": 5, "B": 99, "C": 333}
+	bs, err = testMarshalErr(mm, h, t, "mm")
+	type ttt struct {
+		A uint8
+		C int32
+	}
+	var t2 ttt
+	testUnmarshalErr(&t2, bs, h, t, "t2")
+	t3 := ttt{5, 333}
+	checkEqualT(t, t2, t3, "t2=t3")
+
+	// println(">>>>>")
+	// test simple arrays, non-addressable arrays, slices
+	type tarr struct {
+		A int64
+		B [3]int64
+		C []byte
+		D [3]byte
+	}
+	var tarr0 = tarr{1, [3]int64{2, 3, 4}, []byte{4, 5, 6}, [3]byte{7, 8, 9}}
+	// test both pointer and non-pointer (value)
+	for _, tarr1 := range []interface{}{tarr0, &tarr0} {
+		bs, err = testMarshalErr(tarr1, h, t, "tarr1")
+		if err != nil {
+			logT(t, "Error marshalling: %v", err)
+			t.FailNow()
+		}
+		if _, ok := h.(*JsonHandle); ok {
+			logT(t, "Marshal as: %s", bs)
+		}
+		var tarr2 tarr
+		testUnmarshalErr(&tarr2, bs, h, t, "tarr2")
+		checkEqualT(t, tarr0, tarr2, "tarr0=tarr2")
+		// fmt.Printf(">>>> err: %v. tarr1: %v, tarr2: %v\n", err, tarr0, tarr2)
+	}
+
+	// test byte array, even if empty (msgpack only)
+	if h == testMsgpackH {
+		type ystruct struct {
+			Anarray []byte
+		}
+		var ya = ystruct{}
+		testUnmarshalErr(&ya, []byte{0x91, 0x90}, h, t, "ya")
+	}
+}
+
+func testCodecEmbeddedPointer(t *testing.T, h Handle) {
+	testOnce.Do(testInitAll)
+	type Z int
+	type A struct {
+		AnInt int
+	}
+	type B struct {
+		*Z
+		*A
+		MoreInt int
+	}
+	var z Z = 4
+	x1 := &B{&z, &A{5}, 6}
+	bs, err := testMarshalErr(x1, h, t, "x1")
+	// fmt.Printf("buf: len(%v): %x\n", buf.Len(), buf.Bytes())
+	var x2 = new(B)
+	err = testUnmarshalErr(x2, bs, h, t, "x2")
+	err = checkEqualT(t, x1, x2, "x1=x2")
+	_ = err
+}
+
+func testCodecUnderlyingType(t *testing.T, h Handle) {
+	testOnce.Do(testInitAll)
+	// Manual Test.
+	// Run by hand, with accompanying print statements in fast-path.go
+	// to ensure that the fast functions are called.
+	type T1 map[string]string
+	v := T1{"1": "1s", "2": "2s"}
+	var bs []byte
+	var err error
+	NewEncoderBytes(&bs, h).MustEncode(v)
+	if err != nil {
+		logT(t, "Error during encode: %v", err)
+		failT(t)
+	}
+	var v2 T1
+	NewDecoderBytes(bs, h).MustDecode(&v2)
+	if err != nil {
+		logT(t, "Error during decode: %v", err)
+		failT(t)
+	}
+}
+
+func testCodecChan(t *testing.T, h Handle) {
+	// - send a slice []*int64 (sl1) into an chan (ch1) with cap > len(s1)
+	// - encode ch1 as a stream array
+	// - decode a chan (ch2), with cap > len(s1) from the stream array
+	// - receive from ch2 into slice sl2
+	// - compare sl1 and sl2
+	// - do this for codecs: json, cbor (covers all types)
+	sl1 := make([]*int64, 4)
+	for i := range sl1 {
+		var j int64 = int64(i)
+		sl1[i] = &j
+	}
+	ch1 := make(chan *int64, 4)
+	for _, j := range sl1 {
+		ch1 <- j
+	}
+	var bs []byte
+	NewEncoderBytes(&bs, h).MustEncode(ch1)
+	// if !h.isBinary() {
+	// 	fmt.Printf("before: len(ch1): %v, bs: %s\n", len(ch1), bs)
+	// }
+	// var ch2 chan *int64 // this will block if json, etc.
+	ch2 := make(chan *int64, 8)
+	NewDecoderBytes(bs, h).MustDecode(&ch2)
+	// logT(t, "Len(ch2): %v", len(ch2))
+	// fmt.Printf("after:  len(ch2): %v, ch2: %v\n", len(ch2), ch2)
+	close(ch2)
+	var sl2 []*int64
+	for j := range ch2 {
+		sl2 = append(sl2, j)
+	}
+	if err := deepEqual(sl1, sl2); err != nil {
+		logT(t, "Not Match: %v; len: %v, %v", err, len(sl1), len(sl2))
+		failT(t)
+	}
+}
+
+func testCodecRpcOne(t *testing.T, rr Rpc, h Handle, doRequest bool, exitSleepMs time.Duration,
+) (port int) {
+	testOnce.Do(testInitAll)
+	if testSkipRPCTests {
+		return
+	}
+	// rpc needs EOF, which is sent via a panic, and so must be recovered.
+	if !recoverPanicToErr {
+		logT(t, "EXPECTED. set recoverPanicToErr=true, since rpc needs EOF")
+		t.FailNow()
+	}
+	srv := rpc.NewServer()
+	srv.Register(testRpcInt)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	// log("listener: %v", ln.Addr())
+	checkErrT(t, err)
+	port = (ln.Addr().(*net.TCPAddr)).Port
+	// var opts *DecoderOptions
+	// opts := testDecOpts
+	// opts.MapType = mapStrIntfTyp
+	// opts.RawToString = false
+	serverExitChan := make(chan bool, 1)
+	var serverExitFlag uint64 = 0
+	serverFn := func() {
+		for {
+			conn1, err1 := ln.Accept()
+			// if err1 != nil {
+			// 	//fmt.Printf("accept err1: %v\n", err1)
+			// 	continue
+			// }
+			if atomic.LoadUint64(&serverExitFlag) == 1 {
+				serverExitChan <- true
+				conn1.Close()
+				return // exit serverFn goroutine
+			}
+			if err1 == nil {
+				var sc rpc.ServerCodec = rr.ServerCodec(conn1, h)
+				srv.ServeCodec(sc)
+			}
+		}
+	}
+
+	clientFn := func(cc rpc.ClientCodec) {
+		cl := rpc.NewClientWithCodec(cc)
+		defer cl.Close()
+		//	defer func() { println("##### client closing"); cl.Close() }()
+		var up, sq, mult int
+		var rstr string
+		// log("Calling client")
+		checkErrT(t, cl.Call("TestRpcInt.Update", 5, &up))
+		// log("Called TestRpcInt.Update")
+		checkEqualT(t, testRpcInt.i, 5, "testRpcInt.i=5")
+		checkEqualT(t, up, 5, "up=5")
+		checkErrT(t, cl.Call("TestRpcInt.Square", 1, &sq))
+		checkEqualT(t, sq, 25, "sq=25")
+		checkErrT(t, cl.Call("TestRpcInt.Mult", 20, &mult))
+		checkEqualT(t, mult, 100, "mult=100")
+		checkErrT(t, cl.Call("TestRpcInt.EchoStruct", TestRpcABC{"Aa", "Bb", "Cc"}, &rstr))
+		checkEqualT(t, rstr, fmt.Sprintf("%#v", TestRpcABC{"Aa", "Bb", "Cc"}), "rstr=")
+		checkErrT(t, cl.Call("TestRpcInt.Echo123", []string{"A1", "B2", "C3"}, &rstr))
+		checkEqualT(t, rstr, fmt.Sprintf("%#v", []string{"A1", "B2", "C3"}), "rstr=")
+	}
+
+	connFn := func() (bs net.Conn) {
+		// log("calling f1")
+		bs, err2 := net.Dial(ln.Addr().Network(), ln.Addr().String())
+		//fmt.Printf("f1. bs: %v, err2: %v\n", bs, err2)
+		checkErrT(t, err2)
+		return
+	}
+
+	exitFn := func() {
+		atomic.StoreUint64(&serverExitFlag, 1)
+		bs := connFn()
+		<-serverExitChan
+		bs.Close()
+		// serverExitChan <- true
+	}
+
+	go serverFn()
+	runtime.Gosched()
+	//time.Sleep(100 * time.Millisecond)
+	if exitSleepMs == 0 {
+		defer ln.Close()
+		defer exitFn()
+	}
+	if doRequest {
+		bs := connFn()
+		cc := rr.ClientCodec(bs, h)
+		clientFn(cc)
+	}
+	if exitSleepMs != 0 {
+		go func() {
+			defer ln.Close()
+			time.Sleep(exitSleepMs)
+			exitFn()
+		}()
+	}
+	return
+}
+
+func doTestMapEncodeForCanonical(t *testing.T, name string, h Handle) {
+	v1 := map[string]interface{}{
+		"a": 1,
+		"b": "hello",
+		"c": map[string]interface{}{
+			"c/a": 1,
+			"c/b": "world",
+			"c/c": []int{1, 2, 3, 4},
+			"c/d": map[string]interface{}{
+				"c/d/a": "fdisajfoidsajfopdjsaopfjdsapofda",
+				"c/d/b": "fdsafjdposakfodpsakfopdsakfpodsakfpodksaopfkdsopafkdopsa",
+				"c/d/c": "poir02  ir30qif4p03qir0pogjfpoaerfgjp ofke[padfk[ewapf kdp[afep[aw",
+				"c/d/d": "fdsopafkd[sa f-32qor-=4qeof -afo-erfo r-eafo 4e-  o r4-qwo ag",
+				"c/d/e": "kfep[a sfkr0[paf[a foe-[wq  ewpfao-q ro3-q ro-4qof4-qor 3-e orfkropzjbvoisdb",
+				"c/d/f": "",
+			},
+			"c/e": map[int]string{
+				1:     "1",
+				22:    "22",
+				333:   "333",
+				4444:  "4444",
+				55555: "55555",
+			},
+			"c/f": map[string]int{
+				"1":     1,
+				"22":    22,
+				"333":   333,
+				"4444":  4444,
+				"55555": 55555,
+			},
+		},
+	}
+	var v2 map[string]interface{}
+	var b1, b2 []byte
+
+	// encode v1 into b1, decode b1 into v2, encode v2 into b2, compare b1 and b2
+
+	bh := h.getBasicHandle()
+	if !bh.Canonical {
+		bh.Canonical = true
+		defer func() { bh.Canonical = false }()
+	}
+
+	e1 := NewEncoderBytes(&b1, h)
+	e1.MustEncode(v1)
+	d1 := NewDecoderBytes(b1, h)
+	d1.MustDecode(&v2)
+	e2 := NewEncoderBytes(&b2, h)
+	e2.MustEncode(v2)
+	if !bytes.Equal(b1, b2) {
+		logT(t, "Unequal bytes: %v VS %v", b1, b2)
+		t.FailNow()
+	}
+}
+
+func doTestStdEncIntf(t *testing.T, name string, h Handle) {
+	args := [][2]interface{}{
+		{&TestABC{"A", "BB", "CCC"}, new(TestABC)},
+		{&TestABC2{"AAA", "BB", "C"}, new(TestABC2)},
+	}
+	for _, a := range args {
+		var b []byte
+		e := NewEncoderBytes(&b, h)
+		e.MustEncode(a[0])
+		d := NewDecoderBytes(b, h)
+		d.MustDecode(a[1])
+		if err := deepEqual(a[0], a[1]); err == nil {
+			logT(t, "++++ Objects match")
+		} else {
+			logT(t, "---- Objects do not match: y1: %v, err: %v", a[1], err)
+			failT(t)
+		}
+	}
+}
+
+func doTestEncCircularRef(t *testing.T, name string, h Handle) {
+	type T1 struct {
+		S string
+		B bool
+		T interface{}
+	}
+	type T2 struct {
+		S string
+		T *T1
+	}
+	type T3 struct {
+		S string
+		T *T2
+	}
+	t1 := T1{"t1", true, nil}
+	t2 := T2{"t2", &t1}
+	t3 := T3{"t3", &t2}
+	t1.T = &t3
+
+	var bs []byte
+	var err error
+
+	bh := h.getBasicHandle()
+	if !bh.CheckCircularRef {
+		bh.CheckCircularRef = true
+		defer func() { bh.CheckCircularRef = false }()
+	}
+	err = NewEncoderBytes(&bs, h).Encode(&t3)
+	if err == nil {
+		logT(t, "expecting error due to circular reference. found none")
+		t.FailNow()
+	}
+	if x := err.Error(); strings.Contains(x, "circular") || strings.Contains(x, "cyclic") {
+		logT(t, "error detected as expected: %v", x)
+	} else {
+		logT(t, "error detected was not as expected: %v", x)
+		t.FailNow()
+	}
+}
+
+// TestAnonCycleT{1,2,3} types are used to test anonymous cycles.
+// They are top-level, so that they can have circular references.
+type (
+	TestAnonCycleT1 struct {
+		S string
+		TestAnonCycleT2
+	}
+	TestAnonCycleT2 struct {
+		S2 string
+		TestAnonCycleT3
+	}
+	TestAnonCycleT3 struct {
+		*TestAnonCycleT1
+	}
+)
+
+func doTestAnonCycle(t *testing.T, name string, h Handle) {
+	var x TestAnonCycleT1
+	x.S = "hello"
+	x.TestAnonCycleT2.S2 = "hello.2"
+	x.TestAnonCycleT2.TestAnonCycleT3.TestAnonCycleT1 = &x
+
+	// just check that you can get typeInfo for T1
+	rt := reflect.TypeOf((*TestAnonCycleT1)(nil)).Elem()
+	rtid := reflect.ValueOf(rt).Pointer()
+	pti := h.getBasicHandle().getTypeInfo(rtid, rt)
+	logT(t, "pti: %v", pti)
+}
+
+func doTestJsonLargeInteger(t *testing.T, v interface{}, ias uint8) {
+	logT(t, "Running doTestJsonLargeInteger: v: %#v, ias: %c", v, ias)
+	oldIAS := testJsonH.IntegerAsString
+	defer func() { testJsonH.IntegerAsString = oldIAS }()
+	testJsonH.IntegerAsString = ias
+
+	var vu uint
+	var vi int
+	var vb bool
+	var b []byte
+	e := NewEncoderBytes(&b, testJsonH)
+	e.MustEncode(v)
+	e.MustEncode(true)
+	d := NewDecoderBytes(b, testJsonH)
+	// below, we validate that the json string or number was encoded,
+	// then decode, and validate that the correct value was decoded.
+	fnStrChk := func() {
+		// check that output started with ", and ended with "true
+		if !(b[0] == '"' && string(b[len(b)-5:]) == `"true`) {
+			logT(t, "Expecting a JSON string, got: %s", b)
+			failT(t)
+		}
+	}
+
+	switch ias {
+	case 'L':
+		switch v2 := v.(type) {
+		case int:
+			v2n := int64(v2) // done to work with 32-bit OS
+			if v2n > 1<<53 || (v2n < 0 && -v2n > 1<<53) {
+				fnStrChk()
+			}
+		case uint:
+			v2n := uint64(v2) // done to work with 32-bit OS
+			if v2n > 1<<53 {
+				fnStrChk()
+			}
+		}
+	case 'A':
+		fnStrChk()
+	default:
+		// check that output doesn't contain " at all
+		for _, i := range b {
+			if i == '"' {
+				logT(t, "Expecting a JSON Number without quotation: got: %s", b)
+				failT(t)
+			}
+		}
+	}
+	switch v2 := v.(type) {
+	case int:
+		d.MustDecode(&vi)
+		d.MustDecode(&vb)
+		// check that vb = true, and vi == v2
+		if !(vb && vi == v2) {
+			logT(t, "Expecting equal values from %s: got golden: %v, decoded: %v", b, v2, vi)
+			failT(t)
+		}
+	case uint:
+		d.MustDecode(&vu)
+		d.MustDecode(&vb)
+		// check that vb = true, and vi == v2
+		if !(vb && vu == v2) {
+			logT(t, "Expecting equal values from %s: got golden: %v, decoded: %v", b, v2, vu)
+			failT(t)
+		}
+		// fmt.Printf("%v: %s, decode: %d, bool: %v, equal_on_decode: %v\n", v, b, vu, vb, vu == v.(uint))
+	}
+}
+
+func doTestRawValue(t *testing.T, name string, h Handle) {
+	bh := h.getBasicHandle()
+	if !bh.Raw {
+		bh.Raw = true
+		defer func() { bh.Raw = false }()
+	}
+
+	var i, i2 int
+	var v, v2 TestRawValue
+	var bs, bs2 []byte
+
+	i = 1234 //1234567890
+	v = TestRawValue{I: i}
+	e := NewEncoderBytes(&bs, h)
+	e.MustEncode(v.I)
+	logT(t, ">>> raw: %v\n", bs)
+
+	v.R = Raw(bs)
+	e.ResetBytes(&bs2)
+	e.MustEncode(v)
+
+	logT(t, ">>> bs2: %v\n", bs2)
+	d := NewDecoderBytes(bs2, h)
+	d.MustDecode(&v2)
+	d.ResetBytes(v2.R)
+	logT(t, ">>> v2.R: %v\n", ([]byte)(v2.R))
+	d.MustDecode(&i2)
+
+	logT(t, ">>> Encoded %v, decoded %v\n", i, i2)
+	// logT(t, "Encoded %v, decoded %v", i, i2)
+	if i != i2 {
+		logT(t, "Error: encoded %v, decoded %v", i, i2)
+		t.FailNow()
+	}
+}
+
+// Comprehensive testing that generates data encoded from python handle (cbor, msgpack),
+// and validates that our code can read and write it out accordingly.
+// We keep this unexported here, and put actual test in ext_dep_test.go.
+// This way, it can be excluded by excluding file completely.
+func doTestPythonGenStreams(t *testing.T, name string, h Handle) {
+	logT(t, "TestPythonGenStreams-%v", name)
+	tmpdir, err := ioutil.TempDir("", "golang-"+name+"-test")
+	if err != nil {
+		logT(t, "-------- Unable to create temp directory\n")
+		t.FailNow()
+	}
+	defer os.RemoveAll(tmpdir)
+	logT(t, "tmpdir: %v", tmpdir)
+	cmd := exec.Command("python", "test.py", "testdata", tmpdir)
+	//cmd.Stdin = strings.NewReader("some input")
+	//cmd.Stdout = &out
+	var cmdout []byte
+	if cmdout, err = cmd.CombinedOutput(); err != nil {
+		logT(t, "-------- Error running test.py testdata. Err: %v", err)
+		logT(t, "         %v", string(cmdout))
+		t.FailNow()
+	}
+
+	bh := h.getBasicHandle()
+
+	oldMapType := bh.MapType
+	for i, v := range tablePythonVerify {
+		// if v == uint64(0) && h == testMsgpackH {
+		// 	v = int64(0)
+		// }
+		bh.MapType = oldMapType
+		//load up the golden file based on number
+		//decode it
+		//compare to in-mem object
+		//encode it again
+		//compare to output stream
+		logT(t, "..............................................")
+		logT(t, "         Testing: #%d: %T, %#v\n", i, v, v)
+		var bss []byte
+		bss, err = ioutil.ReadFile(filepath.Join(tmpdir, strconv.Itoa(i)+"."+name+".golden"))
+		if err != nil {
+			logT(t, "-------- Error reading golden file: %d. Err: %v", i, err)
+			failT(t)
+			continue
+		}
+		bh.MapType = testMapStrIntfTyp
+
+		var v1 interface{}
+		if err = testUnmarshal(&v1, bss, h); err != nil {
+			logT(t, "-------- Error decoding stream: %d: Err: %v", i, err)
+			failT(t)
+			continue
+		}
+		if v == skipVerifyVal {
+			continue
+		}
+		//no need to indirect, because we pass a nil ptr, so we already have the value
+		//if v1 != nil { v1 = reflect.Indirect(reflect.ValueOf(v1)).Interface() }
+		if err = deepEqual(v, v1); err == nil {
+			logT(t, "++++++++ Objects match: %T, %v", v, v)
+		} else {
+			logT(t, "-------- Objects do not match: %v. Source: %T. Decoded: %T", err, v, v1)
+			logT(t, "--------   GOLDEN: %#v", v)
+			// logT(t, "--------   DECODED: %#v <====> %#v", v1, reflect.Indirect(reflect.ValueOf(v1)).Interface())
+			logT(t, "--------   DECODED: %#v <====> %#v", v1, reflect.Indirect(reflect.ValueOf(v1)).Interface())
+			failT(t)
+		}
+		bsb, err := testMarshal(v1, h)
+		if err != nil {
+			logT(t, "Error encoding to stream: %d: Err: %v", i, err)
+			failT(t)
+			continue
+		}
+		if err = deepEqual(bsb, bss); err == nil {
+			logT(t, "++++++++ Bytes match")
+		} else {
+			logT(t, "???????? Bytes do not match. %v.", err)
+			xs := "--------"
+			if reflect.ValueOf(v).Kind() == reflect.Map {
+				xs = "        "
+				logT(t, "%s It's a map. Ok that they don't match (dependent on ordering).", xs)
+			} else {
+				logT(t, "%s It's not a map. They should match.", xs)
+				failT(t)
+			}
+			logT(t, "%s   FROM_FILE: %4d] %v", xs, len(bss), bss)
+			logT(t, "%s     ENCODED: %4d] %v", xs, len(bsb), bsb)
+		}
+	}
+	bh.MapType = oldMapType
+}
+
+// To test MsgpackSpecRpc, we test 3 scenarios:
+//    - Go Client to Go RPC Service (contained within TestMsgpackRpcSpec)
+//    - Go client to Python RPC Service (contained within doTestMsgpackRpcSpecGoClientToPythonSvc)
+//    - Python Client to Go RPC Service (contained within doTestMsgpackRpcSpecPythonClientToGoSvc)
+//
+// This allows us test the different calling conventions
+//    - Go Service requires only one argument
+//    - Python Service allows multiple arguments
+
+func doTestMsgpackRpcSpecGoClientToPythonSvc(t *testing.T) {
+	if testSkipRPCTests {
+		return
+	}
+	// openPorts are between 6700 and 6800
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	openPort := strconv.FormatInt(6700+r.Int63n(99), 10)
+	// openPort := "6792"
+	cmd := exec.Command("python", "test.py", "rpc-server", openPort, "4")
+	checkErrT(t, cmd.Start())
+	bs, err2 := net.Dial("tcp", ":"+openPort)
+	for i := 0; i < 10 && err2 != nil; i++ {
+		time.Sleep(50 * time.Millisecond) // time for python rpc server to start
+		bs, err2 = net.Dial("tcp", ":"+openPort)
+	}
+	checkErrT(t, err2)
+	cc := MsgpackSpecRpc.ClientCodec(bs, testMsgpackH)
+	cl := rpc.NewClientWithCodec(cc)
+	defer cl.Close()
+	var rstr string
+	checkErrT(t, cl.Call("EchoStruct", TestRpcABC{"Aa", "Bb", "Cc"}, &rstr))
+	//checkEqualT(t, rstr, "{'A': 'Aa', 'B': 'Bb', 'C': 'Cc'}")
+	var mArgs MsgpackSpecRpcMultiArgs = []interface{}{"A1", "B2", "C3"}
+	checkErrT(t, cl.Call("Echo123", mArgs, &rstr))
+	checkEqualT(t, rstr, "1:A1 2:B2 3:C3", "rstr=")
+	cmd.Process.Kill()
+}
+
+func doTestMsgpackRpcSpecPythonClientToGoSvc(t *testing.T) {
+	if testSkipRPCTests {
+		return
+	}
+	port := testCodecRpcOne(t, MsgpackSpecRpc, testMsgpackH, false, 1*time.Second)
+	//time.Sleep(1000 * time.Millisecond)
+	cmd := exec.Command("python", "test.py", "rpc-client-go-service", strconv.Itoa(port))
+	var cmdout []byte
+	var err error
+	if cmdout, err = cmd.CombinedOutput(); err != nil {
+		logT(t, "-------- Error running test.py rpc-client-go-service. Err: %v", err)
+		logT(t, "         %v", string(cmdout))
+		t.FailNow()
+	}
+	checkEqualT(t, string(cmdout),
+		fmt.Sprintf("%#v\n%#v\n", []string{"A1", "B2", "C3"}, TestRpcABC{"Aa", "Bb", "Cc"}), "cmdout=")
+}
+
+func TestBincCodecsTable(t *testing.T) {
+	testCodecTableOne(t, testBincH)
+}
+
+func TestBincCodecsMisc(t *testing.T) {
+	testCodecMiscOne(t, testBincH)
+}
+
+func TestBincCodecsEmbeddedPointer(t *testing.T) {
+	testCodecEmbeddedPointer(t, testBincH)
+}
+
+func TestBincStdEncIntf(t *testing.T) {
+	doTestStdEncIntf(t, "binc", testBincH)
+}
+
+func TestSimpleCodecsTable(t *testing.T) {
+	testCodecTableOne(t, testSimpleH)
+}
+
+func TestSimpleCodecsMisc(t *testing.T) {
+	testCodecMiscOne(t, testSimpleH)
+}
+
+func TestSimpleCodecsEmbeddedPointer(t *testing.T) {
+	testCodecEmbeddedPointer(t, testSimpleH)
+}
+
+func TestSimpleStdEncIntf(t *testing.T) {
+	doTestStdEncIntf(t, "simple", testSimpleH)
+}
+
+func TestMsgpackCodecsTable(t *testing.T) {
+	testCodecTableOne(t, testMsgpackH)
+}
+
+func TestMsgpackCodecsMisc(t *testing.T) {
+	testCodecMiscOne(t, testMsgpackH)
+}
+
+func TestMsgpackCodecsEmbeddedPointer(t *testing.T) {
+	testCodecEmbeddedPointer(t, testMsgpackH)
+}
+
+func TestMsgpackStdEncIntf(t *testing.T) {
+	doTestStdEncIntf(t, "msgpack", testMsgpackH)
+}
+
+func TestCborCodecsTable(t *testing.T) {
+	testCodecTableOne(t, testCborH)
+}
+
+func TestCborCodecsMisc(t *testing.T) {
+	testCodecMiscOne(t, testCborH)
+}
+
+func TestCborCodecsEmbeddedPointer(t *testing.T) {
+	testCodecEmbeddedPointer(t, testCborH)
+}
+
+func TestCborMapEncodeForCanonical(t *testing.T) {
+	doTestMapEncodeForCanonical(t, "cbor", testCborH)
+}
+
+func TestCborCodecChan(t *testing.T) {
+	testCodecChan(t, testCborH)
+}
+
+func TestCborStdEncIntf(t *testing.T) {
+	doTestStdEncIntf(t, "cbor", testCborH)
+}
+
+func TestJsonCodecsTable(t *testing.T) {
+	testCodecTableOne(t, testJsonH)
+}
+
+func TestJsonCodecsMisc(t *testing.T) {
+	testCodecMiscOne(t, testJsonH)
+}
+
+func TestJsonCodecsEmbeddedPointer(t *testing.T) {
+	testCodecEmbeddedPointer(t, testJsonH)
+}
+
+func TestJsonCodecChan(t *testing.T) {
+	testCodecChan(t, testJsonH)
+}
+
+func TestJsonStdEncIntf(t *testing.T) {
+	doTestStdEncIntf(t, "json", testJsonH)
+}
+
+// ----- Raw ---------
+func TestJsonRaw(t *testing.T) {
+	doTestRawValue(t, "json", testJsonH)
+}
+func TestBincRaw(t *testing.T) {
+	doTestRawValue(t, "binc", testBincH)
+}
+func TestMsgpackRaw(t *testing.T) {
+	doTestRawValue(t, "msgpack", testMsgpackH)
+}
+func TestSimpleRaw(t *testing.T) {
+	doTestRawValue(t, "simple", testSimpleH)
+}
+func TestCborRaw(t *testing.T) {
+	doTestRawValue(t, "cbor", testCborH)
+}
+
+// ----- ALL (framework based) -----
+
+func TestAllEncCircularRef(t *testing.T) {
+	doTestEncCircularRef(t, "cbor", testCborH)
+}
+
+func TestAllAnonCycle(t *testing.T) {
+	doTestAnonCycle(t, "cbor", testCborH)
+}
+
+// ----- RPC -----
+
+func TestBincRpcGo(t *testing.T) {
+	testCodecRpcOne(t, GoRpc, testBincH, true, 0)
+}
+
+func TestSimpleRpcGo(t *testing.T) {
+	testCodecRpcOne(t, GoRpc, testSimpleH, true, 0)
+}
+
+func TestMsgpackRpcGo(t *testing.T) {
+	testCodecRpcOne(t, GoRpc, testMsgpackH, true, 0)
+}
+
+func TestCborRpcGo(t *testing.T) {
+	testCodecRpcOne(t, GoRpc, testCborH, true, 0)
+}
+
+func TestJsonRpcGo(t *testing.T) {
+	testCodecRpcOne(t, GoRpc, testJsonH, true, 0)
+}
+
+func TestMsgpackRpcSpec(t *testing.T) {
+	testCodecRpcOne(t, MsgpackSpecRpc, testMsgpackH, true, 0)
+}
+
+func TestBincUnderlyingType(t *testing.T) {
+	testCodecUnderlyingType(t, testBincH)
+}
+
+func TestJsonLargeInteger(t *testing.T) {
+	for _, i := range []uint8{'L', 'A', 0} {
+		for _, j := range []interface{}{
+			int64(1 << 60),
+			-int64(1 << 60),
+			0,
+			1 << 20,
+			-(1 << 20),
+			uint64(1 << 60),
+			uint(0),
+			uint(1 << 20),
+		} {
+			doTestJsonLargeInteger(t, j, i)
+		}
+	}
+}
+
+func TestJsonDecodeNonStringScalarInStringContext(t *testing.T) {
+	var b = `{"s.true": "true", "b.true": true, "s.false": "false", "b.false": false, "s.10": "10", "i.10": 10, "i.-10": -10}`
+	var golden = map[string]string{"s.true": "true", "b.true": "true", "s.false": "false", "b.false": "false", "s.10": "10", "i.10": "10", "i.-10": "-10"}
+
+	var m map[string]string
+	d := NewDecoderBytes([]byte(b), testJsonH)
+	d.MustDecode(&m)
+	if err := deepEqual(golden, m); err == nil {
+		logT(t, "++++ match: decoded: %#v", m)
+	} else {
+		logT(t, "---- mismatch: %v ==> golden: %#v, decoded: %#v", err, golden, m)
+		failT(t)
+	}
+}
+
+// TODO:
+//   Add Tests for:
+//   - decoding empty list/map in stream into a nil slice/map
+//   - binary(M|Unm)arsher support for time.Time (e.g. cbor encoding)
+//   - text(M|Unm)arshaler support for time.Time (e.g. json encoding)
+//   - non fast-path scenarios e.g. map[string]uint16, []customStruct.
+//     Expand cbor to include indefinite length stuff for this non-fast-path types.
+//     This may not be necessary, since we have the manual tests (fastpathEnabled=false) to test/validate with.
+//   - CodecSelfer
+//     Ensure it is called when (en|de)coding interface{} or reflect.Value (2 different codepaths).
+//   - interfaces: textMarshaler, binaryMarshaler, codecSelfer
+//   - struct tags:
+//     on anonymous fields, _struct (all fields), etc
+//   - codecgen of struct containing channels.
+//   - bad input with large array length prefix
+//
+//   Cleanup tests:
+//   - The are brittle in their handling of validation and skipping

--- a/vendor/github.com/ugorji/go/codec/codecgen/README.md
+++ b/vendor/github.com/ugorji/go/codec/codecgen/README.md
@@ -1,0 +1,37 @@
+# codecgen tool
+
+Generate is given a list of *.go files to parse, and an output file (fout),
+codecgen will create an output file __file.go__ which
+contains `codec.Selfer` implementations for the named types found
+in the files parsed.
+
+Using codecgen is very straightforward.
+
+**Download and install the tool**
+
+`go get -u github.com/ugorji/go/codec/codecgen`
+
+**Run the tool on your files**
+
+The command line format is:
+
+`codecgen [options] (-o outfile) (infile ...)`
+
+```sh
+% codecgen -?
+Usage of codecgen:
+  -c="github.com/ugorji/go/codec": codec path
+  -o="": out file
+  -r=".*": regex for type name to match
+  -nr="": regex for type name to exclude
+  -rt="": tags for go run
+  -t="": build tag to put in file
+  -u=false: Use unsafe, e.g. to avoid unnecessary allocation on []byte->string
+  -x=false: keep temp file
+
+% codecgen -o values_codecgen.go values.go values2.go moretypedefs.go
+```
+
+Please see the [blog article](http://ugorji.net/blog/go-codecgen)
+for more information on how to use the tool.
+

--- a/vendor/github.com/ugorji/go/codec/codecgen/gen.go
+++ b/vendor/github.com/ugorji/go/codec/codecgen/gen.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// codecgen generates codec.Selfer implementations for a set of types.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const genCodecPkg = "codec1978" // keep this in sync with codec.genCodecPkg
+
+const genFrunMainTmpl = `//+build ignore
+
+package main
+{{ if .Types }}import "{{ .ImportPath }}"{{ end }}
+func main() {
+	{{ $.PackageName }}.CodecGenTempWrite{{ .RandString }}()
+}
+`
+
+// const genFrunPkgTmpl = `//+build codecgen
+const genFrunPkgTmpl = `
+package {{ $.PackageName }}
+
+import (
+	{{ if not .CodecPkgFiles }}{{ .CodecPkgName }} "{{ .CodecImportPath }}"{{ end }}
+	"os"
+	"reflect"
+	"bytes"
+	"strings"
+	"go/format"
+)
+
+func CodecGenTempWrite{{ .RandString }}() {
+	fout, err := os.Create("{{ .OutFile }}")
+	if err != nil {
+		panic(err)
+	}
+	defer fout.Close()
+	var out bytes.Buffer
+	
+	var typs []reflect.Type 
+{{ range $index, $element := .Types }}
+	var t{{ $index }} {{ . }}
+	typs = append(typs, reflect.TypeOf(t{{ $index }}))
+{{ end }}
+	{{ if not .CodecPkgFiles }}{{ .CodecPkgName }}.{{ end }}Gen(&out, "{{ .BuildTag }}", "{{ .PackageName }}", "{{ .RandString }}", {{ .UseUnsafe }}, {{ if not .CodecPkgFiles }}{{ .CodecPkgName }}.{{ end }}NewTypeInfos(strings.Split("{{ .StructTags }}", ",")), typs...)
+	bout, err := format.Source(out.Bytes())
+	if err != nil {
+		fout.Write(out.Bytes())
+		panic(err)
+	}
+	fout.Write(bout)
+}
+
+`
+
+// Generate is given a list of *.go files to parse, and an output file (fout).
+//
+// It finds all types T in the files, and it creates 2 tmp files (frun).
+//   - main package file passed to 'go run'
+//   - package level file which calls *genRunner.Selfer to write Selfer impls for each T.
+// We use a package level file so that it can reference unexported types in the package being worked on.
+// Tool then executes: "go run __frun__" which creates fout.
+// fout contains Codec(En|De)codeSelf implementations for every type T.
+//
+func Generate(outfile, buildTag, codecPkgPath string, uid int64, useUnsafe bool, goRunTag string,
+	st string, regexName *regexp.Regexp, notRegexName *regexp.Regexp, deleteTempFile bool, infiles ...string) (err error) {
+	// For each file, grab AST, find each type, and write a call to it.
+	if len(infiles) == 0 {
+		return
+	}
+	if outfile == "" || codecPkgPath == "" {
+		err = errors.New("outfile and codec package path cannot be blank")
+		return
+	}
+	if uid < 0 {
+		uid = -uid
+	}
+	if uid == 0 {
+		rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+		uid = 101 + rr.Int63n(9777)
+	}
+	// We have to parse dir for package, before opening the temp file for writing (else ImportDir fails).
+	// Also, ImportDir(...) must take an absolute path.
+	lastdir := filepath.Dir(outfile)
+	absdir, err := filepath.Abs(lastdir)
+	if err != nil {
+		return
+	}
+	pkg, err := build.Default.ImportDir(absdir, build.AllowBinary)
+	if err != nil {
+		return
+	}
+	type tmplT struct {
+		CodecPkgName    string
+		CodecImportPath string
+		ImportPath      string
+		OutFile         string
+		PackageName     string
+		RandString      string
+		BuildTag        string
+		StructTags      string
+		Types           []string
+		CodecPkgFiles   bool
+		UseUnsafe       bool
+	}
+	tv := tmplT{
+		CodecPkgName:    genCodecPkg,
+		OutFile:         outfile,
+		CodecImportPath: codecPkgPath,
+		BuildTag:        buildTag,
+		UseUnsafe:       useUnsafe,
+		RandString:      strconv.FormatInt(uid, 10),
+		StructTags:      st,
+	}
+	tv.ImportPath = pkg.ImportPath
+	if tv.ImportPath == tv.CodecImportPath {
+		tv.CodecPkgFiles = true
+		tv.CodecPkgName = "codec"
+	} else {
+		// HACK: always handle vendoring. It should be typically on in go 1.6, 1.7
+		tv.ImportPath = stripVendor(tv.ImportPath)
+	}
+	astfiles := make([]*ast.File, len(infiles))
+	for i, infile := range infiles {
+		if filepath.Dir(infile) != lastdir {
+			err = errors.New("in files must all be in same directory as outfile")
+			return
+		}
+		fset := token.NewFileSet()
+		astfiles[i], err = parser.ParseFile(fset, infile, nil, 0)
+		if err != nil {
+			return
+		}
+		if i == 0 {
+			tv.PackageName = astfiles[i].Name.Name
+			if tv.PackageName == "main" {
+				// codecgen cannot be run on types in the 'main' package.
+				// A temporary 'main' package must be created, and should reference the fully built
+				// package containing the types.
+				// Also, the temporary main package will conflict with the main package which already has a main method.
+				err = errors.New("codecgen cannot be run on types in the 'main' package")
+				return
+			}
+		}
+	}
+
+	// keep track of types with selfer methods
+	// selferMethods := []string{"CodecEncodeSelf", "CodecDecodeSelf"}
+	selferEncTyps := make(map[string]bool)
+	selferDecTyps := make(map[string]bool)
+	for _, f := range astfiles {
+		for _, d := range f.Decls {
+			// if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil && fd.Recv.NumFields() == 1 {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil && len(fd.Recv.List) == 1 {
+				recvType := fd.Recv.List[0].Type
+				if ptr, ok := recvType.(*ast.StarExpr); ok {
+					recvType = ptr.X
+				}
+				if id, ok := recvType.(*ast.Ident); ok {
+					switch fd.Name.Name {
+					case "CodecEncodeSelf":
+						selferEncTyps[id.Name] = true
+					case "CodecDecodeSelf":
+						selferDecTyps[id.Name] = true
+					}
+				}
+			}
+		}
+	}
+
+	// now find types
+	for _, f := range astfiles {
+		for _, d := range f.Decls {
+			if gd, ok := d.(*ast.GenDecl); ok {
+				for _, dd := range gd.Specs {
+					if td, ok := dd.(*ast.TypeSpec); ok {
+						// if len(td.Name.Name) == 0 || td.Name.Name[0] > 'Z' || td.Name.Name[0] < 'A' {
+						if len(td.Name.Name) == 0 {
+							continue
+						}
+
+						// only generate for:
+						//   struct: StructType
+						//   primitives (numbers, bool, string): Ident
+						//   map: MapType
+						//   slice, array: ArrayType
+						//   chan: ChanType
+						// do not generate:
+						//   FuncType, InterfaceType, StarExpr (ptr), etc
+						switch td.Type.(type) {
+						case *ast.StructType, *ast.Ident, *ast.MapType, *ast.ArrayType, *ast.ChanType:
+							// only add to tv.Types iff
+							//   - it matches per the -r parameter
+							//   - it doesn't match per the -nr parameter
+							//   - it doesn't have any of the Selfer methods in the file
+							if regexName.FindStringIndex(td.Name.Name) != nil &&
+								notRegexName.FindStringIndex(td.Name.Name) == nil &&
+								!selferEncTyps[td.Name.Name] &&
+								!selferDecTyps[td.Name.Name] {
+								tv.Types = append(tv.Types, td.Name.Name)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(tv.Types) == 0 {
+		return
+	}
+
+	// we cannot use ioutil.TempFile, because we cannot guarantee the file suffix (.go).
+	// Also, we cannot create file in temp directory,
+	// because go run will not work (as it needs to see the types here).
+	// Consequently, create the temp file in the current directory, and remove when done.
+
+	// frun, err = ioutil.TempFile("", "codecgen-")
+	// frunName := filepath.Join(os.TempDir(), "codecgen-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".go")
+
+	frunMainName := "codecgen-main-" + tv.RandString + ".generated.go"
+	frunPkgName := "codecgen-pkg-" + tv.RandString + ".generated.go"
+	if deleteTempFile {
+		defer os.Remove(frunMainName)
+		defer os.Remove(frunPkgName)
+	}
+	// var frunMain, frunPkg *os.File
+	if _, err = gen1(frunMainName, genFrunMainTmpl, &tv); err != nil {
+		return
+	}
+	if _, err = gen1(frunPkgName, genFrunPkgTmpl, &tv); err != nil {
+		return
+	}
+
+	// remove outfile, so "go run ..." will not think that types in outfile already exist.
+	os.Remove(outfile)
+
+	// execute go run frun
+	cmd := exec.Command("go", "run", "-tags="+goRunTag, frunMainName) //, frunPkg.Name())
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err = cmd.Run(); err != nil {
+		err = fmt.Errorf("error running 'go run %s': %v, console: %s",
+			frunMainName, err, buf.Bytes())
+		return
+	}
+	os.Stdout.Write(buf.Bytes())
+	return
+}
+
+func gen1(frunName, tmplStr string, tv interface{}) (frun *os.File, err error) {
+	os.Remove(frunName)
+	if frun, err = os.Create(frunName); err != nil {
+		return
+	}
+	defer frun.Close()
+
+	t := template.New("")
+	if t, err = t.Parse(tmplStr); err != nil {
+		return
+	}
+	bw := bufio.NewWriter(frun)
+	if err = t.Execute(bw, tv); err != nil {
+		return
+	}
+	if err = bw.Flush(); err != nil {
+		return
+	}
+	return
+}
+
+// copied from ../gen.go (keep in sync).
+func stripVendor(s string) string {
+	// HACK: Misbehaviour occurs in go 1.5. May have to re-visit this later.
+	// if s contains /vendor/ OR startsWith vendor/, then return everything after it.
+	const vendorStart = "vendor/"
+	const vendorInline = "/vendor/"
+	if i := strings.LastIndex(s, vendorInline); i >= 0 {
+		s = s[i+len(vendorInline):]
+	} else if strings.HasPrefix(s, vendorStart) {
+		s = s[len(vendorStart):]
+	}
+	return s
+}
+
+func main() {
+	o := flag.String("o", "", "out file")
+	c := flag.String("c", genCodecPath, "codec path")
+	t := flag.String("t", "", "build tag to put in file")
+	r := flag.String("r", ".*", "regex for type name to match")
+	nr := flag.String("nr", "^$", "regex for type name to exclude")
+	rt := flag.String("rt", "", "tags for go run")
+	st := flag.String("st", "codec,json", "struct tag keys to introspect")
+	x := flag.Bool("x", false, "keep temp file")
+	u := flag.Bool("u", false, "Use unsafe, e.g. to avoid unnecessary allocation on []byte->string")
+	d := flag.Int64("d", 0, "random identifier for use in generated code")
+	flag.Parse()
+	if err := Generate(*o, *t, *c, *d, *u, *rt, *st,
+		regexp.MustCompile(*r), regexp.MustCompile(*nr), !*x, flag.Args()...); err != nil {
+		fmt.Fprintf(os.Stderr, "codecgen error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/ugorji/go/codec/codecgen/z.go
+++ b/vendor/github.com/ugorji/go/codec/codecgen/z.go
@@ -1,0 +1,3 @@
+package main
+
+const genCodecPath = "github.com/ugorji/go/codec"

--- a/vendor/github.com/ugorji/go/codec/codecgen_test.go
+++ b/vendor/github.com/ugorji/go/codec/codecgen_test.go
@@ -1,0 +1,24 @@
+// +build x,codecgen
+
+package codec
+
+import (
+	"fmt"
+	"testing"
+)
+
+func _TestCodecgenJson1(t *testing.T) {
+	// This is just a simplistic test for codecgen.
+	// It is typically disabled. We only enable it for debugging purposes.
+	const callCodecgenDirect bool = true
+	v := newTestStruc(2, false, !testSkipIntf, false)
+	var bs []byte
+	e := NewEncoderBytes(&bs, testJsonH)
+	if callCodecgenDirect {
+		v.CodecEncodeSelf(e)
+		e.w.atEndOfEncode()
+	} else {
+		e.MustEncode(v)
+	}
+	fmt.Printf("%s\n", bs)
+}

--- a/vendor/github.com/ugorji/go/codec/decode.go
+++ b/vendor/github.com/ugorji/go/codec/decode.go
@@ -1,0 +1,2076 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+)
+
+// Some tagging information for error messages.
+const (
+	msgBadDesc            = "Unrecognized descriptor byte"
+	msgDecCannotExpandArr = "cannot expand go array from %v to stream length: %v"
+)
+
+var (
+	onlyMapOrArrayCanDecodeIntoStructErr = errors.New("only encoded map or array can be decoded into a struct")
+	cannotDecodeIntoNilErr               = errors.New("cannot decode into nil")
+)
+
+// decReader abstracts the reading source, allowing implementations that can
+// read from an io.Reader or directly off a byte slice with zero-copying.
+type decReader interface {
+	unreadn1()
+
+	// readx will use the implementation scratch buffer if possible i.e. n < len(scratchbuf), OR
+	// just return a view of the []byte being decoded from.
+	// Ensure you call detachZeroCopyBytes later if this needs to be sent outside codec control.
+	readx(n int) []byte
+	readb([]byte)
+	readn1() uint8
+	readn1eof() (v uint8, eof bool)
+	numread() int // number of bytes read
+	track()
+	stopTrack() []byte
+}
+
+type decReaderByteScanner interface {
+	io.Reader
+	io.ByteScanner
+}
+
+type decDriver interface {
+	// this will check if the next token is a break.
+	CheckBreak() bool
+	TryDecodeAsNil() bool
+	// vt is one of: Bytes, String, Nil, Slice or Map. Return unSet if not known.
+	ContainerType() (vt valueType)
+	IsBuiltinType(rt uintptr) bool
+	DecodeBuiltin(rt uintptr, v interface{})
+
+	// DecodeNaked will decode primitives (number, bool, string, []byte) and RawExt.
+	// For maps and arrays, it will not do the decoding in-band, but will signal
+	// the decoder, so that is done later, by setting the decNaked.valueType field.
+	//
+	// Note: Numbers are decoded as int64, uint64, float64 only (no smaller sized number types).
+	// for extensions, DecodeNaked must read the tag and the []byte if it exists.
+	// if the []byte is not read, then kInterfaceNaked will treat it as a Handle
+	// that stores the subsequent value in-band, and complete reading the RawExt.
+	//
+	// extensions should also use readx to decode them, for efficiency.
+	// kInterface will extract the detached byte slice if it has to pass it outside its realm.
+	DecodeNaked()
+	DecodeInt(bitsize uint8) (i int64)
+	DecodeUint(bitsize uint8) (ui uint64)
+	DecodeFloat(chkOverflow32 bool) (f float64)
+	DecodeBool() (b bool)
+	// DecodeString can also decode symbols.
+	// It looks redundant as DecodeBytes is available.
+	// However, some codecs (e.g. binc) support symbols and can
+	// return a pre-stored string value, meaning that it can bypass
+	// the cost of []byte->string conversion.
+	DecodeString() (s string)
+
+	// DecodeBytes may be called directly, without going through reflection.
+	// Consequently, it must be designed to handle possible nil.
+	DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte)
+
+	// decodeExt will decode into a *RawExt or into an extension.
+	DecodeExt(v interface{}, xtag uint64, ext Ext) (realxtag uint64)
+	// decodeExt(verifyTag bool, tag byte) (xtag byte, xbs []byte)
+	ReadMapStart() int
+	ReadArrayStart() int
+
+	reset()
+	uncacheRead()
+}
+
+type decNoSeparator struct {
+}
+
+func (_ decNoSeparator) ReadEnd() {}
+
+// func (_ decNoSeparator) uncacheRead() {}
+
+type DecodeOptions struct {
+	// MapType specifies type to use during schema-less decoding of a map in the stream.
+	// If nil, we use map[interface{}]interface{}
+	MapType reflect.Type
+
+	// SliceType specifies type to use during schema-less decoding of an array in the stream.
+	// If nil, we use []interface{}
+	SliceType reflect.Type
+
+	// MaxInitLen defines the maxinum initial length that we "make" a collection (string, slice, map, chan).
+	// If 0 or negative, we default to a sensible value based on the size of an element in the collection.
+	//
+	// For example, when decoding, a stream may say that it has 2^64 elements.
+	// We should not auto-matically provision a slice of that length, to prevent Out-Of-Memory crash.
+	// Instead, we provision up to MaxInitLen, fill that up, and start appending after that.
+	MaxInitLen int
+
+	// If ErrorIfNoField, return an error when decoding a map
+	// from a codec stream into a struct, and no matching struct field is found.
+	ErrorIfNoField bool
+
+	// If ErrorIfNoArrayExpand, return an error when decoding a slice/array that cannot be expanded.
+	// For example, the stream contains an array of 8 items, but you are decoding into a [4]T array,
+	// or you are decoding into a slice of length 4 which is non-addressable (and so cannot be set).
+	ErrorIfNoArrayExpand bool
+
+	// If SignedInteger, use the int64 during schema-less decoding of unsigned values (not uint64).
+	SignedInteger bool
+
+	// MapValueReset controls how we decode into a map value.
+	//
+	// By default, we MAY retrieve the mapping for a key, and then decode into that.
+	// However, especially with big maps, that retrieval may be expensive and unnecessary
+	// if the stream already contains all that is necessary to recreate the value.
+	//
+	// If true, we will never retrieve the previous mapping,
+	// but rather decode into a new value and set that in the map.
+	//
+	// If false, we will retrieve the previous mapping if necessary e.g.
+	// the previous mapping is a pointer, or is a struct or array with pre-set state,
+	// or is an interface.
+	MapValueReset bool
+
+	// InterfaceReset controls how we decode into an interface.
+	//
+	// By default, when we see a field that is an interface{...},
+	// or a map with interface{...} value, we will attempt decoding into the
+	// "contained" value.
+	//
+	// However, this prevents us from reading a string into an interface{}
+	// that formerly contained a number.
+	//
+	// If true, we will decode into a new "blank" value, and set that in the interface.
+	// If false, we will decode into whatever is contained in the interface.
+	InterfaceReset bool
+
+	// InternString controls interning of strings during decoding.
+	//
+	// Some handles, e.g. json, typically will read map keys as strings.
+	// If the set of keys are finite, it may help reduce allocation to
+	// look them up from a map (than to allocate them afresh).
+	//
+	// Note: Handles will be smart when using the intern functionality.
+	// Every string should not be interned.
+	// An excellent use-case for interning is struct field names,
+	// or map keys where key type is string.
+	InternString bool
+
+	// PreferArrayOverSlice controls whether to decode to an array or a slice.
+	//
+	// This only impacts decoding into a nil interface{}.
+	// Consequently, it has no effect on codecgen.
+	//
+	// *Note*: This only applies if using go1.5 and above,
+	// as it requires reflect.ArrayOf support which was absent before go1.5.
+	PreferArrayOverSlice bool
+}
+
+// ------------------------------------
+
+// ioDecByteScanner implements Read(), ReadByte(...), UnreadByte(...) methods
+// of io.Reader, io.ByteScanner.
+type ioDecByteScanner struct {
+	r  io.Reader
+	l  byte    // last byte
+	ls byte    // last byte status. 0: init-canDoNothing, 1: canRead, 2: canUnread
+	b  [1]byte // tiny buffer for reading single bytes
+}
+
+func (z *ioDecByteScanner) Read(p []byte) (n int, err error) {
+	var firstByte bool
+	if z.ls == 1 {
+		z.ls = 2
+		p[0] = z.l
+		if len(p) == 1 {
+			n = 1
+			return
+		}
+		firstByte = true
+		p = p[1:]
+	}
+	n, err = z.r.Read(p)
+	if n > 0 {
+		if err == io.EOF && n == len(p) {
+			err = nil // read was successful, so postpone EOF (till next time)
+		}
+		z.l = p[n-1]
+		z.ls = 2
+	}
+	if firstByte {
+		n++
+	}
+	return
+}
+
+func (z *ioDecByteScanner) ReadByte() (c byte, err error) {
+	n, err := z.Read(z.b[:])
+	if n == 1 {
+		c = z.b[0]
+		if err == io.EOF {
+			err = nil // read was successful, so postpone EOF (till next time)
+		}
+	}
+	return
+}
+
+func (z *ioDecByteScanner) UnreadByte() (err error) {
+	x := z.ls
+	if x == 0 {
+		err = errors.New("cannot unread - nothing has been read")
+	} else if x == 1 {
+		err = errors.New("cannot unread - last byte has not been read")
+	} else if x == 2 {
+		z.ls = 1
+	}
+	return
+}
+
+// ioDecReader is a decReader that reads off an io.Reader
+type ioDecReader struct {
+	br decReaderByteScanner
+	// temp byte array re-used internally for efficiency during read.
+	// shares buffer with Decoder, so we keep size of struct within 8 words.
+	x   *[scratchByteArrayLen]byte
+	bs  ioDecByteScanner
+	n   int    // num read
+	tr  []byte // tracking bytes read
+	trb bool
+}
+
+func (z *ioDecReader) numread() int {
+	return z.n
+}
+
+func (z *ioDecReader) readx(n int) (bs []byte) {
+	if n <= 0 {
+		return
+	}
+	if n < len(z.x) {
+		bs = z.x[:n]
+	} else {
+		bs = make([]byte, n)
+	}
+	if _, err := io.ReadAtLeast(z.br, bs, n); err != nil {
+		panic(err)
+	}
+	z.n += len(bs)
+	if z.trb {
+		z.tr = append(z.tr, bs...)
+	}
+	return
+}
+
+func (z *ioDecReader) readb(bs []byte) {
+	if len(bs) == 0 {
+		return
+	}
+	n, err := io.ReadAtLeast(z.br, bs, len(bs))
+	z.n += n
+	if err != nil {
+		panic(err)
+	}
+	if z.trb {
+		z.tr = append(z.tr, bs...)
+	}
+}
+
+func (z *ioDecReader) readn1() (b uint8) {
+	b, err := z.br.ReadByte()
+	if err != nil {
+		panic(err)
+	}
+	z.n++
+	if z.trb {
+		z.tr = append(z.tr, b)
+	}
+	return b
+}
+
+func (z *ioDecReader) readn1eof() (b uint8, eof bool) {
+	b, err := z.br.ReadByte()
+	if err == nil {
+		z.n++
+		if z.trb {
+			z.tr = append(z.tr, b)
+		}
+	} else if err == io.EOF {
+		eof = true
+	} else {
+		panic(err)
+	}
+	return
+}
+
+func (z *ioDecReader) unreadn1() {
+	err := z.br.UnreadByte()
+	if err != nil {
+		panic(err)
+	}
+	z.n--
+	if z.trb {
+		if l := len(z.tr) - 1; l >= 0 {
+			z.tr = z.tr[:l]
+		}
+	}
+}
+
+func (z *ioDecReader) track() {
+	if z.tr != nil {
+		z.tr = z.tr[:0]
+	}
+	z.trb = true
+}
+
+func (z *ioDecReader) stopTrack() (bs []byte) {
+	z.trb = false
+	return z.tr
+}
+
+// ------------------------------------
+
+var bytesDecReaderCannotUnreadErr = errors.New("cannot unread last byte read")
+
+// bytesDecReader is a decReader that reads off a byte slice with zero copying
+type bytesDecReader struct {
+	b []byte // data
+	c int    // cursor
+	a int    // available
+	t int    // track start
+}
+
+func (z *bytesDecReader) reset(in []byte) {
+	z.b = in
+	z.a = len(in)
+	z.c = 0
+	z.t = 0
+}
+
+func (z *bytesDecReader) numread() int {
+	return z.c
+}
+
+func (z *bytesDecReader) unreadn1() {
+	if z.c == 0 || len(z.b) == 0 {
+		panic(bytesDecReaderCannotUnreadErr)
+	}
+	z.c--
+	z.a++
+	return
+}
+
+func (z *bytesDecReader) readx(n int) (bs []byte) {
+	// slicing from a non-constant start position is more expensive,
+	// as more computation is required to decipher the pointer start position.
+	// However, we do it only once, and it's better than reslicing both z.b and return value.
+
+	if n <= 0 {
+	} else if z.a == 0 {
+		panic(io.EOF)
+	} else if n > z.a {
+		panic(io.ErrUnexpectedEOF)
+	} else {
+		c0 := z.c
+		z.c = c0 + n
+		z.a = z.a - n
+		bs = z.b[c0:z.c]
+	}
+	return
+}
+
+func (z *bytesDecReader) readn1() (v uint8) {
+	if z.a == 0 {
+		panic(io.EOF)
+	}
+	v = z.b[z.c]
+	z.c++
+	z.a--
+	return
+}
+
+func (z *bytesDecReader) readn1eof() (v uint8, eof bool) {
+	if z.a == 0 {
+		eof = true
+		return
+	}
+	v = z.b[z.c]
+	z.c++
+	z.a--
+	return
+}
+
+func (z *bytesDecReader) readb(bs []byte) {
+	copy(bs, z.readx(len(bs)))
+}
+
+func (z *bytesDecReader) track() {
+	z.t = z.c
+}
+
+func (z *bytesDecReader) stopTrack() (bs []byte) {
+	return z.b[z.t:z.c]
+}
+
+// ------------------------------------
+
+type decFnInfo struct {
+	d     *Decoder
+	ti    *typeInfo
+	xfFn  Ext
+	xfTag uint64
+	seq   seqType
+}
+
+// ----------------------------------------
+
+type decFn struct {
+	i decFnInfo
+	f func(*decFnInfo, reflect.Value)
+}
+
+func (f *decFnInfo) builtin(rv reflect.Value) {
+	f.d.d.DecodeBuiltin(f.ti.rtid, rv.Addr().Interface())
+}
+
+func (f *decFnInfo) rawExt(rv reflect.Value) {
+	f.d.d.DecodeExt(rv.Addr().Interface(), 0, nil)
+}
+
+func (f *decFnInfo) raw(rv reflect.Value) {
+	rv.SetBytes(f.d.raw())
+}
+
+func (f *decFnInfo) ext(rv reflect.Value) {
+	f.d.d.DecodeExt(rv.Addr().Interface(), f.xfTag, f.xfFn)
+}
+
+func (f *decFnInfo) getValueForUnmarshalInterface(rv reflect.Value, indir int8) (v interface{}) {
+	if indir == -1 {
+		v = rv.Addr().Interface()
+	} else if indir == 0 {
+		v = rv.Interface()
+	} else {
+		for j := int8(0); j < indir; j++ {
+			if rv.IsNil() {
+				rv.Set(reflect.New(rv.Type().Elem()))
+			}
+			rv = rv.Elem()
+		}
+		v = rv.Interface()
+	}
+	return
+}
+
+func (f *decFnInfo) selferUnmarshal(rv reflect.Value) {
+	f.getValueForUnmarshalInterface(rv, f.ti.csIndir).(Selfer).CodecDecodeSelf(f.d)
+}
+
+func (f *decFnInfo) binaryUnmarshal(rv reflect.Value) {
+	bm := f.getValueForUnmarshalInterface(rv, f.ti.bunmIndir).(encoding.BinaryUnmarshaler)
+	xbs := f.d.d.DecodeBytes(nil, false, true)
+	if fnerr := bm.UnmarshalBinary(xbs); fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+func (f *decFnInfo) textUnmarshal(rv reflect.Value) {
+	tm := f.getValueForUnmarshalInterface(rv, f.ti.tunmIndir).(encoding.TextUnmarshaler)
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+func (f *decFnInfo) jsonUnmarshal(rv reflect.Value) {
+	tm := f.getValueForUnmarshalInterface(rv, f.ti.junmIndir).(jsonUnmarshaler)
+	// bs := f.d.d.DecodeBytes(f.d.b[:], true, true)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+func (f *decFnInfo) kErr(rv reflect.Value) {
+	f.d.errorf("no decoding function defined for kind %v", rv.Kind())
+}
+
+func (f *decFnInfo) kString(rv reflect.Value) {
+	rv.SetString(f.d.d.DecodeString())
+}
+
+func (f *decFnInfo) kBool(rv reflect.Value) {
+	rv.SetBool(f.d.d.DecodeBool())
+}
+
+func (f *decFnInfo) kInt(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(intBitsize))
+}
+
+func (f *decFnInfo) kInt64(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(64))
+}
+
+func (f *decFnInfo) kInt32(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(32))
+}
+
+func (f *decFnInfo) kInt8(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(8))
+}
+
+func (f *decFnInfo) kInt16(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(16))
+}
+
+func (f *decFnInfo) kFloat32(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(true))
+}
+
+func (f *decFnInfo) kFloat64(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(false))
+}
+
+func (f *decFnInfo) kUint8(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(8))
+}
+
+func (f *decFnInfo) kUint64(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(64))
+}
+
+func (f *decFnInfo) kUint(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUintptr(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUint32(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(32))
+}
+
+func (f *decFnInfo) kUint16(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(16))
+}
+
+// func (f *decFnInfo) kPtr(rv reflect.Value) {
+// 	debugf(">>>>>>> ??? decode kPtr called - shouldn't get called")
+// 	if rv.IsNil() {
+// 		rv.Set(reflect.New(rv.Type().Elem()))
+// 	}
+// 	f.d.decodeValue(rv.Elem())
+// }
+
+// var kIntfCtr uint64
+
+func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
+	// nil interface:
+	// use some hieristics to decode it appropriately
+	// based on the detected next value in the stream.
+	d := f.d
+	d.d.DecodeNaked()
+	n := &d.n
+	if n.v == valueTypeNil {
+		return
+	}
+	// We cannot decode non-nil stream value into nil interface with methods (e.g. io.Reader).
+	// if num := f.ti.rt.NumMethod(); num > 0 {
+	if f.ti.numMeth > 0 {
+		d.errorf("cannot decode non-nil codec value into nil %v (%v methods)", f.ti.rt, f.ti.numMeth)
+		return
+	}
+	// var useRvn bool
+	switch n.v {
+	case valueTypeMap:
+		// if d.h.MapType == nil || d.h.MapType == mapIntfIntfTyp {
+		// } else if d.h.MapType == mapStrIntfTyp { // for json performance
+		// }
+		if d.mtid == 0 || d.mtid == mapIntfIntfTypId {
+			l := len(n.ms)
+			n.ms = append(n.ms, nil)
+			var v2 interface{} = &n.ms[l]
+			d.decode(v2)
+			rvn = reflect.ValueOf(v2).Elem()
+			n.ms = n.ms[:l]
+		} else if d.mtid == mapStrIntfTypId { // for json performance
+			l := len(n.ns)
+			n.ns = append(n.ns, nil)
+			var v2 interface{} = &n.ns[l]
+			d.decode(v2)
+			rvn = reflect.ValueOf(v2).Elem()
+			n.ns = n.ns[:l]
+		} else {
+			rvn = reflect.New(d.h.MapType).Elem()
+			d.decodeValue(rvn, nil)
+		}
+	case valueTypeArray:
+		// if d.h.SliceType == nil || d.h.SliceType == intfSliceTyp {
+		if d.stid == 0 || d.stid == intfSliceTypId {
+			l := len(n.ss)
+			n.ss = append(n.ss, nil)
+			var v2 interface{} = &n.ss[l]
+			d.decode(v2)
+			n.ss = n.ss[:l]
+			rvn = reflect.ValueOf(v2).Elem()
+			if reflectArrayOfSupported && d.stid == 0 && d.h.PreferArrayOverSlice {
+				rvn = reflectArrayOf(rvn)
+			}
+		} else {
+			rvn = reflect.New(d.h.SliceType).Elem()
+			d.decodeValue(rvn, nil)
+		}
+	case valueTypeExt:
+		var v interface{}
+		tag, bytes := n.u, n.l // calling decode below might taint the values
+		if bytes == nil {
+			l := len(n.is)
+			n.is = append(n.is, nil)
+			v2 := &n.is[l]
+			d.decode(v2)
+			v = *v2
+			n.is = n.is[:l]
+		}
+		bfn := d.h.getExtForTag(tag)
+		if bfn == nil {
+			var re RawExt
+			re.Tag = tag
+			re.Data = detachZeroCopyBytes(d.bytes, nil, bytes)
+			rvn = reflect.ValueOf(re)
+		} else {
+			rvnA := reflect.New(bfn.rt)
+			rvn = rvnA.Elem()
+			if bytes != nil {
+				bfn.ext.ReadExt(rvnA.Interface(), bytes)
+			} else {
+				bfn.ext.UpdateExt(rvnA.Interface(), v)
+			}
+		}
+	case valueTypeNil:
+		// no-op
+	case valueTypeInt:
+		rvn = reflect.ValueOf(&n.i).Elem()
+	case valueTypeUint:
+		rvn = reflect.ValueOf(&n.u).Elem()
+	case valueTypeFloat:
+		rvn = reflect.ValueOf(&n.f).Elem()
+	case valueTypeBool:
+		rvn = reflect.ValueOf(&n.b).Elem()
+	case valueTypeString, valueTypeSymbol:
+		rvn = reflect.ValueOf(&n.s).Elem()
+	case valueTypeBytes:
+		rvn = reflect.ValueOf(&n.l).Elem()
+	case valueTypeTimestamp:
+		rvn = reflect.ValueOf(&n.t).Elem()
+	default:
+		panic(fmt.Errorf("kInterfaceNaked: unexpected valueType: %d", n.v))
+	}
+	return
+}
+
+func (f *decFnInfo) kInterface(rv reflect.Value) {
+	// debugf("\t===> kInterface")
+
+	// Note:
+	// A consequence of how kInterface works, is that
+	// if an interface already contains something, we try
+	// to decode into what was there before.
+	// We do not replace with a generic value (as got from decodeNaked).
+
+	var rvn reflect.Value
+	if rv.IsNil() {
+		rvn = f.kInterfaceNaked()
+		if rvn.IsValid() {
+			rv.Set(rvn)
+		}
+	} else if f.d.h.InterfaceReset {
+		rvn = f.kInterfaceNaked()
+		if rvn.IsValid() {
+			rv.Set(rvn)
+		} else {
+			// reset to zero value based on current type in there.
+			rv.Set(reflect.Zero(rv.Elem().Type()))
+		}
+	} else {
+		rvn = rv.Elem()
+		// Note: interface{} is settable, but underlying type may not be.
+		// Consequently, we have to set the reflect.Value directly.
+		// if underlying type is settable (e.g. ptr or interface),
+		// we just decode into it.
+		// Else we create a settable value, decode into it, and set on the interface.
+		if rvn.CanSet() {
+			f.d.decodeValue(rvn, nil)
+		} else {
+			rvn2 := reflect.New(rvn.Type()).Elem()
+			rvn2.Set(rvn)
+			f.d.decodeValue(rvn2, nil)
+			rv.Set(rvn2)
+		}
+	}
+}
+
+func (f *decFnInfo) kStruct(rv reflect.Value) {
+	fti := f.ti
+	d := f.d
+	dd := d.d
+	cr := d.cr
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeMap {
+		containerLen := dd.ReadMapStart()
+		if containerLen == 0 {
+			if cr != nil {
+				cr.sendContainerState(containerMapEnd)
+			}
+			return
+		}
+		tisfi := fti.sfi
+		hasLen := containerLen >= 0
+		if hasLen {
+			for j := 0; j < containerLen; j++ {
+				// rvkencname := dd.DecodeString()
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				rvkencnameB := dd.DecodeBytes(f.d.b[:], true, true)
+				rvkencname := stringView(rvkencnameB)
+				// rvksi := ti.getForEncName(rvkencname)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				if k := fti.indexForEncName(rvkencname); k > -1 {
+					si := tisfi[k]
+					if dd.TryDecodeAsNil() {
+						si.setToZeroValue(rv)
+					} else {
+						d.decodeValue(si.field(rv, true), nil)
+					}
+				} else {
+					d.structFieldNotFound(-1, rvkencname)
+				}
+				keepAlive4StringView(rvkencnameB) // maintain ref 4 stringView
+			}
+		} else {
+			for j := 0; !dd.CheckBreak(); j++ {
+				// rvkencname := dd.DecodeString()
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				rvkencnameB := dd.DecodeBytes(f.d.b[:], true, true)
+				rvkencname := stringView(rvkencnameB)
+				// rvksi := ti.getForEncName(rvkencname)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				if k := fti.indexForEncName(rvkencname); k > -1 {
+					si := tisfi[k]
+					if dd.TryDecodeAsNil() {
+						si.setToZeroValue(rv)
+					} else {
+						d.decodeValue(si.field(rv, true), nil)
+					}
+				} else {
+					d.structFieldNotFound(-1, rvkencname)
+				}
+				keepAlive4StringView(rvkencnameB) // maintain ref 4 stringView
+			}
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+	} else if ctyp == valueTypeArray {
+		containerLen := dd.ReadArrayStart()
+		if containerLen == 0 {
+			if cr != nil {
+				cr.sendContainerState(containerArrayEnd)
+			}
+			return
+		}
+		// Not much gain from doing it two ways for array.
+		// Arrays are not used as much for structs.
+		hasLen := containerLen >= 0
+		for j, si := range fti.sfip {
+			if hasLen {
+				if j == containerLen {
+					break
+				}
+			} else if dd.CheckBreak() {
+				break
+			}
+			if cr != nil {
+				cr.sendContainerState(containerArrayElem)
+			}
+			if dd.TryDecodeAsNil() {
+				si.setToZeroValue(rv)
+			} else {
+				d.decodeValue(si.field(rv, true), nil)
+			}
+		}
+		if containerLen > len(fti.sfip) {
+			// read remaining values and throw away
+			for j := len(fti.sfip); j < containerLen; j++ {
+				if cr != nil {
+					cr.sendContainerState(containerArrayElem)
+				}
+				d.structFieldNotFound(j, "")
+			}
+		}
+		if cr != nil {
+			cr.sendContainerState(containerArrayEnd)
+		}
+	} else {
+		f.d.error(onlyMapOrArrayCanDecodeIntoStructErr)
+		return
+	}
+}
+
+func (f *decFnInfo) kSlice(rv reflect.Value) {
+	// A slice can be set from a map or array in stream.
+	// This way, the order can be kept (as order is lost with map).
+	ti := f.ti
+	d := f.d
+	dd := d.d
+	rtelem0 := ti.rt.Elem()
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeBytes || ctyp == valueTypeString {
+		// you can only decode bytes or string in the stream into a slice or array of bytes
+		if !(ti.rtid == uint8SliceTypId || rtelem0.Kind() == reflect.Uint8) {
+			f.d.errorf("bytes or string in the stream must be decoded into a slice or array of bytes, not %v", ti.rt)
+		}
+		if f.seq == seqTypeChan {
+			bs2 := dd.DecodeBytes(nil, false, true)
+			ch := rv.Interface().(chan<- byte)
+			for _, b := range bs2 {
+				ch <- b
+			}
+		} else {
+			rvbs := rv.Bytes()
+			bs2 := dd.DecodeBytes(rvbs, false, false)
+			if rvbs == nil && bs2 != nil || rvbs != nil && bs2 == nil || len(bs2) != len(rvbs) {
+				if rv.CanSet() {
+					rv.SetBytes(bs2)
+				} else {
+					copy(rvbs, bs2)
+				}
+			}
+		}
+		return
+	}
+
+	// array := f.seq == seqTypeChan
+
+	slh, containerLenS := d.decSliceHelperStart() // only expects valueType(Array|Map)
+
+	// // an array can never return a nil slice. so no need to check f.array here.
+	if containerLenS == 0 {
+		if f.seq == seqTypeSlice {
+			if rv.IsNil() {
+				rv.Set(reflect.MakeSlice(ti.rt, 0, 0))
+			} else {
+				rv.SetLen(0)
+			}
+		} else if f.seq == seqTypeChan {
+			if rv.IsNil() {
+				rv.Set(reflect.MakeChan(ti.rt, 0))
+			}
+		}
+		slh.End()
+		return
+	}
+
+	rtelem := rtelem0
+	for rtelem.Kind() == reflect.Ptr {
+		rtelem = rtelem.Elem()
+	}
+	fn := d.getDecFn(rtelem, true, true)
+
+	var rv0, rv9 reflect.Value
+	rv0 = rv
+	rvChanged := false
+
+	// for j := 0; j < containerLenS; j++ {
+	var rvlen int
+	if containerLenS > 0 { // hasLen
+		if f.seq == seqTypeChan {
+			if rv.IsNil() {
+				rvlen, _ = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size()))
+				rv.Set(reflect.MakeChan(ti.rt, rvlen))
+			}
+			// handle chan specially:
+			for j := 0; j < containerLenS; j++ {
+				rv9 = reflect.New(rtelem0).Elem()
+				slh.ElemContainerState(j)
+				d.decodeValue(rv9, fn)
+				rv.Send(rv9)
+			}
+		} else { // slice or array
+			var truncated bool         // says len of sequence is not same as expected number of elements
+			numToRead := containerLenS // if truncated, reset numToRead
+
+			rvcap := rv.Cap()
+			rvlen = rv.Len()
+			if containerLenS > rvcap {
+				if f.seq == seqTypeArray {
+					d.arrayCannotExpand(rvlen, containerLenS)
+				} else {
+					oldRvlenGtZero := rvlen > 0
+					rvlen, truncated = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size()))
+					if truncated {
+						if rvlen <= rvcap {
+							rv.SetLen(rvlen)
+						} else {
+							rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
+							rvChanged = true
+						}
+					} else {
+						rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
+						rvChanged = true
+					}
+					if rvChanged && oldRvlenGtZero && !isImmutableKind(rtelem0.Kind()) {
+						reflect.Copy(rv, rv0) // only copy up to length NOT cap i.e. rv0.Slice(0, rvcap)
+					}
+					rvcap = rvlen
+				}
+				numToRead = rvlen
+			} else if containerLenS != rvlen {
+				if f.seq == seqTypeSlice {
+					rv.SetLen(containerLenS)
+					rvlen = containerLenS
+				}
+			}
+			j := 0
+			// we read up to the numToRead
+			for ; j < numToRead; j++ {
+				slh.ElemContainerState(j)
+				d.decodeValue(rv.Index(j), fn)
+			}
+
+			// if slice, expand and read up to containerLenS (or EOF) iff truncated
+			// if array, swallow all the rest.
+
+			if f.seq == seqTypeArray {
+				for ; j < containerLenS; j++ {
+					slh.ElemContainerState(j)
+					d.swallow()
+				}
+			} else if truncated { // slice was truncated, as chan NOT in this block
+				for ; j < containerLenS; j++ {
+					rv = expandSliceValue(rv, 1)
+					rv9 = rv.Index(j)
+					if resetSliceElemToZeroValue {
+						rv9.Set(reflect.Zero(rtelem0))
+					}
+					slh.ElemContainerState(j)
+					d.decodeValue(rv9, fn)
+				}
+			}
+		}
+	} else {
+		rvlen = rv.Len()
+		j := 0
+		for ; !dd.CheckBreak(); j++ {
+			if f.seq == seqTypeChan {
+				slh.ElemContainerState(j)
+				rv9 = reflect.New(rtelem0).Elem()
+				d.decodeValue(rv9, fn)
+				rv.Send(rv9)
+			} else {
+				// if indefinite, etc, then expand the slice if necessary
+				var decodeIntoBlank bool
+				if j >= rvlen {
+					if f.seq == seqTypeArray {
+						d.arrayCannotExpand(rvlen, j+1)
+						decodeIntoBlank = true
+					} else { // if f.seq == seqTypeSlice
+						// rv = reflect.Append(rv, reflect.Zero(rtelem0)) // uses append logic, plus varargs
+						rv = expandSliceValue(rv, 1)
+						rv9 = rv.Index(j)
+						// rv.Index(rv.Len() - 1).Set(reflect.Zero(rtelem0))
+						if resetSliceElemToZeroValue {
+							rv9.Set(reflect.Zero(rtelem0))
+						}
+						rvlen++
+						rvChanged = true
+					}
+				} else { // slice or array
+					rv9 = rv.Index(j)
+				}
+				slh.ElemContainerState(j)
+				if decodeIntoBlank {
+					d.swallow()
+				} else { // seqTypeSlice
+					d.decodeValue(rv9, fn)
+				}
+			}
+		}
+		if f.seq == seqTypeSlice {
+			if j < rvlen {
+				rv.SetLen(j)
+			} else if j == 0 && rv.IsNil() {
+				rv = reflect.MakeSlice(ti.rt, 0, 0)
+				rvChanged = true
+			}
+		}
+	}
+	slh.End()
+
+	if rvChanged {
+		rv0.Set(rv)
+	}
+}
+
+func (f *decFnInfo) kArray(rv reflect.Value) {
+	// f.d.decodeValue(rv.Slice(0, rv.Len()))
+	f.kSlice(rv.Slice(0, rv.Len()))
+}
+
+func (f *decFnInfo) kMap(rv reflect.Value) {
+	d := f.d
+	dd := d.d
+	containerLen := dd.ReadMapStart()
+	cr := d.cr
+	ti := f.ti
+	if rv.IsNil() {
+		rv.Set(reflect.MakeMap(ti.rt))
+	}
+
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return
+	}
+
+	ktype, vtype := ti.rt.Key(), ti.rt.Elem()
+	ktypeId := reflect.ValueOf(ktype).Pointer()
+	vtypeKind := vtype.Kind()
+	var keyFn, valFn *decFn
+	var xtyp reflect.Type
+	for xtyp = ktype; xtyp.Kind() == reflect.Ptr; xtyp = xtyp.Elem() {
+	}
+	keyFn = d.getDecFn(xtyp, true, true)
+	for xtyp = vtype; xtyp.Kind() == reflect.Ptr; xtyp = xtyp.Elem() {
+	}
+	valFn = d.getDecFn(xtyp, true, true)
+	var mapGet, mapSet bool
+	if !f.d.h.MapValueReset {
+		// if pointer, mapGet = true
+		// if interface, mapGet = true if !DecodeNakedAlways (else false)
+		// if builtin, mapGet = false
+		// else mapGet = true
+		if vtypeKind == reflect.Ptr {
+			mapGet = true
+		} else if vtypeKind == reflect.Interface {
+			if !f.d.h.InterfaceReset {
+				mapGet = true
+			}
+		} else if !isImmutableKind(vtypeKind) {
+			mapGet = true
+		}
+	}
+
+	var rvk, rvv, rvz reflect.Value
+
+	// for j := 0; j < containerLen; j++ {
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			rvk = reflect.New(ktype).Elem()
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			d.decodeValue(rvk, keyFn)
+
+			// special case if a byte array.
+			if ktypeId == intfTypId {
+				rvk = rvk.Elem()
+				if rvk.Type() == uint8SliceTyp {
+					rvk = reflect.ValueOf(d.string(rvk.Bytes()))
+				}
+			}
+			mapSet = true // set to false if u do a get, and its a pointer, and exists
+			if mapGet {
+				rvv = rv.MapIndex(rvk)
+				if rvv.IsValid() {
+					if vtypeKind == reflect.Ptr {
+						mapSet = false
+					}
+				} else {
+					if rvz.IsValid() {
+						rvz.Set(reflect.Zero(vtype))
+					} else {
+						rvz = reflect.New(vtype).Elem()
+					}
+					rvv = rvz
+				}
+			} else {
+				if rvz.IsValid() {
+					rvz.Set(reflect.Zero(vtype))
+				} else {
+					rvz = reflect.New(vtype).Elem()
+				}
+				rvv = rvz
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			d.decodeValue(rvv, valFn)
+			if mapSet {
+				rv.SetMapIndex(rvk, rvv)
+			}
+		}
+	} else {
+		for j := 0; !dd.CheckBreak(); j++ {
+			rvk = reflect.New(ktype).Elem()
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			d.decodeValue(rvk, keyFn)
+
+			// special case if a byte array.
+			if ktypeId == intfTypId {
+				rvk = rvk.Elem()
+				if rvk.Type() == uint8SliceTyp {
+					rvk = reflect.ValueOf(d.string(rvk.Bytes()))
+				}
+			}
+			mapSet = true // set to false if u do a get, and its a pointer, and exists
+			if mapGet {
+				rvv = rv.MapIndex(rvk)
+				if rvv.IsValid() {
+					if vtypeKind == reflect.Ptr {
+						mapSet = false
+					}
+				} else {
+					if rvz.IsValid() {
+						rvz.Set(reflect.Zero(vtype))
+					} else {
+						rvz = reflect.New(vtype).Elem()
+					}
+					rvv = rvz
+				}
+			} else {
+				if rvz.IsValid() {
+					rvz.Set(reflect.Zero(vtype))
+				} else {
+					rvz = reflect.New(vtype).Elem()
+				}
+				rvv = rvz
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			d.decodeValue(rvv, valFn)
+			if mapSet {
+				rv.SetMapIndex(rvk, rvv)
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+type decRtidFn struct {
+	rtid uintptr
+	fn   decFn
+}
+
+// decNaked is used to keep track of the primitives decoded.
+// Without it, we would have to decode each primitive and wrap it
+// in an interface{}, causing an allocation.
+// In this model, the primitives are decoded in a "pseudo-atomic" fashion,
+// so we can rest assured that no other decoding happens while these
+// primitives are being decoded.
+//
+// maps and arrays are not handled by this mechanism.
+// However, RawExt is, and we accommodate for extensions that decode
+// RawExt from DecodeNaked, but need to decode the value subsequently.
+// kInterfaceNaked and swallow, which call DecodeNaked, handle this caveat.
+//
+// However, decNaked also keeps some arrays of default maps and slices
+// used in DecodeNaked. This way, we can get a pointer to it
+// without causing a new heap allocation.
+//
+// kInterfaceNaked will ensure that there is no allocation for the common
+// uses.
+type decNaked struct {
+	// r RawExt // used for RawExt, uint, []byte.
+	u uint64
+	i int64
+	f float64
+	l []byte
+	s string
+	t time.Time
+	b bool
+	v valueType
+
+	// stacks for reducing allocation
+	is []interface{}
+	ms []map[interface{}]interface{}
+	ns []map[string]interface{}
+	ss [][]interface{}
+	// rs []RawExt
+
+	// keep arrays at the bottom? Chance is that they are not used much.
+	ia [4]interface{}
+	ma [4]map[interface{}]interface{}
+	na [4]map[string]interface{}
+	sa [4][]interface{}
+	// ra [2]RawExt
+}
+
+func (n *decNaked) reset() {
+	if n.ss != nil {
+		n.ss = n.ss[:0]
+	}
+	if n.is != nil {
+		n.is = n.is[:0]
+	}
+	if n.ms != nil {
+		n.ms = n.ms[:0]
+	}
+	if n.ns != nil {
+		n.ns = n.ns[:0]
+	}
+}
+
+// A Decoder reads and decodes an object from an input stream in the codec format.
+type Decoder struct {
+	// hopefully, reduce derefencing cost by laying the decReader inside the Decoder.
+	// Try to put things that go together to fit within a cache line (8 words).
+
+	d decDriver
+	// NOTE: Decoder shouldn't call it's read methods,
+	// as the handler MAY need to do some coordination.
+	r decReader
+	// sa [initCollectionCap]decRtidFn
+	h  *BasicHandle
+	hh Handle
+
+	be    bool // is binary encoding
+	bytes bool // is bytes reader
+	js    bool // is json handle
+
+	rb bytesDecReader
+	ri ioDecReader
+	cr containerStateRecv
+
+	s []decRtidFn
+	f map[uintptr]*decFn
+
+	// _  uintptr // for alignment purposes, so next one starts from a cache line
+
+	// cache the mapTypeId and sliceTypeId for faster comparisons
+	mtid uintptr
+	stid uintptr
+
+	n  decNaked
+	b  [scratchByteArrayLen]byte
+	is map[string]string // used for interning strings
+}
+
+// NewDecoder returns a Decoder for decoding a stream of bytes from an io.Reader.
+//
+// For efficiency, Users are encouraged to pass in a memory buffered reader
+// (eg bufio.Reader, bytes.Buffer).
+func NewDecoder(r io.Reader, h Handle) *Decoder {
+	d := newDecoder(h)
+	d.Reset(r)
+	return d
+}
+
+// NewDecoderBytes returns a Decoder which efficiently decodes directly
+// from a byte slice with zero copying.
+func NewDecoderBytes(in []byte, h Handle) *Decoder {
+	d := newDecoder(h)
+	d.ResetBytes(in)
+	return d
+}
+
+func newDecoder(h Handle) *Decoder {
+	d := &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary()}
+	n := &d.n
+	// n.rs = n.ra[:0]
+	n.ms = n.ma[:0]
+	n.is = n.ia[:0]
+	n.ns = n.na[:0]
+	n.ss = n.sa[:0]
+	_, d.js = h.(*JsonHandle)
+	if d.h.InternString {
+		d.is = make(map[string]string, 32)
+	}
+	d.d = h.newDecDriver(d)
+	d.cr, _ = d.d.(containerStateRecv)
+	// d.d = h.newDecDriver(decReaderT{true, &d.rb, &d.ri})
+	return d
+}
+
+func (d *Decoder) resetCommon() {
+	d.n.reset()
+	d.d.reset()
+	// reset all things which were cached from the Handle,
+	// but could be changed.
+	d.mtid, d.stid = 0, 0
+	if d.h.MapType != nil {
+		d.mtid = reflect.ValueOf(d.h.MapType).Pointer()
+	}
+	if d.h.SliceType != nil {
+		d.stid = reflect.ValueOf(d.h.SliceType).Pointer()
+	}
+}
+
+func (d *Decoder) Reset(r io.Reader) {
+	d.ri.x = &d.b
+	// d.s = d.sa[:0]
+	d.ri.bs.r = r
+	var ok bool
+	d.ri.br, ok = r.(decReaderByteScanner)
+	if !ok {
+		d.ri.br = &d.ri.bs
+	}
+	d.r = &d.ri
+	d.resetCommon()
+}
+
+func (d *Decoder) ResetBytes(in []byte) {
+	// d.s = d.sa[:0]
+	d.bytes = true
+	d.rb.reset(in)
+	d.r = &d.rb
+	d.resetCommon()
+}
+
+// func (d *Decoder) sendContainerState(c containerState) {
+// 	if d.cr != nil {
+// 		d.cr.sendContainerState(c)
+// 	}
+// }
+
+// Decode decodes the stream from reader and stores the result in the
+// value pointed to by v. v cannot be a nil pointer. v can also be
+// a reflect.Value of a pointer.
+//
+// Note that a pointer to a nil interface is not a nil pointer.
+// If you do not know what type of stream it is, pass in a pointer to a nil interface.
+// We will decode and store a value in that nil interface.
+//
+// Sample usages:
+//   // Decoding into a non-nil typed value
+//   var f float32
+//   err = codec.NewDecoder(r, handle).Decode(&f)
+//
+//   // Decoding into nil interface
+//   var v interface{}
+//   dec := codec.NewDecoder(r, handle)
+//   err = dec.Decode(&v)
+//
+// When decoding into a nil interface{}, we will decode into an appropriate value based
+// on the contents of the stream:
+//   - Numbers are decoded as float64, int64 or uint64.
+//   - Other values are decoded appropriately depending on the type:
+//     bool, string, []byte, time.Time, etc
+//   - Extensions are decoded as RawExt (if no ext function registered for the tag)
+// Configurations exist on the Handle to override defaults
+// (e.g. for MapType, SliceType and how to decode raw bytes).
+//
+// When decoding into a non-nil interface{} value, the mode of encoding is based on the
+// type of the value. When a value is seen:
+//   - If an extension is registered for it, call that extension function
+//   - If it implements BinaryUnmarshaler, call its UnmarshalBinary(data []byte) error
+//   - Else decode it based on its reflect.Kind
+//
+// There are some special rules when decoding into containers (slice/array/map/struct).
+// Decode will typically use the stream contents to UPDATE the container.
+//   - A map can be decoded from a stream map, by updating matching keys.
+//   - A slice can be decoded from a stream array,
+//     by updating the first n elements, where n is length of the stream.
+//   - A slice can be decoded from a stream map, by decoding as if
+//     it contains a sequence of key-value pairs.
+//   - A struct can be decoded from a stream map, by updating matching fields.
+//   - A struct can be decoded from a stream array,
+//     by updating fields as they occur in the struct (by index).
+//
+// When decoding a stream map or array with length of 0 into a nil map or slice,
+// we reset the destination map or slice to a zero-length value.
+//
+// However, when decoding a stream nil, we reset the destination container
+// to its "zero" value (e.g. nil for slice/map, etc).
+//
+func (d *Decoder) Decode(v interface{}) (err error) {
+	defer panicToErr(&err)
+	d.decode(v)
+	return
+}
+
+// this is not a smart swallow, as it allocates objects and does unnecessary work.
+func (d *Decoder) swallowViaHammer() {
+	var blank interface{}
+	d.decodeValue(reflect.ValueOf(&blank).Elem(), nil)
+}
+
+func (d *Decoder) swallow() {
+	// smarter decode that just swallows the content
+	dd := d.d
+	if dd.TryDecodeAsNil() {
+		return
+	}
+	cr := d.cr
+	switch dd.ContainerType() {
+	case valueTypeMap:
+		containerLen := dd.ReadMapStart()
+		clenGtEqualZero := containerLen >= 0
+		for j := 0; ; j++ {
+			if clenGtEqualZero {
+				if j >= containerLen {
+					break
+				}
+			} else if dd.CheckBreak() {
+				break
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			d.swallow()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			d.swallow()
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+	case valueTypeArray:
+		containerLenS := dd.ReadArrayStart()
+		clenGtEqualZero := containerLenS >= 0
+		for j := 0; ; j++ {
+			if clenGtEqualZero {
+				if j >= containerLenS {
+					break
+				}
+			} else if dd.CheckBreak() {
+				break
+			}
+			if cr != nil {
+				cr.sendContainerState(containerArrayElem)
+			}
+			d.swallow()
+		}
+		if cr != nil {
+			cr.sendContainerState(containerArrayEnd)
+		}
+	case valueTypeBytes:
+		dd.DecodeBytes(d.b[:], false, true)
+	case valueTypeString:
+		dd.DecodeBytes(d.b[:], true, true)
+		// dd.DecodeStringAsBytes(d.b[:])
+	default:
+		// these are all primitives, which we can get from decodeNaked
+		// if RawExt using Value, complete the processing.
+		dd.DecodeNaked()
+		if n := &d.n; n.v == valueTypeExt && n.l == nil {
+			l := len(n.is)
+			n.is = append(n.is, nil)
+			v2 := &n.is[l]
+			d.decode(v2)
+			n.is = n.is[:l]
+		}
+	}
+}
+
+// MustDecode is like Decode, but panics if unable to Decode.
+// This provides insight to the code location that triggered the error.
+func (d *Decoder) MustDecode(v interface{}) {
+	d.decode(v)
+}
+
+func (d *Decoder) decode(iv interface{}) {
+	// if ics, ok := iv.(Selfer); ok {
+	// 	ics.CodecDecodeSelf(d)
+	// 	return
+	// }
+
+	if d.d.TryDecodeAsNil() {
+		switch v := iv.(type) {
+		case nil:
+		case *string:
+			*v = ""
+		case *bool:
+			*v = false
+		case *int:
+			*v = 0
+		case *int8:
+			*v = 0
+		case *int16:
+			*v = 0
+		case *int32:
+			*v = 0
+		case *int64:
+			*v = 0
+		case *uint:
+			*v = 0
+		case *uint8:
+			*v = 0
+		case *uint16:
+			*v = 0
+		case *uint32:
+			*v = 0
+		case *uint64:
+			*v = 0
+		case *float32:
+			*v = 0
+		case *float64:
+			*v = 0
+		case *[]uint8:
+			*v = nil
+		case *Raw:
+			*v = nil
+		case reflect.Value:
+			if v.Kind() != reflect.Ptr || v.IsNil() {
+				d.errNotValidPtrValue(v)
+			}
+			// d.chkPtrValue(v)
+			v = v.Elem()
+			if v.IsValid() {
+				v.Set(reflect.Zero(v.Type()))
+			}
+		default:
+			rv := reflect.ValueOf(iv)
+			if rv.Kind() != reflect.Ptr || rv.IsNil() {
+				d.errNotValidPtrValue(rv)
+			}
+			// d.chkPtrValue(rv)
+			rv = rv.Elem()
+			if rv.IsValid() {
+				rv.Set(reflect.Zero(rv.Type()))
+			}
+		}
+		return
+	}
+
+	switch v := iv.(type) {
+	case nil:
+		d.error(cannotDecodeIntoNilErr)
+		return
+
+	case Selfer:
+		v.CodecDecodeSelf(d)
+
+	case reflect.Value:
+		if v.Kind() != reflect.Ptr || v.IsNil() {
+			d.errNotValidPtrValue(v)
+		}
+		// d.chkPtrValue(v)
+		d.decodeValueNotNil(v.Elem(), nil)
+
+	case *string:
+		*v = d.d.DecodeString()
+	case *bool:
+		*v = d.d.DecodeBool()
+	case *int:
+		*v = int(d.d.DecodeInt(intBitsize))
+	case *int8:
+		*v = int8(d.d.DecodeInt(8))
+	case *int16:
+		*v = int16(d.d.DecodeInt(16))
+	case *int32:
+		*v = int32(d.d.DecodeInt(32))
+	case *int64:
+		*v = d.d.DecodeInt(64)
+	case *uint:
+		*v = uint(d.d.DecodeUint(uintBitsize))
+	case *uint8:
+		*v = uint8(d.d.DecodeUint(8))
+	case *uint16:
+		*v = uint16(d.d.DecodeUint(16))
+	case *uint32:
+		*v = uint32(d.d.DecodeUint(32))
+	case *uint64:
+		*v = d.d.DecodeUint(64)
+	case *float32:
+		*v = float32(d.d.DecodeFloat(true))
+	case *float64:
+		*v = d.d.DecodeFloat(false)
+	case *[]uint8:
+		*v = d.d.DecodeBytes(*v, false, false)
+
+	case *Raw:
+		*v = d.raw()
+
+	case *interface{}:
+		d.decodeValueNotNil(reflect.ValueOf(iv).Elem(), nil)
+
+	default:
+		if !fastpathDecodeTypeSwitch(iv, d) {
+			d.decodeI(iv, true, false, false, false)
+		}
+	}
+}
+
+func (d *Decoder) preDecodeValue(rv reflect.Value, tryNil bool) (rv2 reflect.Value, proceed bool) {
+	if tryNil && d.d.TryDecodeAsNil() {
+		// No need to check if a ptr, recursively, to determine
+		// whether to set value to nil.
+		// Just always set value to its zero type.
+		if rv.IsValid() { // rv.CanSet() // always settable, except it's invalid
+			rv.Set(reflect.Zero(rv.Type()))
+		}
+		return
+	}
+
+	// If stream is not containing a nil value, then we can deref to the base
+	// non-pointer value, and decode into that.
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			rv.Set(reflect.New(rv.Type().Elem()))
+		}
+		rv = rv.Elem()
+	}
+	return rv, true
+}
+
+func (d *Decoder) decodeI(iv interface{}, checkPtr, tryNil, checkFastpath, checkCodecSelfer bool) {
+	rv := reflect.ValueOf(iv)
+	if checkPtr {
+		if rv.Kind() != reflect.Ptr || rv.IsNil() {
+			d.errNotValidPtrValue(rv)
+		}
+		// d.chkPtrValue(rv)
+	}
+	rv, proceed := d.preDecodeValue(rv, tryNil)
+	if proceed {
+		fn := d.getDecFn(rv.Type(), checkFastpath, checkCodecSelfer)
+		fn.f(&fn.i, rv)
+	}
+}
+
+func (d *Decoder) decodeValue(rv reflect.Value, fn *decFn) {
+	if rv, proceed := d.preDecodeValue(rv, true); proceed {
+		if fn == nil {
+			fn = d.getDecFn(rv.Type(), true, true)
+		}
+		fn.f(&fn.i, rv)
+	}
+}
+
+func (d *Decoder) decodeValueNotNil(rv reflect.Value, fn *decFn) {
+	if rv, proceed := d.preDecodeValue(rv, false); proceed {
+		if fn == nil {
+			fn = d.getDecFn(rv.Type(), true, true)
+		}
+		fn.f(&fn.i, rv)
+	}
+}
+
+func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn *decFn) {
+	rtid := reflect.ValueOf(rt).Pointer()
+
+	// retrieve or register a focus'ed function for this type
+	// to eliminate need to do the retrieval multiple times
+
+	// if d.f == nil && d.s == nil { debugf("---->Creating new dec f map for type: %v\n", rt) }
+	var ok bool
+	if useMapForCodecCache {
+		fn, ok = d.f[rtid]
+	} else {
+		for i := range d.s {
+			v := &(d.s[i])
+			if v.rtid == rtid {
+				fn, ok = &(v.fn), true
+				break
+			}
+		}
+	}
+	if ok {
+		return
+	}
+
+	if useMapForCodecCache {
+		if d.f == nil {
+			d.f = make(map[uintptr]*decFn, initCollectionCap)
+		}
+		fn = new(decFn)
+		d.f[rtid] = fn
+	} else {
+		if d.s == nil {
+			d.s = make([]decRtidFn, 0, initCollectionCap)
+		}
+		d.s = append(d.s, decRtidFn{rtid: rtid})
+		fn = &(d.s[len(d.s)-1]).fn
+	}
+
+	// debugf("\tCreating new dec fn for type: %v\n", rt)
+	ti := d.h.getTypeInfo(rtid, rt)
+	fi := &(fn.i)
+	fi.d = d
+	fi.ti = ti
+
+	// An extension can be registered for any type, regardless of the Kind
+	// (e.g. type BitSet int64, type MyStruct { / * unexported fields * / }, type X []int, etc.
+	//
+	// We can't check if it's an extension byte here first, because the user may have
+	// registered a pointer or non-pointer type, meaning we may have to recurse first
+	// before matching a mapped type, even though the extension byte is already detected.
+	//
+	// NOTE: if decoding into a nil interface{}, we return a non-nil
+	// value except even if the container registers a length of 0.
+	if checkCodecSelfer && ti.cs {
+		fn.f = (*decFnInfo).selferUnmarshal
+	} else if rtid == rawExtTypId {
+		fn.f = (*decFnInfo).rawExt
+	} else if rtid == rawTypId {
+		fn.f = (*decFnInfo).raw
+	} else if d.d.IsBuiltinType(rtid) {
+		fn.f = (*decFnInfo).builtin
+	} else if xfFn := d.h.getExt(rtid); xfFn != nil {
+		fi.xfTag, fi.xfFn = xfFn.tag, xfFn.ext
+		fn.f = (*decFnInfo).ext
+	} else if supportMarshalInterfaces && d.be && ti.bunm {
+		fn.f = (*decFnInfo).binaryUnmarshal
+	} else if supportMarshalInterfaces && !d.be && d.js && ti.junm {
+		//If JSON, we should check JSONUnmarshal before textUnmarshal
+		fn.f = (*decFnInfo).jsonUnmarshal
+	} else if supportMarshalInterfaces && !d.be && ti.tunm {
+		fn.f = (*decFnInfo).textUnmarshal
+	} else {
+		rk := rt.Kind()
+		if fastpathEnabled && checkFastpath && (rk == reflect.Map || rk == reflect.Slice) {
+			if rt.PkgPath() == "" {
+				if idx := fastpathAV.index(rtid); idx != -1 {
+					fn.f = fastpathAV[idx].decfn
+				}
+			} else {
+				// use mapping for underlying type if there
+				ok = false
+				var rtu reflect.Type
+				if rk == reflect.Map {
+					rtu = reflect.MapOf(rt.Key(), rt.Elem())
+				} else {
+					rtu = reflect.SliceOf(rt.Elem())
+				}
+				rtuid := reflect.ValueOf(rtu).Pointer()
+				if idx := fastpathAV.index(rtuid); idx != -1 {
+					xfnf := fastpathAV[idx].decfn
+					xrt := fastpathAV[idx].rt
+					fn.f = func(xf *decFnInfo, xrv reflect.Value) {
+						// xfnf(xf, xrv.Convert(xrt))
+						xfnf(xf, xrv.Addr().Convert(reflect.PtrTo(xrt)).Elem())
+					}
+				}
+			}
+		}
+		if fn.f == nil {
+			switch rk {
+			case reflect.String:
+				fn.f = (*decFnInfo).kString
+			case reflect.Bool:
+				fn.f = (*decFnInfo).kBool
+			case reflect.Int:
+				fn.f = (*decFnInfo).kInt
+			case reflect.Int64:
+				fn.f = (*decFnInfo).kInt64
+			case reflect.Int32:
+				fn.f = (*decFnInfo).kInt32
+			case reflect.Int8:
+				fn.f = (*decFnInfo).kInt8
+			case reflect.Int16:
+				fn.f = (*decFnInfo).kInt16
+			case reflect.Float32:
+				fn.f = (*decFnInfo).kFloat32
+			case reflect.Float64:
+				fn.f = (*decFnInfo).kFloat64
+			case reflect.Uint8:
+				fn.f = (*decFnInfo).kUint8
+			case reflect.Uint64:
+				fn.f = (*decFnInfo).kUint64
+			case reflect.Uint:
+				fn.f = (*decFnInfo).kUint
+			case reflect.Uint32:
+				fn.f = (*decFnInfo).kUint32
+			case reflect.Uint16:
+				fn.f = (*decFnInfo).kUint16
+				// case reflect.Ptr:
+				// 	fn.f = (*decFnInfo).kPtr
+			case reflect.Uintptr:
+				fn.f = (*decFnInfo).kUintptr
+			case reflect.Interface:
+				fn.f = (*decFnInfo).kInterface
+			case reflect.Struct:
+				fn.f = (*decFnInfo).kStruct
+			case reflect.Chan:
+				fi.seq = seqTypeChan
+				fn.f = (*decFnInfo).kSlice
+			case reflect.Slice:
+				fi.seq = seqTypeSlice
+				fn.f = (*decFnInfo).kSlice
+			case reflect.Array:
+				fi.seq = seqTypeArray
+				fn.f = (*decFnInfo).kArray
+			case reflect.Map:
+				fn.f = (*decFnInfo).kMap
+			default:
+				fn.f = (*decFnInfo).kErr
+			}
+		}
+	}
+
+	return
+}
+
+func (d *Decoder) structFieldNotFound(index int, rvkencname string) {
+	// NOTE: rvkencname may be a stringView, so don't pass it to another function.
+	if d.h.ErrorIfNoField {
+		if index >= 0 {
+			d.errorf("no matching struct field found when decoding stream array at index %v", index)
+			return
+		} else if rvkencname != "" {
+			d.errorf("no matching struct field found when decoding stream map with key " + rvkencname)
+			return
+		}
+	}
+	d.swallow()
+}
+
+func (d *Decoder) arrayCannotExpand(sliceLen, streamLen int) {
+	if d.h.ErrorIfNoArrayExpand {
+		d.errorf("cannot expand array len during decode from %v to %v", sliceLen, streamLen)
+	}
+}
+
+func (d *Decoder) chkPtrValue(rv reflect.Value) {
+	// We can only decode into a non-nil pointer
+	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		return
+	}
+	d.errNotValidPtrValue(rv)
+}
+
+func (d *Decoder) errNotValidPtrValue(rv reflect.Value) {
+	if !rv.IsValid() {
+		d.error(cannotDecodeIntoNilErr)
+		return
+	}
+	if !rv.CanInterface() {
+		d.errorf("cannot decode into a value without an interface: %v", rv)
+		return
+	}
+	rvi := rv.Interface()
+	d.errorf("cannot decode into non-pointer or nil pointer. Got: %v, %T, %v", rv.Kind(), rvi, rvi)
+}
+
+func (d *Decoder) error(err error) {
+	panic(err)
+}
+
+func (d *Decoder) errorf(format string, params ...interface{}) {
+	params2 := make([]interface{}, len(params)+1)
+	params2[0] = d.r.numread()
+	copy(params2[1:], params)
+	err := fmt.Errorf("[pos %d]: "+format, params2...)
+	panic(err)
+}
+
+// Possibly get an interned version of a string
+//
+// This should mostly be used for map keys, where the key type is string
+func (d *Decoder) string(v []byte) (s string) {
+	if d.is != nil {
+		s, ok := d.is[string(v)] // no allocation here, per go implementation
+		if !ok {
+			s = string(v) // new allocation here
+			d.is[s] = s
+		}
+		return s
+	}
+	return string(v) // don't return stringView, as we need a real string here.
+}
+
+// func (d *Decoder) intern(s string) {
+// 	if d.is != nil {
+// 		d.is[s] = s
+// 	}
+// }
+
+// nextValueBytes returns the next value in the stream as a set of bytes.
+func (d *Decoder) nextValueBytes() []byte {
+	d.d.uncacheRead()
+	d.r.track()
+	d.swallow()
+	return d.r.stopTrack()
+}
+
+func (d *Decoder) raw() []byte {
+	// ensure that this is not a view into the bytes
+	// i.e. make new copy always.
+	bs := d.nextValueBytes()
+	bs2 := make([]byte, len(bs))
+	copy(bs2, bs)
+	return bs2
+}
+
+// --------------------------------------------------
+
+// decSliceHelper assists when decoding into a slice, from a map or an array in the stream.
+// A slice can be set from a map or array in stream. This supports the MapBySlice interface.
+type decSliceHelper struct {
+	d *Decoder
+	// ct valueType
+	array bool
+}
+
+func (d *Decoder) decSliceHelperStart() (x decSliceHelper, clen int) {
+	dd := d.d
+	ctyp := dd.ContainerType()
+	if ctyp == valueTypeArray {
+		x.array = true
+		clen = dd.ReadArrayStart()
+	} else if ctyp == valueTypeMap {
+		clen = dd.ReadMapStart() * 2
+	} else {
+		d.errorf("only encoded map or array can be decoded into a slice (%d)", ctyp)
+	}
+	// x.ct = ctyp
+	x.d = d
+	return
+}
+
+func (x decSliceHelper) End() {
+	cr := x.d.cr
+	if cr == nil {
+		return
+	}
+	if x.array {
+		cr.sendContainerState(containerArrayEnd)
+	} else {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (x decSliceHelper) ElemContainerState(index int) {
+	cr := x.d.cr
+	if cr == nil {
+		return
+	}
+	if x.array {
+		cr.sendContainerState(containerArrayElem)
+	} else {
+		if index%2 == 0 {
+			cr.sendContainerState(containerMapKey)
+		} else {
+			cr.sendContainerState(containerMapValue)
+		}
+	}
+}
+
+func decByteSlice(r decReader, clen, maxInitLen int, bs []byte) (bsOut []byte) {
+	if clen == 0 {
+		return zeroByteSlice
+	}
+	if len(bs) == clen {
+		bsOut = bs
+		r.readb(bsOut)
+	} else if cap(bs) >= clen {
+		bsOut = bs[:clen]
+		r.readb(bsOut)
+	} else {
+		// bsOut = make([]byte, clen)
+		len2, _ := decInferLen(clen, maxInitLen, 1)
+		bsOut = make([]byte, len2)
+		r.readb(bsOut)
+		for len2 < clen {
+			len3, _ := decInferLen(clen-len2, maxInitLen, 1)
+			// fmt.Printf(">>>>> TESTING: in loop: clen: %v, maxInitLen: %v, len2: %v, len3: %v\n", clen, maxInitLen, len2, len3)
+			bs3 := bsOut
+			bsOut = make([]byte, len2+len3)
+			copy(bsOut, bs3)
+			r.readb(bsOut[len2:])
+			len2 += len3
+		}
+	}
+	return
+}
+
+func detachZeroCopyBytes(isBytesReader bool, dest []byte, in []byte) (out []byte) {
+	if xlen := len(in); xlen > 0 {
+		if isBytesReader || xlen <= scratchByteArrayLen {
+			if cap(dest) >= xlen {
+				out = dest[:xlen]
+			} else {
+				out = make([]byte, xlen)
+			}
+			copy(out, in)
+			return
+		}
+	}
+	return in
+}
+
+// decInferLen will infer a sensible length, given the following:
+//    - clen: length wanted.
+//    - maxlen: max length to be returned.
+//      if <= 0, it is unset, and we infer it based on the unit size
+//    - unit: number of bytes for each element of the collection
+func decInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	// handle when maxlen is not set i.e. <= 0
+	if clen <= 0 {
+		return
+	}
+	if maxlen <= 0 {
+		// no maxlen defined. Use maximum of 256K memory, with a floor of 4K items.
+		// maxlen = 256 * 1024 / unit
+		// if maxlen < (4 * 1024) {
+		// 	maxlen = 4 * 1024
+		// }
+		if unit < (256 / 4) {
+			maxlen = 256 * 1024 / unit
+		} else {
+			maxlen = 4 * 1024
+		}
+	}
+	if clen > maxlen {
+		rvlen = maxlen
+		truncated = true
+	} else {
+		rvlen = clen
+	}
+	return
+	// if clen <= 0 {
+	// 	rvlen = 0
+	// } else if maxlen > 0 && clen > maxlen {
+	// 	rvlen = maxlen
+	// 	truncated = true
+	// } else {
+	// 	rvlen = clen
+	// }
+	// return
+}
+
+// // implement overall decReader wrapping both, for possible use inline:
+// type decReaderT struct {
+// 	bytes bool
+// 	rb    *bytesDecReader
+// 	ri    *ioDecReader
+// }
+//
+// // implement *Decoder as a decReader.
+// // Using decReaderT (defined just above) caused performance degradation
+// // possibly because of constant copying the value,
+// // and some value->interface conversion causing allocation.
+// func (d *Decoder) unreadn1() {
+// 	if d.bytes {
+// 		d.rb.unreadn1()
+// 	} else {
+// 		d.ri.unreadn1()
+// 	}
+// }
+// ... for other methods of decReader.
+// Testing showed that performance improvement was negligible.

--- a/vendor/github.com/ugorji/go/codec/decode_go.go
+++ b/vendor/github.com/ugorji/go/codec/decode_go.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build go1.5
+
+package codec
+
+import "reflect"
+
+const reflectArrayOfSupported = true
+
+func reflectArrayOf(rvn reflect.Value) (rvn2 reflect.Value) {
+	rvn2 = reflect.New(reflect.ArrayOf(rvn.Len(), intfTyp)).Elem()
+	reflect.Copy(rvn2, rvn)
+	return
+}

--- a/vendor/github.com/ugorji/go/codec/decode_go14.go
+++ b/vendor/github.com/ugorji/go/codec/decode_go14.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build !go1.5
+
+package codec
+
+import "reflect"
+
+const reflectArrayOfSupported = false
+
+func reflectArrayOf(rvn reflect.Value) (rvn2 reflect.Value) {
+	panic("reflect.ArrayOf unsupported")
+}

--- a/vendor/github.com/ugorji/go/codec/encode.go
+++ b/vendor/github.com/ugorji/go/codec/encode.go
@@ -1,0 +1,1462 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"encoding"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"sync"
+)
+
+const (
+	defEncByteBufSize = 1 << 6 // 4:16, 6:64, 8:256, 10:1024
+)
+
+// AsSymbolFlag defines what should be encoded as symbols.
+type AsSymbolFlag uint8
+
+const (
+	// AsSymbolDefault is default.
+	// Currently, this means only encode struct field names as symbols.
+	// The default is subject to change.
+	AsSymbolDefault AsSymbolFlag = iota
+
+	// AsSymbolAll means encode anything which could be a symbol as a symbol.
+	AsSymbolAll = 0xfe
+
+	// AsSymbolNone means do not encode anything as a symbol.
+	AsSymbolNone = 1 << iota
+
+	// AsSymbolMapStringKeys means encode keys in map[string]XXX as symbols.
+	AsSymbolMapStringKeysFlag
+
+	// AsSymbolStructFieldName means encode struct field names as symbols.
+	AsSymbolStructFieldNameFlag
+)
+
+// encWriter abstracts writing to a byte array or to an io.Writer.
+type encWriter interface {
+	writeb([]byte)
+	writestr(string)
+	writen1(byte)
+	writen2(byte, byte)
+	atEndOfEncode()
+}
+
+// encDriver abstracts the actual codec (binc vs msgpack, etc)
+type encDriver interface {
+	IsBuiltinType(rt uintptr) bool
+	EncodeBuiltin(rt uintptr, v interface{})
+	EncodeNil()
+	EncodeInt(i int64)
+	EncodeUint(i uint64)
+	EncodeBool(b bool)
+	EncodeFloat32(f float32)
+	EncodeFloat64(f float64)
+	// encodeExtPreamble(xtag byte, length int)
+	EncodeRawExt(re *RawExt, e *Encoder)
+	EncodeExt(v interface{}, xtag uint64, ext Ext, e *Encoder)
+	EncodeArrayStart(length int)
+	EncodeMapStart(length int)
+	EncodeString(c charEncoding, v string)
+	EncodeSymbol(v string)
+	EncodeStringBytes(c charEncoding, v []byte)
+	//TODO
+	//encBignum(f *big.Int)
+	//encStringRunes(c charEncoding, v []rune)
+
+	reset()
+}
+
+type encDriverAsis interface {
+	EncodeAsis(v []byte)
+}
+
+type encNoSeparator struct{}
+
+func (_ encNoSeparator) EncodeEnd() {}
+
+type ioEncWriterWriter interface {
+	WriteByte(c byte) error
+	WriteString(s string) (n int, err error)
+	Write(p []byte) (n int, err error)
+}
+
+type ioEncStringWriter interface {
+	WriteString(s string) (n int, err error)
+}
+
+type EncodeOptions struct {
+	// Encode a struct as an array, and not as a map
+	StructToArray bool
+
+	// Canonical representation means that encoding a value will always result in the same
+	// sequence of bytes.
+	//
+	// This only affects maps, as the iteration order for maps is random.
+	//
+	// The implementation MAY use the natural sort order for the map keys if possible:
+	//
+	//     - If there is a natural sort order (ie for number, bool, string or []byte keys),
+	//       then the map keys are first sorted in natural order and then written
+	//       with corresponding map values to the strema.
+	//     - If there is no natural sort order, then the map keys will first be
+	//       encoded into []byte, and then sorted,
+	//       before writing the sorted keys and the corresponding map values to the stream.
+	//
+	Canonical bool
+
+	// CheckCircularRef controls whether we check for circular references
+	// and error fast during an encode.
+	//
+	// If enabled, an error is received if a pointer to a struct
+	// references itself either directly or through one of its fields (iteratively).
+	//
+	// This is opt-in, as there may be a performance hit to checking circular references.
+	CheckCircularRef bool
+
+	// RecursiveEmptyCheck controls whether we descend into interfaces, structs and pointers
+	// when checking if a value is empty.
+	//
+	// Note that this may make OmitEmpty more expensive, as it incurs a lot more reflect calls.
+	RecursiveEmptyCheck bool
+
+	// Raw controls whether we encode Raw values.
+	// This is a "dangerous" option and must be explicitly set.
+	// If set, we blindly encode Raw values as-is, without checking
+	// if they are a correct representation of a value in that format.
+	// If unset, we error out.
+	Raw bool
+
+	// AsSymbols defines what should be encoded as symbols.
+	//
+	// Encoding as symbols can reduce the encoded size significantly.
+	//
+	// However, during decoding, each string to be encoded as a symbol must
+	// be checked to see if it has been seen before. Consequently, encoding time
+	// will increase if using symbols, because string comparisons has a clear cost.
+	//
+	// Sample values:
+	//   AsSymbolNone
+	//   AsSymbolAll
+	//   AsSymbolMapStringKeys
+	//   AsSymbolMapStringKeysFlag | AsSymbolStructFieldNameFlag
+	AsSymbols AsSymbolFlag
+}
+
+// ---------------------------------------------
+
+type simpleIoEncWriterWriter struct {
+	w  io.Writer
+	bw io.ByteWriter
+	sw ioEncStringWriter
+	bs [1]byte
+}
+
+func (o *simpleIoEncWriterWriter) WriteByte(c byte) (err error) {
+	if o.bw != nil {
+		return o.bw.WriteByte(c)
+	}
+	// _, err = o.w.Write([]byte{c})
+	o.bs[0] = c
+	_, err = o.w.Write(o.bs[:])
+	return
+}
+
+func (o *simpleIoEncWriterWriter) WriteString(s string) (n int, err error) {
+	if o.sw != nil {
+		return o.sw.WriteString(s)
+	}
+	// return o.w.Write([]byte(s))
+	return o.w.Write(bytesView(s))
+}
+
+func (o *simpleIoEncWriterWriter) Write(p []byte) (n int, err error) {
+	return o.w.Write(p)
+}
+
+// ----------------------------------------
+
+// ioEncWriter implements encWriter and can write to an io.Writer implementation
+type ioEncWriter struct {
+	w ioEncWriterWriter
+	s simpleIoEncWriterWriter
+	// x [8]byte // temp byte array re-used internally for efficiency
+}
+
+func (z *ioEncWriter) writeb(bs []byte) {
+	if len(bs) == 0 {
+		return
+	}
+	n, err := z.w.Write(bs)
+	if err != nil {
+		panic(err)
+	}
+	if n != len(bs) {
+		panic(fmt.Errorf("incorrect num bytes written. Expecting: %v, Wrote: %v", len(bs), n))
+	}
+}
+
+func (z *ioEncWriter) writestr(s string) {
+	n, err := z.w.WriteString(s)
+	if err != nil {
+		panic(err)
+	}
+	if n != len(s) {
+		panic(fmt.Errorf("incorrect num bytes written. Expecting: %v, Wrote: %v", len(s), n))
+	}
+}
+
+func (z *ioEncWriter) writen1(b byte) {
+	if err := z.w.WriteByte(b); err != nil {
+		panic(err)
+	}
+}
+
+func (z *ioEncWriter) writen2(b1 byte, b2 byte) {
+	z.writen1(b1)
+	z.writen1(b2)
+}
+
+func (z *ioEncWriter) atEndOfEncode() {}
+
+// ----------------------------------------
+
+// bytesEncWriter implements encWriter and can write to an byte slice.
+// It is used by Marshal function.
+type bytesEncWriter struct {
+	b   []byte
+	c   int     // cursor
+	out *[]byte // write out on atEndOfEncode
+}
+
+func (z *bytesEncWriter) writeb(s []byte) {
+	if len(s) == 0 {
+		return
+	}
+	oc, a := z.growNoAlloc(len(s))
+	if a {
+		z.growAlloc(len(s), oc)
+	}
+	copy(z.b[oc:], s)
+}
+
+func (z *bytesEncWriter) writestr(s string) {
+	if len(s) == 0 {
+		return
+	}
+	oc, a := z.growNoAlloc(len(s))
+	if a {
+		z.growAlloc(len(s), oc)
+	}
+	copy(z.b[oc:], s)
+}
+
+func (z *bytesEncWriter) writen1(b1 byte) {
+	oc, a := z.growNoAlloc(1)
+	if a {
+		z.growAlloc(1, oc)
+	}
+	z.b[oc] = b1
+}
+
+func (z *bytesEncWriter) writen2(b1 byte, b2 byte) {
+	oc, a := z.growNoAlloc(2)
+	if a {
+		z.growAlloc(2, oc)
+	}
+	z.b[oc+1] = b2
+	z.b[oc] = b1
+}
+
+func (z *bytesEncWriter) atEndOfEncode() {
+	*(z.out) = z.b[:z.c]
+}
+
+// have a growNoalloc(n int), which can be inlined.
+// if allocation is needed, then call growAlloc(n int)
+
+func (z *bytesEncWriter) growNoAlloc(n int) (oldcursor int, allocNeeded bool) {
+	oldcursor = z.c
+	z.c = z.c + n
+	if z.c > len(z.b) {
+		if z.c > cap(z.b) {
+			allocNeeded = true
+		} else {
+			z.b = z.b[:cap(z.b)]
+		}
+	}
+	return
+}
+
+func (z *bytesEncWriter) growAlloc(n int, oldcursor int) {
+	// appendslice logic (if cap < 1024, *2, else *1.25): more expensive. many copy calls.
+	// bytes.Buffer model (2*cap + n): much better
+	// bs := make([]byte, 2*cap(z.b)+n)
+	bs := make([]byte, growCap(cap(z.b), 1, n))
+	copy(bs, z.b[:oldcursor])
+	z.b = bs
+}
+
+// ---------------------------------------------
+
+type encFnInfo struct {
+	e     *Encoder
+	ti    *typeInfo
+	xfFn  Ext
+	xfTag uint64
+	seq   seqType
+}
+
+func (f *encFnInfo) builtin(rv reflect.Value) {
+	f.e.e.EncodeBuiltin(f.ti.rtid, rv.Interface())
+}
+
+func (f *encFnInfo) raw(rv reflect.Value) {
+	f.e.raw(rv.Interface().(Raw))
+}
+
+func (f *encFnInfo) rawExt(rv reflect.Value) {
+	// rev := rv.Interface().(RawExt)
+	// f.e.e.EncodeRawExt(&rev, f.e)
+	var re *RawExt
+	if rv.CanAddr() {
+		re = rv.Addr().Interface().(*RawExt)
+	} else {
+		rev := rv.Interface().(RawExt)
+		re = &rev
+	}
+	f.e.e.EncodeRawExt(re, f.e)
+}
+
+func (f *encFnInfo) ext(rv reflect.Value) {
+	// if this is a struct|array and it was addressable, then pass the address directly (not the value)
+	if k := rv.Kind(); (k == reflect.Struct || k == reflect.Array) && rv.CanAddr() {
+		rv = rv.Addr()
+	}
+	f.e.e.EncodeExt(rv.Interface(), f.xfTag, f.xfFn, f.e)
+}
+
+func (f *encFnInfo) getValueForMarshalInterface(rv reflect.Value, indir int8) (v interface{}, proceed bool) {
+	if indir == 0 {
+		v = rv.Interface()
+	} else if indir == -1 {
+		// If a non-pointer was passed to Encode(), then that value is not addressable.
+		// Take addr if addressable, else copy value to an addressable value.
+		if rv.CanAddr() {
+			v = rv.Addr().Interface()
+		} else {
+			rv2 := reflect.New(rv.Type())
+			rv2.Elem().Set(rv)
+			v = rv2.Interface()
+			// fmt.Printf("rv.Type: %v, rv2.Type: %v, v: %v\n", rv.Type(), rv2.Type(), v)
+		}
+	} else {
+		for j := int8(0); j < indir; j++ {
+			if rv.IsNil() {
+				f.e.e.EncodeNil()
+				return
+			}
+			rv = rv.Elem()
+		}
+		v = rv.Interface()
+	}
+	return v, true
+}
+
+func (f *encFnInfo) selferMarshal(rv reflect.Value) {
+	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.csIndir); proceed {
+		v.(Selfer).CodecEncodeSelf(f.e)
+	}
+}
+
+func (f *encFnInfo) binaryMarshal(rv reflect.Value) {
+	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.bmIndir); proceed {
+		bs, fnerr := v.(encoding.BinaryMarshaler).MarshalBinary()
+		f.e.marshal(bs, fnerr, false, c_RAW)
+	}
+}
+
+func (f *encFnInfo) textMarshal(rv reflect.Value) {
+	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.tmIndir); proceed {
+		// debugf(">>>> encoding.TextMarshaler: %T", rv.Interface())
+		bs, fnerr := v.(encoding.TextMarshaler).MarshalText()
+		f.e.marshal(bs, fnerr, false, c_UTF8)
+	}
+}
+
+func (f *encFnInfo) jsonMarshal(rv reflect.Value) {
+	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.jmIndir); proceed {
+		bs, fnerr := v.(jsonMarshaler).MarshalJSON()
+		f.e.marshal(bs, fnerr, true, c_UTF8)
+	}
+}
+
+func (f *encFnInfo) kBool(rv reflect.Value) {
+	f.e.e.EncodeBool(rv.Bool())
+}
+
+func (f *encFnInfo) kString(rv reflect.Value) {
+	f.e.e.EncodeString(c_UTF8, rv.String())
+}
+
+func (f *encFnInfo) kFloat64(rv reflect.Value) {
+	f.e.e.EncodeFloat64(rv.Float())
+}
+
+func (f *encFnInfo) kFloat32(rv reflect.Value) {
+	f.e.e.EncodeFloat32(float32(rv.Float()))
+}
+
+func (f *encFnInfo) kInt(rv reflect.Value) {
+	f.e.e.EncodeInt(rv.Int())
+}
+
+func (f *encFnInfo) kUint(rv reflect.Value) {
+	f.e.e.EncodeUint(rv.Uint())
+}
+
+func (f *encFnInfo) kInvalid(rv reflect.Value) {
+	f.e.e.EncodeNil()
+}
+
+func (f *encFnInfo) kErr(rv reflect.Value) {
+	f.e.errorf("unsupported kind %s, for %#v", rv.Kind(), rv)
+}
+
+func (f *encFnInfo) kSlice(rv reflect.Value) {
+	ti := f.ti
+	// array may be non-addressable, so we have to manage with care
+	//   (don't call rv.Bytes, rv.Slice, etc).
+	// E.g. type struct S{B [2]byte};
+	//   Encode(S{}) will bomb on "panic: slice of unaddressable array".
+	e := f.e
+	if f.seq != seqTypeArray {
+		if rv.IsNil() {
+			e.e.EncodeNil()
+			return
+		}
+		// If in this method, then there was no extension function defined.
+		// So it's okay to treat as []byte.
+		if ti.rtid == uint8SliceTypId {
+			e.e.EncodeStringBytes(c_RAW, rv.Bytes())
+			return
+		}
+	}
+	cr := e.cr
+	rtelem := ti.rt.Elem()
+	l := rv.Len()
+	if ti.rtid == uint8SliceTypId || rtelem.Kind() == reflect.Uint8 {
+		switch f.seq {
+		case seqTypeArray:
+			// if l == 0 { e.e.encodeStringBytes(c_RAW, nil) } else
+			if rv.CanAddr() {
+				e.e.EncodeStringBytes(c_RAW, rv.Slice(0, l).Bytes())
+			} else {
+				var bs []byte
+				if l <= cap(e.b) {
+					bs = e.b[:l]
+				} else {
+					bs = make([]byte, l)
+				}
+				reflect.Copy(reflect.ValueOf(bs), rv)
+				// TODO: Test that reflect.Copy works instead of manual one-by-one
+				// for i := 0; i < l; i++ {
+				// 	bs[i] = byte(rv.Index(i).Uint())
+				// }
+				e.e.EncodeStringBytes(c_RAW, bs)
+			}
+		case seqTypeSlice:
+			e.e.EncodeStringBytes(c_RAW, rv.Bytes())
+		case seqTypeChan:
+			bs := e.b[:0]
+			// do not use range, so that the number of elements encoded
+			// does not change, and encoding does not hang waiting on someone to close chan.
+			// for b := range rv.Interface().(<-chan byte) {
+			// 	bs = append(bs, b)
+			// }
+			ch := rv.Interface().(<-chan byte)
+			for i := 0; i < l; i++ {
+				bs = append(bs, <-ch)
+			}
+			e.e.EncodeStringBytes(c_RAW, bs)
+		}
+		return
+	}
+
+	if ti.mbs {
+		if l%2 == 1 {
+			e.errorf("mapBySlice requires even slice length, but got %v", l)
+			return
+		}
+		e.e.EncodeMapStart(l / 2)
+	} else {
+		e.e.EncodeArrayStart(l)
+	}
+
+	if l > 0 {
+		for rtelem.Kind() == reflect.Ptr {
+			rtelem = rtelem.Elem()
+		}
+		// if kind is reflect.Interface, do not pre-determine the
+		// encoding type, because preEncodeValue may break it down to
+		// a concrete type and kInterface will bomb.
+		var fn *encFn
+		if rtelem.Kind() != reflect.Interface {
+			rtelemid := reflect.ValueOf(rtelem).Pointer()
+			fn = e.getEncFn(rtelemid, rtelem, true, true)
+		}
+		// TODO: Consider perf implication of encoding odd index values as symbols if type is string
+		for j := 0; j < l; j++ {
+			if cr != nil {
+				if ti.mbs {
+					if j%2 == 0 {
+						cr.sendContainerState(containerMapKey)
+					} else {
+						cr.sendContainerState(containerMapValue)
+					}
+				} else {
+					cr.sendContainerState(containerArrayElem)
+				}
+			}
+			if f.seq == seqTypeChan {
+				if rv2, ok2 := rv.Recv(); ok2 {
+					e.encodeValue(rv2, fn)
+				} else {
+					e.encode(nil) // WE HAVE TO DO SOMETHING, so nil if nothing received.
+				}
+			} else {
+				e.encodeValue(rv.Index(j), fn)
+			}
+		}
+	}
+
+	if cr != nil {
+		if ti.mbs {
+			cr.sendContainerState(containerMapEnd)
+		} else {
+			cr.sendContainerState(containerArrayEnd)
+		}
+	}
+}
+
+func (f *encFnInfo) kStruct(rv reflect.Value) {
+	fti := f.ti
+	e := f.e
+	cr := e.cr
+	tisfi := fti.sfip
+	toMap := !(fti.toArray || e.h.StructToArray)
+	newlen := len(fti.sfi)
+
+	// Use sync.Pool to reduce allocating slices unnecessarily.
+	// The cost of sync.Pool is less than the cost of new allocation.
+	pool, poolv, fkvs := encStructPoolGet(newlen)
+
+	// if toMap, use the sorted array. If toArray, use unsorted array (to match sequence in struct)
+	if toMap {
+		tisfi = fti.sfi
+	}
+	newlen = 0
+	var kv stringRv
+	recur := e.h.RecursiveEmptyCheck
+	for _, si := range tisfi {
+		kv.r = si.field(rv, false)
+		if toMap {
+			if si.omitEmpty && isEmptyValue(kv.r, recur, recur) {
+				continue
+			}
+			kv.v = si.encName
+		} else {
+			// use the zero value.
+			// if a reference or struct, set to nil (so you do not output too much)
+			if si.omitEmpty && isEmptyValue(kv.r, recur, recur) {
+				switch kv.r.Kind() {
+				case reflect.Struct, reflect.Interface, reflect.Ptr, reflect.Array, reflect.Map, reflect.Slice:
+					kv.r = reflect.Value{} //encode as nil
+				}
+			}
+		}
+		fkvs[newlen] = kv
+		newlen++
+	}
+
+	// debugf(">>>> kStruct: newlen: %v", newlen)
+	// sep := !e.be
+	ee := e.e //don't dereference every time
+
+	if toMap {
+		ee.EncodeMapStart(newlen)
+		// asSymbols := e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
+		asSymbols := e.h.AsSymbols == AsSymbolDefault || e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
+		for j := 0; j < newlen; j++ {
+			kv = fkvs[j]
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(kv.v)
+			} else {
+				ee.EncodeString(c_UTF8, kv.v)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encodeValue(kv.r, nil)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+	} else {
+		ee.EncodeArrayStart(newlen)
+		for j := 0; j < newlen; j++ {
+			kv = fkvs[j]
+			if cr != nil {
+				cr.sendContainerState(containerArrayElem)
+			}
+			e.encodeValue(kv.r, nil)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerArrayEnd)
+		}
+	}
+
+	// do not use defer. Instead, use explicit pool return at end of function.
+	// defer has a cost we are trying to avoid.
+	// If there is a panic and these slices are not returned, it is ok.
+	if pool != nil {
+		pool.Put(poolv)
+	}
+}
+
+// func (f *encFnInfo) kPtr(rv reflect.Value) {
+// 	debugf(">>>>>>> ??? encode kPtr called - shouldn't get called")
+// 	if rv.IsNil() {
+// 		f.e.e.encodeNil()
+// 		return
+// 	}
+// 	f.e.encodeValue(rv.Elem())
+// }
+
+// func (f *encFnInfo) kInterface(rv reflect.Value) {
+// 	println("kInterface called")
+// 	debug.PrintStack()
+// 	if rv.IsNil() {
+// 		f.e.e.EncodeNil()
+// 		return
+// 	}
+// 	f.e.encodeValue(rv.Elem(), nil)
+// }
+
+func (f *encFnInfo) kMap(rv reflect.Value) {
+	ee := f.e.e
+	if rv.IsNil() {
+		ee.EncodeNil()
+		return
+	}
+
+	l := rv.Len()
+	ee.EncodeMapStart(l)
+	e := f.e
+	cr := e.cr
+	if l == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return
+	}
+	var asSymbols bool
+	// determine the underlying key and val encFn's for the map.
+	// This eliminates some work which is done for each loop iteration i.e.
+	// rv.Type(), ref.ValueOf(rt).Pointer(), then check map/list for fn.
+	//
+	// However, if kind is reflect.Interface, do not pre-determine the
+	// encoding type, because preEncodeValue may break it down to
+	// a concrete type and kInterface will bomb.
+	var keyFn, valFn *encFn
+	ti := f.ti
+	rtkey := ti.rt.Key()
+	rtval := ti.rt.Elem()
+	rtkeyid := reflect.ValueOf(rtkey).Pointer()
+	// keyTypeIsString := f.ti.rt.Key().Kind() == reflect.String
+	var keyTypeIsString = rtkeyid == stringTypId
+	if keyTypeIsString {
+		asSymbols = e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	} else {
+		for rtkey.Kind() == reflect.Ptr {
+			rtkey = rtkey.Elem()
+		}
+		if rtkey.Kind() != reflect.Interface {
+			rtkeyid = reflect.ValueOf(rtkey).Pointer()
+			keyFn = e.getEncFn(rtkeyid, rtkey, true, true)
+		}
+	}
+	for rtval.Kind() == reflect.Ptr {
+		rtval = rtval.Elem()
+	}
+	if rtval.Kind() != reflect.Interface {
+		rtvalid := reflect.ValueOf(rtval).Pointer()
+		valFn = e.getEncFn(rtvalid, rtval, true, true)
+	}
+	mks := rv.MapKeys()
+	// for j, lmks := 0, len(mks); j < lmks; j++ {
+
+	if e.h.Canonical {
+		e.kMapCanonical(rtkeyid, rtkey, rv, mks, valFn, asSymbols)
+	} else {
+		for j := range mks {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if keyTypeIsString {
+				if asSymbols {
+					ee.EncodeSymbol(mks[j].String())
+				} else {
+					ee.EncodeString(c_UTF8, mks[j].String())
+				}
+			} else {
+				e.encodeValue(mks[j], keyFn)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encodeValue(rv.MapIndex(mks[j]), valFn)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (e *Encoder) kMapCanonical(rtkeyid uintptr, rtkey reflect.Type, rv reflect.Value, mks []reflect.Value, valFn *encFn, asSymbols bool) {
+	ee := e.e
+	cr := e.cr
+	// we previously did out-of-band if an extension was registered.
+	// This is not necessary, as the natural kind is sufficient for ordering.
+
+	if rtkeyid == uint8SliceTypId {
+		mksv := make([]bytesRv, len(mks))
+		for i, k := range mks {
+			v := &mksv[i]
+			v.r = k
+			v.v = k.Bytes()
+		}
+		sort.Sort(bytesRvSlice(mksv))
+		for i := range mksv {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeStringBytes(c_RAW, mksv[i].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+		}
+	} else {
+		switch rtkey.Kind() {
+		case reflect.Bool:
+			mksv := make([]boolRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.Bool()
+			}
+			sort.Sort(boolRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				ee.EncodeBool(mksv[i].v)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		case reflect.String:
+			mksv := make([]stringRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.String()
+			}
+			sort.Sort(stringRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				if asSymbols {
+					ee.EncodeSymbol(mksv[i].v)
+				} else {
+					ee.EncodeString(c_UTF8, mksv[i].v)
+				}
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint, reflect.Uintptr:
+			mksv := make([]uintRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.Uint()
+			}
+			sort.Sort(uintRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				ee.EncodeUint(mksv[i].v)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+			mksv := make([]intRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.Int()
+			}
+			sort.Sort(intRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				ee.EncodeInt(mksv[i].v)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		case reflect.Float32:
+			mksv := make([]floatRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.Float()
+			}
+			sort.Sort(floatRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				ee.EncodeFloat32(float32(mksv[i].v))
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		case reflect.Float64:
+			mksv := make([]floatRv, len(mks))
+			for i, k := range mks {
+				v := &mksv[i]
+				v.r = k
+				v.v = k.Float()
+			}
+			sort.Sort(floatRvSlice(mksv))
+			for i := range mksv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				ee.EncodeFloat64(mksv[i].v)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksv[i].r), valFn)
+			}
+		default:
+			// out-of-band
+			// first encode each key to a []byte first, then sort them, then record
+			var mksv []byte = make([]byte, 0, len(mks)*16) // temporary byte slice for the encoding
+			e2 := NewEncoderBytes(&mksv, e.hh)
+			mksbv := make([]bytesRv, len(mks))
+			for i, k := range mks {
+				v := &mksbv[i]
+				l := len(mksv)
+				e2.MustEncode(k)
+				v.r = k
+				v.v = mksv[l:]
+				// fmt.Printf(">>>>> %s\n", mksv[l:])
+			}
+			sort.Sort(bytesRvSlice(mksbv))
+			for j := range mksbv {
+				if cr != nil {
+					cr.sendContainerState(containerMapKey)
+				}
+				e.asis(mksbv[j].v)
+				if cr != nil {
+					cr.sendContainerState(containerMapValue)
+				}
+				e.encodeValue(rv.MapIndex(mksbv[j].r), valFn)
+			}
+		}
+	}
+}
+
+// --------------------------------------------------
+
+// encFn encapsulates the captured variables and the encode function.
+// This way, we only do some calculations one times, and pass to the
+// code block that should be called (encapsulated in a function)
+// instead of executing the checks every time.
+type encFn struct {
+	i encFnInfo
+	f func(*encFnInfo, reflect.Value)
+}
+
+// --------------------------------------------------
+
+type encRtidFn struct {
+	rtid uintptr
+	fn   encFn
+}
+
+// An Encoder writes an object to an output stream in the codec format.
+type Encoder struct {
+	// hopefully, reduce derefencing cost by laying the encWriter inside the Encoder
+	e encDriver
+	// NOTE: Encoder shouldn't call it's write methods,
+	// as the handler MAY need to do some coordination.
+	w  encWriter
+	s  []encRtidFn
+	ci set
+	be bool // is binary encoding
+	js bool // is json handle
+
+	wi ioEncWriter
+	wb bytesEncWriter
+
+	h  *BasicHandle
+	hh Handle
+
+	cr containerStateRecv
+	as encDriverAsis
+
+	f map[uintptr]*encFn
+	b [scratchByteArrayLen]byte
+}
+
+// NewEncoder returns an Encoder for encoding into an io.Writer.
+//
+// For efficiency, Users are encouraged to pass in a memory buffered writer
+// (eg bufio.Writer, bytes.Buffer).
+func NewEncoder(w io.Writer, h Handle) *Encoder {
+	e := newEncoder(h)
+	e.Reset(w)
+	return e
+}
+
+// NewEncoderBytes returns an encoder for encoding directly and efficiently
+// into a byte slice, using zero-copying to temporary slices.
+//
+// It will potentially replace the output byte slice pointed to.
+// After encoding, the out parameter contains the encoded contents.
+func NewEncoderBytes(out *[]byte, h Handle) *Encoder {
+	e := newEncoder(h)
+	e.ResetBytes(out)
+	return e
+}
+
+func newEncoder(h Handle) *Encoder {
+	e := &Encoder{hh: h, h: h.getBasicHandle(), be: h.isBinary()}
+	_, e.js = h.(*JsonHandle)
+	e.e = h.newEncDriver(e)
+	e.as, _ = e.e.(encDriverAsis)
+	e.cr, _ = e.e.(containerStateRecv)
+	return e
+}
+
+// Reset the Encoder with a new output stream.
+//
+// This accommodates using the state of the Encoder,
+// where it has "cached" information about sub-engines.
+func (e *Encoder) Reset(w io.Writer) {
+	ww, ok := w.(ioEncWriterWriter)
+	if ok {
+		e.wi.w = ww
+	} else {
+		sww := &e.wi.s
+		sww.w = w
+		sww.bw, _ = w.(io.ByteWriter)
+		sww.sw, _ = w.(ioEncStringWriter)
+		e.wi.w = sww
+		//ww = bufio.NewWriterSize(w, defEncByteBufSize)
+	}
+	e.w = &e.wi
+	e.e.reset()
+}
+
+func (e *Encoder) ResetBytes(out *[]byte) {
+	in := *out
+	if in == nil {
+		in = make([]byte, defEncByteBufSize)
+	}
+	e.wb.b, e.wb.out, e.wb.c = in, out, 0
+	e.w = &e.wb
+	e.e.reset()
+}
+
+// func (e *Encoder) sendContainerState(c containerState) {
+// 	if e.cr != nil {
+// 		e.cr.sendContainerState(c)
+// 	}
+// }
+
+// Encode writes an object into a stream.
+//
+// Encoding can be configured via the struct tag for the fields.
+// The "codec" key in struct field's tag value is the key name,
+// followed by an optional comma and options.
+// Note that the "json" key is used in the absence of the "codec" key.
+//
+// To set an option on all fields (e.g. omitempty on all fields), you
+// can create a field called _struct, and set flags on it.
+//
+// Struct values "usually" encode as maps. Each exported struct field is encoded unless:
+//    - the field's tag is "-", OR
+//    - the field is empty (empty or the zero value) and its tag specifies the "omitempty" option.
+//
+// When encoding as a map, the first string in the tag (before the comma)
+// is the map key string to use when encoding.
+//
+// However, struct values may encode as arrays. This happens when:
+//    - StructToArray Encode option is set, OR
+//    - the tag on the _struct field sets the "toarray" option
+// Note that omitempty is ignored when encoding struct values as arrays,
+// as an entry must be encoded for each field, to maintain its position.
+//
+// Values with types that implement MapBySlice are encoded as stream maps.
+//
+// The empty values (for omitempty option) are false, 0, any nil pointer
+// or interface value, and any array, slice, map, or string of length zero.
+//
+// Anonymous fields are encoded inline except:
+//    - the struct tag specifies a replacement name (first value)
+//    - the field is of an interface type
+//
+// Examples:
+//
+//      // NOTE: 'json:' can be used as struct tag key, in place 'codec:' below.
+//      type MyStruct struct {
+//          _struct bool    `codec:",omitempty"`   //set omitempty for every field
+//          Field1 string   `codec:"-"`            //skip this field
+//          Field2 int      `codec:"myName"`       //Use key "myName" in encode stream
+//          Field3 int32    `codec:",omitempty"`   //use key "Field3". Omit if empty.
+//          Field4 bool     `codec:"f4,omitempty"` //use key "f4". Omit if empty.
+//          io.Reader                              //use key "Reader".
+//          MyStruct        `codec:"my1"           //use key "my1".
+//          MyStruct                               //inline it
+//          ...
+//      }
+//
+//      type MyStruct struct {
+//          _struct bool    `codec:",toarray"`   //encode struct as an array
+//      }
+//
+// The mode of encoding is based on the type of the value. When a value is seen:
+//   - If a Selfer, call its CodecEncodeSelf method
+//   - If an extension is registered for it, call that extension function
+//   - If it implements encoding.(Binary|Text|JSON)Marshaler, call its Marshal(Binary|Text|JSON) method
+//   - Else encode it based on its reflect.Kind
+//
+// Note that struct field names and keys in map[string]XXX will be treated as symbols.
+// Some formats support symbols (e.g. binc) and will properly encode the string
+// only once in the stream, and use a tag to refer to it thereafter.
+func (e *Encoder) Encode(v interface{}) (err error) {
+	defer panicToErr(&err)
+	e.encode(v)
+	e.w.atEndOfEncode()
+	return
+}
+
+// MustEncode is like Encode, but panics if unable to Encode.
+// This provides insight to the code location that triggered the error.
+func (e *Encoder) MustEncode(v interface{}) {
+	e.encode(v)
+	e.w.atEndOfEncode()
+}
+
+func (e *Encoder) encode(iv interface{}) {
+	// if ics, ok := iv.(Selfer); ok {
+	// 	ics.CodecEncodeSelf(e)
+	// 	return
+	// }
+
+	switch v := iv.(type) {
+	case nil:
+		e.e.EncodeNil()
+	case Selfer:
+		v.CodecEncodeSelf(e)
+	case Raw:
+		e.raw(v)
+	case reflect.Value:
+		e.encodeValue(v, nil)
+
+	case string:
+		e.e.EncodeString(c_UTF8, v)
+	case bool:
+		e.e.EncodeBool(v)
+	case int:
+		e.e.EncodeInt(int64(v))
+	case int8:
+		e.e.EncodeInt(int64(v))
+	case int16:
+		e.e.EncodeInt(int64(v))
+	case int32:
+		e.e.EncodeInt(int64(v))
+	case int64:
+		e.e.EncodeInt(v)
+	case uint:
+		e.e.EncodeUint(uint64(v))
+	case uint8:
+		e.e.EncodeUint(uint64(v))
+	case uint16:
+		e.e.EncodeUint(uint64(v))
+	case uint32:
+		e.e.EncodeUint(uint64(v))
+	case uint64:
+		e.e.EncodeUint(v)
+	case float32:
+		e.e.EncodeFloat32(v)
+	case float64:
+		e.e.EncodeFloat64(v)
+
+	case []uint8:
+		e.e.EncodeStringBytes(c_RAW, v)
+
+	case *string:
+		e.e.EncodeString(c_UTF8, *v)
+	case *bool:
+		e.e.EncodeBool(*v)
+	case *int:
+		e.e.EncodeInt(int64(*v))
+	case *int8:
+		e.e.EncodeInt(int64(*v))
+	case *int16:
+		e.e.EncodeInt(int64(*v))
+	case *int32:
+		e.e.EncodeInt(int64(*v))
+	case *int64:
+		e.e.EncodeInt(*v)
+	case *uint:
+		e.e.EncodeUint(uint64(*v))
+	case *uint8:
+		e.e.EncodeUint(uint64(*v))
+	case *uint16:
+		e.e.EncodeUint(uint64(*v))
+	case *uint32:
+		e.e.EncodeUint(uint64(*v))
+	case *uint64:
+		e.e.EncodeUint(*v)
+	case *float32:
+		e.e.EncodeFloat32(*v)
+	case *float64:
+		e.e.EncodeFloat64(*v)
+
+	case *[]uint8:
+		e.e.EncodeStringBytes(c_RAW, *v)
+
+	default:
+		const checkCodecSelfer1 = true // in case T is passed, where *T is a Selfer, still checkCodecSelfer
+		if !fastpathEncodeTypeSwitch(iv, e) {
+			e.encodeI(iv, false, checkCodecSelfer1)
+		}
+	}
+}
+
+func (e *Encoder) preEncodeValue(rv reflect.Value) (rv2 reflect.Value, sptr uintptr, proceed bool) {
+	// use a goto statement instead of a recursive function for ptr/interface.
+TOP:
+	switch rv.Kind() {
+	case reflect.Ptr:
+		if rv.IsNil() {
+			e.e.EncodeNil()
+			return
+		}
+		rv = rv.Elem()
+		if e.h.CheckCircularRef && rv.Kind() == reflect.Struct {
+			// TODO: Movable pointers will be an issue here. Future problem.
+			sptr = rv.UnsafeAddr()
+			break TOP
+		}
+		goto TOP
+	case reflect.Interface:
+		if rv.IsNil() {
+			e.e.EncodeNil()
+			return
+		}
+		rv = rv.Elem()
+		goto TOP
+	case reflect.Slice, reflect.Map:
+		if rv.IsNil() {
+			e.e.EncodeNil()
+			return
+		}
+	case reflect.Invalid, reflect.Func:
+		e.e.EncodeNil()
+		return
+	}
+
+	proceed = true
+	rv2 = rv
+	return
+}
+
+func (e *Encoder) doEncodeValue(rv reflect.Value, fn *encFn, sptr uintptr,
+	checkFastpath, checkCodecSelfer bool) {
+	if sptr != 0 {
+		if (&e.ci).add(sptr) {
+			e.errorf("circular reference found: # %d", sptr)
+		}
+	}
+	if fn == nil {
+		rt := rv.Type()
+		rtid := reflect.ValueOf(rt).Pointer()
+		// fn = e.getEncFn(rtid, rt, true, true)
+		fn = e.getEncFn(rtid, rt, checkFastpath, checkCodecSelfer)
+	}
+	fn.f(&fn.i, rv)
+	if sptr != 0 {
+		(&e.ci).remove(sptr)
+	}
+}
+
+func (e *Encoder) encodeI(iv interface{}, checkFastpath, checkCodecSelfer bool) {
+	if rv, sptr, proceed := e.preEncodeValue(reflect.ValueOf(iv)); proceed {
+		e.doEncodeValue(rv, nil, sptr, checkFastpath, checkCodecSelfer)
+	}
+}
+
+func (e *Encoder) encodeValue(rv reflect.Value, fn *encFn) {
+	// if a valid fn is passed, it MUST BE for the dereferenced type of rv
+	if rv, sptr, proceed := e.preEncodeValue(rv); proceed {
+		e.doEncodeValue(rv, fn, sptr, true, true)
+	}
+}
+
+func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn *encFn) {
+	// rtid := reflect.ValueOf(rt).Pointer()
+	var ok bool
+	if useMapForCodecCache {
+		fn, ok = e.f[rtid]
+	} else {
+		for i := range e.s {
+			v := &(e.s[i])
+			if v.rtid == rtid {
+				fn, ok = &(v.fn), true
+				break
+			}
+		}
+	}
+	if ok {
+		return
+	}
+
+	if useMapForCodecCache {
+		if e.f == nil {
+			e.f = make(map[uintptr]*encFn, initCollectionCap)
+		}
+		fn = new(encFn)
+		e.f[rtid] = fn
+	} else {
+		if e.s == nil {
+			e.s = make([]encRtidFn, 0, initCollectionCap)
+		}
+		e.s = append(e.s, encRtidFn{rtid: rtid})
+		fn = &(e.s[len(e.s)-1]).fn
+	}
+
+	ti := e.h.getTypeInfo(rtid, rt)
+	fi := &(fn.i)
+	fi.e = e
+	fi.ti = ti
+
+	if checkCodecSelfer && ti.cs {
+		fn.f = (*encFnInfo).selferMarshal
+	} else if rtid == rawTypId {
+		fn.f = (*encFnInfo).raw
+	} else if rtid == rawExtTypId {
+		fn.f = (*encFnInfo).rawExt
+	} else if e.e.IsBuiltinType(rtid) {
+		fn.f = (*encFnInfo).builtin
+	} else if xfFn := e.h.getExt(rtid); xfFn != nil {
+		fi.xfTag, fi.xfFn = xfFn.tag, xfFn.ext
+		fn.f = (*encFnInfo).ext
+	} else if supportMarshalInterfaces && e.be && ti.bm {
+		fn.f = (*encFnInfo).binaryMarshal
+	} else if supportMarshalInterfaces && !e.be && e.js && ti.jm {
+		//If JSON, we should check JSONMarshal before textMarshal
+		fn.f = (*encFnInfo).jsonMarshal
+	} else if supportMarshalInterfaces && !e.be && ti.tm {
+		fn.f = (*encFnInfo).textMarshal
+	} else {
+		rk := rt.Kind()
+		if fastpathEnabled && checkFastpath && (rk == reflect.Map || rk == reflect.Slice) {
+			if rt.PkgPath() == "" { // un-named slice or map
+				if idx := fastpathAV.index(rtid); idx != -1 {
+					fn.f = fastpathAV[idx].encfn
+				}
+			} else {
+				ok = false
+				// use mapping for underlying type if there
+				var rtu reflect.Type
+				if rk == reflect.Map {
+					rtu = reflect.MapOf(rt.Key(), rt.Elem())
+				} else {
+					rtu = reflect.SliceOf(rt.Elem())
+				}
+				rtuid := reflect.ValueOf(rtu).Pointer()
+				if idx := fastpathAV.index(rtuid); idx != -1 {
+					xfnf := fastpathAV[idx].encfn
+					xrt := fastpathAV[idx].rt
+					fn.f = func(xf *encFnInfo, xrv reflect.Value) {
+						xfnf(xf, xrv.Convert(xrt))
+					}
+				}
+			}
+		}
+		if fn.f == nil {
+			switch rk {
+			case reflect.Bool:
+				fn.f = (*encFnInfo).kBool
+			case reflect.String:
+				fn.f = (*encFnInfo).kString
+			case reflect.Float64:
+				fn.f = (*encFnInfo).kFloat64
+			case reflect.Float32:
+				fn.f = (*encFnInfo).kFloat32
+			case reflect.Int, reflect.Int8, reflect.Int64, reflect.Int32, reflect.Int16:
+				fn.f = (*encFnInfo).kInt
+			case reflect.Uint8, reflect.Uint64, reflect.Uint, reflect.Uint32, reflect.Uint16, reflect.Uintptr:
+				fn.f = (*encFnInfo).kUint
+			case reflect.Invalid:
+				fn.f = (*encFnInfo).kInvalid
+			case reflect.Chan:
+				fi.seq = seqTypeChan
+				fn.f = (*encFnInfo).kSlice
+			case reflect.Slice:
+				fi.seq = seqTypeSlice
+				fn.f = (*encFnInfo).kSlice
+			case reflect.Array:
+				fi.seq = seqTypeArray
+				fn.f = (*encFnInfo).kSlice
+			case reflect.Struct:
+				fn.f = (*encFnInfo).kStruct
+				// reflect.Ptr and reflect.Interface are handled already by preEncodeValue
+				// case reflect.Ptr:
+				// 	fn.f = (*encFnInfo).kPtr
+				// case reflect.Interface:
+				// 	fn.f = (*encFnInfo).kInterface
+			case reflect.Map:
+				fn.f = (*encFnInfo).kMap
+			default:
+				fn.f = (*encFnInfo).kErr
+			}
+		}
+	}
+
+	return
+}
+
+func (e *Encoder) marshal(bs []byte, fnerr error, asis bool, c charEncoding) {
+	if fnerr != nil {
+		panic(fnerr)
+	}
+	if bs == nil {
+		e.e.EncodeNil()
+	} else if asis {
+		e.asis(bs)
+	} else {
+		e.e.EncodeStringBytes(c, bs)
+	}
+}
+
+func (e *Encoder) asis(v []byte) {
+	if e.as == nil {
+		e.w.writeb(v)
+	} else {
+		e.as.EncodeAsis(v)
+	}
+}
+
+func (e *Encoder) raw(vv Raw) {
+	v := []byte(vv)
+	if !e.h.Raw {
+		e.errorf("Raw values cannot be encoded: %v", v)
+	}
+	if e.as == nil {
+		e.w.writeb(v)
+	} else {
+		e.as.EncodeAsis(v)
+	}
+}
+
+func (e *Encoder) errorf(format string, params ...interface{}) {
+	err := fmt.Errorf(format, params...)
+	panic(err)
+}
+
+// ----------------------------------------
+
+const encStructPoolLen = 5
+
+// encStructPool is an array of sync.Pool.
+// Each element of the array pools one of encStructPool(8|16|32|64).
+// It allows the re-use of slices up to 64 in length.
+// A performance cost of encoding structs was collecting
+// which values were empty and should be omitted.
+// We needed slices of reflect.Value and string to collect them.
+// This shared pool reduces the amount of unnecessary creation we do.
+// The cost is that of locking sometimes, but sync.Pool is efficient
+// enough to reduce thread contention.
+var encStructPool [encStructPoolLen]sync.Pool
+
+func init() {
+	encStructPool[0].New = func() interface{} { return new([8]stringRv) }
+	encStructPool[1].New = func() interface{} { return new([16]stringRv) }
+	encStructPool[2].New = func() interface{} { return new([32]stringRv) }
+	encStructPool[3].New = func() interface{} { return new([64]stringRv) }
+	encStructPool[4].New = func() interface{} { return new([128]stringRv) }
+}
+
+func encStructPoolGet(newlen int) (p *sync.Pool, v interface{}, s []stringRv) {
+	// if encStructPoolLen != 5 { // constant chec, so removed at build time.
+	// 	panic(errors.New("encStructPoolLen must be equal to 4")) // defensive, in case it is changed
+	// }
+	// idxpool := newlen / 8
+	if newlen <= 8 {
+		p = &encStructPool[0]
+		v = p.Get()
+		s = v.(*[8]stringRv)[:newlen]
+	} else if newlen <= 16 {
+		p = &encStructPool[1]
+		v = p.Get()
+		s = v.(*[16]stringRv)[:newlen]
+	} else if newlen <= 32 {
+		p = &encStructPool[2]
+		v = p.Get()
+		s = v.(*[32]stringRv)[:newlen]
+	} else if newlen <= 64 {
+		p = &encStructPool[3]
+		v = p.Get()
+		s = v.(*[64]stringRv)[:newlen]
+	} else if newlen <= 128 {
+		p = &encStructPool[4]
+		v = p.Get()
+		s = v.(*[128]stringRv)[:newlen]
+	} else {
+		s = make([]stringRv, newlen)
+	}
+	return
+}
+
+// ----------------------------------------
+
+// func encErr(format string, params ...interface{}) {
+// 	doPanic(msgTagEnc, format, params...)
+// }

--- a/vendor/github.com/ugorji/go/codec/fast-path.generated.go
+++ b/vendor/github.com/ugorji/go/codec/fast-path.generated.go
@@ -1,0 +1,39352 @@
+// +build !notfastpath
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// ************************************************************
+// DO NOT EDIT.
+// THIS FILE IS AUTO-GENERATED from fast-path.go.tmpl
+// ************************************************************
+
+package codec
+
+// Fast path functions try to create a fast path encode or decode implementation
+// for common maps and slices.
+//
+// We define the functions and register then in this single file
+// so as not to pollute the encode.go and decode.go, and create a dependency in there.
+// This file can be omitted without causing a build failure.
+//
+// The advantage of fast paths is:
+//    - Many calls bypass reflection altogether
+//
+// Currently support
+//    - slice of all builtin types,
+//    - map of all builtin types to string or interface value
+//    - symmetrical maps of all builtin types (e.g. str-str, uint8-uint8)
+// This should provide adequate "typical" implementations.
+//
+// Note that fast track decode functions must handle values for which an address cannot be obtained.
+// For example:
+//   m2 := map[string]int{}
+//   p2 := []interface{}{m2}
+//   // decoding into p2 will bomb if fast track functions do not treat like unaddressable.
+//
+
+import (
+	"reflect"
+	"sort"
+)
+
+const fastpathEnabled = true
+
+const fastpathCheckNilFalse = false // for reflect
+const fastpathCheckNilTrue = true   // for type switch
+
+type fastpathT struct{}
+
+var fastpathTV fastpathT
+
+type fastpathE struct {
+	rtid  uintptr
+	rt    reflect.Type
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
+}
+
+type fastpathA [271]fastpathE
+
+func (x *fastpathA) index(rtid uintptr) int {
+	// use binary search to grab the index (adapted from sort/search.go)
+	h, i, j := 0, 0, 271 // len(x)
+	for i < j {
+		h = i + (j-i)/2
+		if x[h].rtid < rtid {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	if i < 271 && x[i].rtid == rtid {
+		return i
+	}
+	return -1
+}
+
+type fastpathAslice []fastpathE
+
+func (x fastpathAslice) Len() int           { return len(x) }
+func (x fastpathAslice) Less(i, j int) bool { return x[i].rtid < x[j].rtid }
+func (x fastpathAslice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+
+var fastpathAV fastpathA
+
+// due to possible initialization loop error, make fastpath in an init()
+func init() {
+	i := 0
+	fn := func(v interface{}, fe func(*encFnInfo, reflect.Value), fd func(*decFnInfo, reflect.Value)) (f fastpathE) {
+		xrt := reflect.TypeOf(v)
+		xptr := reflect.ValueOf(xrt).Pointer()
+		fastpathAV[i] = fastpathE{xptr, xrt, fe, fd}
+		i++
+		return
+	}
+
+	fn([]interface{}(nil), (*encFnInfo).fastpathEncSliceIntfR, (*decFnInfo).fastpathDecSliceIntfR)
+	fn([]string(nil), (*encFnInfo).fastpathEncSliceStringR, (*decFnInfo).fastpathDecSliceStringR)
+	fn([]float32(nil), (*encFnInfo).fastpathEncSliceFloat32R, (*decFnInfo).fastpathDecSliceFloat32R)
+	fn([]float64(nil), (*encFnInfo).fastpathEncSliceFloat64R, (*decFnInfo).fastpathDecSliceFloat64R)
+	fn([]uint(nil), (*encFnInfo).fastpathEncSliceUintR, (*decFnInfo).fastpathDecSliceUintR)
+	fn([]uint16(nil), (*encFnInfo).fastpathEncSliceUint16R, (*decFnInfo).fastpathDecSliceUint16R)
+	fn([]uint32(nil), (*encFnInfo).fastpathEncSliceUint32R, (*decFnInfo).fastpathDecSliceUint32R)
+	fn([]uint64(nil), (*encFnInfo).fastpathEncSliceUint64R, (*decFnInfo).fastpathDecSliceUint64R)
+	fn([]uintptr(nil), (*encFnInfo).fastpathEncSliceUintptrR, (*decFnInfo).fastpathDecSliceUintptrR)
+	fn([]int(nil), (*encFnInfo).fastpathEncSliceIntR, (*decFnInfo).fastpathDecSliceIntR)
+	fn([]int8(nil), (*encFnInfo).fastpathEncSliceInt8R, (*decFnInfo).fastpathDecSliceInt8R)
+	fn([]int16(nil), (*encFnInfo).fastpathEncSliceInt16R, (*decFnInfo).fastpathDecSliceInt16R)
+	fn([]int32(nil), (*encFnInfo).fastpathEncSliceInt32R, (*decFnInfo).fastpathDecSliceInt32R)
+	fn([]int64(nil), (*encFnInfo).fastpathEncSliceInt64R, (*decFnInfo).fastpathDecSliceInt64R)
+	fn([]bool(nil), (*encFnInfo).fastpathEncSliceBoolR, (*decFnInfo).fastpathDecSliceBoolR)
+
+	fn(map[interface{}]interface{}(nil), (*encFnInfo).fastpathEncMapIntfIntfR, (*decFnInfo).fastpathDecMapIntfIntfR)
+	fn(map[interface{}]string(nil), (*encFnInfo).fastpathEncMapIntfStringR, (*decFnInfo).fastpathDecMapIntfStringR)
+	fn(map[interface{}]uint(nil), (*encFnInfo).fastpathEncMapIntfUintR, (*decFnInfo).fastpathDecMapIntfUintR)
+	fn(map[interface{}]uint8(nil), (*encFnInfo).fastpathEncMapIntfUint8R, (*decFnInfo).fastpathDecMapIntfUint8R)
+	fn(map[interface{}]uint16(nil), (*encFnInfo).fastpathEncMapIntfUint16R, (*decFnInfo).fastpathDecMapIntfUint16R)
+	fn(map[interface{}]uint32(nil), (*encFnInfo).fastpathEncMapIntfUint32R, (*decFnInfo).fastpathDecMapIntfUint32R)
+	fn(map[interface{}]uint64(nil), (*encFnInfo).fastpathEncMapIntfUint64R, (*decFnInfo).fastpathDecMapIntfUint64R)
+	fn(map[interface{}]uintptr(nil), (*encFnInfo).fastpathEncMapIntfUintptrR, (*decFnInfo).fastpathDecMapIntfUintptrR)
+	fn(map[interface{}]int(nil), (*encFnInfo).fastpathEncMapIntfIntR, (*decFnInfo).fastpathDecMapIntfIntR)
+	fn(map[interface{}]int8(nil), (*encFnInfo).fastpathEncMapIntfInt8R, (*decFnInfo).fastpathDecMapIntfInt8R)
+	fn(map[interface{}]int16(nil), (*encFnInfo).fastpathEncMapIntfInt16R, (*decFnInfo).fastpathDecMapIntfInt16R)
+	fn(map[interface{}]int32(nil), (*encFnInfo).fastpathEncMapIntfInt32R, (*decFnInfo).fastpathDecMapIntfInt32R)
+	fn(map[interface{}]int64(nil), (*encFnInfo).fastpathEncMapIntfInt64R, (*decFnInfo).fastpathDecMapIntfInt64R)
+	fn(map[interface{}]float32(nil), (*encFnInfo).fastpathEncMapIntfFloat32R, (*decFnInfo).fastpathDecMapIntfFloat32R)
+	fn(map[interface{}]float64(nil), (*encFnInfo).fastpathEncMapIntfFloat64R, (*decFnInfo).fastpathDecMapIntfFloat64R)
+	fn(map[interface{}]bool(nil), (*encFnInfo).fastpathEncMapIntfBoolR, (*decFnInfo).fastpathDecMapIntfBoolR)
+	fn(map[string]interface{}(nil), (*encFnInfo).fastpathEncMapStringIntfR, (*decFnInfo).fastpathDecMapStringIntfR)
+	fn(map[string]string(nil), (*encFnInfo).fastpathEncMapStringStringR, (*decFnInfo).fastpathDecMapStringStringR)
+	fn(map[string]uint(nil), (*encFnInfo).fastpathEncMapStringUintR, (*decFnInfo).fastpathDecMapStringUintR)
+	fn(map[string]uint8(nil), (*encFnInfo).fastpathEncMapStringUint8R, (*decFnInfo).fastpathDecMapStringUint8R)
+	fn(map[string]uint16(nil), (*encFnInfo).fastpathEncMapStringUint16R, (*decFnInfo).fastpathDecMapStringUint16R)
+	fn(map[string]uint32(nil), (*encFnInfo).fastpathEncMapStringUint32R, (*decFnInfo).fastpathDecMapStringUint32R)
+	fn(map[string]uint64(nil), (*encFnInfo).fastpathEncMapStringUint64R, (*decFnInfo).fastpathDecMapStringUint64R)
+	fn(map[string]uintptr(nil), (*encFnInfo).fastpathEncMapStringUintptrR, (*decFnInfo).fastpathDecMapStringUintptrR)
+	fn(map[string]int(nil), (*encFnInfo).fastpathEncMapStringIntR, (*decFnInfo).fastpathDecMapStringIntR)
+	fn(map[string]int8(nil), (*encFnInfo).fastpathEncMapStringInt8R, (*decFnInfo).fastpathDecMapStringInt8R)
+	fn(map[string]int16(nil), (*encFnInfo).fastpathEncMapStringInt16R, (*decFnInfo).fastpathDecMapStringInt16R)
+	fn(map[string]int32(nil), (*encFnInfo).fastpathEncMapStringInt32R, (*decFnInfo).fastpathDecMapStringInt32R)
+	fn(map[string]int64(nil), (*encFnInfo).fastpathEncMapStringInt64R, (*decFnInfo).fastpathDecMapStringInt64R)
+	fn(map[string]float32(nil), (*encFnInfo).fastpathEncMapStringFloat32R, (*decFnInfo).fastpathDecMapStringFloat32R)
+	fn(map[string]float64(nil), (*encFnInfo).fastpathEncMapStringFloat64R, (*decFnInfo).fastpathDecMapStringFloat64R)
+	fn(map[string]bool(nil), (*encFnInfo).fastpathEncMapStringBoolR, (*decFnInfo).fastpathDecMapStringBoolR)
+	fn(map[float32]interface{}(nil), (*encFnInfo).fastpathEncMapFloat32IntfR, (*decFnInfo).fastpathDecMapFloat32IntfR)
+	fn(map[float32]string(nil), (*encFnInfo).fastpathEncMapFloat32StringR, (*decFnInfo).fastpathDecMapFloat32StringR)
+	fn(map[float32]uint(nil), (*encFnInfo).fastpathEncMapFloat32UintR, (*decFnInfo).fastpathDecMapFloat32UintR)
+	fn(map[float32]uint8(nil), (*encFnInfo).fastpathEncMapFloat32Uint8R, (*decFnInfo).fastpathDecMapFloat32Uint8R)
+	fn(map[float32]uint16(nil), (*encFnInfo).fastpathEncMapFloat32Uint16R, (*decFnInfo).fastpathDecMapFloat32Uint16R)
+	fn(map[float32]uint32(nil), (*encFnInfo).fastpathEncMapFloat32Uint32R, (*decFnInfo).fastpathDecMapFloat32Uint32R)
+	fn(map[float32]uint64(nil), (*encFnInfo).fastpathEncMapFloat32Uint64R, (*decFnInfo).fastpathDecMapFloat32Uint64R)
+	fn(map[float32]uintptr(nil), (*encFnInfo).fastpathEncMapFloat32UintptrR, (*decFnInfo).fastpathDecMapFloat32UintptrR)
+	fn(map[float32]int(nil), (*encFnInfo).fastpathEncMapFloat32IntR, (*decFnInfo).fastpathDecMapFloat32IntR)
+	fn(map[float32]int8(nil), (*encFnInfo).fastpathEncMapFloat32Int8R, (*decFnInfo).fastpathDecMapFloat32Int8R)
+	fn(map[float32]int16(nil), (*encFnInfo).fastpathEncMapFloat32Int16R, (*decFnInfo).fastpathDecMapFloat32Int16R)
+	fn(map[float32]int32(nil), (*encFnInfo).fastpathEncMapFloat32Int32R, (*decFnInfo).fastpathDecMapFloat32Int32R)
+	fn(map[float32]int64(nil), (*encFnInfo).fastpathEncMapFloat32Int64R, (*decFnInfo).fastpathDecMapFloat32Int64R)
+	fn(map[float32]float32(nil), (*encFnInfo).fastpathEncMapFloat32Float32R, (*decFnInfo).fastpathDecMapFloat32Float32R)
+	fn(map[float32]float64(nil), (*encFnInfo).fastpathEncMapFloat32Float64R, (*decFnInfo).fastpathDecMapFloat32Float64R)
+	fn(map[float32]bool(nil), (*encFnInfo).fastpathEncMapFloat32BoolR, (*decFnInfo).fastpathDecMapFloat32BoolR)
+	fn(map[float64]interface{}(nil), (*encFnInfo).fastpathEncMapFloat64IntfR, (*decFnInfo).fastpathDecMapFloat64IntfR)
+	fn(map[float64]string(nil), (*encFnInfo).fastpathEncMapFloat64StringR, (*decFnInfo).fastpathDecMapFloat64StringR)
+	fn(map[float64]uint(nil), (*encFnInfo).fastpathEncMapFloat64UintR, (*decFnInfo).fastpathDecMapFloat64UintR)
+	fn(map[float64]uint8(nil), (*encFnInfo).fastpathEncMapFloat64Uint8R, (*decFnInfo).fastpathDecMapFloat64Uint8R)
+	fn(map[float64]uint16(nil), (*encFnInfo).fastpathEncMapFloat64Uint16R, (*decFnInfo).fastpathDecMapFloat64Uint16R)
+	fn(map[float64]uint32(nil), (*encFnInfo).fastpathEncMapFloat64Uint32R, (*decFnInfo).fastpathDecMapFloat64Uint32R)
+	fn(map[float64]uint64(nil), (*encFnInfo).fastpathEncMapFloat64Uint64R, (*decFnInfo).fastpathDecMapFloat64Uint64R)
+	fn(map[float64]uintptr(nil), (*encFnInfo).fastpathEncMapFloat64UintptrR, (*decFnInfo).fastpathDecMapFloat64UintptrR)
+	fn(map[float64]int(nil), (*encFnInfo).fastpathEncMapFloat64IntR, (*decFnInfo).fastpathDecMapFloat64IntR)
+	fn(map[float64]int8(nil), (*encFnInfo).fastpathEncMapFloat64Int8R, (*decFnInfo).fastpathDecMapFloat64Int8R)
+	fn(map[float64]int16(nil), (*encFnInfo).fastpathEncMapFloat64Int16R, (*decFnInfo).fastpathDecMapFloat64Int16R)
+	fn(map[float64]int32(nil), (*encFnInfo).fastpathEncMapFloat64Int32R, (*decFnInfo).fastpathDecMapFloat64Int32R)
+	fn(map[float64]int64(nil), (*encFnInfo).fastpathEncMapFloat64Int64R, (*decFnInfo).fastpathDecMapFloat64Int64R)
+	fn(map[float64]float32(nil), (*encFnInfo).fastpathEncMapFloat64Float32R, (*decFnInfo).fastpathDecMapFloat64Float32R)
+	fn(map[float64]float64(nil), (*encFnInfo).fastpathEncMapFloat64Float64R, (*decFnInfo).fastpathDecMapFloat64Float64R)
+	fn(map[float64]bool(nil), (*encFnInfo).fastpathEncMapFloat64BoolR, (*decFnInfo).fastpathDecMapFloat64BoolR)
+	fn(map[uint]interface{}(nil), (*encFnInfo).fastpathEncMapUintIntfR, (*decFnInfo).fastpathDecMapUintIntfR)
+	fn(map[uint]string(nil), (*encFnInfo).fastpathEncMapUintStringR, (*decFnInfo).fastpathDecMapUintStringR)
+	fn(map[uint]uint(nil), (*encFnInfo).fastpathEncMapUintUintR, (*decFnInfo).fastpathDecMapUintUintR)
+	fn(map[uint]uint8(nil), (*encFnInfo).fastpathEncMapUintUint8R, (*decFnInfo).fastpathDecMapUintUint8R)
+	fn(map[uint]uint16(nil), (*encFnInfo).fastpathEncMapUintUint16R, (*decFnInfo).fastpathDecMapUintUint16R)
+	fn(map[uint]uint32(nil), (*encFnInfo).fastpathEncMapUintUint32R, (*decFnInfo).fastpathDecMapUintUint32R)
+	fn(map[uint]uint64(nil), (*encFnInfo).fastpathEncMapUintUint64R, (*decFnInfo).fastpathDecMapUintUint64R)
+	fn(map[uint]uintptr(nil), (*encFnInfo).fastpathEncMapUintUintptrR, (*decFnInfo).fastpathDecMapUintUintptrR)
+	fn(map[uint]int(nil), (*encFnInfo).fastpathEncMapUintIntR, (*decFnInfo).fastpathDecMapUintIntR)
+	fn(map[uint]int8(nil), (*encFnInfo).fastpathEncMapUintInt8R, (*decFnInfo).fastpathDecMapUintInt8R)
+	fn(map[uint]int16(nil), (*encFnInfo).fastpathEncMapUintInt16R, (*decFnInfo).fastpathDecMapUintInt16R)
+	fn(map[uint]int32(nil), (*encFnInfo).fastpathEncMapUintInt32R, (*decFnInfo).fastpathDecMapUintInt32R)
+	fn(map[uint]int64(nil), (*encFnInfo).fastpathEncMapUintInt64R, (*decFnInfo).fastpathDecMapUintInt64R)
+	fn(map[uint]float32(nil), (*encFnInfo).fastpathEncMapUintFloat32R, (*decFnInfo).fastpathDecMapUintFloat32R)
+	fn(map[uint]float64(nil), (*encFnInfo).fastpathEncMapUintFloat64R, (*decFnInfo).fastpathDecMapUintFloat64R)
+	fn(map[uint]bool(nil), (*encFnInfo).fastpathEncMapUintBoolR, (*decFnInfo).fastpathDecMapUintBoolR)
+	fn(map[uint8]interface{}(nil), (*encFnInfo).fastpathEncMapUint8IntfR, (*decFnInfo).fastpathDecMapUint8IntfR)
+	fn(map[uint8]string(nil), (*encFnInfo).fastpathEncMapUint8StringR, (*decFnInfo).fastpathDecMapUint8StringR)
+	fn(map[uint8]uint(nil), (*encFnInfo).fastpathEncMapUint8UintR, (*decFnInfo).fastpathDecMapUint8UintR)
+	fn(map[uint8]uint8(nil), (*encFnInfo).fastpathEncMapUint8Uint8R, (*decFnInfo).fastpathDecMapUint8Uint8R)
+	fn(map[uint8]uint16(nil), (*encFnInfo).fastpathEncMapUint8Uint16R, (*decFnInfo).fastpathDecMapUint8Uint16R)
+	fn(map[uint8]uint32(nil), (*encFnInfo).fastpathEncMapUint8Uint32R, (*decFnInfo).fastpathDecMapUint8Uint32R)
+	fn(map[uint8]uint64(nil), (*encFnInfo).fastpathEncMapUint8Uint64R, (*decFnInfo).fastpathDecMapUint8Uint64R)
+	fn(map[uint8]uintptr(nil), (*encFnInfo).fastpathEncMapUint8UintptrR, (*decFnInfo).fastpathDecMapUint8UintptrR)
+	fn(map[uint8]int(nil), (*encFnInfo).fastpathEncMapUint8IntR, (*decFnInfo).fastpathDecMapUint8IntR)
+	fn(map[uint8]int8(nil), (*encFnInfo).fastpathEncMapUint8Int8R, (*decFnInfo).fastpathDecMapUint8Int8R)
+	fn(map[uint8]int16(nil), (*encFnInfo).fastpathEncMapUint8Int16R, (*decFnInfo).fastpathDecMapUint8Int16R)
+	fn(map[uint8]int32(nil), (*encFnInfo).fastpathEncMapUint8Int32R, (*decFnInfo).fastpathDecMapUint8Int32R)
+	fn(map[uint8]int64(nil), (*encFnInfo).fastpathEncMapUint8Int64R, (*decFnInfo).fastpathDecMapUint8Int64R)
+	fn(map[uint8]float32(nil), (*encFnInfo).fastpathEncMapUint8Float32R, (*decFnInfo).fastpathDecMapUint8Float32R)
+	fn(map[uint8]float64(nil), (*encFnInfo).fastpathEncMapUint8Float64R, (*decFnInfo).fastpathDecMapUint8Float64R)
+	fn(map[uint8]bool(nil), (*encFnInfo).fastpathEncMapUint8BoolR, (*decFnInfo).fastpathDecMapUint8BoolR)
+	fn(map[uint16]interface{}(nil), (*encFnInfo).fastpathEncMapUint16IntfR, (*decFnInfo).fastpathDecMapUint16IntfR)
+	fn(map[uint16]string(nil), (*encFnInfo).fastpathEncMapUint16StringR, (*decFnInfo).fastpathDecMapUint16StringR)
+	fn(map[uint16]uint(nil), (*encFnInfo).fastpathEncMapUint16UintR, (*decFnInfo).fastpathDecMapUint16UintR)
+	fn(map[uint16]uint8(nil), (*encFnInfo).fastpathEncMapUint16Uint8R, (*decFnInfo).fastpathDecMapUint16Uint8R)
+	fn(map[uint16]uint16(nil), (*encFnInfo).fastpathEncMapUint16Uint16R, (*decFnInfo).fastpathDecMapUint16Uint16R)
+	fn(map[uint16]uint32(nil), (*encFnInfo).fastpathEncMapUint16Uint32R, (*decFnInfo).fastpathDecMapUint16Uint32R)
+	fn(map[uint16]uint64(nil), (*encFnInfo).fastpathEncMapUint16Uint64R, (*decFnInfo).fastpathDecMapUint16Uint64R)
+	fn(map[uint16]uintptr(nil), (*encFnInfo).fastpathEncMapUint16UintptrR, (*decFnInfo).fastpathDecMapUint16UintptrR)
+	fn(map[uint16]int(nil), (*encFnInfo).fastpathEncMapUint16IntR, (*decFnInfo).fastpathDecMapUint16IntR)
+	fn(map[uint16]int8(nil), (*encFnInfo).fastpathEncMapUint16Int8R, (*decFnInfo).fastpathDecMapUint16Int8R)
+	fn(map[uint16]int16(nil), (*encFnInfo).fastpathEncMapUint16Int16R, (*decFnInfo).fastpathDecMapUint16Int16R)
+	fn(map[uint16]int32(nil), (*encFnInfo).fastpathEncMapUint16Int32R, (*decFnInfo).fastpathDecMapUint16Int32R)
+	fn(map[uint16]int64(nil), (*encFnInfo).fastpathEncMapUint16Int64R, (*decFnInfo).fastpathDecMapUint16Int64R)
+	fn(map[uint16]float32(nil), (*encFnInfo).fastpathEncMapUint16Float32R, (*decFnInfo).fastpathDecMapUint16Float32R)
+	fn(map[uint16]float64(nil), (*encFnInfo).fastpathEncMapUint16Float64R, (*decFnInfo).fastpathDecMapUint16Float64R)
+	fn(map[uint16]bool(nil), (*encFnInfo).fastpathEncMapUint16BoolR, (*decFnInfo).fastpathDecMapUint16BoolR)
+	fn(map[uint32]interface{}(nil), (*encFnInfo).fastpathEncMapUint32IntfR, (*decFnInfo).fastpathDecMapUint32IntfR)
+	fn(map[uint32]string(nil), (*encFnInfo).fastpathEncMapUint32StringR, (*decFnInfo).fastpathDecMapUint32StringR)
+	fn(map[uint32]uint(nil), (*encFnInfo).fastpathEncMapUint32UintR, (*decFnInfo).fastpathDecMapUint32UintR)
+	fn(map[uint32]uint8(nil), (*encFnInfo).fastpathEncMapUint32Uint8R, (*decFnInfo).fastpathDecMapUint32Uint8R)
+	fn(map[uint32]uint16(nil), (*encFnInfo).fastpathEncMapUint32Uint16R, (*decFnInfo).fastpathDecMapUint32Uint16R)
+	fn(map[uint32]uint32(nil), (*encFnInfo).fastpathEncMapUint32Uint32R, (*decFnInfo).fastpathDecMapUint32Uint32R)
+	fn(map[uint32]uint64(nil), (*encFnInfo).fastpathEncMapUint32Uint64R, (*decFnInfo).fastpathDecMapUint32Uint64R)
+	fn(map[uint32]uintptr(nil), (*encFnInfo).fastpathEncMapUint32UintptrR, (*decFnInfo).fastpathDecMapUint32UintptrR)
+	fn(map[uint32]int(nil), (*encFnInfo).fastpathEncMapUint32IntR, (*decFnInfo).fastpathDecMapUint32IntR)
+	fn(map[uint32]int8(nil), (*encFnInfo).fastpathEncMapUint32Int8R, (*decFnInfo).fastpathDecMapUint32Int8R)
+	fn(map[uint32]int16(nil), (*encFnInfo).fastpathEncMapUint32Int16R, (*decFnInfo).fastpathDecMapUint32Int16R)
+	fn(map[uint32]int32(nil), (*encFnInfo).fastpathEncMapUint32Int32R, (*decFnInfo).fastpathDecMapUint32Int32R)
+	fn(map[uint32]int64(nil), (*encFnInfo).fastpathEncMapUint32Int64R, (*decFnInfo).fastpathDecMapUint32Int64R)
+	fn(map[uint32]float32(nil), (*encFnInfo).fastpathEncMapUint32Float32R, (*decFnInfo).fastpathDecMapUint32Float32R)
+	fn(map[uint32]float64(nil), (*encFnInfo).fastpathEncMapUint32Float64R, (*decFnInfo).fastpathDecMapUint32Float64R)
+	fn(map[uint32]bool(nil), (*encFnInfo).fastpathEncMapUint32BoolR, (*decFnInfo).fastpathDecMapUint32BoolR)
+	fn(map[uint64]interface{}(nil), (*encFnInfo).fastpathEncMapUint64IntfR, (*decFnInfo).fastpathDecMapUint64IntfR)
+	fn(map[uint64]string(nil), (*encFnInfo).fastpathEncMapUint64StringR, (*decFnInfo).fastpathDecMapUint64StringR)
+	fn(map[uint64]uint(nil), (*encFnInfo).fastpathEncMapUint64UintR, (*decFnInfo).fastpathDecMapUint64UintR)
+	fn(map[uint64]uint8(nil), (*encFnInfo).fastpathEncMapUint64Uint8R, (*decFnInfo).fastpathDecMapUint64Uint8R)
+	fn(map[uint64]uint16(nil), (*encFnInfo).fastpathEncMapUint64Uint16R, (*decFnInfo).fastpathDecMapUint64Uint16R)
+	fn(map[uint64]uint32(nil), (*encFnInfo).fastpathEncMapUint64Uint32R, (*decFnInfo).fastpathDecMapUint64Uint32R)
+	fn(map[uint64]uint64(nil), (*encFnInfo).fastpathEncMapUint64Uint64R, (*decFnInfo).fastpathDecMapUint64Uint64R)
+	fn(map[uint64]uintptr(nil), (*encFnInfo).fastpathEncMapUint64UintptrR, (*decFnInfo).fastpathDecMapUint64UintptrR)
+	fn(map[uint64]int(nil), (*encFnInfo).fastpathEncMapUint64IntR, (*decFnInfo).fastpathDecMapUint64IntR)
+	fn(map[uint64]int8(nil), (*encFnInfo).fastpathEncMapUint64Int8R, (*decFnInfo).fastpathDecMapUint64Int8R)
+	fn(map[uint64]int16(nil), (*encFnInfo).fastpathEncMapUint64Int16R, (*decFnInfo).fastpathDecMapUint64Int16R)
+	fn(map[uint64]int32(nil), (*encFnInfo).fastpathEncMapUint64Int32R, (*decFnInfo).fastpathDecMapUint64Int32R)
+	fn(map[uint64]int64(nil), (*encFnInfo).fastpathEncMapUint64Int64R, (*decFnInfo).fastpathDecMapUint64Int64R)
+	fn(map[uint64]float32(nil), (*encFnInfo).fastpathEncMapUint64Float32R, (*decFnInfo).fastpathDecMapUint64Float32R)
+	fn(map[uint64]float64(nil), (*encFnInfo).fastpathEncMapUint64Float64R, (*decFnInfo).fastpathDecMapUint64Float64R)
+	fn(map[uint64]bool(nil), (*encFnInfo).fastpathEncMapUint64BoolR, (*decFnInfo).fastpathDecMapUint64BoolR)
+	fn(map[uintptr]interface{}(nil), (*encFnInfo).fastpathEncMapUintptrIntfR, (*decFnInfo).fastpathDecMapUintptrIntfR)
+	fn(map[uintptr]string(nil), (*encFnInfo).fastpathEncMapUintptrStringR, (*decFnInfo).fastpathDecMapUintptrStringR)
+	fn(map[uintptr]uint(nil), (*encFnInfo).fastpathEncMapUintptrUintR, (*decFnInfo).fastpathDecMapUintptrUintR)
+	fn(map[uintptr]uint8(nil), (*encFnInfo).fastpathEncMapUintptrUint8R, (*decFnInfo).fastpathDecMapUintptrUint8R)
+	fn(map[uintptr]uint16(nil), (*encFnInfo).fastpathEncMapUintptrUint16R, (*decFnInfo).fastpathDecMapUintptrUint16R)
+	fn(map[uintptr]uint32(nil), (*encFnInfo).fastpathEncMapUintptrUint32R, (*decFnInfo).fastpathDecMapUintptrUint32R)
+	fn(map[uintptr]uint64(nil), (*encFnInfo).fastpathEncMapUintptrUint64R, (*decFnInfo).fastpathDecMapUintptrUint64R)
+	fn(map[uintptr]uintptr(nil), (*encFnInfo).fastpathEncMapUintptrUintptrR, (*decFnInfo).fastpathDecMapUintptrUintptrR)
+	fn(map[uintptr]int(nil), (*encFnInfo).fastpathEncMapUintptrIntR, (*decFnInfo).fastpathDecMapUintptrIntR)
+	fn(map[uintptr]int8(nil), (*encFnInfo).fastpathEncMapUintptrInt8R, (*decFnInfo).fastpathDecMapUintptrInt8R)
+	fn(map[uintptr]int16(nil), (*encFnInfo).fastpathEncMapUintptrInt16R, (*decFnInfo).fastpathDecMapUintptrInt16R)
+	fn(map[uintptr]int32(nil), (*encFnInfo).fastpathEncMapUintptrInt32R, (*decFnInfo).fastpathDecMapUintptrInt32R)
+	fn(map[uintptr]int64(nil), (*encFnInfo).fastpathEncMapUintptrInt64R, (*decFnInfo).fastpathDecMapUintptrInt64R)
+	fn(map[uintptr]float32(nil), (*encFnInfo).fastpathEncMapUintptrFloat32R, (*decFnInfo).fastpathDecMapUintptrFloat32R)
+	fn(map[uintptr]float64(nil), (*encFnInfo).fastpathEncMapUintptrFloat64R, (*decFnInfo).fastpathDecMapUintptrFloat64R)
+	fn(map[uintptr]bool(nil), (*encFnInfo).fastpathEncMapUintptrBoolR, (*decFnInfo).fastpathDecMapUintptrBoolR)
+	fn(map[int]interface{}(nil), (*encFnInfo).fastpathEncMapIntIntfR, (*decFnInfo).fastpathDecMapIntIntfR)
+	fn(map[int]string(nil), (*encFnInfo).fastpathEncMapIntStringR, (*decFnInfo).fastpathDecMapIntStringR)
+	fn(map[int]uint(nil), (*encFnInfo).fastpathEncMapIntUintR, (*decFnInfo).fastpathDecMapIntUintR)
+	fn(map[int]uint8(nil), (*encFnInfo).fastpathEncMapIntUint8R, (*decFnInfo).fastpathDecMapIntUint8R)
+	fn(map[int]uint16(nil), (*encFnInfo).fastpathEncMapIntUint16R, (*decFnInfo).fastpathDecMapIntUint16R)
+	fn(map[int]uint32(nil), (*encFnInfo).fastpathEncMapIntUint32R, (*decFnInfo).fastpathDecMapIntUint32R)
+	fn(map[int]uint64(nil), (*encFnInfo).fastpathEncMapIntUint64R, (*decFnInfo).fastpathDecMapIntUint64R)
+	fn(map[int]uintptr(nil), (*encFnInfo).fastpathEncMapIntUintptrR, (*decFnInfo).fastpathDecMapIntUintptrR)
+	fn(map[int]int(nil), (*encFnInfo).fastpathEncMapIntIntR, (*decFnInfo).fastpathDecMapIntIntR)
+	fn(map[int]int8(nil), (*encFnInfo).fastpathEncMapIntInt8R, (*decFnInfo).fastpathDecMapIntInt8R)
+	fn(map[int]int16(nil), (*encFnInfo).fastpathEncMapIntInt16R, (*decFnInfo).fastpathDecMapIntInt16R)
+	fn(map[int]int32(nil), (*encFnInfo).fastpathEncMapIntInt32R, (*decFnInfo).fastpathDecMapIntInt32R)
+	fn(map[int]int64(nil), (*encFnInfo).fastpathEncMapIntInt64R, (*decFnInfo).fastpathDecMapIntInt64R)
+	fn(map[int]float32(nil), (*encFnInfo).fastpathEncMapIntFloat32R, (*decFnInfo).fastpathDecMapIntFloat32R)
+	fn(map[int]float64(nil), (*encFnInfo).fastpathEncMapIntFloat64R, (*decFnInfo).fastpathDecMapIntFloat64R)
+	fn(map[int]bool(nil), (*encFnInfo).fastpathEncMapIntBoolR, (*decFnInfo).fastpathDecMapIntBoolR)
+	fn(map[int8]interface{}(nil), (*encFnInfo).fastpathEncMapInt8IntfR, (*decFnInfo).fastpathDecMapInt8IntfR)
+	fn(map[int8]string(nil), (*encFnInfo).fastpathEncMapInt8StringR, (*decFnInfo).fastpathDecMapInt8StringR)
+	fn(map[int8]uint(nil), (*encFnInfo).fastpathEncMapInt8UintR, (*decFnInfo).fastpathDecMapInt8UintR)
+	fn(map[int8]uint8(nil), (*encFnInfo).fastpathEncMapInt8Uint8R, (*decFnInfo).fastpathDecMapInt8Uint8R)
+	fn(map[int8]uint16(nil), (*encFnInfo).fastpathEncMapInt8Uint16R, (*decFnInfo).fastpathDecMapInt8Uint16R)
+	fn(map[int8]uint32(nil), (*encFnInfo).fastpathEncMapInt8Uint32R, (*decFnInfo).fastpathDecMapInt8Uint32R)
+	fn(map[int8]uint64(nil), (*encFnInfo).fastpathEncMapInt8Uint64R, (*decFnInfo).fastpathDecMapInt8Uint64R)
+	fn(map[int8]uintptr(nil), (*encFnInfo).fastpathEncMapInt8UintptrR, (*decFnInfo).fastpathDecMapInt8UintptrR)
+	fn(map[int8]int(nil), (*encFnInfo).fastpathEncMapInt8IntR, (*decFnInfo).fastpathDecMapInt8IntR)
+	fn(map[int8]int8(nil), (*encFnInfo).fastpathEncMapInt8Int8R, (*decFnInfo).fastpathDecMapInt8Int8R)
+	fn(map[int8]int16(nil), (*encFnInfo).fastpathEncMapInt8Int16R, (*decFnInfo).fastpathDecMapInt8Int16R)
+	fn(map[int8]int32(nil), (*encFnInfo).fastpathEncMapInt8Int32R, (*decFnInfo).fastpathDecMapInt8Int32R)
+	fn(map[int8]int64(nil), (*encFnInfo).fastpathEncMapInt8Int64R, (*decFnInfo).fastpathDecMapInt8Int64R)
+	fn(map[int8]float32(nil), (*encFnInfo).fastpathEncMapInt8Float32R, (*decFnInfo).fastpathDecMapInt8Float32R)
+	fn(map[int8]float64(nil), (*encFnInfo).fastpathEncMapInt8Float64R, (*decFnInfo).fastpathDecMapInt8Float64R)
+	fn(map[int8]bool(nil), (*encFnInfo).fastpathEncMapInt8BoolR, (*decFnInfo).fastpathDecMapInt8BoolR)
+	fn(map[int16]interface{}(nil), (*encFnInfo).fastpathEncMapInt16IntfR, (*decFnInfo).fastpathDecMapInt16IntfR)
+	fn(map[int16]string(nil), (*encFnInfo).fastpathEncMapInt16StringR, (*decFnInfo).fastpathDecMapInt16StringR)
+	fn(map[int16]uint(nil), (*encFnInfo).fastpathEncMapInt16UintR, (*decFnInfo).fastpathDecMapInt16UintR)
+	fn(map[int16]uint8(nil), (*encFnInfo).fastpathEncMapInt16Uint8R, (*decFnInfo).fastpathDecMapInt16Uint8R)
+	fn(map[int16]uint16(nil), (*encFnInfo).fastpathEncMapInt16Uint16R, (*decFnInfo).fastpathDecMapInt16Uint16R)
+	fn(map[int16]uint32(nil), (*encFnInfo).fastpathEncMapInt16Uint32R, (*decFnInfo).fastpathDecMapInt16Uint32R)
+	fn(map[int16]uint64(nil), (*encFnInfo).fastpathEncMapInt16Uint64R, (*decFnInfo).fastpathDecMapInt16Uint64R)
+	fn(map[int16]uintptr(nil), (*encFnInfo).fastpathEncMapInt16UintptrR, (*decFnInfo).fastpathDecMapInt16UintptrR)
+	fn(map[int16]int(nil), (*encFnInfo).fastpathEncMapInt16IntR, (*decFnInfo).fastpathDecMapInt16IntR)
+	fn(map[int16]int8(nil), (*encFnInfo).fastpathEncMapInt16Int8R, (*decFnInfo).fastpathDecMapInt16Int8R)
+	fn(map[int16]int16(nil), (*encFnInfo).fastpathEncMapInt16Int16R, (*decFnInfo).fastpathDecMapInt16Int16R)
+	fn(map[int16]int32(nil), (*encFnInfo).fastpathEncMapInt16Int32R, (*decFnInfo).fastpathDecMapInt16Int32R)
+	fn(map[int16]int64(nil), (*encFnInfo).fastpathEncMapInt16Int64R, (*decFnInfo).fastpathDecMapInt16Int64R)
+	fn(map[int16]float32(nil), (*encFnInfo).fastpathEncMapInt16Float32R, (*decFnInfo).fastpathDecMapInt16Float32R)
+	fn(map[int16]float64(nil), (*encFnInfo).fastpathEncMapInt16Float64R, (*decFnInfo).fastpathDecMapInt16Float64R)
+	fn(map[int16]bool(nil), (*encFnInfo).fastpathEncMapInt16BoolR, (*decFnInfo).fastpathDecMapInt16BoolR)
+	fn(map[int32]interface{}(nil), (*encFnInfo).fastpathEncMapInt32IntfR, (*decFnInfo).fastpathDecMapInt32IntfR)
+	fn(map[int32]string(nil), (*encFnInfo).fastpathEncMapInt32StringR, (*decFnInfo).fastpathDecMapInt32StringR)
+	fn(map[int32]uint(nil), (*encFnInfo).fastpathEncMapInt32UintR, (*decFnInfo).fastpathDecMapInt32UintR)
+	fn(map[int32]uint8(nil), (*encFnInfo).fastpathEncMapInt32Uint8R, (*decFnInfo).fastpathDecMapInt32Uint8R)
+	fn(map[int32]uint16(nil), (*encFnInfo).fastpathEncMapInt32Uint16R, (*decFnInfo).fastpathDecMapInt32Uint16R)
+	fn(map[int32]uint32(nil), (*encFnInfo).fastpathEncMapInt32Uint32R, (*decFnInfo).fastpathDecMapInt32Uint32R)
+	fn(map[int32]uint64(nil), (*encFnInfo).fastpathEncMapInt32Uint64R, (*decFnInfo).fastpathDecMapInt32Uint64R)
+	fn(map[int32]uintptr(nil), (*encFnInfo).fastpathEncMapInt32UintptrR, (*decFnInfo).fastpathDecMapInt32UintptrR)
+	fn(map[int32]int(nil), (*encFnInfo).fastpathEncMapInt32IntR, (*decFnInfo).fastpathDecMapInt32IntR)
+	fn(map[int32]int8(nil), (*encFnInfo).fastpathEncMapInt32Int8R, (*decFnInfo).fastpathDecMapInt32Int8R)
+	fn(map[int32]int16(nil), (*encFnInfo).fastpathEncMapInt32Int16R, (*decFnInfo).fastpathDecMapInt32Int16R)
+	fn(map[int32]int32(nil), (*encFnInfo).fastpathEncMapInt32Int32R, (*decFnInfo).fastpathDecMapInt32Int32R)
+	fn(map[int32]int64(nil), (*encFnInfo).fastpathEncMapInt32Int64R, (*decFnInfo).fastpathDecMapInt32Int64R)
+	fn(map[int32]float32(nil), (*encFnInfo).fastpathEncMapInt32Float32R, (*decFnInfo).fastpathDecMapInt32Float32R)
+	fn(map[int32]float64(nil), (*encFnInfo).fastpathEncMapInt32Float64R, (*decFnInfo).fastpathDecMapInt32Float64R)
+	fn(map[int32]bool(nil), (*encFnInfo).fastpathEncMapInt32BoolR, (*decFnInfo).fastpathDecMapInt32BoolR)
+	fn(map[int64]interface{}(nil), (*encFnInfo).fastpathEncMapInt64IntfR, (*decFnInfo).fastpathDecMapInt64IntfR)
+	fn(map[int64]string(nil), (*encFnInfo).fastpathEncMapInt64StringR, (*decFnInfo).fastpathDecMapInt64StringR)
+	fn(map[int64]uint(nil), (*encFnInfo).fastpathEncMapInt64UintR, (*decFnInfo).fastpathDecMapInt64UintR)
+	fn(map[int64]uint8(nil), (*encFnInfo).fastpathEncMapInt64Uint8R, (*decFnInfo).fastpathDecMapInt64Uint8R)
+	fn(map[int64]uint16(nil), (*encFnInfo).fastpathEncMapInt64Uint16R, (*decFnInfo).fastpathDecMapInt64Uint16R)
+	fn(map[int64]uint32(nil), (*encFnInfo).fastpathEncMapInt64Uint32R, (*decFnInfo).fastpathDecMapInt64Uint32R)
+	fn(map[int64]uint64(nil), (*encFnInfo).fastpathEncMapInt64Uint64R, (*decFnInfo).fastpathDecMapInt64Uint64R)
+	fn(map[int64]uintptr(nil), (*encFnInfo).fastpathEncMapInt64UintptrR, (*decFnInfo).fastpathDecMapInt64UintptrR)
+	fn(map[int64]int(nil), (*encFnInfo).fastpathEncMapInt64IntR, (*decFnInfo).fastpathDecMapInt64IntR)
+	fn(map[int64]int8(nil), (*encFnInfo).fastpathEncMapInt64Int8R, (*decFnInfo).fastpathDecMapInt64Int8R)
+	fn(map[int64]int16(nil), (*encFnInfo).fastpathEncMapInt64Int16R, (*decFnInfo).fastpathDecMapInt64Int16R)
+	fn(map[int64]int32(nil), (*encFnInfo).fastpathEncMapInt64Int32R, (*decFnInfo).fastpathDecMapInt64Int32R)
+	fn(map[int64]int64(nil), (*encFnInfo).fastpathEncMapInt64Int64R, (*decFnInfo).fastpathDecMapInt64Int64R)
+	fn(map[int64]float32(nil), (*encFnInfo).fastpathEncMapInt64Float32R, (*decFnInfo).fastpathDecMapInt64Float32R)
+	fn(map[int64]float64(nil), (*encFnInfo).fastpathEncMapInt64Float64R, (*decFnInfo).fastpathDecMapInt64Float64R)
+	fn(map[int64]bool(nil), (*encFnInfo).fastpathEncMapInt64BoolR, (*decFnInfo).fastpathDecMapInt64BoolR)
+	fn(map[bool]interface{}(nil), (*encFnInfo).fastpathEncMapBoolIntfR, (*decFnInfo).fastpathDecMapBoolIntfR)
+	fn(map[bool]string(nil), (*encFnInfo).fastpathEncMapBoolStringR, (*decFnInfo).fastpathDecMapBoolStringR)
+	fn(map[bool]uint(nil), (*encFnInfo).fastpathEncMapBoolUintR, (*decFnInfo).fastpathDecMapBoolUintR)
+	fn(map[bool]uint8(nil), (*encFnInfo).fastpathEncMapBoolUint8R, (*decFnInfo).fastpathDecMapBoolUint8R)
+	fn(map[bool]uint16(nil), (*encFnInfo).fastpathEncMapBoolUint16R, (*decFnInfo).fastpathDecMapBoolUint16R)
+	fn(map[bool]uint32(nil), (*encFnInfo).fastpathEncMapBoolUint32R, (*decFnInfo).fastpathDecMapBoolUint32R)
+	fn(map[bool]uint64(nil), (*encFnInfo).fastpathEncMapBoolUint64R, (*decFnInfo).fastpathDecMapBoolUint64R)
+	fn(map[bool]uintptr(nil), (*encFnInfo).fastpathEncMapBoolUintptrR, (*decFnInfo).fastpathDecMapBoolUintptrR)
+	fn(map[bool]int(nil), (*encFnInfo).fastpathEncMapBoolIntR, (*decFnInfo).fastpathDecMapBoolIntR)
+	fn(map[bool]int8(nil), (*encFnInfo).fastpathEncMapBoolInt8R, (*decFnInfo).fastpathDecMapBoolInt8R)
+	fn(map[bool]int16(nil), (*encFnInfo).fastpathEncMapBoolInt16R, (*decFnInfo).fastpathDecMapBoolInt16R)
+	fn(map[bool]int32(nil), (*encFnInfo).fastpathEncMapBoolInt32R, (*decFnInfo).fastpathDecMapBoolInt32R)
+	fn(map[bool]int64(nil), (*encFnInfo).fastpathEncMapBoolInt64R, (*decFnInfo).fastpathDecMapBoolInt64R)
+	fn(map[bool]float32(nil), (*encFnInfo).fastpathEncMapBoolFloat32R, (*decFnInfo).fastpathDecMapBoolFloat32R)
+	fn(map[bool]float64(nil), (*encFnInfo).fastpathEncMapBoolFloat64R, (*decFnInfo).fastpathDecMapBoolFloat64R)
+	fn(map[bool]bool(nil), (*encFnInfo).fastpathEncMapBoolBoolR, (*decFnInfo).fastpathDecMapBoolBoolR)
+
+	sort.Sort(fastpathAslice(fastpathAV[:]))
+}
+
+// -- encode
+
+// -- -- fast path type switch
+func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+
+	case []interface{}:
+		fastpathTV.EncSliceIntfV(v, fastpathCheckNilTrue, e)
+	case *[]interface{}:
+		fastpathTV.EncSliceIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]interface{}:
+		fastpathTV.EncMapIntfIntfV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]interface{}:
+		fastpathTV.EncMapIntfIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]string:
+		fastpathTV.EncMapIntfStringV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]string:
+		fastpathTV.EncMapIntfStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint:
+		fastpathTV.EncMapIntfUintV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint:
+		fastpathTV.EncMapIntfUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint8:
+		fastpathTV.EncMapIntfUint8V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint8:
+		fastpathTV.EncMapIntfUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint16:
+		fastpathTV.EncMapIntfUint16V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint16:
+		fastpathTV.EncMapIntfUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint32:
+		fastpathTV.EncMapIntfUint32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint32:
+		fastpathTV.EncMapIntfUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint64:
+		fastpathTV.EncMapIntfUint64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint64:
+		fastpathTV.EncMapIntfUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uintptr:
+		fastpathTV.EncMapIntfUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uintptr:
+		fastpathTV.EncMapIntfUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int:
+		fastpathTV.EncMapIntfIntV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int:
+		fastpathTV.EncMapIntfIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int8:
+		fastpathTV.EncMapIntfInt8V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int8:
+		fastpathTV.EncMapIntfInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int16:
+		fastpathTV.EncMapIntfInt16V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int16:
+		fastpathTV.EncMapIntfInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int32:
+		fastpathTV.EncMapIntfInt32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int32:
+		fastpathTV.EncMapIntfInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int64:
+		fastpathTV.EncMapIntfInt64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int64:
+		fastpathTV.EncMapIntfInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]float32:
+		fastpathTV.EncMapIntfFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]float32:
+		fastpathTV.EncMapIntfFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]float64:
+		fastpathTV.EncMapIntfFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]float64:
+		fastpathTV.EncMapIntfFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]bool:
+		fastpathTV.EncMapIntfBoolV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]bool:
+		fastpathTV.EncMapIntfBoolV(*v, fastpathCheckNilTrue, e)
+
+	case []string:
+		fastpathTV.EncSliceStringV(v, fastpathCheckNilTrue, e)
+	case *[]string:
+		fastpathTV.EncSliceStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]interface{}:
+		fastpathTV.EncMapStringIntfV(v, fastpathCheckNilTrue, e)
+	case *map[string]interface{}:
+		fastpathTV.EncMapStringIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]string:
+		fastpathTV.EncMapStringStringV(v, fastpathCheckNilTrue, e)
+	case *map[string]string:
+		fastpathTV.EncMapStringStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint:
+		fastpathTV.EncMapStringUintV(v, fastpathCheckNilTrue, e)
+	case *map[string]uint:
+		fastpathTV.EncMapStringUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint8:
+		fastpathTV.EncMapStringUint8V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint8:
+		fastpathTV.EncMapStringUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint16:
+		fastpathTV.EncMapStringUint16V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint16:
+		fastpathTV.EncMapStringUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint32:
+		fastpathTV.EncMapStringUint32V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint32:
+		fastpathTV.EncMapStringUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint64:
+		fastpathTV.EncMapStringUint64V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint64:
+		fastpathTV.EncMapStringUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uintptr:
+		fastpathTV.EncMapStringUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[string]uintptr:
+		fastpathTV.EncMapStringUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int:
+		fastpathTV.EncMapStringIntV(v, fastpathCheckNilTrue, e)
+	case *map[string]int:
+		fastpathTV.EncMapStringIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int8:
+		fastpathTV.EncMapStringInt8V(v, fastpathCheckNilTrue, e)
+	case *map[string]int8:
+		fastpathTV.EncMapStringInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int16:
+		fastpathTV.EncMapStringInt16V(v, fastpathCheckNilTrue, e)
+	case *map[string]int16:
+		fastpathTV.EncMapStringInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int32:
+		fastpathTV.EncMapStringInt32V(v, fastpathCheckNilTrue, e)
+	case *map[string]int32:
+		fastpathTV.EncMapStringInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int64:
+		fastpathTV.EncMapStringInt64V(v, fastpathCheckNilTrue, e)
+	case *map[string]int64:
+		fastpathTV.EncMapStringInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]float32:
+		fastpathTV.EncMapStringFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[string]float32:
+		fastpathTV.EncMapStringFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]float64:
+		fastpathTV.EncMapStringFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[string]float64:
+		fastpathTV.EncMapStringFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]bool:
+		fastpathTV.EncMapStringBoolV(v, fastpathCheckNilTrue, e)
+	case *map[string]bool:
+		fastpathTV.EncMapStringBoolV(*v, fastpathCheckNilTrue, e)
+
+	case []float32:
+		fastpathTV.EncSliceFloat32V(v, fastpathCheckNilTrue, e)
+	case *[]float32:
+		fastpathTV.EncSliceFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]interface{}:
+		fastpathTV.EncMapFloat32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[float32]interface{}:
+		fastpathTV.EncMapFloat32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]string:
+		fastpathTV.EncMapFloat32StringV(v, fastpathCheckNilTrue, e)
+	case *map[float32]string:
+		fastpathTV.EncMapFloat32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint:
+		fastpathTV.EncMapFloat32UintV(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint:
+		fastpathTV.EncMapFloat32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint8:
+		fastpathTV.EncMapFloat32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint8:
+		fastpathTV.EncMapFloat32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint16:
+		fastpathTV.EncMapFloat32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint16:
+		fastpathTV.EncMapFloat32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint32:
+		fastpathTV.EncMapFloat32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint32:
+		fastpathTV.EncMapFloat32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint64:
+		fastpathTV.EncMapFloat32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint64:
+		fastpathTV.EncMapFloat32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uintptr:
+		fastpathTV.EncMapFloat32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[float32]uintptr:
+		fastpathTV.EncMapFloat32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int:
+		fastpathTV.EncMapFloat32IntV(v, fastpathCheckNilTrue, e)
+	case *map[float32]int:
+		fastpathTV.EncMapFloat32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int8:
+		fastpathTV.EncMapFloat32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int8:
+		fastpathTV.EncMapFloat32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int16:
+		fastpathTV.EncMapFloat32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int16:
+		fastpathTV.EncMapFloat32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int32:
+		fastpathTV.EncMapFloat32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int32:
+		fastpathTV.EncMapFloat32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int64:
+		fastpathTV.EncMapFloat32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int64:
+		fastpathTV.EncMapFloat32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]float32:
+		fastpathTV.EncMapFloat32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]float32:
+		fastpathTV.EncMapFloat32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]float64:
+		fastpathTV.EncMapFloat32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]float64:
+		fastpathTV.EncMapFloat32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]bool:
+		fastpathTV.EncMapFloat32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[float32]bool:
+		fastpathTV.EncMapFloat32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []float64:
+		fastpathTV.EncSliceFloat64V(v, fastpathCheckNilTrue, e)
+	case *[]float64:
+		fastpathTV.EncSliceFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]interface{}:
+		fastpathTV.EncMapFloat64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[float64]interface{}:
+		fastpathTV.EncMapFloat64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]string:
+		fastpathTV.EncMapFloat64StringV(v, fastpathCheckNilTrue, e)
+	case *map[float64]string:
+		fastpathTV.EncMapFloat64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint:
+		fastpathTV.EncMapFloat64UintV(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint:
+		fastpathTV.EncMapFloat64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint8:
+		fastpathTV.EncMapFloat64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint8:
+		fastpathTV.EncMapFloat64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint16:
+		fastpathTV.EncMapFloat64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint16:
+		fastpathTV.EncMapFloat64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint32:
+		fastpathTV.EncMapFloat64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint32:
+		fastpathTV.EncMapFloat64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint64:
+		fastpathTV.EncMapFloat64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint64:
+		fastpathTV.EncMapFloat64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uintptr:
+		fastpathTV.EncMapFloat64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[float64]uintptr:
+		fastpathTV.EncMapFloat64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int:
+		fastpathTV.EncMapFloat64IntV(v, fastpathCheckNilTrue, e)
+	case *map[float64]int:
+		fastpathTV.EncMapFloat64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int8:
+		fastpathTV.EncMapFloat64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int8:
+		fastpathTV.EncMapFloat64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int16:
+		fastpathTV.EncMapFloat64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int16:
+		fastpathTV.EncMapFloat64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int32:
+		fastpathTV.EncMapFloat64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int32:
+		fastpathTV.EncMapFloat64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int64:
+		fastpathTV.EncMapFloat64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int64:
+		fastpathTV.EncMapFloat64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]float32:
+		fastpathTV.EncMapFloat64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]float32:
+		fastpathTV.EncMapFloat64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]float64:
+		fastpathTV.EncMapFloat64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]float64:
+		fastpathTV.EncMapFloat64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]bool:
+		fastpathTV.EncMapFloat64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[float64]bool:
+		fastpathTV.EncMapFloat64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []uint:
+		fastpathTV.EncSliceUintV(v, fastpathCheckNilTrue, e)
+	case *[]uint:
+		fastpathTV.EncSliceUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]interface{}:
+		fastpathTV.EncMapUintIntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint]interface{}:
+		fastpathTV.EncMapUintIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]string:
+		fastpathTV.EncMapUintStringV(v, fastpathCheckNilTrue, e)
+	case *map[uint]string:
+		fastpathTV.EncMapUintStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint:
+		fastpathTV.EncMapUintUintV(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint:
+		fastpathTV.EncMapUintUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint8:
+		fastpathTV.EncMapUintUint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint8:
+		fastpathTV.EncMapUintUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint16:
+		fastpathTV.EncMapUintUint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint16:
+		fastpathTV.EncMapUintUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint32:
+		fastpathTV.EncMapUintUint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint32:
+		fastpathTV.EncMapUintUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint64:
+		fastpathTV.EncMapUintUint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint64:
+		fastpathTV.EncMapUintUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uintptr:
+		fastpathTV.EncMapUintUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint]uintptr:
+		fastpathTV.EncMapUintUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int:
+		fastpathTV.EncMapUintIntV(v, fastpathCheckNilTrue, e)
+	case *map[uint]int:
+		fastpathTV.EncMapUintIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int8:
+		fastpathTV.EncMapUintInt8V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int8:
+		fastpathTV.EncMapUintInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int16:
+		fastpathTV.EncMapUintInt16V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int16:
+		fastpathTV.EncMapUintInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int32:
+		fastpathTV.EncMapUintInt32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int32:
+		fastpathTV.EncMapUintInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int64:
+		fastpathTV.EncMapUintInt64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int64:
+		fastpathTV.EncMapUintInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]float32:
+		fastpathTV.EncMapUintFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]float32:
+		fastpathTV.EncMapUintFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]float64:
+		fastpathTV.EncMapUintFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]float64:
+		fastpathTV.EncMapUintFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]bool:
+		fastpathTV.EncMapUintBoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint]bool:
+		fastpathTV.EncMapUintBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]interface{}:
+		fastpathTV.EncMapUint8IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]interface{}:
+		fastpathTV.EncMapUint8IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]string:
+		fastpathTV.EncMapUint8StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]string:
+		fastpathTV.EncMapUint8StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint:
+		fastpathTV.EncMapUint8UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint:
+		fastpathTV.EncMapUint8UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint8:
+		fastpathTV.EncMapUint8Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint8:
+		fastpathTV.EncMapUint8Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint16:
+		fastpathTV.EncMapUint8Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint16:
+		fastpathTV.EncMapUint8Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint32:
+		fastpathTV.EncMapUint8Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint32:
+		fastpathTV.EncMapUint8Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint64:
+		fastpathTV.EncMapUint8Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint64:
+		fastpathTV.EncMapUint8Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uintptr:
+		fastpathTV.EncMapUint8UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uintptr:
+		fastpathTV.EncMapUint8UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int:
+		fastpathTV.EncMapUint8IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int:
+		fastpathTV.EncMapUint8IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int8:
+		fastpathTV.EncMapUint8Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int8:
+		fastpathTV.EncMapUint8Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int16:
+		fastpathTV.EncMapUint8Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int16:
+		fastpathTV.EncMapUint8Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int32:
+		fastpathTV.EncMapUint8Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int32:
+		fastpathTV.EncMapUint8Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int64:
+		fastpathTV.EncMapUint8Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int64:
+		fastpathTV.EncMapUint8Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]float32:
+		fastpathTV.EncMapUint8Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]float32:
+		fastpathTV.EncMapUint8Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]float64:
+		fastpathTV.EncMapUint8Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]float64:
+		fastpathTV.EncMapUint8Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]bool:
+		fastpathTV.EncMapUint8BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]bool:
+		fastpathTV.EncMapUint8BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []uint16:
+		fastpathTV.EncSliceUint16V(v, fastpathCheckNilTrue, e)
+	case *[]uint16:
+		fastpathTV.EncSliceUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]interface{}:
+		fastpathTV.EncMapUint16IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]interface{}:
+		fastpathTV.EncMapUint16IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]string:
+		fastpathTV.EncMapUint16StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]string:
+		fastpathTV.EncMapUint16StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint:
+		fastpathTV.EncMapUint16UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint:
+		fastpathTV.EncMapUint16UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint8:
+		fastpathTV.EncMapUint16Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint8:
+		fastpathTV.EncMapUint16Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint16:
+		fastpathTV.EncMapUint16Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint16:
+		fastpathTV.EncMapUint16Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint32:
+		fastpathTV.EncMapUint16Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint32:
+		fastpathTV.EncMapUint16Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint64:
+		fastpathTV.EncMapUint16Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint64:
+		fastpathTV.EncMapUint16Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uintptr:
+		fastpathTV.EncMapUint16UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uintptr:
+		fastpathTV.EncMapUint16UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int:
+		fastpathTV.EncMapUint16IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int:
+		fastpathTV.EncMapUint16IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int8:
+		fastpathTV.EncMapUint16Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int8:
+		fastpathTV.EncMapUint16Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int16:
+		fastpathTV.EncMapUint16Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int16:
+		fastpathTV.EncMapUint16Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int32:
+		fastpathTV.EncMapUint16Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int32:
+		fastpathTV.EncMapUint16Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int64:
+		fastpathTV.EncMapUint16Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int64:
+		fastpathTV.EncMapUint16Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]float32:
+		fastpathTV.EncMapUint16Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]float32:
+		fastpathTV.EncMapUint16Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]float64:
+		fastpathTV.EncMapUint16Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]float64:
+		fastpathTV.EncMapUint16Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]bool:
+		fastpathTV.EncMapUint16BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]bool:
+		fastpathTV.EncMapUint16BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []uint32:
+		fastpathTV.EncSliceUint32V(v, fastpathCheckNilTrue, e)
+	case *[]uint32:
+		fastpathTV.EncSliceUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]interface{}:
+		fastpathTV.EncMapUint32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]interface{}:
+		fastpathTV.EncMapUint32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]string:
+		fastpathTV.EncMapUint32StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]string:
+		fastpathTV.EncMapUint32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint:
+		fastpathTV.EncMapUint32UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint:
+		fastpathTV.EncMapUint32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint8:
+		fastpathTV.EncMapUint32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint8:
+		fastpathTV.EncMapUint32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint16:
+		fastpathTV.EncMapUint32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint16:
+		fastpathTV.EncMapUint32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint32:
+		fastpathTV.EncMapUint32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint32:
+		fastpathTV.EncMapUint32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint64:
+		fastpathTV.EncMapUint32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint64:
+		fastpathTV.EncMapUint32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uintptr:
+		fastpathTV.EncMapUint32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uintptr:
+		fastpathTV.EncMapUint32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int:
+		fastpathTV.EncMapUint32IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int:
+		fastpathTV.EncMapUint32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int8:
+		fastpathTV.EncMapUint32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int8:
+		fastpathTV.EncMapUint32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int16:
+		fastpathTV.EncMapUint32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int16:
+		fastpathTV.EncMapUint32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int32:
+		fastpathTV.EncMapUint32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int32:
+		fastpathTV.EncMapUint32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int64:
+		fastpathTV.EncMapUint32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int64:
+		fastpathTV.EncMapUint32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]float32:
+		fastpathTV.EncMapUint32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]float32:
+		fastpathTV.EncMapUint32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]float64:
+		fastpathTV.EncMapUint32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]float64:
+		fastpathTV.EncMapUint32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]bool:
+		fastpathTV.EncMapUint32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]bool:
+		fastpathTV.EncMapUint32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []uint64:
+		fastpathTV.EncSliceUint64V(v, fastpathCheckNilTrue, e)
+	case *[]uint64:
+		fastpathTV.EncSliceUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]interface{}:
+		fastpathTV.EncMapUint64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]interface{}:
+		fastpathTV.EncMapUint64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]string:
+		fastpathTV.EncMapUint64StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]string:
+		fastpathTV.EncMapUint64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint:
+		fastpathTV.EncMapUint64UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint:
+		fastpathTV.EncMapUint64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint8:
+		fastpathTV.EncMapUint64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint8:
+		fastpathTV.EncMapUint64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint16:
+		fastpathTV.EncMapUint64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint16:
+		fastpathTV.EncMapUint64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint32:
+		fastpathTV.EncMapUint64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint32:
+		fastpathTV.EncMapUint64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint64:
+		fastpathTV.EncMapUint64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint64:
+		fastpathTV.EncMapUint64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uintptr:
+		fastpathTV.EncMapUint64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uintptr:
+		fastpathTV.EncMapUint64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int:
+		fastpathTV.EncMapUint64IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int:
+		fastpathTV.EncMapUint64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int8:
+		fastpathTV.EncMapUint64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int8:
+		fastpathTV.EncMapUint64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int16:
+		fastpathTV.EncMapUint64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int16:
+		fastpathTV.EncMapUint64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int32:
+		fastpathTV.EncMapUint64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int32:
+		fastpathTV.EncMapUint64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int64:
+		fastpathTV.EncMapUint64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int64:
+		fastpathTV.EncMapUint64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]float32:
+		fastpathTV.EncMapUint64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]float32:
+		fastpathTV.EncMapUint64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]float64:
+		fastpathTV.EncMapUint64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]float64:
+		fastpathTV.EncMapUint64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]bool:
+		fastpathTV.EncMapUint64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]bool:
+		fastpathTV.EncMapUint64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []uintptr:
+		fastpathTV.EncSliceUintptrV(v, fastpathCheckNilTrue, e)
+	case *[]uintptr:
+		fastpathTV.EncSliceUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]interface{}:
+		fastpathTV.EncMapUintptrIntfV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]interface{}:
+		fastpathTV.EncMapUintptrIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]string:
+		fastpathTV.EncMapUintptrStringV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]string:
+		fastpathTV.EncMapUintptrStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint:
+		fastpathTV.EncMapUintptrUintV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint:
+		fastpathTV.EncMapUintptrUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint8:
+		fastpathTV.EncMapUintptrUint8V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint8:
+		fastpathTV.EncMapUintptrUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint16:
+		fastpathTV.EncMapUintptrUint16V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint16:
+		fastpathTV.EncMapUintptrUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint32:
+		fastpathTV.EncMapUintptrUint32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint32:
+		fastpathTV.EncMapUintptrUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint64:
+		fastpathTV.EncMapUintptrUint64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint64:
+		fastpathTV.EncMapUintptrUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uintptr:
+		fastpathTV.EncMapUintptrUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uintptr:
+		fastpathTV.EncMapUintptrUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int:
+		fastpathTV.EncMapUintptrIntV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int:
+		fastpathTV.EncMapUintptrIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int8:
+		fastpathTV.EncMapUintptrInt8V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int8:
+		fastpathTV.EncMapUintptrInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int16:
+		fastpathTV.EncMapUintptrInt16V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int16:
+		fastpathTV.EncMapUintptrInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int32:
+		fastpathTV.EncMapUintptrInt32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int32:
+		fastpathTV.EncMapUintptrInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int64:
+		fastpathTV.EncMapUintptrInt64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int64:
+		fastpathTV.EncMapUintptrInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]float32:
+		fastpathTV.EncMapUintptrFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]float32:
+		fastpathTV.EncMapUintptrFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]float64:
+		fastpathTV.EncMapUintptrFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]float64:
+		fastpathTV.EncMapUintptrFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]bool:
+		fastpathTV.EncMapUintptrBoolV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]bool:
+		fastpathTV.EncMapUintptrBoolV(*v, fastpathCheckNilTrue, e)
+
+	case []int:
+		fastpathTV.EncSliceIntV(v, fastpathCheckNilTrue, e)
+	case *[]int:
+		fastpathTV.EncSliceIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]interface{}:
+		fastpathTV.EncMapIntIntfV(v, fastpathCheckNilTrue, e)
+	case *map[int]interface{}:
+		fastpathTV.EncMapIntIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]string:
+		fastpathTV.EncMapIntStringV(v, fastpathCheckNilTrue, e)
+	case *map[int]string:
+		fastpathTV.EncMapIntStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint:
+		fastpathTV.EncMapIntUintV(v, fastpathCheckNilTrue, e)
+	case *map[int]uint:
+		fastpathTV.EncMapIntUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint8:
+		fastpathTV.EncMapIntUint8V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint8:
+		fastpathTV.EncMapIntUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint16:
+		fastpathTV.EncMapIntUint16V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint16:
+		fastpathTV.EncMapIntUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint32:
+		fastpathTV.EncMapIntUint32V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint32:
+		fastpathTV.EncMapIntUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint64:
+		fastpathTV.EncMapIntUint64V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint64:
+		fastpathTV.EncMapIntUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uintptr:
+		fastpathTV.EncMapIntUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int]uintptr:
+		fastpathTV.EncMapIntUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int:
+		fastpathTV.EncMapIntIntV(v, fastpathCheckNilTrue, e)
+	case *map[int]int:
+		fastpathTV.EncMapIntIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int8:
+		fastpathTV.EncMapIntInt8V(v, fastpathCheckNilTrue, e)
+	case *map[int]int8:
+		fastpathTV.EncMapIntInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int16:
+		fastpathTV.EncMapIntInt16V(v, fastpathCheckNilTrue, e)
+	case *map[int]int16:
+		fastpathTV.EncMapIntInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int32:
+		fastpathTV.EncMapIntInt32V(v, fastpathCheckNilTrue, e)
+	case *map[int]int32:
+		fastpathTV.EncMapIntInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int64:
+		fastpathTV.EncMapIntInt64V(v, fastpathCheckNilTrue, e)
+	case *map[int]int64:
+		fastpathTV.EncMapIntInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]float32:
+		fastpathTV.EncMapIntFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[int]float32:
+		fastpathTV.EncMapIntFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]float64:
+		fastpathTV.EncMapIntFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[int]float64:
+		fastpathTV.EncMapIntFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]bool:
+		fastpathTV.EncMapIntBoolV(v, fastpathCheckNilTrue, e)
+	case *map[int]bool:
+		fastpathTV.EncMapIntBoolV(*v, fastpathCheckNilTrue, e)
+
+	case []int8:
+		fastpathTV.EncSliceInt8V(v, fastpathCheckNilTrue, e)
+	case *[]int8:
+		fastpathTV.EncSliceInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]interface{}:
+		fastpathTV.EncMapInt8IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int8]interface{}:
+		fastpathTV.EncMapInt8IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]string:
+		fastpathTV.EncMapInt8StringV(v, fastpathCheckNilTrue, e)
+	case *map[int8]string:
+		fastpathTV.EncMapInt8StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint:
+		fastpathTV.EncMapInt8UintV(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint:
+		fastpathTV.EncMapInt8UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint8:
+		fastpathTV.EncMapInt8Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint8:
+		fastpathTV.EncMapInt8Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint16:
+		fastpathTV.EncMapInt8Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint16:
+		fastpathTV.EncMapInt8Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint32:
+		fastpathTV.EncMapInt8Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint32:
+		fastpathTV.EncMapInt8Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint64:
+		fastpathTV.EncMapInt8Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint64:
+		fastpathTV.EncMapInt8Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uintptr:
+		fastpathTV.EncMapInt8UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int8]uintptr:
+		fastpathTV.EncMapInt8UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int:
+		fastpathTV.EncMapInt8IntV(v, fastpathCheckNilTrue, e)
+	case *map[int8]int:
+		fastpathTV.EncMapInt8IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int8:
+		fastpathTV.EncMapInt8Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int8:
+		fastpathTV.EncMapInt8Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int16:
+		fastpathTV.EncMapInt8Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int16:
+		fastpathTV.EncMapInt8Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int32:
+		fastpathTV.EncMapInt8Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int32:
+		fastpathTV.EncMapInt8Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int64:
+		fastpathTV.EncMapInt8Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int64:
+		fastpathTV.EncMapInt8Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]float32:
+		fastpathTV.EncMapInt8Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]float32:
+		fastpathTV.EncMapInt8Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]float64:
+		fastpathTV.EncMapInt8Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]float64:
+		fastpathTV.EncMapInt8Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]bool:
+		fastpathTV.EncMapInt8BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int8]bool:
+		fastpathTV.EncMapInt8BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []int16:
+		fastpathTV.EncSliceInt16V(v, fastpathCheckNilTrue, e)
+	case *[]int16:
+		fastpathTV.EncSliceInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]interface{}:
+		fastpathTV.EncMapInt16IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int16]interface{}:
+		fastpathTV.EncMapInt16IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]string:
+		fastpathTV.EncMapInt16StringV(v, fastpathCheckNilTrue, e)
+	case *map[int16]string:
+		fastpathTV.EncMapInt16StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint:
+		fastpathTV.EncMapInt16UintV(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint:
+		fastpathTV.EncMapInt16UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint8:
+		fastpathTV.EncMapInt16Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint8:
+		fastpathTV.EncMapInt16Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint16:
+		fastpathTV.EncMapInt16Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint16:
+		fastpathTV.EncMapInt16Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint32:
+		fastpathTV.EncMapInt16Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint32:
+		fastpathTV.EncMapInt16Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint64:
+		fastpathTV.EncMapInt16Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint64:
+		fastpathTV.EncMapInt16Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uintptr:
+		fastpathTV.EncMapInt16UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int16]uintptr:
+		fastpathTV.EncMapInt16UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int:
+		fastpathTV.EncMapInt16IntV(v, fastpathCheckNilTrue, e)
+	case *map[int16]int:
+		fastpathTV.EncMapInt16IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int8:
+		fastpathTV.EncMapInt16Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int8:
+		fastpathTV.EncMapInt16Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int16:
+		fastpathTV.EncMapInt16Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int16:
+		fastpathTV.EncMapInt16Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int32:
+		fastpathTV.EncMapInt16Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int32:
+		fastpathTV.EncMapInt16Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int64:
+		fastpathTV.EncMapInt16Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int64:
+		fastpathTV.EncMapInt16Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]float32:
+		fastpathTV.EncMapInt16Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]float32:
+		fastpathTV.EncMapInt16Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]float64:
+		fastpathTV.EncMapInt16Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]float64:
+		fastpathTV.EncMapInt16Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]bool:
+		fastpathTV.EncMapInt16BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int16]bool:
+		fastpathTV.EncMapInt16BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []int32:
+		fastpathTV.EncSliceInt32V(v, fastpathCheckNilTrue, e)
+	case *[]int32:
+		fastpathTV.EncSliceInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]interface{}:
+		fastpathTV.EncMapInt32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int32]interface{}:
+		fastpathTV.EncMapInt32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]string:
+		fastpathTV.EncMapInt32StringV(v, fastpathCheckNilTrue, e)
+	case *map[int32]string:
+		fastpathTV.EncMapInt32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint:
+		fastpathTV.EncMapInt32UintV(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint:
+		fastpathTV.EncMapInt32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint8:
+		fastpathTV.EncMapInt32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint8:
+		fastpathTV.EncMapInt32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint16:
+		fastpathTV.EncMapInt32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint16:
+		fastpathTV.EncMapInt32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint32:
+		fastpathTV.EncMapInt32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint32:
+		fastpathTV.EncMapInt32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint64:
+		fastpathTV.EncMapInt32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint64:
+		fastpathTV.EncMapInt32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uintptr:
+		fastpathTV.EncMapInt32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int32]uintptr:
+		fastpathTV.EncMapInt32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int:
+		fastpathTV.EncMapInt32IntV(v, fastpathCheckNilTrue, e)
+	case *map[int32]int:
+		fastpathTV.EncMapInt32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int8:
+		fastpathTV.EncMapInt32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int8:
+		fastpathTV.EncMapInt32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int16:
+		fastpathTV.EncMapInt32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int16:
+		fastpathTV.EncMapInt32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int32:
+		fastpathTV.EncMapInt32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int32:
+		fastpathTV.EncMapInt32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int64:
+		fastpathTV.EncMapInt32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int64:
+		fastpathTV.EncMapInt32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]float32:
+		fastpathTV.EncMapInt32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]float32:
+		fastpathTV.EncMapInt32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]float64:
+		fastpathTV.EncMapInt32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]float64:
+		fastpathTV.EncMapInt32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]bool:
+		fastpathTV.EncMapInt32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int32]bool:
+		fastpathTV.EncMapInt32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []int64:
+		fastpathTV.EncSliceInt64V(v, fastpathCheckNilTrue, e)
+	case *[]int64:
+		fastpathTV.EncSliceInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]interface{}:
+		fastpathTV.EncMapInt64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int64]interface{}:
+		fastpathTV.EncMapInt64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]string:
+		fastpathTV.EncMapInt64StringV(v, fastpathCheckNilTrue, e)
+	case *map[int64]string:
+		fastpathTV.EncMapInt64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint:
+		fastpathTV.EncMapInt64UintV(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint:
+		fastpathTV.EncMapInt64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint8:
+		fastpathTV.EncMapInt64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint8:
+		fastpathTV.EncMapInt64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint16:
+		fastpathTV.EncMapInt64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint16:
+		fastpathTV.EncMapInt64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint32:
+		fastpathTV.EncMapInt64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint32:
+		fastpathTV.EncMapInt64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint64:
+		fastpathTV.EncMapInt64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint64:
+		fastpathTV.EncMapInt64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uintptr:
+		fastpathTV.EncMapInt64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int64]uintptr:
+		fastpathTV.EncMapInt64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int:
+		fastpathTV.EncMapInt64IntV(v, fastpathCheckNilTrue, e)
+	case *map[int64]int:
+		fastpathTV.EncMapInt64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int8:
+		fastpathTV.EncMapInt64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int8:
+		fastpathTV.EncMapInt64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int16:
+		fastpathTV.EncMapInt64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int16:
+		fastpathTV.EncMapInt64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int32:
+		fastpathTV.EncMapInt64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int32:
+		fastpathTV.EncMapInt64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int64:
+		fastpathTV.EncMapInt64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int64:
+		fastpathTV.EncMapInt64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]float32:
+		fastpathTV.EncMapInt64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]float32:
+		fastpathTV.EncMapInt64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]float64:
+		fastpathTV.EncMapInt64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]float64:
+		fastpathTV.EncMapInt64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]bool:
+		fastpathTV.EncMapInt64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int64]bool:
+		fastpathTV.EncMapInt64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case []bool:
+		fastpathTV.EncSliceBoolV(v, fastpathCheckNilTrue, e)
+	case *[]bool:
+		fastpathTV.EncSliceBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]interface{}:
+		fastpathTV.EncMapBoolIntfV(v, fastpathCheckNilTrue, e)
+	case *map[bool]interface{}:
+		fastpathTV.EncMapBoolIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]string:
+		fastpathTV.EncMapBoolStringV(v, fastpathCheckNilTrue, e)
+	case *map[bool]string:
+		fastpathTV.EncMapBoolStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint:
+		fastpathTV.EncMapBoolUintV(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint:
+		fastpathTV.EncMapBoolUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint8:
+		fastpathTV.EncMapBoolUint8V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint8:
+		fastpathTV.EncMapBoolUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint16:
+		fastpathTV.EncMapBoolUint16V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint16:
+		fastpathTV.EncMapBoolUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint32:
+		fastpathTV.EncMapBoolUint32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint32:
+		fastpathTV.EncMapBoolUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint64:
+		fastpathTV.EncMapBoolUint64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint64:
+		fastpathTV.EncMapBoolUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uintptr:
+		fastpathTV.EncMapBoolUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[bool]uintptr:
+		fastpathTV.EncMapBoolUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int:
+		fastpathTV.EncMapBoolIntV(v, fastpathCheckNilTrue, e)
+	case *map[bool]int:
+		fastpathTV.EncMapBoolIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int8:
+		fastpathTV.EncMapBoolInt8V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int8:
+		fastpathTV.EncMapBoolInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int16:
+		fastpathTV.EncMapBoolInt16V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int16:
+		fastpathTV.EncMapBoolInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int32:
+		fastpathTV.EncMapBoolInt32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int32:
+		fastpathTV.EncMapBoolInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int64:
+		fastpathTV.EncMapBoolInt64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int64:
+		fastpathTV.EncMapBoolInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]float32:
+		fastpathTV.EncMapBoolFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]float32:
+		fastpathTV.EncMapBoolFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]float64:
+		fastpathTV.EncMapBoolFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]float64:
+		fastpathTV.EncMapBoolFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]bool:
+		fastpathTV.EncMapBoolBoolV(v, fastpathCheckNilTrue, e)
+	case *map[bool]bool:
+		fastpathTV.EncMapBoolBoolV(*v, fastpathCheckNilTrue, e)
+
+	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+
+	case []interface{}:
+		fastpathTV.EncSliceIntfV(v, fastpathCheckNilTrue, e)
+	case *[]interface{}:
+		fastpathTV.EncSliceIntfV(*v, fastpathCheckNilTrue, e)
+
+	case []string:
+		fastpathTV.EncSliceStringV(v, fastpathCheckNilTrue, e)
+	case *[]string:
+		fastpathTV.EncSliceStringV(*v, fastpathCheckNilTrue, e)
+
+	case []float32:
+		fastpathTV.EncSliceFloat32V(v, fastpathCheckNilTrue, e)
+	case *[]float32:
+		fastpathTV.EncSliceFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case []float64:
+		fastpathTV.EncSliceFloat64V(v, fastpathCheckNilTrue, e)
+	case *[]float64:
+		fastpathTV.EncSliceFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case []uint:
+		fastpathTV.EncSliceUintV(v, fastpathCheckNilTrue, e)
+	case *[]uint:
+		fastpathTV.EncSliceUintV(*v, fastpathCheckNilTrue, e)
+
+	case []uint16:
+		fastpathTV.EncSliceUint16V(v, fastpathCheckNilTrue, e)
+	case *[]uint16:
+		fastpathTV.EncSliceUint16V(*v, fastpathCheckNilTrue, e)
+
+	case []uint32:
+		fastpathTV.EncSliceUint32V(v, fastpathCheckNilTrue, e)
+	case *[]uint32:
+		fastpathTV.EncSliceUint32V(*v, fastpathCheckNilTrue, e)
+
+	case []uint64:
+		fastpathTV.EncSliceUint64V(v, fastpathCheckNilTrue, e)
+	case *[]uint64:
+		fastpathTV.EncSliceUint64V(*v, fastpathCheckNilTrue, e)
+
+	case []uintptr:
+		fastpathTV.EncSliceUintptrV(v, fastpathCheckNilTrue, e)
+	case *[]uintptr:
+		fastpathTV.EncSliceUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case []int:
+		fastpathTV.EncSliceIntV(v, fastpathCheckNilTrue, e)
+	case *[]int:
+		fastpathTV.EncSliceIntV(*v, fastpathCheckNilTrue, e)
+
+	case []int8:
+		fastpathTV.EncSliceInt8V(v, fastpathCheckNilTrue, e)
+	case *[]int8:
+		fastpathTV.EncSliceInt8V(*v, fastpathCheckNilTrue, e)
+
+	case []int16:
+		fastpathTV.EncSliceInt16V(v, fastpathCheckNilTrue, e)
+	case *[]int16:
+		fastpathTV.EncSliceInt16V(*v, fastpathCheckNilTrue, e)
+
+	case []int32:
+		fastpathTV.EncSliceInt32V(v, fastpathCheckNilTrue, e)
+	case *[]int32:
+		fastpathTV.EncSliceInt32V(*v, fastpathCheckNilTrue, e)
+
+	case []int64:
+		fastpathTV.EncSliceInt64V(v, fastpathCheckNilTrue, e)
+	case *[]int64:
+		fastpathTV.EncSliceInt64V(*v, fastpathCheckNilTrue, e)
+
+	case []bool:
+		fastpathTV.EncSliceBoolV(v, fastpathCheckNilTrue, e)
+	case *[]bool:
+		fastpathTV.EncSliceBoolV(*v, fastpathCheckNilTrue, e)
+
+	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+
+	case map[interface{}]interface{}:
+		fastpathTV.EncMapIntfIntfV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]interface{}:
+		fastpathTV.EncMapIntfIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]string:
+		fastpathTV.EncMapIntfStringV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]string:
+		fastpathTV.EncMapIntfStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint:
+		fastpathTV.EncMapIntfUintV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint:
+		fastpathTV.EncMapIntfUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint8:
+		fastpathTV.EncMapIntfUint8V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint8:
+		fastpathTV.EncMapIntfUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint16:
+		fastpathTV.EncMapIntfUint16V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint16:
+		fastpathTV.EncMapIntfUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint32:
+		fastpathTV.EncMapIntfUint32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint32:
+		fastpathTV.EncMapIntfUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uint64:
+		fastpathTV.EncMapIntfUint64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uint64:
+		fastpathTV.EncMapIntfUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]uintptr:
+		fastpathTV.EncMapIntfUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]uintptr:
+		fastpathTV.EncMapIntfUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int:
+		fastpathTV.EncMapIntfIntV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int:
+		fastpathTV.EncMapIntfIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int8:
+		fastpathTV.EncMapIntfInt8V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int8:
+		fastpathTV.EncMapIntfInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int16:
+		fastpathTV.EncMapIntfInt16V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int16:
+		fastpathTV.EncMapIntfInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int32:
+		fastpathTV.EncMapIntfInt32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int32:
+		fastpathTV.EncMapIntfInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]int64:
+		fastpathTV.EncMapIntfInt64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]int64:
+		fastpathTV.EncMapIntfInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]float32:
+		fastpathTV.EncMapIntfFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]float32:
+		fastpathTV.EncMapIntfFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]float64:
+		fastpathTV.EncMapIntfFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]float64:
+		fastpathTV.EncMapIntfFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[interface{}]bool:
+		fastpathTV.EncMapIntfBoolV(v, fastpathCheckNilTrue, e)
+	case *map[interface{}]bool:
+		fastpathTV.EncMapIntfBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]interface{}:
+		fastpathTV.EncMapStringIntfV(v, fastpathCheckNilTrue, e)
+	case *map[string]interface{}:
+		fastpathTV.EncMapStringIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]string:
+		fastpathTV.EncMapStringStringV(v, fastpathCheckNilTrue, e)
+	case *map[string]string:
+		fastpathTV.EncMapStringStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint:
+		fastpathTV.EncMapStringUintV(v, fastpathCheckNilTrue, e)
+	case *map[string]uint:
+		fastpathTV.EncMapStringUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint8:
+		fastpathTV.EncMapStringUint8V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint8:
+		fastpathTV.EncMapStringUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint16:
+		fastpathTV.EncMapStringUint16V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint16:
+		fastpathTV.EncMapStringUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint32:
+		fastpathTV.EncMapStringUint32V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint32:
+		fastpathTV.EncMapStringUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uint64:
+		fastpathTV.EncMapStringUint64V(v, fastpathCheckNilTrue, e)
+	case *map[string]uint64:
+		fastpathTV.EncMapStringUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]uintptr:
+		fastpathTV.EncMapStringUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[string]uintptr:
+		fastpathTV.EncMapStringUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int:
+		fastpathTV.EncMapStringIntV(v, fastpathCheckNilTrue, e)
+	case *map[string]int:
+		fastpathTV.EncMapStringIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int8:
+		fastpathTV.EncMapStringInt8V(v, fastpathCheckNilTrue, e)
+	case *map[string]int8:
+		fastpathTV.EncMapStringInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int16:
+		fastpathTV.EncMapStringInt16V(v, fastpathCheckNilTrue, e)
+	case *map[string]int16:
+		fastpathTV.EncMapStringInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int32:
+		fastpathTV.EncMapStringInt32V(v, fastpathCheckNilTrue, e)
+	case *map[string]int32:
+		fastpathTV.EncMapStringInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]int64:
+		fastpathTV.EncMapStringInt64V(v, fastpathCheckNilTrue, e)
+	case *map[string]int64:
+		fastpathTV.EncMapStringInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]float32:
+		fastpathTV.EncMapStringFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[string]float32:
+		fastpathTV.EncMapStringFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]float64:
+		fastpathTV.EncMapStringFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[string]float64:
+		fastpathTV.EncMapStringFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[string]bool:
+		fastpathTV.EncMapStringBoolV(v, fastpathCheckNilTrue, e)
+	case *map[string]bool:
+		fastpathTV.EncMapStringBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]interface{}:
+		fastpathTV.EncMapFloat32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[float32]interface{}:
+		fastpathTV.EncMapFloat32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]string:
+		fastpathTV.EncMapFloat32StringV(v, fastpathCheckNilTrue, e)
+	case *map[float32]string:
+		fastpathTV.EncMapFloat32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint:
+		fastpathTV.EncMapFloat32UintV(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint:
+		fastpathTV.EncMapFloat32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint8:
+		fastpathTV.EncMapFloat32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint8:
+		fastpathTV.EncMapFloat32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint16:
+		fastpathTV.EncMapFloat32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint16:
+		fastpathTV.EncMapFloat32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint32:
+		fastpathTV.EncMapFloat32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint32:
+		fastpathTV.EncMapFloat32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uint64:
+		fastpathTV.EncMapFloat32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]uint64:
+		fastpathTV.EncMapFloat32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]uintptr:
+		fastpathTV.EncMapFloat32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[float32]uintptr:
+		fastpathTV.EncMapFloat32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int:
+		fastpathTV.EncMapFloat32IntV(v, fastpathCheckNilTrue, e)
+	case *map[float32]int:
+		fastpathTV.EncMapFloat32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int8:
+		fastpathTV.EncMapFloat32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int8:
+		fastpathTV.EncMapFloat32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int16:
+		fastpathTV.EncMapFloat32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int16:
+		fastpathTV.EncMapFloat32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int32:
+		fastpathTV.EncMapFloat32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int32:
+		fastpathTV.EncMapFloat32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]int64:
+		fastpathTV.EncMapFloat32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]int64:
+		fastpathTV.EncMapFloat32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]float32:
+		fastpathTV.EncMapFloat32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[float32]float32:
+		fastpathTV.EncMapFloat32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]float64:
+		fastpathTV.EncMapFloat32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[float32]float64:
+		fastpathTV.EncMapFloat32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float32]bool:
+		fastpathTV.EncMapFloat32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[float32]bool:
+		fastpathTV.EncMapFloat32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]interface{}:
+		fastpathTV.EncMapFloat64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[float64]interface{}:
+		fastpathTV.EncMapFloat64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]string:
+		fastpathTV.EncMapFloat64StringV(v, fastpathCheckNilTrue, e)
+	case *map[float64]string:
+		fastpathTV.EncMapFloat64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint:
+		fastpathTV.EncMapFloat64UintV(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint:
+		fastpathTV.EncMapFloat64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint8:
+		fastpathTV.EncMapFloat64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint8:
+		fastpathTV.EncMapFloat64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint16:
+		fastpathTV.EncMapFloat64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint16:
+		fastpathTV.EncMapFloat64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint32:
+		fastpathTV.EncMapFloat64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint32:
+		fastpathTV.EncMapFloat64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uint64:
+		fastpathTV.EncMapFloat64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]uint64:
+		fastpathTV.EncMapFloat64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]uintptr:
+		fastpathTV.EncMapFloat64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[float64]uintptr:
+		fastpathTV.EncMapFloat64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int:
+		fastpathTV.EncMapFloat64IntV(v, fastpathCheckNilTrue, e)
+	case *map[float64]int:
+		fastpathTV.EncMapFloat64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int8:
+		fastpathTV.EncMapFloat64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int8:
+		fastpathTV.EncMapFloat64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int16:
+		fastpathTV.EncMapFloat64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int16:
+		fastpathTV.EncMapFloat64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int32:
+		fastpathTV.EncMapFloat64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int32:
+		fastpathTV.EncMapFloat64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]int64:
+		fastpathTV.EncMapFloat64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]int64:
+		fastpathTV.EncMapFloat64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]float32:
+		fastpathTV.EncMapFloat64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[float64]float32:
+		fastpathTV.EncMapFloat64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]float64:
+		fastpathTV.EncMapFloat64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[float64]float64:
+		fastpathTV.EncMapFloat64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[float64]bool:
+		fastpathTV.EncMapFloat64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[float64]bool:
+		fastpathTV.EncMapFloat64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]interface{}:
+		fastpathTV.EncMapUintIntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint]interface{}:
+		fastpathTV.EncMapUintIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]string:
+		fastpathTV.EncMapUintStringV(v, fastpathCheckNilTrue, e)
+	case *map[uint]string:
+		fastpathTV.EncMapUintStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint:
+		fastpathTV.EncMapUintUintV(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint:
+		fastpathTV.EncMapUintUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint8:
+		fastpathTV.EncMapUintUint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint8:
+		fastpathTV.EncMapUintUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint16:
+		fastpathTV.EncMapUintUint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint16:
+		fastpathTV.EncMapUintUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint32:
+		fastpathTV.EncMapUintUint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint32:
+		fastpathTV.EncMapUintUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uint64:
+		fastpathTV.EncMapUintUint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]uint64:
+		fastpathTV.EncMapUintUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]uintptr:
+		fastpathTV.EncMapUintUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint]uintptr:
+		fastpathTV.EncMapUintUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int:
+		fastpathTV.EncMapUintIntV(v, fastpathCheckNilTrue, e)
+	case *map[uint]int:
+		fastpathTV.EncMapUintIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int8:
+		fastpathTV.EncMapUintInt8V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int8:
+		fastpathTV.EncMapUintInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int16:
+		fastpathTV.EncMapUintInt16V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int16:
+		fastpathTV.EncMapUintInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int32:
+		fastpathTV.EncMapUintInt32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int32:
+		fastpathTV.EncMapUintInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]int64:
+		fastpathTV.EncMapUintInt64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]int64:
+		fastpathTV.EncMapUintInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]float32:
+		fastpathTV.EncMapUintFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[uint]float32:
+		fastpathTV.EncMapUintFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]float64:
+		fastpathTV.EncMapUintFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[uint]float64:
+		fastpathTV.EncMapUintFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint]bool:
+		fastpathTV.EncMapUintBoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint]bool:
+		fastpathTV.EncMapUintBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]interface{}:
+		fastpathTV.EncMapUint8IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]interface{}:
+		fastpathTV.EncMapUint8IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]string:
+		fastpathTV.EncMapUint8StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]string:
+		fastpathTV.EncMapUint8StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint:
+		fastpathTV.EncMapUint8UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint:
+		fastpathTV.EncMapUint8UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint8:
+		fastpathTV.EncMapUint8Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint8:
+		fastpathTV.EncMapUint8Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint16:
+		fastpathTV.EncMapUint8Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint16:
+		fastpathTV.EncMapUint8Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint32:
+		fastpathTV.EncMapUint8Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint32:
+		fastpathTV.EncMapUint8Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uint64:
+		fastpathTV.EncMapUint8Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uint64:
+		fastpathTV.EncMapUint8Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]uintptr:
+		fastpathTV.EncMapUint8UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]uintptr:
+		fastpathTV.EncMapUint8UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int:
+		fastpathTV.EncMapUint8IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int:
+		fastpathTV.EncMapUint8IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int8:
+		fastpathTV.EncMapUint8Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int8:
+		fastpathTV.EncMapUint8Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int16:
+		fastpathTV.EncMapUint8Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int16:
+		fastpathTV.EncMapUint8Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int32:
+		fastpathTV.EncMapUint8Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int32:
+		fastpathTV.EncMapUint8Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]int64:
+		fastpathTV.EncMapUint8Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]int64:
+		fastpathTV.EncMapUint8Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]float32:
+		fastpathTV.EncMapUint8Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]float32:
+		fastpathTV.EncMapUint8Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]float64:
+		fastpathTV.EncMapUint8Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint8]float64:
+		fastpathTV.EncMapUint8Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint8]bool:
+		fastpathTV.EncMapUint8BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint8]bool:
+		fastpathTV.EncMapUint8BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]interface{}:
+		fastpathTV.EncMapUint16IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]interface{}:
+		fastpathTV.EncMapUint16IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]string:
+		fastpathTV.EncMapUint16StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]string:
+		fastpathTV.EncMapUint16StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint:
+		fastpathTV.EncMapUint16UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint:
+		fastpathTV.EncMapUint16UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint8:
+		fastpathTV.EncMapUint16Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint8:
+		fastpathTV.EncMapUint16Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint16:
+		fastpathTV.EncMapUint16Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint16:
+		fastpathTV.EncMapUint16Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint32:
+		fastpathTV.EncMapUint16Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint32:
+		fastpathTV.EncMapUint16Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uint64:
+		fastpathTV.EncMapUint16Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uint64:
+		fastpathTV.EncMapUint16Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]uintptr:
+		fastpathTV.EncMapUint16UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]uintptr:
+		fastpathTV.EncMapUint16UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int:
+		fastpathTV.EncMapUint16IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int:
+		fastpathTV.EncMapUint16IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int8:
+		fastpathTV.EncMapUint16Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int8:
+		fastpathTV.EncMapUint16Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int16:
+		fastpathTV.EncMapUint16Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int16:
+		fastpathTV.EncMapUint16Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int32:
+		fastpathTV.EncMapUint16Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int32:
+		fastpathTV.EncMapUint16Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]int64:
+		fastpathTV.EncMapUint16Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]int64:
+		fastpathTV.EncMapUint16Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]float32:
+		fastpathTV.EncMapUint16Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]float32:
+		fastpathTV.EncMapUint16Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]float64:
+		fastpathTV.EncMapUint16Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint16]float64:
+		fastpathTV.EncMapUint16Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint16]bool:
+		fastpathTV.EncMapUint16BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint16]bool:
+		fastpathTV.EncMapUint16BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]interface{}:
+		fastpathTV.EncMapUint32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]interface{}:
+		fastpathTV.EncMapUint32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]string:
+		fastpathTV.EncMapUint32StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]string:
+		fastpathTV.EncMapUint32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint:
+		fastpathTV.EncMapUint32UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint:
+		fastpathTV.EncMapUint32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint8:
+		fastpathTV.EncMapUint32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint8:
+		fastpathTV.EncMapUint32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint16:
+		fastpathTV.EncMapUint32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint16:
+		fastpathTV.EncMapUint32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint32:
+		fastpathTV.EncMapUint32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint32:
+		fastpathTV.EncMapUint32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uint64:
+		fastpathTV.EncMapUint32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uint64:
+		fastpathTV.EncMapUint32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]uintptr:
+		fastpathTV.EncMapUint32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]uintptr:
+		fastpathTV.EncMapUint32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int:
+		fastpathTV.EncMapUint32IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int:
+		fastpathTV.EncMapUint32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int8:
+		fastpathTV.EncMapUint32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int8:
+		fastpathTV.EncMapUint32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int16:
+		fastpathTV.EncMapUint32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int16:
+		fastpathTV.EncMapUint32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int32:
+		fastpathTV.EncMapUint32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int32:
+		fastpathTV.EncMapUint32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]int64:
+		fastpathTV.EncMapUint32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]int64:
+		fastpathTV.EncMapUint32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]float32:
+		fastpathTV.EncMapUint32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]float32:
+		fastpathTV.EncMapUint32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]float64:
+		fastpathTV.EncMapUint32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint32]float64:
+		fastpathTV.EncMapUint32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint32]bool:
+		fastpathTV.EncMapUint32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint32]bool:
+		fastpathTV.EncMapUint32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]interface{}:
+		fastpathTV.EncMapUint64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]interface{}:
+		fastpathTV.EncMapUint64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]string:
+		fastpathTV.EncMapUint64StringV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]string:
+		fastpathTV.EncMapUint64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint:
+		fastpathTV.EncMapUint64UintV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint:
+		fastpathTV.EncMapUint64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint8:
+		fastpathTV.EncMapUint64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint8:
+		fastpathTV.EncMapUint64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint16:
+		fastpathTV.EncMapUint64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint16:
+		fastpathTV.EncMapUint64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint32:
+		fastpathTV.EncMapUint64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint32:
+		fastpathTV.EncMapUint64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uint64:
+		fastpathTV.EncMapUint64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uint64:
+		fastpathTV.EncMapUint64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]uintptr:
+		fastpathTV.EncMapUint64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]uintptr:
+		fastpathTV.EncMapUint64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int:
+		fastpathTV.EncMapUint64IntV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int:
+		fastpathTV.EncMapUint64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int8:
+		fastpathTV.EncMapUint64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int8:
+		fastpathTV.EncMapUint64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int16:
+		fastpathTV.EncMapUint64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int16:
+		fastpathTV.EncMapUint64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int32:
+		fastpathTV.EncMapUint64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int32:
+		fastpathTV.EncMapUint64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]int64:
+		fastpathTV.EncMapUint64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]int64:
+		fastpathTV.EncMapUint64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]float32:
+		fastpathTV.EncMapUint64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]float32:
+		fastpathTV.EncMapUint64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]float64:
+		fastpathTV.EncMapUint64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[uint64]float64:
+		fastpathTV.EncMapUint64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uint64]bool:
+		fastpathTV.EncMapUint64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[uint64]bool:
+		fastpathTV.EncMapUint64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]interface{}:
+		fastpathTV.EncMapUintptrIntfV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]interface{}:
+		fastpathTV.EncMapUintptrIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]string:
+		fastpathTV.EncMapUintptrStringV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]string:
+		fastpathTV.EncMapUintptrStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint:
+		fastpathTV.EncMapUintptrUintV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint:
+		fastpathTV.EncMapUintptrUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint8:
+		fastpathTV.EncMapUintptrUint8V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint8:
+		fastpathTV.EncMapUintptrUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint16:
+		fastpathTV.EncMapUintptrUint16V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint16:
+		fastpathTV.EncMapUintptrUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint32:
+		fastpathTV.EncMapUintptrUint32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint32:
+		fastpathTV.EncMapUintptrUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uint64:
+		fastpathTV.EncMapUintptrUint64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uint64:
+		fastpathTV.EncMapUintptrUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]uintptr:
+		fastpathTV.EncMapUintptrUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]uintptr:
+		fastpathTV.EncMapUintptrUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int:
+		fastpathTV.EncMapUintptrIntV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int:
+		fastpathTV.EncMapUintptrIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int8:
+		fastpathTV.EncMapUintptrInt8V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int8:
+		fastpathTV.EncMapUintptrInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int16:
+		fastpathTV.EncMapUintptrInt16V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int16:
+		fastpathTV.EncMapUintptrInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int32:
+		fastpathTV.EncMapUintptrInt32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int32:
+		fastpathTV.EncMapUintptrInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]int64:
+		fastpathTV.EncMapUintptrInt64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]int64:
+		fastpathTV.EncMapUintptrInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]float32:
+		fastpathTV.EncMapUintptrFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]float32:
+		fastpathTV.EncMapUintptrFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]float64:
+		fastpathTV.EncMapUintptrFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]float64:
+		fastpathTV.EncMapUintptrFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[uintptr]bool:
+		fastpathTV.EncMapUintptrBoolV(v, fastpathCheckNilTrue, e)
+	case *map[uintptr]bool:
+		fastpathTV.EncMapUintptrBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]interface{}:
+		fastpathTV.EncMapIntIntfV(v, fastpathCheckNilTrue, e)
+	case *map[int]interface{}:
+		fastpathTV.EncMapIntIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]string:
+		fastpathTV.EncMapIntStringV(v, fastpathCheckNilTrue, e)
+	case *map[int]string:
+		fastpathTV.EncMapIntStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint:
+		fastpathTV.EncMapIntUintV(v, fastpathCheckNilTrue, e)
+	case *map[int]uint:
+		fastpathTV.EncMapIntUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint8:
+		fastpathTV.EncMapIntUint8V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint8:
+		fastpathTV.EncMapIntUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint16:
+		fastpathTV.EncMapIntUint16V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint16:
+		fastpathTV.EncMapIntUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint32:
+		fastpathTV.EncMapIntUint32V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint32:
+		fastpathTV.EncMapIntUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uint64:
+		fastpathTV.EncMapIntUint64V(v, fastpathCheckNilTrue, e)
+	case *map[int]uint64:
+		fastpathTV.EncMapIntUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]uintptr:
+		fastpathTV.EncMapIntUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int]uintptr:
+		fastpathTV.EncMapIntUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int:
+		fastpathTV.EncMapIntIntV(v, fastpathCheckNilTrue, e)
+	case *map[int]int:
+		fastpathTV.EncMapIntIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int8:
+		fastpathTV.EncMapIntInt8V(v, fastpathCheckNilTrue, e)
+	case *map[int]int8:
+		fastpathTV.EncMapIntInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int16:
+		fastpathTV.EncMapIntInt16V(v, fastpathCheckNilTrue, e)
+	case *map[int]int16:
+		fastpathTV.EncMapIntInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int32:
+		fastpathTV.EncMapIntInt32V(v, fastpathCheckNilTrue, e)
+	case *map[int]int32:
+		fastpathTV.EncMapIntInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]int64:
+		fastpathTV.EncMapIntInt64V(v, fastpathCheckNilTrue, e)
+	case *map[int]int64:
+		fastpathTV.EncMapIntInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]float32:
+		fastpathTV.EncMapIntFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[int]float32:
+		fastpathTV.EncMapIntFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]float64:
+		fastpathTV.EncMapIntFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[int]float64:
+		fastpathTV.EncMapIntFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int]bool:
+		fastpathTV.EncMapIntBoolV(v, fastpathCheckNilTrue, e)
+	case *map[int]bool:
+		fastpathTV.EncMapIntBoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]interface{}:
+		fastpathTV.EncMapInt8IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int8]interface{}:
+		fastpathTV.EncMapInt8IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]string:
+		fastpathTV.EncMapInt8StringV(v, fastpathCheckNilTrue, e)
+	case *map[int8]string:
+		fastpathTV.EncMapInt8StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint:
+		fastpathTV.EncMapInt8UintV(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint:
+		fastpathTV.EncMapInt8UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint8:
+		fastpathTV.EncMapInt8Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint8:
+		fastpathTV.EncMapInt8Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint16:
+		fastpathTV.EncMapInt8Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint16:
+		fastpathTV.EncMapInt8Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint32:
+		fastpathTV.EncMapInt8Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint32:
+		fastpathTV.EncMapInt8Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uint64:
+		fastpathTV.EncMapInt8Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]uint64:
+		fastpathTV.EncMapInt8Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]uintptr:
+		fastpathTV.EncMapInt8UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int8]uintptr:
+		fastpathTV.EncMapInt8UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int:
+		fastpathTV.EncMapInt8IntV(v, fastpathCheckNilTrue, e)
+	case *map[int8]int:
+		fastpathTV.EncMapInt8IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int8:
+		fastpathTV.EncMapInt8Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int8:
+		fastpathTV.EncMapInt8Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int16:
+		fastpathTV.EncMapInt8Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int16:
+		fastpathTV.EncMapInt8Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int32:
+		fastpathTV.EncMapInt8Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int32:
+		fastpathTV.EncMapInt8Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]int64:
+		fastpathTV.EncMapInt8Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]int64:
+		fastpathTV.EncMapInt8Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]float32:
+		fastpathTV.EncMapInt8Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int8]float32:
+		fastpathTV.EncMapInt8Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]float64:
+		fastpathTV.EncMapInt8Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int8]float64:
+		fastpathTV.EncMapInt8Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int8]bool:
+		fastpathTV.EncMapInt8BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int8]bool:
+		fastpathTV.EncMapInt8BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]interface{}:
+		fastpathTV.EncMapInt16IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int16]interface{}:
+		fastpathTV.EncMapInt16IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]string:
+		fastpathTV.EncMapInt16StringV(v, fastpathCheckNilTrue, e)
+	case *map[int16]string:
+		fastpathTV.EncMapInt16StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint:
+		fastpathTV.EncMapInt16UintV(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint:
+		fastpathTV.EncMapInt16UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint8:
+		fastpathTV.EncMapInt16Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint8:
+		fastpathTV.EncMapInt16Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint16:
+		fastpathTV.EncMapInt16Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint16:
+		fastpathTV.EncMapInt16Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint32:
+		fastpathTV.EncMapInt16Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint32:
+		fastpathTV.EncMapInt16Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uint64:
+		fastpathTV.EncMapInt16Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]uint64:
+		fastpathTV.EncMapInt16Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]uintptr:
+		fastpathTV.EncMapInt16UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int16]uintptr:
+		fastpathTV.EncMapInt16UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int:
+		fastpathTV.EncMapInt16IntV(v, fastpathCheckNilTrue, e)
+	case *map[int16]int:
+		fastpathTV.EncMapInt16IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int8:
+		fastpathTV.EncMapInt16Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int8:
+		fastpathTV.EncMapInt16Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int16:
+		fastpathTV.EncMapInt16Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int16:
+		fastpathTV.EncMapInt16Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int32:
+		fastpathTV.EncMapInt16Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int32:
+		fastpathTV.EncMapInt16Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]int64:
+		fastpathTV.EncMapInt16Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]int64:
+		fastpathTV.EncMapInt16Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]float32:
+		fastpathTV.EncMapInt16Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int16]float32:
+		fastpathTV.EncMapInt16Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]float64:
+		fastpathTV.EncMapInt16Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int16]float64:
+		fastpathTV.EncMapInt16Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int16]bool:
+		fastpathTV.EncMapInt16BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int16]bool:
+		fastpathTV.EncMapInt16BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]interface{}:
+		fastpathTV.EncMapInt32IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int32]interface{}:
+		fastpathTV.EncMapInt32IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]string:
+		fastpathTV.EncMapInt32StringV(v, fastpathCheckNilTrue, e)
+	case *map[int32]string:
+		fastpathTV.EncMapInt32StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint:
+		fastpathTV.EncMapInt32UintV(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint:
+		fastpathTV.EncMapInt32UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint8:
+		fastpathTV.EncMapInt32Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint8:
+		fastpathTV.EncMapInt32Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint16:
+		fastpathTV.EncMapInt32Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint16:
+		fastpathTV.EncMapInt32Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint32:
+		fastpathTV.EncMapInt32Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint32:
+		fastpathTV.EncMapInt32Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uint64:
+		fastpathTV.EncMapInt32Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]uint64:
+		fastpathTV.EncMapInt32Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]uintptr:
+		fastpathTV.EncMapInt32UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int32]uintptr:
+		fastpathTV.EncMapInt32UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int:
+		fastpathTV.EncMapInt32IntV(v, fastpathCheckNilTrue, e)
+	case *map[int32]int:
+		fastpathTV.EncMapInt32IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int8:
+		fastpathTV.EncMapInt32Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int8:
+		fastpathTV.EncMapInt32Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int16:
+		fastpathTV.EncMapInt32Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int16:
+		fastpathTV.EncMapInt32Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int32:
+		fastpathTV.EncMapInt32Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int32:
+		fastpathTV.EncMapInt32Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]int64:
+		fastpathTV.EncMapInt32Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]int64:
+		fastpathTV.EncMapInt32Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]float32:
+		fastpathTV.EncMapInt32Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int32]float32:
+		fastpathTV.EncMapInt32Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]float64:
+		fastpathTV.EncMapInt32Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int32]float64:
+		fastpathTV.EncMapInt32Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int32]bool:
+		fastpathTV.EncMapInt32BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int32]bool:
+		fastpathTV.EncMapInt32BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]interface{}:
+		fastpathTV.EncMapInt64IntfV(v, fastpathCheckNilTrue, e)
+	case *map[int64]interface{}:
+		fastpathTV.EncMapInt64IntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]string:
+		fastpathTV.EncMapInt64StringV(v, fastpathCheckNilTrue, e)
+	case *map[int64]string:
+		fastpathTV.EncMapInt64StringV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint:
+		fastpathTV.EncMapInt64UintV(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint:
+		fastpathTV.EncMapInt64UintV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint8:
+		fastpathTV.EncMapInt64Uint8V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint8:
+		fastpathTV.EncMapInt64Uint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint16:
+		fastpathTV.EncMapInt64Uint16V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint16:
+		fastpathTV.EncMapInt64Uint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint32:
+		fastpathTV.EncMapInt64Uint32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint32:
+		fastpathTV.EncMapInt64Uint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uint64:
+		fastpathTV.EncMapInt64Uint64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]uint64:
+		fastpathTV.EncMapInt64Uint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]uintptr:
+		fastpathTV.EncMapInt64UintptrV(v, fastpathCheckNilTrue, e)
+	case *map[int64]uintptr:
+		fastpathTV.EncMapInt64UintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int:
+		fastpathTV.EncMapInt64IntV(v, fastpathCheckNilTrue, e)
+	case *map[int64]int:
+		fastpathTV.EncMapInt64IntV(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int8:
+		fastpathTV.EncMapInt64Int8V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int8:
+		fastpathTV.EncMapInt64Int8V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int16:
+		fastpathTV.EncMapInt64Int16V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int16:
+		fastpathTV.EncMapInt64Int16V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int32:
+		fastpathTV.EncMapInt64Int32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int32:
+		fastpathTV.EncMapInt64Int32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]int64:
+		fastpathTV.EncMapInt64Int64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]int64:
+		fastpathTV.EncMapInt64Int64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]float32:
+		fastpathTV.EncMapInt64Float32V(v, fastpathCheckNilTrue, e)
+	case *map[int64]float32:
+		fastpathTV.EncMapInt64Float32V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]float64:
+		fastpathTV.EncMapInt64Float64V(v, fastpathCheckNilTrue, e)
+	case *map[int64]float64:
+		fastpathTV.EncMapInt64Float64V(*v, fastpathCheckNilTrue, e)
+
+	case map[int64]bool:
+		fastpathTV.EncMapInt64BoolV(v, fastpathCheckNilTrue, e)
+	case *map[int64]bool:
+		fastpathTV.EncMapInt64BoolV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]interface{}:
+		fastpathTV.EncMapBoolIntfV(v, fastpathCheckNilTrue, e)
+	case *map[bool]interface{}:
+		fastpathTV.EncMapBoolIntfV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]string:
+		fastpathTV.EncMapBoolStringV(v, fastpathCheckNilTrue, e)
+	case *map[bool]string:
+		fastpathTV.EncMapBoolStringV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint:
+		fastpathTV.EncMapBoolUintV(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint:
+		fastpathTV.EncMapBoolUintV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint8:
+		fastpathTV.EncMapBoolUint8V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint8:
+		fastpathTV.EncMapBoolUint8V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint16:
+		fastpathTV.EncMapBoolUint16V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint16:
+		fastpathTV.EncMapBoolUint16V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint32:
+		fastpathTV.EncMapBoolUint32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint32:
+		fastpathTV.EncMapBoolUint32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uint64:
+		fastpathTV.EncMapBoolUint64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]uint64:
+		fastpathTV.EncMapBoolUint64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]uintptr:
+		fastpathTV.EncMapBoolUintptrV(v, fastpathCheckNilTrue, e)
+	case *map[bool]uintptr:
+		fastpathTV.EncMapBoolUintptrV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int:
+		fastpathTV.EncMapBoolIntV(v, fastpathCheckNilTrue, e)
+	case *map[bool]int:
+		fastpathTV.EncMapBoolIntV(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int8:
+		fastpathTV.EncMapBoolInt8V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int8:
+		fastpathTV.EncMapBoolInt8V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int16:
+		fastpathTV.EncMapBoolInt16V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int16:
+		fastpathTV.EncMapBoolInt16V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int32:
+		fastpathTV.EncMapBoolInt32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int32:
+		fastpathTV.EncMapBoolInt32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]int64:
+		fastpathTV.EncMapBoolInt64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]int64:
+		fastpathTV.EncMapBoolInt64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]float32:
+		fastpathTV.EncMapBoolFloat32V(v, fastpathCheckNilTrue, e)
+	case *map[bool]float32:
+		fastpathTV.EncMapBoolFloat32V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]float64:
+		fastpathTV.EncMapBoolFloat64V(v, fastpathCheckNilTrue, e)
+	case *map[bool]float64:
+		fastpathTV.EncMapBoolFloat64V(*v, fastpathCheckNilTrue, e)
+
+	case map[bool]bool:
+		fastpathTV.EncMapBoolBoolV(v, fastpathCheckNilTrue, e)
+	case *map[bool]bool:
+		fastpathTV.EncMapBoolBoolV(*v, fastpathCheckNilTrue, e)
+
+	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+// -- -- fast path functions
+
+func (f *encFnInfo) fastpathEncSliceIntfR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceIntfV(rv.Interface().([]interface{}), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceIntfV(rv.Interface().([]interface{}), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		e.encode(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		e.encode(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceStringV(rv.Interface().([]string), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceStringV(rv.Interface().([]string), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceStringV(v []string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeString(c_UTF8, v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceStringV(v []string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeString(c_UTF8, v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceFloat32V(rv.Interface().([]float32), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceFloat32V(rv.Interface().([]float32), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeFloat32(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeFloat32(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceFloat64V(rv.Interface().([]float64), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceFloat64V(rv.Interface().([]float64), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeFloat64(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeFloat64(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceUintV(rv.Interface().([]uint), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceUintV(rv.Interface().([]uint), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceUintV(v []uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceUintV(v []uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceUint16V(rv.Interface().([]uint16), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceUint16V(rv.Interface().([]uint16), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceUint32V(rv.Interface().([]uint32), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceUint32V(rv.Interface().([]uint32), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceUint64V(rv.Interface().([]uint64), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceUint64V(rv.Interface().([]uint64), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeUint(uint64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceUintptrR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceUintptrV(rv.Interface().([]uintptr), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceUintptrV(rv.Interface().([]uintptr), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceUintptrV(v []uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		e.encode(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceUintptrV(v []uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		e.encode(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceIntV(rv.Interface().([]int), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceIntV(rv.Interface().([]int), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceIntV(v []int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceIntV(v []int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceInt8V(rv.Interface().([]int8), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceInt8V(rv.Interface().([]int8), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceInt8V(v []int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceInt8V(v []int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceInt16V(rv.Interface().([]int16), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceInt16V(rv.Interface().([]int16), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceInt16V(v []int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceInt16V(v []int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceInt32V(rv.Interface().([]int32), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceInt32V(rv.Interface().([]int32), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceInt32V(v []int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceInt32V(v []int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceInt64V(rv.Interface().([]int64), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceInt64V(rv.Interface().([]int64), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceInt64V(v []int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceInt64V(v []int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeInt(int64(v2))
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.EncAsMapSliceBoolV(rv.Interface().([]bool), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.EncSliceBoolV(rv.Interface().([]bool), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) EncSliceBoolV(v []bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil {
+			cr.sendContainerState(containerArrayElem)
+		}
+		ee.EncodeBool(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerArrayEnd)
+	}
+}
+
+func (_ fastpathT) EncAsMapSliceBoolV(v []bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		ee.EncodeBool(v2)
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
+	fastpathTV.EncMapIntfIntfV(rv.Interface().(map[interface{}]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
+	fastpathTV.EncMapIntfStringV(rv.Interface().(map[interface{}]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
+	fastpathTV.EncMapIntfUintV(rv.Interface().(map[interface{}]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
+	fastpathTV.EncMapIntfUint8V(rv.Interface().(map[interface{}]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
+	fastpathTV.EncMapIntfUint16V(rv.Interface().(map[interface{}]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
+	fastpathTV.EncMapIntfUint32V(rv.Interface().(map[interface{}]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
+	fastpathTV.EncMapIntfUint64V(rv.Interface().(map[interface{}]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapIntfUintptrV(rv.Interface().(map[interface{}]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
+	fastpathTV.EncMapIntfIntV(rv.Interface().(map[interface{}]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
+	fastpathTV.EncMapIntfInt8V(rv.Interface().(map[interface{}]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
+	fastpathTV.EncMapIntfInt16V(rv.Interface().(map[interface{}]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
+	fastpathTV.EncMapIntfInt32V(rv.Interface().(map[interface{}]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
+	fastpathTV.EncMapIntfInt64V(rv.Interface().(map[interface{}]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapIntfFloat32V(rv.Interface().(map[interface{}]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapIntfFloat64V(rv.Interface().(map[interface{}]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
+	fastpathTV.EncMapIntfBoolV(rv.Interface().(map[interface{}]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.asis(v2[j].v)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[v2[j].i])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
+	fastpathTV.EncMapStringIntfV(rv.Interface().(map[string]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
+	fastpathTV.EncMapStringStringV(rv.Interface().(map[string]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
+	fastpathTV.EncMapStringUintV(rv.Interface().(map[string]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
+	fastpathTV.EncMapStringUint8V(rv.Interface().(map[string]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
+	fastpathTV.EncMapStringUint16V(rv.Interface().(map[string]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
+	fastpathTV.EncMapStringUint32V(rv.Interface().(map[string]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
+	fastpathTV.EncMapStringUint64V(rv.Interface().(map[string]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapStringUintptrV(rv.Interface().(map[string]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringUintptrV(v map[string]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
+	fastpathTV.EncMapStringIntV(rv.Interface().(map[string]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
+	fastpathTV.EncMapStringInt8V(rv.Interface().(map[string]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
+	fastpathTV.EncMapStringInt16V(rv.Interface().(map[string]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
+	fastpathTV.EncMapStringInt32V(rv.Interface().(map[string]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
+	fastpathTV.EncMapStringInt64V(rv.Interface().(map[string]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[string(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapStringFloat32V(rv.Interface().(map[string]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapStringFloat64V(rv.Interface().(map[string]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
+	fastpathTV.EncMapStringBoolV(rv.Interface().(map[string]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	if e.h.Canonical {
+		v2 := make([]string, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = string(k)
+			i++
+		}
+		sort.Sort(stringSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[string(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32IntfV(rv.Interface().(map[float32]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32StringV(rv.Interface().(map[float32]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32UintV(rv.Interface().(map[float32]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Uint8V(rv.Interface().(map[float32]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Uint16V(rv.Interface().(map[float32]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Uint32V(rv.Interface().(map[float32]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Uint64V(rv.Interface().(map[float32]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32UintptrV(rv.Interface().(map[float32]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32IntV(rv.Interface().(map[float32]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Int8V(rv.Interface().(map[float32]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Int16V(rv.Interface().(map[float32]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Int32V(rv.Interface().(map[float32]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Int64V(rv.Interface().(map[float32]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Float32V(rv.Interface().(map[float32]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat32Float64V(rv.Interface().(map[float32]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
+	fastpathTV.EncMapFloat32BoolV(rv.Interface().(map[float32]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(float32(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[float32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat32(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64IntfV(rv.Interface().(map[float64]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64StringV(rv.Interface().(map[float64]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64UintV(rv.Interface().(map[float64]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Uint8V(rv.Interface().(map[float64]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Uint16V(rv.Interface().(map[float64]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Uint32V(rv.Interface().(map[float64]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Uint64V(rv.Interface().(map[float64]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64UintptrV(rv.Interface().(map[float64]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64IntV(rv.Interface().(map[float64]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Int8V(rv.Interface().(map[float64]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Int16V(rv.Interface().(map[float64]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Int32V(rv.Interface().(map[float64]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Int64V(rv.Interface().(map[float64]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[float64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Float32V(rv.Interface().(map[float64]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
+	fastpathTV.EncMapFloat64Float64V(rv.Interface().(map[float64]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
+	fastpathTV.EncMapFloat64BoolV(rv.Interface().(map[float64]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]float64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = float64(k)
+			i++
+		}
+		sort.Sort(floatSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(float64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[float64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeFloat64(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
+	fastpathTV.EncMapUintIntfV(rv.Interface().(map[uint]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
+	fastpathTV.EncMapUintStringV(rv.Interface().(map[uint]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
+	fastpathTV.EncMapUintUintV(rv.Interface().(map[uint]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
+	fastpathTV.EncMapUintUint8V(rv.Interface().(map[uint]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
+	fastpathTV.EncMapUintUint16V(rv.Interface().(map[uint]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
+	fastpathTV.EncMapUintUint32V(rv.Interface().(map[uint]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
+	fastpathTV.EncMapUintUint64V(rv.Interface().(map[uint]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUintUintptrV(rv.Interface().(map[uint]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintUintptrV(v map[uint]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
+	fastpathTV.EncMapUintIntV(rv.Interface().(map[uint]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
+	fastpathTV.EncMapUintInt8V(rv.Interface().(map[uint]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
+	fastpathTV.EncMapUintInt16V(rv.Interface().(map[uint]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
+	fastpathTV.EncMapUintInt32V(rv.Interface().(map[uint]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
+	fastpathTV.EncMapUintInt64V(rv.Interface().(map[uint]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapUintFloat32V(rv.Interface().(map[uint]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapUintFloat64V(rv.Interface().(map[uint]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
+	fastpathTV.EncMapUintBoolV(rv.Interface().(map[uint]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uint(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
+	fastpathTV.EncMapUint8IntfV(rv.Interface().(map[uint8]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
+	fastpathTV.EncMapUint8StringV(rv.Interface().(map[uint8]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
+	fastpathTV.EncMapUint8UintV(rv.Interface().(map[uint8]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Uint8V(rv.Interface().(map[uint8]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Uint16V(rv.Interface().(map[uint8]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Uint32V(rv.Interface().(map[uint8]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Uint64V(rv.Interface().(map[uint8]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUint8UintptrV(rv.Interface().(map[uint8]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
+	fastpathTV.EncMapUint8IntV(rv.Interface().(map[uint8]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Int8V(rv.Interface().(map[uint8]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Int16V(rv.Interface().(map[uint8]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Int32V(rv.Interface().(map[uint8]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Int64V(rv.Interface().(map[uint8]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Float32V(rv.Interface().(map[uint8]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
+	fastpathTV.EncMapUint8Float64V(rv.Interface().(map[uint8]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
+	fastpathTV.EncMapUint8BoolV(rv.Interface().(map[uint8]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uint8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
+	fastpathTV.EncMapUint16IntfV(rv.Interface().(map[uint16]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
+	fastpathTV.EncMapUint16StringV(rv.Interface().(map[uint16]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
+	fastpathTV.EncMapUint16UintV(rv.Interface().(map[uint16]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Uint8V(rv.Interface().(map[uint16]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Uint16V(rv.Interface().(map[uint16]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Uint32V(rv.Interface().(map[uint16]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Uint64V(rv.Interface().(map[uint16]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUint16UintptrV(rv.Interface().(map[uint16]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
+	fastpathTV.EncMapUint16IntV(rv.Interface().(map[uint16]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Int8V(rv.Interface().(map[uint16]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Int16V(rv.Interface().(map[uint16]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Int32V(rv.Interface().(map[uint16]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Int64V(rv.Interface().(map[uint16]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Float32V(rv.Interface().(map[uint16]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
+	fastpathTV.EncMapUint16Float64V(rv.Interface().(map[uint16]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
+	fastpathTV.EncMapUint16BoolV(rv.Interface().(map[uint16]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uint16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
+	fastpathTV.EncMapUint32IntfV(rv.Interface().(map[uint32]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
+	fastpathTV.EncMapUint32StringV(rv.Interface().(map[uint32]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
+	fastpathTV.EncMapUint32UintV(rv.Interface().(map[uint32]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Uint8V(rv.Interface().(map[uint32]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Uint16V(rv.Interface().(map[uint32]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Uint32V(rv.Interface().(map[uint32]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Uint64V(rv.Interface().(map[uint32]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUint32UintptrV(rv.Interface().(map[uint32]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
+	fastpathTV.EncMapUint32IntV(rv.Interface().(map[uint32]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Int8V(rv.Interface().(map[uint32]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Int16V(rv.Interface().(map[uint32]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Int32V(rv.Interface().(map[uint32]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Int64V(rv.Interface().(map[uint32]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Float32V(rv.Interface().(map[uint32]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
+	fastpathTV.EncMapUint32Float64V(rv.Interface().(map[uint32]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
+	fastpathTV.EncMapUint32BoolV(rv.Interface().(map[uint32]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uint32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
+	fastpathTV.EncMapUint64IntfV(rv.Interface().(map[uint64]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
+	fastpathTV.EncMapUint64StringV(rv.Interface().(map[uint64]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
+	fastpathTV.EncMapUint64UintV(rv.Interface().(map[uint64]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Uint8V(rv.Interface().(map[uint64]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Uint16V(rv.Interface().(map[uint64]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Uint32V(rv.Interface().(map[uint64]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Uint64V(rv.Interface().(map[uint64]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUint64UintptrV(rv.Interface().(map[uint64]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
+	fastpathTV.EncMapUint64IntV(rv.Interface().(map[uint64]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Int8V(rv.Interface().(map[uint64]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Int16V(rv.Interface().(map[uint64]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Int32V(rv.Interface().(map[uint64]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Int64V(rv.Interface().(map[uint64]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uint64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Float32V(rv.Interface().(map[uint64]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
+	fastpathTV.EncMapUint64Float64V(rv.Interface().(map[uint64]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
+	fastpathTV.EncMapUint64BoolV(rv.Interface().(map[uint64]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(uint64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uint64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeUint(uint64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrIntfR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrIntfV(rv.Interface().(map[uintptr]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrStringR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrStringV(rv.Interface().(map[uintptr]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrStringV(v map[uintptr]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUintR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUintV(rv.Interface().(map[uintptr]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUintV(v map[uintptr]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUint8R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUint8V(rv.Interface().(map[uintptr]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUint16R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUint16V(rv.Interface().(map[uintptr]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUint32R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUint32V(rv.Interface().(map[uintptr]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUint64R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUint64V(rv.Interface().(map[uintptr]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrUintptrV(rv.Interface().(map[uintptr]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrIntR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrIntV(rv.Interface().(map[uintptr]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrIntV(v map[uintptr]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrInt8R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrInt8V(rv.Interface().(map[uintptr]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrInt8V(v map[uintptr]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrInt16R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrInt16V(rv.Interface().(map[uintptr]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrInt16V(v map[uintptr]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrInt32R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrInt32V(rv.Interface().(map[uintptr]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrInt32V(v map[uintptr]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrInt64R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrInt64V(rv.Interface().(map[uintptr]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrInt64V(v map[uintptr]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[uintptr(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrFloat32V(rv.Interface().(map[uintptr]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapUintptrFloat64V(rv.Interface().(map[uintptr]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapUintptrBoolR(rv reflect.Value) {
+	fastpathTV.EncMapUintptrBoolV(rv.Interface().(map[uintptr]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapUintptrBoolV(v map[uintptr]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]uint64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = uint64(k)
+			i++
+		}
+		sort.Sort(uintSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(uintptr(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[uintptr(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			e.encode(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
+	fastpathTV.EncMapIntIntfV(rv.Interface().(map[int]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
+	fastpathTV.EncMapIntStringV(rv.Interface().(map[int]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
+	fastpathTV.EncMapIntUintV(rv.Interface().(map[int]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
+	fastpathTV.EncMapIntUint8V(rv.Interface().(map[int]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
+	fastpathTV.EncMapIntUint16V(rv.Interface().(map[int]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
+	fastpathTV.EncMapIntUint32V(rv.Interface().(map[int]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
+	fastpathTV.EncMapIntUint64V(rv.Interface().(map[int]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapIntUintptrV(rv.Interface().(map[int]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntUintptrV(v map[int]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
+	fastpathTV.EncMapIntIntV(rv.Interface().(map[int]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
+	fastpathTV.EncMapIntInt8V(rv.Interface().(map[int]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
+	fastpathTV.EncMapIntInt16V(rv.Interface().(map[int]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
+	fastpathTV.EncMapIntInt32V(rv.Interface().(map[int]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
+	fastpathTV.EncMapIntInt64V(rv.Interface().(map[int]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapIntFloat32V(rv.Interface().(map[int]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapIntFloat64V(rv.Interface().(map[int]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
+	fastpathTV.EncMapIntBoolV(rv.Interface().(map[int]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[int(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
+	fastpathTV.EncMapInt8IntfV(rv.Interface().(map[int8]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
+	fastpathTV.EncMapInt8StringV(rv.Interface().(map[int8]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
+	fastpathTV.EncMapInt8UintV(rv.Interface().(map[int8]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Uint8V(rv.Interface().(map[int8]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Uint16V(rv.Interface().(map[int8]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Uint32V(rv.Interface().(map[int8]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Uint64V(rv.Interface().(map[int8]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapInt8UintptrV(rv.Interface().(map[int8]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8UintptrV(v map[int8]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
+	fastpathTV.EncMapInt8IntV(rv.Interface().(map[int8]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Int8V(rv.Interface().(map[int8]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Int16V(rv.Interface().(map[int8]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Int32V(rv.Interface().(map[int8]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Int64V(rv.Interface().(map[int8]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int8(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Float32V(rv.Interface().(map[int8]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
+	fastpathTV.EncMapInt8Float64V(rv.Interface().(map[int8]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
+	fastpathTV.EncMapInt8BoolV(rv.Interface().(map[int8]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int8(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[int8(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
+	fastpathTV.EncMapInt16IntfV(rv.Interface().(map[int16]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
+	fastpathTV.EncMapInt16StringV(rv.Interface().(map[int16]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
+	fastpathTV.EncMapInt16UintV(rv.Interface().(map[int16]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Uint8V(rv.Interface().(map[int16]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Uint16V(rv.Interface().(map[int16]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Uint32V(rv.Interface().(map[int16]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Uint64V(rv.Interface().(map[int16]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapInt16UintptrV(rv.Interface().(map[int16]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16UintptrV(v map[int16]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
+	fastpathTV.EncMapInt16IntV(rv.Interface().(map[int16]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Int8V(rv.Interface().(map[int16]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Int16V(rv.Interface().(map[int16]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Int32V(rv.Interface().(map[int16]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Int64V(rv.Interface().(map[int16]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int16(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Float32V(rv.Interface().(map[int16]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
+	fastpathTV.EncMapInt16Float64V(rv.Interface().(map[int16]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
+	fastpathTV.EncMapInt16BoolV(rv.Interface().(map[int16]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int16(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[int16(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
+	fastpathTV.EncMapInt32IntfV(rv.Interface().(map[int32]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
+	fastpathTV.EncMapInt32StringV(rv.Interface().(map[int32]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
+	fastpathTV.EncMapInt32UintV(rv.Interface().(map[int32]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Uint8V(rv.Interface().(map[int32]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Uint16V(rv.Interface().(map[int32]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Uint32V(rv.Interface().(map[int32]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Uint64V(rv.Interface().(map[int32]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapInt32UintptrV(rv.Interface().(map[int32]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32UintptrV(v map[int32]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
+	fastpathTV.EncMapInt32IntV(rv.Interface().(map[int32]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Int8V(rv.Interface().(map[int32]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Int16V(rv.Interface().(map[int32]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Int32V(rv.Interface().(map[int32]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Int64V(rv.Interface().(map[int32]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int32(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Float32V(rv.Interface().(map[int32]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
+	fastpathTV.EncMapInt32Float64V(rv.Interface().(map[int32]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
+	fastpathTV.EncMapInt32BoolV(rv.Interface().(map[int32]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int32(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[int32(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
+	fastpathTV.EncMapInt64IntfV(rv.Interface().(map[int64]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
+	fastpathTV.EncMapInt64StringV(rv.Interface().(map[int64]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
+	fastpathTV.EncMapInt64UintV(rv.Interface().(map[int64]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Uint8V(rv.Interface().(map[int64]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Uint16V(rv.Interface().(map[int64]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Uint32V(rv.Interface().(map[int64]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Uint64V(rv.Interface().(map[int64]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64UintptrR(rv reflect.Value) {
+	fastpathTV.EncMapInt64UintptrV(rv.Interface().(map[int64]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64UintptrV(v map[int64]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
+	fastpathTV.EncMapInt64IntV(rv.Interface().(map[int64]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Int8V(rv.Interface().(map[int64]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Int16V(rv.Interface().(map[int64]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Int32V(rv.Interface().(map[int64]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Int64V(rv.Interface().(map[int64]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[int64(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Float32V(rv.Interface().(map[int64]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
+	fastpathTV.EncMapInt64Float64V(rv.Interface().(map[int64]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
+	fastpathTV.EncMapInt64BoolV(rv.Interface().(map[int64]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]int64, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = int64(k)
+			i++
+		}
+		sort.Sort(intSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(int64(k2)))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[int64(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeInt(int64(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
+	fastpathTV.EncMapBoolIntfV(rv.Interface().(map[bool]interface{}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
+	fastpathTV.EncMapBoolStringV(rv.Interface().(map[bool]string), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeString(c_UTF8, v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
+	fastpathTV.EncMapBoolUintV(rv.Interface().(map[bool]uint), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
+	fastpathTV.EncMapBoolUint8V(rv.Interface().(map[bool]uint8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
+	fastpathTV.EncMapBoolUint16V(rv.Interface().(map[bool]uint16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
+	fastpathTV.EncMapBoolUint32V(rv.Interface().(map[bool]uint32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
+	fastpathTV.EncMapBoolUint64V(rv.Interface().(map[bool]uint64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeUint(uint64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolUintptrR(rv reflect.Value) {
+	fastpathTV.EncMapBoolUintptrV(rv.Interface().(map[bool]uintptr), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolUintptrV(v map[bool]uintptr, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			e.encode(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
+	fastpathTV.EncMapBoolIntV(rv.Interface().(map[bool]int), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
+	fastpathTV.EncMapBoolInt8V(rv.Interface().(map[bool]int8), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
+	fastpathTV.EncMapBoolInt16V(rv.Interface().(map[bool]int16), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
+	fastpathTV.EncMapBoolInt32V(rv.Interface().(map[bool]int32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
+	fastpathTV.EncMapBoolInt64V(rv.Interface().(map[bool]int64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v[bool(k2)]))
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeInt(int64(v2))
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
+	fastpathTV.EncMapBoolFloat32V(rv.Interface().(map[bool]float32), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat32(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
+	fastpathTV.EncMapBoolFloat64V(rv.Interface().(map[bool]float64), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeFloat64(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+func (f *encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
+	fastpathTV.EncMapBoolBoolV(rv.Interface().(map[bool]bool), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	if e.h.Canonical {
+		v2 := make([]bool, len(v))
+		var i int
+		for k, _ := range v {
+			v2[i] = bool(k)
+			i++
+		}
+		sort.Sort(boolSlice(v2))
+		for _, k2 := range v2 {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(bool(k2))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v[bool(k2)])
+		}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			ee.EncodeBool(k2)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			ee.EncodeBool(v2)
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+}
+
+// -- decode
+
+// -- -- fast path type switch
+func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
+	switch v := iv.(type) {
+
+	case []interface{}:
+		fastpathTV.DecSliceIntfV(v, fastpathCheckNilFalse, false, d)
+	case *[]interface{}:
+		v2, changed2 := fastpathTV.DecSliceIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]interface{}:
+		fastpathTV.DecMapIntfIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]interface{}:
+		v2, changed2 := fastpathTV.DecMapIntfIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]string:
+		fastpathTV.DecMapIntfStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]string:
+		v2, changed2 := fastpathTV.DecMapIntfStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uint:
+		fastpathTV.DecMapIntfUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uint:
+		v2, changed2 := fastpathTV.DecMapIntfUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uint8:
+		fastpathTV.DecMapIntfUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uint8:
+		v2, changed2 := fastpathTV.DecMapIntfUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uint16:
+		fastpathTV.DecMapIntfUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uint16:
+		v2, changed2 := fastpathTV.DecMapIntfUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uint32:
+		fastpathTV.DecMapIntfUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uint32:
+		v2, changed2 := fastpathTV.DecMapIntfUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uint64:
+		fastpathTV.DecMapIntfUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uint64:
+		v2, changed2 := fastpathTV.DecMapIntfUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]uintptr:
+		fastpathTV.DecMapIntfUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]uintptr:
+		v2, changed2 := fastpathTV.DecMapIntfUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]int:
+		fastpathTV.DecMapIntfIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]int:
+		v2, changed2 := fastpathTV.DecMapIntfIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]int8:
+		fastpathTV.DecMapIntfInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]int8:
+		v2, changed2 := fastpathTV.DecMapIntfInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]int16:
+		fastpathTV.DecMapIntfInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]int16:
+		v2, changed2 := fastpathTV.DecMapIntfInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]int32:
+		fastpathTV.DecMapIntfInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]int32:
+		v2, changed2 := fastpathTV.DecMapIntfInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]int64:
+		fastpathTV.DecMapIntfInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]int64:
+		v2, changed2 := fastpathTV.DecMapIntfInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]float32:
+		fastpathTV.DecMapIntfFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]float32:
+		v2, changed2 := fastpathTV.DecMapIntfFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]float64:
+		fastpathTV.DecMapIntfFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]float64:
+		v2, changed2 := fastpathTV.DecMapIntfFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[interface{}]bool:
+		fastpathTV.DecMapIntfBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[interface{}]bool:
+		v2, changed2 := fastpathTV.DecMapIntfBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []string:
+		fastpathTV.DecSliceStringV(v, fastpathCheckNilFalse, false, d)
+	case *[]string:
+		v2, changed2 := fastpathTV.DecSliceStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]interface{}:
+		fastpathTV.DecMapStringIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]interface{}:
+		v2, changed2 := fastpathTV.DecMapStringIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]string:
+		fastpathTV.DecMapStringStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]string:
+		v2, changed2 := fastpathTV.DecMapStringStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uint:
+		fastpathTV.DecMapStringUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uint:
+		v2, changed2 := fastpathTV.DecMapStringUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uint8:
+		fastpathTV.DecMapStringUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uint8:
+		v2, changed2 := fastpathTV.DecMapStringUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uint16:
+		fastpathTV.DecMapStringUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uint16:
+		v2, changed2 := fastpathTV.DecMapStringUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uint32:
+		fastpathTV.DecMapStringUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uint32:
+		v2, changed2 := fastpathTV.DecMapStringUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uint64:
+		fastpathTV.DecMapStringUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uint64:
+		v2, changed2 := fastpathTV.DecMapStringUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]uintptr:
+		fastpathTV.DecMapStringUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]uintptr:
+		v2, changed2 := fastpathTV.DecMapStringUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]int:
+		fastpathTV.DecMapStringIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]int:
+		v2, changed2 := fastpathTV.DecMapStringIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]int8:
+		fastpathTV.DecMapStringInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]int8:
+		v2, changed2 := fastpathTV.DecMapStringInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]int16:
+		fastpathTV.DecMapStringInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]int16:
+		v2, changed2 := fastpathTV.DecMapStringInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]int32:
+		fastpathTV.DecMapStringInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]int32:
+		v2, changed2 := fastpathTV.DecMapStringInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]int64:
+		fastpathTV.DecMapStringInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]int64:
+		v2, changed2 := fastpathTV.DecMapStringInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]float32:
+		fastpathTV.DecMapStringFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]float32:
+		v2, changed2 := fastpathTV.DecMapStringFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]float64:
+		fastpathTV.DecMapStringFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[string]float64:
+		v2, changed2 := fastpathTV.DecMapStringFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[string]bool:
+		fastpathTV.DecMapStringBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[string]bool:
+		v2, changed2 := fastpathTV.DecMapStringBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []float32:
+		fastpathTV.DecSliceFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *[]float32:
+		v2, changed2 := fastpathTV.DecSliceFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]interface{}:
+		fastpathTV.DecMapFloat32IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]interface{}:
+		v2, changed2 := fastpathTV.DecMapFloat32IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]string:
+		fastpathTV.DecMapFloat32StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]string:
+		v2, changed2 := fastpathTV.DecMapFloat32StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uint:
+		fastpathTV.DecMapFloat32UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uint:
+		v2, changed2 := fastpathTV.DecMapFloat32UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uint8:
+		fastpathTV.DecMapFloat32Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uint8:
+		v2, changed2 := fastpathTV.DecMapFloat32Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uint16:
+		fastpathTV.DecMapFloat32Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uint16:
+		v2, changed2 := fastpathTV.DecMapFloat32Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uint32:
+		fastpathTV.DecMapFloat32Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uint32:
+		v2, changed2 := fastpathTV.DecMapFloat32Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uint64:
+		fastpathTV.DecMapFloat32Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uint64:
+		v2, changed2 := fastpathTV.DecMapFloat32Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]uintptr:
+		fastpathTV.DecMapFloat32UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]uintptr:
+		v2, changed2 := fastpathTV.DecMapFloat32UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]int:
+		fastpathTV.DecMapFloat32IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]int:
+		v2, changed2 := fastpathTV.DecMapFloat32IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]int8:
+		fastpathTV.DecMapFloat32Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]int8:
+		v2, changed2 := fastpathTV.DecMapFloat32Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]int16:
+		fastpathTV.DecMapFloat32Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]int16:
+		v2, changed2 := fastpathTV.DecMapFloat32Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]int32:
+		fastpathTV.DecMapFloat32Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]int32:
+		v2, changed2 := fastpathTV.DecMapFloat32Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]int64:
+		fastpathTV.DecMapFloat32Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]int64:
+		v2, changed2 := fastpathTV.DecMapFloat32Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]float32:
+		fastpathTV.DecMapFloat32Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]float32:
+		v2, changed2 := fastpathTV.DecMapFloat32Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]float64:
+		fastpathTV.DecMapFloat32Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]float64:
+		v2, changed2 := fastpathTV.DecMapFloat32Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float32]bool:
+		fastpathTV.DecMapFloat32BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[float32]bool:
+		v2, changed2 := fastpathTV.DecMapFloat32BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []float64:
+		fastpathTV.DecSliceFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *[]float64:
+		v2, changed2 := fastpathTV.DecSliceFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]interface{}:
+		fastpathTV.DecMapFloat64IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]interface{}:
+		v2, changed2 := fastpathTV.DecMapFloat64IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]string:
+		fastpathTV.DecMapFloat64StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]string:
+		v2, changed2 := fastpathTV.DecMapFloat64StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uint:
+		fastpathTV.DecMapFloat64UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uint:
+		v2, changed2 := fastpathTV.DecMapFloat64UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uint8:
+		fastpathTV.DecMapFloat64Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uint8:
+		v2, changed2 := fastpathTV.DecMapFloat64Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uint16:
+		fastpathTV.DecMapFloat64Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uint16:
+		v2, changed2 := fastpathTV.DecMapFloat64Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uint32:
+		fastpathTV.DecMapFloat64Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uint32:
+		v2, changed2 := fastpathTV.DecMapFloat64Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uint64:
+		fastpathTV.DecMapFloat64Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uint64:
+		v2, changed2 := fastpathTV.DecMapFloat64Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]uintptr:
+		fastpathTV.DecMapFloat64UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]uintptr:
+		v2, changed2 := fastpathTV.DecMapFloat64UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]int:
+		fastpathTV.DecMapFloat64IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]int:
+		v2, changed2 := fastpathTV.DecMapFloat64IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]int8:
+		fastpathTV.DecMapFloat64Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]int8:
+		v2, changed2 := fastpathTV.DecMapFloat64Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]int16:
+		fastpathTV.DecMapFloat64Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]int16:
+		v2, changed2 := fastpathTV.DecMapFloat64Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]int32:
+		fastpathTV.DecMapFloat64Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]int32:
+		v2, changed2 := fastpathTV.DecMapFloat64Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]int64:
+		fastpathTV.DecMapFloat64Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]int64:
+		v2, changed2 := fastpathTV.DecMapFloat64Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]float32:
+		fastpathTV.DecMapFloat64Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]float32:
+		v2, changed2 := fastpathTV.DecMapFloat64Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]float64:
+		fastpathTV.DecMapFloat64Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]float64:
+		v2, changed2 := fastpathTV.DecMapFloat64Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[float64]bool:
+		fastpathTV.DecMapFloat64BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[float64]bool:
+		v2, changed2 := fastpathTV.DecMapFloat64BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []uint:
+		fastpathTV.DecSliceUintV(v, fastpathCheckNilFalse, false, d)
+	case *[]uint:
+		v2, changed2 := fastpathTV.DecSliceUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]interface{}:
+		fastpathTV.DecMapUintIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]interface{}:
+		v2, changed2 := fastpathTV.DecMapUintIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]string:
+		fastpathTV.DecMapUintStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]string:
+		v2, changed2 := fastpathTV.DecMapUintStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uint:
+		fastpathTV.DecMapUintUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uint:
+		v2, changed2 := fastpathTV.DecMapUintUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uint8:
+		fastpathTV.DecMapUintUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uint8:
+		v2, changed2 := fastpathTV.DecMapUintUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uint16:
+		fastpathTV.DecMapUintUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uint16:
+		v2, changed2 := fastpathTV.DecMapUintUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uint32:
+		fastpathTV.DecMapUintUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uint32:
+		v2, changed2 := fastpathTV.DecMapUintUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uint64:
+		fastpathTV.DecMapUintUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uint64:
+		v2, changed2 := fastpathTV.DecMapUintUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]uintptr:
+		fastpathTV.DecMapUintUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]uintptr:
+		v2, changed2 := fastpathTV.DecMapUintUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]int:
+		fastpathTV.DecMapUintIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]int:
+		v2, changed2 := fastpathTV.DecMapUintIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]int8:
+		fastpathTV.DecMapUintInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]int8:
+		v2, changed2 := fastpathTV.DecMapUintInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]int16:
+		fastpathTV.DecMapUintInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]int16:
+		v2, changed2 := fastpathTV.DecMapUintInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]int32:
+		fastpathTV.DecMapUintInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]int32:
+		v2, changed2 := fastpathTV.DecMapUintInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]int64:
+		fastpathTV.DecMapUintInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]int64:
+		v2, changed2 := fastpathTV.DecMapUintInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]float32:
+		fastpathTV.DecMapUintFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]float32:
+		v2, changed2 := fastpathTV.DecMapUintFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]float64:
+		fastpathTV.DecMapUintFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]float64:
+		v2, changed2 := fastpathTV.DecMapUintFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint]bool:
+		fastpathTV.DecMapUintBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint]bool:
+		v2, changed2 := fastpathTV.DecMapUintBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]interface{}:
+		fastpathTV.DecMapUint8IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]interface{}:
+		v2, changed2 := fastpathTV.DecMapUint8IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]string:
+		fastpathTV.DecMapUint8StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]string:
+		v2, changed2 := fastpathTV.DecMapUint8StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uint:
+		fastpathTV.DecMapUint8UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uint:
+		v2, changed2 := fastpathTV.DecMapUint8UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uint8:
+		fastpathTV.DecMapUint8Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uint8:
+		v2, changed2 := fastpathTV.DecMapUint8Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uint16:
+		fastpathTV.DecMapUint8Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uint16:
+		v2, changed2 := fastpathTV.DecMapUint8Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uint32:
+		fastpathTV.DecMapUint8Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uint32:
+		v2, changed2 := fastpathTV.DecMapUint8Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uint64:
+		fastpathTV.DecMapUint8Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uint64:
+		v2, changed2 := fastpathTV.DecMapUint8Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]uintptr:
+		fastpathTV.DecMapUint8UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]uintptr:
+		v2, changed2 := fastpathTV.DecMapUint8UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]int:
+		fastpathTV.DecMapUint8IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]int:
+		v2, changed2 := fastpathTV.DecMapUint8IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]int8:
+		fastpathTV.DecMapUint8Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]int8:
+		v2, changed2 := fastpathTV.DecMapUint8Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]int16:
+		fastpathTV.DecMapUint8Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]int16:
+		v2, changed2 := fastpathTV.DecMapUint8Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]int32:
+		fastpathTV.DecMapUint8Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]int32:
+		v2, changed2 := fastpathTV.DecMapUint8Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]int64:
+		fastpathTV.DecMapUint8Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]int64:
+		v2, changed2 := fastpathTV.DecMapUint8Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]float32:
+		fastpathTV.DecMapUint8Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]float32:
+		v2, changed2 := fastpathTV.DecMapUint8Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]float64:
+		fastpathTV.DecMapUint8Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]float64:
+		v2, changed2 := fastpathTV.DecMapUint8Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint8]bool:
+		fastpathTV.DecMapUint8BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint8]bool:
+		v2, changed2 := fastpathTV.DecMapUint8BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []uint16:
+		fastpathTV.DecSliceUint16V(v, fastpathCheckNilFalse, false, d)
+	case *[]uint16:
+		v2, changed2 := fastpathTV.DecSliceUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]interface{}:
+		fastpathTV.DecMapUint16IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]interface{}:
+		v2, changed2 := fastpathTV.DecMapUint16IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]string:
+		fastpathTV.DecMapUint16StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]string:
+		v2, changed2 := fastpathTV.DecMapUint16StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uint:
+		fastpathTV.DecMapUint16UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uint:
+		v2, changed2 := fastpathTV.DecMapUint16UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uint8:
+		fastpathTV.DecMapUint16Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uint8:
+		v2, changed2 := fastpathTV.DecMapUint16Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uint16:
+		fastpathTV.DecMapUint16Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uint16:
+		v2, changed2 := fastpathTV.DecMapUint16Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uint32:
+		fastpathTV.DecMapUint16Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uint32:
+		v2, changed2 := fastpathTV.DecMapUint16Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uint64:
+		fastpathTV.DecMapUint16Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uint64:
+		v2, changed2 := fastpathTV.DecMapUint16Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]uintptr:
+		fastpathTV.DecMapUint16UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]uintptr:
+		v2, changed2 := fastpathTV.DecMapUint16UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]int:
+		fastpathTV.DecMapUint16IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]int:
+		v2, changed2 := fastpathTV.DecMapUint16IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]int8:
+		fastpathTV.DecMapUint16Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]int8:
+		v2, changed2 := fastpathTV.DecMapUint16Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]int16:
+		fastpathTV.DecMapUint16Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]int16:
+		v2, changed2 := fastpathTV.DecMapUint16Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]int32:
+		fastpathTV.DecMapUint16Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]int32:
+		v2, changed2 := fastpathTV.DecMapUint16Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]int64:
+		fastpathTV.DecMapUint16Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]int64:
+		v2, changed2 := fastpathTV.DecMapUint16Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]float32:
+		fastpathTV.DecMapUint16Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]float32:
+		v2, changed2 := fastpathTV.DecMapUint16Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]float64:
+		fastpathTV.DecMapUint16Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]float64:
+		v2, changed2 := fastpathTV.DecMapUint16Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint16]bool:
+		fastpathTV.DecMapUint16BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint16]bool:
+		v2, changed2 := fastpathTV.DecMapUint16BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []uint32:
+		fastpathTV.DecSliceUint32V(v, fastpathCheckNilFalse, false, d)
+	case *[]uint32:
+		v2, changed2 := fastpathTV.DecSliceUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]interface{}:
+		fastpathTV.DecMapUint32IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]interface{}:
+		v2, changed2 := fastpathTV.DecMapUint32IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]string:
+		fastpathTV.DecMapUint32StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]string:
+		v2, changed2 := fastpathTV.DecMapUint32StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uint:
+		fastpathTV.DecMapUint32UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uint:
+		v2, changed2 := fastpathTV.DecMapUint32UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uint8:
+		fastpathTV.DecMapUint32Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uint8:
+		v2, changed2 := fastpathTV.DecMapUint32Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uint16:
+		fastpathTV.DecMapUint32Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uint16:
+		v2, changed2 := fastpathTV.DecMapUint32Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uint32:
+		fastpathTV.DecMapUint32Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uint32:
+		v2, changed2 := fastpathTV.DecMapUint32Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uint64:
+		fastpathTV.DecMapUint32Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uint64:
+		v2, changed2 := fastpathTV.DecMapUint32Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]uintptr:
+		fastpathTV.DecMapUint32UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]uintptr:
+		v2, changed2 := fastpathTV.DecMapUint32UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]int:
+		fastpathTV.DecMapUint32IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]int:
+		v2, changed2 := fastpathTV.DecMapUint32IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]int8:
+		fastpathTV.DecMapUint32Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]int8:
+		v2, changed2 := fastpathTV.DecMapUint32Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]int16:
+		fastpathTV.DecMapUint32Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]int16:
+		v2, changed2 := fastpathTV.DecMapUint32Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]int32:
+		fastpathTV.DecMapUint32Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]int32:
+		v2, changed2 := fastpathTV.DecMapUint32Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]int64:
+		fastpathTV.DecMapUint32Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]int64:
+		v2, changed2 := fastpathTV.DecMapUint32Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]float32:
+		fastpathTV.DecMapUint32Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]float32:
+		v2, changed2 := fastpathTV.DecMapUint32Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]float64:
+		fastpathTV.DecMapUint32Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]float64:
+		v2, changed2 := fastpathTV.DecMapUint32Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint32]bool:
+		fastpathTV.DecMapUint32BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint32]bool:
+		v2, changed2 := fastpathTV.DecMapUint32BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []uint64:
+		fastpathTV.DecSliceUint64V(v, fastpathCheckNilFalse, false, d)
+	case *[]uint64:
+		v2, changed2 := fastpathTV.DecSliceUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]interface{}:
+		fastpathTV.DecMapUint64IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]interface{}:
+		v2, changed2 := fastpathTV.DecMapUint64IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]string:
+		fastpathTV.DecMapUint64StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]string:
+		v2, changed2 := fastpathTV.DecMapUint64StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uint:
+		fastpathTV.DecMapUint64UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uint:
+		v2, changed2 := fastpathTV.DecMapUint64UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uint8:
+		fastpathTV.DecMapUint64Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uint8:
+		v2, changed2 := fastpathTV.DecMapUint64Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uint16:
+		fastpathTV.DecMapUint64Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uint16:
+		v2, changed2 := fastpathTV.DecMapUint64Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uint32:
+		fastpathTV.DecMapUint64Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uint32:
+		v2, changed2 := fastpathTV.DecMapUint64Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uint64:
+		fastpathTV.DecMapUint64Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uint64:
+		v2, changed2 := fastpathTV.DecMapUint64Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]uintptr:
+		fastpathTV.DecMapUint64UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]uintptr:
+		v2, changed2 := fastpathTV.DecMapUint64UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]int:
+		fastpathTV.DecMapUint64IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]int:
+		v2, changed2 := fastpathTV.DecMapUint64IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]int8:
+		fastpathTV.DecMapUint64Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]int8:
+		v2, changed2 := fastpathTV.DecMapUint64Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]int16:
+		fastpathTV.DecMapUint64Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]int16:
+		v2, changed2 := fastpathTV.DecMapUint64Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]int32:
+		fastpathTV.DecMapUint64Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]int32:
+		v2, changed2 := fastpathTV.DecMapUint64Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]int64:
+		fastpathTV.DecMapUint64Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]int64:
+		v2, changed2 := fastpathTV.DecMapUint64Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]float32:
+		fastpathTV.DecMapUint64Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]float32:
+		v2, changed2 := fastpathTV.DecMapUint64Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]float64:
+		fastpathTV.DecMapUint64Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]float64:
+		v2, changed2 := fastpathTV.DecMapUint64Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uint64]bool:
+		fastpathTV.DecMapUint64BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uint64]bool:
+		v2, changed2 := fastpathTV.DecMapUint64BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []uintptr:
+		fastpathTV.DecSliceUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *[]uintptr:
+		v2, changed2 := fastpathTV.DecSliceUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]interface{}:
+		fastpathTV.DecMapUintptrIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]interface{}:
+		v2, changed2 := fastpathTV.DecMapUintptrIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]string:
+		fastpathTV.DecMapUintptrStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]string:
+		v2, changed2 := fastpathTV.DecMapUintptrStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uint:
+		fastpathTV.DecMapUintptrUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uint:
+		v2, changed2 := fastpathTV.DecMapUintptrUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uint8:
+		fastpathTV.DecMapUintptrUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uint8:
+		v2, changed2 := fastpathTV.DecMapUintptrUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uint16:
+		fastpathTV.DecMapUintptrUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uint16:
+		v2, changed2 := fastpathTV.DecMapUintptrUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uint32:
+		fastpathTV.DecMapUintptrUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uint32:
+		v2, changed2 := fastpathTV.DecMapUintptrUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uint64:
+		fastpathTV.DecMapUintptrUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uint64:
+		v2, changed2 := fastpathTV.DecMapUintptrUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]uintptr:
+		fastpathTV.DecMapUintptrUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]uintptr:
+		v2, changed2 := fastpathTV.DecMapUintptrUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]int:
+		fastpathTV.DecMapUintptrIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]int:
+		v2, changed2 := fastpathTV.DecMapUintptrIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]int8:
+		fastpathTV.DecMapUintptrInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]int8:
+		v2, changed2 := fastpathTV.DecMapUintptrInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]int16:
+		fastpathTV.DecMapUintptrInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]int16:
+		v2, changed2 := fastpathTV.DecMapUintptrInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]int32:
+		fastpathTV.DecMapUintptrInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]int32:
+		v2, changed2 := fastpathTV.DecMapUintptrInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]int64:
+		fastpathTV.DecMapUintptrInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]int64:
+		v2, changed2 := fastpathTV.DecMapUintptrInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]float32:
+		fastpathTV.DecMapUintptrFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]float32:
+		v2, changed2 := fastpathTV.DecMapUintptrFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]float64:
+		fastpathTV.DecMapUintptrFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]float64:
+		v2, changed2 := fastpathTV.DecMapUintptrFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[uintptr]bool:
+		fastpathTV.DecMapUintptrBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[uintptr]bool:
+		v2, changed2 := fastpathTV.DecMapUintptrBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []int:
+		fastpathTV.DecSliceIntV(v, fastpathCheckNilFalse, false, d)
+	case *[]int:
+		v2, changed2 := fastpathTV.DecSliceIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]interface{}:
+		fastpathTV.DecMapIntIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]interface{}:
+		v2, changed2 := fastpathTV.DecMapIntIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]string:
+		fastpathTV.DecMapIntStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]string:
+		v2, changed2 := fastpathTV.DecMapIntStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uint:
+		fastpathTV.DecMapIntUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uint:
+		v2, changed2 := fastpathTV.DecMapIntUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uint8:
+		fastpathTV.DecMapIntUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uint8:
+		v2, changed2 := fastpathTV.DecMapIntUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uint16:
+		fastpathTV.DecMapIntUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uint16:
+		v2, changed2 := fastpathTV.DecMapIntUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uint32:
+		fastpathTV.DecMapIntUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uint32:
+		v2, changed2 := fastpathTV.DecMapIntUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uint64:
+		fastpathTV.DecMapIntUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uint64:
+		v2, changed2 := fastpathTV.DecMapIntUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]uintptr:
+		fastpathTV.DecMapIntUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]uintptr:
+		v2, changed2 := fastpathTV.DecMapIntUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]int:
+		fastpathTV.DecMapIntIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]int:
+		v2, changed2 := fastpathTV.DecMapIntIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]int8:
+		fastpathTV.DecMapIntInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]int8:
+		v2, changed2 := fastpathTV.DecMapIntInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]int16:
+		fastpathTV.DecMapIntInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]int16:
+		v2, changed2 := fastpathTV.DecMapIntInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]int32:
+		fastpathTV.DecMapIntInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]int32:
+		v2, changed2 := fastpathTV.DecMapIntInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]int64:
+		fastpathTV.DecMapIntInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]int64:
+		v2, changed2 := fastpathTV.DecMapIntInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]float32:
+		fastpathTV.DecMapIntFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]float32:
+		v2, changed2 := fastpathTV.DecMapIntFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]float64:
+		fastpathTV.DecMapIntFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int]float64:
+		v2, changed2 := fastpathTV.DecMapIntFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int]bool:
+		fastpathTV.DecMapIntBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[int]bool:
+		v2, changed2 := fastpathTV.DecMapIntBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []int8:
+		fastpathTV.DecSliceInt8V(v, fastpathCheckNilFalse, false, d)
+	case *[]int8:
+		v2, changed2 := fastpathTV.DecSliceInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]interface{}:
+		fastpathTV.DecMapInt8IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]interface{}:
+		v2, changed2 := fastpathTV.DecMapInt8IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]string:
+		fastpathTV.DecMapInt8StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]string:
+		v2, changed2 := fastpathTV.DecMapInt8StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uint:
+		fastpathTV.DecMapInt8UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uint:
+		v2, changed2 := fastpathTV.DecMapInt8UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uint8:
+		fastpathTV.DecMapInt8Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uint8:
+		v2, changed2 := fastpathTV.DecMapInt8Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uint16:
+		fastpathTV.DecMapInt8Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uint16:
+		v2, changed2 := fastpathTV.DecMapInt8Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uint32:
+		fastpathTV.DecMapInt8Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uint32:
+		v2, changed2 := fastpathTV.DecMapInt8Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uint64:
+		fastpathTV.DecMapInt8Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uint64:
+		v2, changed2 := fastpathTV.DecMapInt8Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]uintptr:
+		fastpathTV.DecMapInt8UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]uintptr:
+		v2, changed2 := fastpathTV.DecMapInt8UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]int:
+		fastpathTV.DecMapInt8IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]int:
+		v2, changed2 := fastpathTV.DecMapInt8IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]int8:
+		fastpathTV.DecMapInt8Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]int8:
+		v2, changed2 := fastpathTV.DecMapInt8Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]int16:
+		fastpathTV.DecMapInt8Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]int16:
+		v2, changed2 := fastpathTV.DecMapInt8Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]int32:
+		fastpathTV.DecMapInt8Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]int32:
+		v2, changed2 := fastpathTV.DecMapInt8Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]int64:
+		fastpathTV.DecMapInt8Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]int64:
+		v2, changed2 := fastpathTV.DecMapInt8Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]float32:
+		fastpathTV.DecMapInt8Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]float32:
+		v2, changed2 := fastpathTV.DecMapInt8Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]float64:
+		fastpathTV.DecMapInt8Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]float64:
+		v2, changed2 := fastpathTV.DecMapInt8Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int8]bool:
+		fastpathTV.DecMapInt8BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[int8]bool:
+		v2, changed2 := fastpathTV.DecMapInt8BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []int16:
+		fastpathTV.DecSliceInt16V(v, fastpathCheckNilFalse, false, d)
+	case *[]int16:
+		v2, changed2 := fastpathTV.DecSliceInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]interface{}:
+		fastpathTV.DecMapInt16IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]interface{}:
+		v2, changed2 := fastpathTV.DecMapInt16IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]string:
+		fastpathTV.DecMapInt16StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]string:
+		v2, changed2 := fastpathTV.DecMapInt16StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uint:
+		fastpathTV.DecMapInt16UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uint:
+		v2, changed2 := fastpathTV.DecMapInt16UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uint8:
+		fastpathTV.DecMapInt16Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uint8:
+		v2, changed2 := fastpathTV.DecMapInt16Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uint16:
+		fastpathTV.DecMapInt16Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uint16:
+		v2, changed2 := fastpathTV.DecMapInt16Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uint32:
+		fastpathTV.DecMapInt16Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uint32:
+		v2, changed2 := fastpathTV.DecMapInt16Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uint64:
+		fastpathTV.DecMapInt16Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uint64:
+		v2, changed2 := fastpathTV.DecMapInt16Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]uintptr:
+		fastpathTV.DecMapInt16UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]uintptr:
+		v2, changed2 := fastpathTV.DecMapInt16UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]int:
+		fastpathTV.DecMapInt16IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]int:
+		v2, changed2 := fastpathTV.DecMapInt16IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]int8:
+		fastpathTV.DecMapInt16Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]int8:
+		v2, changed2 := fastpathTV.DecMapInt16Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]int16:
+		fastpathTV.DecMapInt16Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]int16:
+		v2, changed2 := fastpathTV.DecMapInt16Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]int32:
+		fastpathTV.DecMapInt16Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]int32:
+		v2, changed2 := fastpathTV.DecMapInt16Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]int64:
+		fastpathTV.DecMapInt16Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]int64:
+		v2, changed2 := fastpathTV.DecMapInt16Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]float32:
+		fastpathTV.DecMapInt16Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]float32:
+		v2, changed2 := fastpathTV.DecMapInt16Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]float64:
+		fastpathTV.DecMapInt16Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]float64:
+		v2, changed2 := fastpathTV.DecMapInt16Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int16]bool:
+		fastpathTV.DecMapInt16BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[int16]bool:
+		v2, changed2 := fastpathTV.DecMapInt16BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []int32:
+		fastpathTV.DecSliceInt32V(v, fastpathCheckNilFalse, false, d)
+	case *[]int32:
+		v2, changed2 := fastpathTV.DecSliceInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]interface{}:
+		fastpathTV.DecMapInt32IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]interface{}:
+		v2, changed2 := fastpathTV.DecMapInt32IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]string:
+		fastpathTV.DecMapInt32StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]string:
+		v2, changed2 := fastpathTV.DecMapInt32StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uint:
+		fastpathTV.DecMapInt32UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uint:
+		v2, changed2 := fastpathTV.DecMapInt32UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uint8:
+		fastpathTV.DecMapInt32Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uint8:
+		v2, changed2 := fastpathTV.DecMapInt32Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uint16:
+		fastpathTV.DecMapInt32Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uint16:
+		v2, changed2 := fastpathTV.DecMapInt32Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uint32:
+		fastpathTV.DecMapInt32Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uint32:
+		v2, changed2 := fastpathTV.DecMapInt32Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uint64:
+		fastpathTV.DecMapInt32Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uint64:
+		v2, changed2 := fastpathTV.DecMapInt32Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]uintptr:
+		fastpathTV.DecMapInt32UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]uintptr:
+		v2, changed2 := fastpathTV.DecMapInt32UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]int:
+		fastpathTV.DecMapInt32IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]int:
+		v2, changed2 := fastpathTV.DecMapInt32IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]int8:
+		fastpathTV.DecMapInt32Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]int8:
+		v2, changed2 := fastpathTV.DecMapInt32Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]int16:
+		fastpathTV.DecMapInt32Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]int16:
+		v2, changed2 := fastpathTV.DecMapInt32Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]int32:
+		fastpathTV.DecMapInt32Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]int32:
+		v2, changed2 := fastpathTV.DecMapInt32Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]int64:
+		fastpathTV.DecMapInt32Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]int64:
+		v2, changed2 := fastpathTV.DecMapInt32Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]float32:
+		fastpathTV.DecMapInt32Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]float32:
+		v2, changed2 := fastpathTV.DecMapInt32Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]float64:
+		fastpathTV.DecMapInt32Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]float64:
+		v2, changed2 := fastpathTV.DecMapInt32Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int32]bool:
+		fastpathTV.DecMapInt32BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[int32]bool:
+		v2, changed2 := fastpathTV.DecMapInt32BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []int64:
+		fastpathTV.DecSliceInt64V(v, fastpathCheckNilFalse, false, d)
+	case *[]int64:
+		v2, changed2 := fastpathTV.DecSliceInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]interface{}:
+		fastpathTV.DecMapInt64IntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]interface{}:
+		v2, changed2 := fastpathTV.DecMapInt64IntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]string:
+		fastpathTV.DecMapInt64StringV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]string:
+		v2, changed2 := fastpathTV.DecMapInt64StringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uint:
+		fastpathTV.DecMapInt64UintV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uint:
+		v2, changed2 := fastpathTV.DecMapInt64UintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uint8:
+		fastpathTV.DecMapInt64Uint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uint8:
+		v2, changed2 := fastpathTV.DecMapInt64Uint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uint16:
+		fastpathTV.DecMapInt64Uint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uint16:
+		v2, changed2 := fastpathTV.DecMapInt64Uint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uint32:
+		fastpathTV.DecMapInt64Uint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uint32:
+		v2, changed2 := fastpathTV.DecMapInt64Uint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uint64:
+		fastpathTV.DecMapInt64Uint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uint64:
+		v2, changed2 := fastpathTV.DecMapInt64Uint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]uintptr:
+		fastpathTV.DecMapInt64UintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]uintptr:
+		v2, changed2 := fastpathTV.DecMapInt64UintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]int:
+		fastpathTV.DecMapInt64IntV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]int:
+		v2, changed2 := fastpathTV.DecMapInt64IntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]int8:
+		fastpathTV.DecMapInt64Int8V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]int8:
+		v2, changed2 := fastpathTV.DecMapInt64Int8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]int16:
+		fastpathTV.DecMapInt64Int16V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]int16:
+		v2, changed2 := fastpathTV.DecMapInt64Int16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]int32:
+		fastpathTV.DecMapInt64Int32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]int32:
+		v2, changed2 := fastpathTV.DecMapInt64Int32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]int64:
+		fastpathTV.DecMapInt64Int64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]int64:
+		v2, changed2 := fastpathTV.DecMapInt64Int64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]float32:
+		fastpathTV.DecMapInt64Float32V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]float32:
+		v2, changed2 := fastpathTV.DecMapInt64Float32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]float64:
+		fastpathTV.DecMapInt64Float64V(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]float64:
+		v2, changed2 := fastpathTV.DecMapInt64Float64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[int64]bool:
+		fastpathTV.DecMapInt64BoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[int64]bool:
+		v2, changed2 := fastpathTV.DecMapInt64BoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case []bool:
+		fastpathTV.DecSliceBoolV(v, fastpathCheckNilFalse, false, d)
+	case *[]bool:
+		v2, changed2 := fastpathTV.DecSliceBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]interface{}:
+		fastpathTV.DecMapBoolIntfV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]interface{}:
+		v2, changed2 := fastpathTV.DecMapBoolIntfV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]string:
+		fastpathTV.DecMapBoolStringV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]string:
+		v2, changed2 := fastpathTV.DecMapBoolStringV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uint:
+		fastpathTV.DecMapBoolUintV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uint:
+		v2, changed2 := fastpathTV.DecMapBoolUintV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uint8:
+		fastpathTV.DecMapBoolUint8V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uint8:
+		v2, changed2 := fastpathTV.DecMapBoolUint8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uint16:
+		fastpathTV.DecMapBoolUint16V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uint16:
+		v2, changed2 := fastpathTV.DecMapBoolUint16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uint32:
+		fastpathTV.DecMapBoolUint32V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uint32:
+		v2, changed2 := fastpathTV.DecMapBoolUint32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uint64:
+		fastpathTV.DecMapBoolUint64V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uint64:
+		v2, changed2 := fastpathTV.DecMapBoolUint64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]uintptr:
+		fastpathTV.DecMapBoolUintptrV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]uintptr:
+		v2, changed2 := fastpathTV.DecMapBoolUintptrV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]int:
+		fastpathTV.DecMapBoolIntV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]int:
+		v2, changed2 := fastpathTV.DecMapBoolIntV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]int8:
+		fastpathTV.DecMapBoolInt8V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]int8:
+		v2, changed2 := fastpathTV.DecMapBoolInt8V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]int16:
+		fastpathTV.DecMapBoolInt16V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]int16:
+		v2, changed2 := fastpathTV.DecMapBoolInt16V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]int32:
+		fastpathTV.DecMapBoolInt32V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]int32:
+		v2, changed2 := fastpathTV.DecMapBoolInt32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]int64:
+		fastpathTV.DecMapBoolInt64V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]int64:
+		v2, changed2 := fastpathTV.DecMapBoolInt64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]float32:
+		fastpathTV.DecMapBoolFloat32V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]float32:
+		v2, changed2 := fastpathTV.DecMapBoolFloat32V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]float64:
+		fastpathTV.DecMapBoolFloat64V(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]float64:
+		v2, changed2 := fastpathTV.DecMapBoolFloat64V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	case map[bool]bool:
+		fastpathTV.DecMapBoolBoolV(v, fastpathCheckNilFalse, false, d)
+	case *map[bool]bool:
+		v2, changed2 := fastpathTV.DecMapBoolBoolV(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2
+		}
+
+	default:
+		_ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+// -- -- fast path functions
+
+func (f *decFnInfo) fastpathDecSliceIntfR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]interface{})
+		v, changed := fastpathTV.DecSliceIntfV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]interface{})
+		fastpathTV.DecSliceIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceIntfX(vp *[]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool, d *Decoder) (_ []interface{}, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []interface{}{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]interface{}, xlen)
+					}
+				} else {
+					v = make([]interface{}, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			d.decode(&v[j])
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, nil)
+				slh.ElemContainerState(j)
+				d.decode(&v[j])
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []interface{}{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]interface{}, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, nil)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				d.decode(&v[j])
+
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceStringR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]string)
+		v, changed := fastpathTV.DecSliceStringV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]string)
+		fastpathTV.DecSliceStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceStringX(vp *[]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d *Decoder) (_ []string, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []string{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]string, xlen)
+					}
+				} else {
+					v = make([]string, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = dd.DecodeString()
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, "")
+				slh.ElemContainerState(j)
+				v[j] = dd.DecodeString()
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []string{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]string, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, "")
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = dd.DecodeString()
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceFloat32R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]float32)
+		v, changed := fastpathTV.DecSliceFloat32V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]float32)
+		fastpathTV.DecSliceFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceFloat32X(vp *[]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, d *Decoder) (_ []float32, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []float32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]float32, xlen)
+					}
+				} else {
+					v = make([]float32, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = float32(dd.DecodeFloat(true))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = float32(dd.DecodeFloat(true))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []float32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]float32, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = float32(dd.DecodeFloat(true))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceFloat64R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]float64)
+		v, changed := fastpathTV.DecSliceFloat64V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]float64)
+		fastpathTV.DecSliceFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceFloat64X(vp *[]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, d *Decoder) (_ []float64, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []float64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]float64, xlen)
+					}
+				} else {
+					v = make([]float64, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = dd.DecodeFloat(false)
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = dd.DecodeFloat(false)
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []float64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]float64, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = dd.DecodeFloat(false)
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceUintR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]uint)
+		v, changed := fastpathTV.DecSliceUintV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]uint)
+		fastpathTV.DecSliceUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceUintX(vp *[]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Decoder) (_ []uint, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []uint{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint, xlen)
+					}
+				} else {
+					v = make([]uint, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = uint(dd.DecodeUint(uintBitsize))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = uint(dd.DecodeUint(uintBitsize))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]uint, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = uint(dd.DecodeUint(uintBitsize))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceUint16R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]uint16)
+		v, changed := fastpathTV.DecSliceUint16V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]uint16)
+		fastpathTV.DecSliceUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceUint16X(vp *[]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d *Decoder) (_ []uint16, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []uint16{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint16, xlen)
+					}
+				} else {
+					v = make([]uint16, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = uint16(dd.DecodeUint(16))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = uint16(dd.DecodeUint(16))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint16{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]uint16, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = uint16(dd.DecodeUint(16))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceUint32R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]uint32)
+		v, changed := fastpathTV.DecSliceUint32V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]uint32)
+		fastpathTV.DecSliceUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceUint32X(vp *[]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d *Decoder) (_ []uint32, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []uint32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint32, xlen)
+					}
+				} else {
+					v = make([]uint32, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = uint32(dd.DecodeUint(32))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = uint32(dd.DecodeUint(32))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]uint32, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = uint32(dd.DecodeUint(32))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceUint64R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]uint64)
+		v, changed := fastpathTV.DecSliceUint64V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]uint64)
+		fastpathTV.DecSliceUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceUint64X(vp *[]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d *Decoder) (_ []uint64, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []uint64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uint64, xlen)
+					}
+				} else {
+					v = make([]uint64, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = dd.DecodeUint(64)
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = dd.DecodeUint(64)
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uint64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]uint64, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = dd.DecodeUint(64)
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceUintptrR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]uintptr)
+		v, changed := fastpathTV.DecSliceUintptrV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]uintptr)
+		fastpathTV.DecSliceUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceUintptrX(vp *[]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, d *Decoder) (_ []uintptr, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []uintptr{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]uintptr, xlen)
+					}
+				} else {
+					v = make([]uintptr, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = uintptr(dd.DecodeUint(uintBitsize))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = uintptr(dd.DecodeUint(uintBitsize))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []uintptr{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]uintptr, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = uintptr(dd.DecodeUint(uintBitsize))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceIntR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]int)
+		v, changed := fastpathTV.DecSliceIntV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]int)
+		fastpathTV.DecSliceIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceIntX(vp *[]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decoder) (_ []int, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []int{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int, xlen)
+					}
+				} else {
+					v = make([]int, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = int(dd.DecodeInt(intBitsize))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = int(dd.DecodeInt(intBitsize))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]int, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = int(dd.DecodeInt(intBitsize))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceInt8R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]int8)
+		v, changed := fastpathTV.DecSliceInt8V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]int8)
+		fastpathTV.DecSliceInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceInt8X(vp *[]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Decoder) (_ []int8, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []int8{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int8, xlen)
+					}
+				} else {
+					v = make([]int8, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = int8(dd.DecodeInt(8))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = int8(dd.DecodeInt(8))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int8{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]int8, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = int8(dd.DecodeInt(8))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceInt16R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]int16)
+		v, changed := fastpathTV.DecSliceInt16V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]int16)
+		fastpathTV.DecSliceInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceInt16X(vp *[]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *Decoder) (_ []int16, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []int16{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int16, xlen)
+					}
+				} else {
+					v = make([]int16, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = int16(dd.DecodeInt(16))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = int16(dd.DecodeInt(16))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int16{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]int16, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = int16(dd.DecodeInt(16))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceInt32R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]int32)
+		v, changed := fastpathTV.DecSliceInt32V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]int32)
+		fastpathTV.DecSliceInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceInt32X(vp *[]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *Decoder) (_ []int32, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []int32{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int32, xlen)
+					}
+				} else {
+					v = make([]int32, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = int32(dd.DecodeInt(32))
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = int32(dd.DecodeInt(32))
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int32{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]int32, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = int32(dd.DecodeInt(32))
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceInt64R(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]int64)
+		v, changed := fastpathTV.DecSliceInt64V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]int64)
+		fastpathTV.DecSliceInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceInt64X(vp *[]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *Decoder) (_ []int64, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []int64{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]int64, xlen)
+					}
+				} else {
+					v = make([]int64, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = dd.DecodeInt(64)
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				slh.ElemContainerState(j)
+				v[j] = dd.DecodeInt(64)
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []int64{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]int64, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, 0)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = dd.DecodeInt(64)
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecSliceBoolR(rv reflect.Value) {
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() {
+		vp := rv.Addr().Interface().(*[]bool)
+		v, changed := fastpathTV.DecSliceBoolV(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]bool)
+		fastpathTV.DecSliceBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) DecSliceBoolX(vp *[]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecSliceBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Decoder) (_ []bool, changed bool) {
+	dd := d.d
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []bool{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool
+		if containerLenS > cap(v) {
+			if canChange {
+				var xlen int
+				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]bool, xlen)
+					}
+				} else {
+					v = make([]bool, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			v[j] = dd.DecodeBool()
+		}
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, false)
+				slh.ElemContainerState(j)
+				v[j] = dd.DecodeBool()
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak()
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []bool{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]bool, 1, 4)
+			changed = true
+		}
+		j := 0
+		for ; !breakFound; j++ {
+			if j >= len(v) {
+				if canChange {
+					v = append(v, false)
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) {
+				v[j] = dd.DecodeBool()
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End()
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]interface{})
+		v, changed := fastpathTV.DecMapIntfIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]interface{})
+		fastpathTV.DecMapIntfIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfIntfX(vp *map[interface{}]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[interface{}]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk interface{}
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]string)
+		v, changed := fastpathTV.DecMapIntfStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]string)
+		fastpathTV.DecMapIntfStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfStringX(vp *map[interface{}]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[interface{}]string, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uint)
+		v, changed := fastpathTV.DecMapIntfUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uint)
+		fastpathTV.DecMapIntfUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUintX(vp *map[interface{}]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]uint, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uint8)
+		v, changed := fastpathTV.DecMapIntfUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uint8)
+		fastpathTV.DecMapIntfUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUint8X(vp *map[interface{}]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]uint8, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uint16)
+		v, changed := fastpathTV.DecMapIntfUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uint16)
+		fastpathTV.DecMapIntfUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUint16X(vp *map[interface{}]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[interface{}]uint16, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uint32)
+		v, changed := fastpathTV.DecMapIntfUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uint32)
+		fastpathTV.DecMapIntfUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUint32X(vp *map[interface{}]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]uint32, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uint64)
+		v, changed := fastpathTV.DecMapIntfUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uint64)
+		fastpathTV.DecMapIntfUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUint64X(vp *map[interface{}]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]uint64, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]uintptr)
+		v, changed := fastpathTV.DecMapIntfUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]uintptr)
+		fastpathTV.DecMapIntfUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfUintptrX(vp *map[interface{}]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]uintptr, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]int)
+		v, changed := fastpathTV.DecMapIntfIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]int)
+		fastpathTV.DecMapIntfIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfIntX(vp *map[interface{}]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]int, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]int8)
+		v, changed := fastpathTV.DecMapIntfInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]int8)
+		fastpathTV.DecMapIntfInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfInt8X(vp *map[interface{}]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]int8, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]int16)
+		v, changed := fastpathTV.DecMapIntfInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]int16)
+		fastpathTV.DecMapIntfInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfInt16X(vp *map[interface{}]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[interface{}]int16, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]int32)
+		v, changed := fastpathTV.DecMapIntfInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]int32)
+		fastpathTV.DecMapIntfInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfInt32X(vp *map[interface{}]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]int32, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]int64)
+		v, changed := fastpathTV.DecMapIntfInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]int64)
+		fastpathTV.DecMapIntfInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfInt64X(vp *map[interface{}]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]int64, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]float32)
+		v, changed := fastpathTV.DecMapIntfFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]float32)
+		fastpathTV.DecMapIntfFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfFloat32X(vp *map[interface{}]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]float32, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]float64)
+		v, changed := fastpathTV.DecMapIntfFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]float64)
+		fastpathTV.DecMapIntfFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfFloat64X(vp *map[interface{}]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]float64, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntfBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[interface{}]bool)
+		v, changed := fastpathTV.DecMapIntfBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[interface{}]bool)
+		fastpathTV.DecMapIntfBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntfBoolX(vp *map[interface{}]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntfBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[interface{}]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]bool, xlen)
+		changed = true
+	}
+
+	var mk interface{}
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = nil
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv)
+			}
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]interface{})
+		v, changed := fastpathTV.DecMapStringIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]interface{})
+		fastpathTV.DecMapStringIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringIntfX(vp *map[string]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[string]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk string
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]string)
+		v, changed := fastpathTV.DecMapStringStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]string)
+		fastpathTV.DecMapStringStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringStringX(vp *map[string]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[string]string, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uint)
+		v, changed := fastpathTV.DecMapStringUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uint)
+		fastpathTV.DecMapStringUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUintX(vp *map[string]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]uint, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uint8)
+		v, changed := fastpathTV.DecMapStringUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uint8)
+		fastpathTV.DecMapStringUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUint8X(vp *map[string]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]uint8, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uint16)
+		v, changed := fastpathTV.DecMapStringUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uint16)
+		fastpathTV.DecMapStringUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUint16X(vp *map[string]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[string]uint16, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uint32)
+		v, changed := fastpathTV.DecMapStringUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uint32)
+		fastpathTV.DecMapStringUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUint32X(vp *map[string]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]uint32, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uint64)
+		v, changed := fastpathTV.DecMapStringUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uint64)
+		fastpathTV.DecMapStringUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUint64X(vp *map[string]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]uint64, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]uintptr)
+		v, changed := fastpathTV.DecMapStringUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]uintptr)
+		fastpathTV.DecMapStringUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringUintptrX(vp *map[string]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]uintptr, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]int)
+		v, changed := fastpathTV.DecMapStringIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]int)
+		fastpathTV.DecMapStringIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringIntX(vp *map[string]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]int, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]int8)
+		v, changed := fastpathTV.DecMapStringInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]int8)
+		fastpathTV.DecMapStringInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringInt8X(vp *map[string]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]int8, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]int16)
+		v, changed := fastpathTV.DecMapStringInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]int16)
+		fastpathTV.DecMapStringInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringInt16X(vp *map[string]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[string]int16, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]int32)
+		v, changed := fastpathTV.DecMapStringInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]int32)
+		fastpathTV.DecMapStringInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringInt32X(vp *map[string]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]int32, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]int64)
+		v, changed := fastpathTV.DecMapStringInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]int64)
+		fastpathTV.DecMapStringInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringInt64X(vp *map[string]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]int64, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]float32)
+		v, changed := fastpathTV.DecMapStringFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]float32)
+		fastpathTV.DecMapStringFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringFloat32X(vp *map[string]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]float32, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]float64)
+		v, changed := fastpathTV.DecMapStringFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]float64)
+		fastpathTV.DecMapStringFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringFloat64X(vp *map[string]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]float64, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapStringBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[string]bool)
+		v, changed := fastpathTV.DecMapStringBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[string]bool)
+		fastpathTV.DecMapStringBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapStringBoolX(vp *map[string]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapStringBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[string]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]bool, xlen)
+		changed = true
+	}
+
+	var mk string
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeString()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]interface{})
+		v, changed := fastpathTV.DecMapFloat32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]interface{})
+		fastpathTV.DecMapFloat32IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32IntfX(vp *map[float32]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[float32]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk float32
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]string)
+		v, changed := fastpathTV.DecMapFloat32StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]string)
+		fastpathTV.DecMapFloat32StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32StringX(vp *map[float32]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[float32]string, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uint)
+		v, changed := fastpathTV.DecMapFloat32UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uint)
+		fastpathTV.DecMapFloat32UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32UintX(vp *map[float32]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]uint, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uint8)
+		v, changed := fastpathTV.DecMapFloat32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uint8)
+		fastpathTV.DecMapFloat32Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Uint8X(vp *map[float32]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]uint8, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uint16)
+		v, changed := fastpathTV.DecMapFloat32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uint16)
+		fastpathTV.DecMapFloat32Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Uint16X(vp *map[float32]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[float32]uint16, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uint32)
+		v, changed := fastpathTV.DecMapFloat32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uint32)
+		fastpathTV.DecMapFloat32Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Uint32X(vp *map[float32]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]uint32, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uint64)
+		v, changed := fastpathTV.DecMapFloat32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uint64)
+		fastpathTV.DecMapFloat32Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Uint64X(vp *map[float32]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]uint64, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]uintptr)
+		v, changed := fastpathTV.DecMapFloat32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]uintptr)
+		fastpathTV.DecMapFloat32UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32UintptrX(vp *map[float32]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]uintptr, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]int)
+		v, changed := fastpathTV.DecMapFloat32IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]int)
+		fastpathTV.DecMapFloat32IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32IntX(vp *map[float32]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]int, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]int8)
+		v, changed := fastpathTV.DecMapFloat32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]int8)
+		fastpathTV.DecMapFloat32Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Int8X(vp *map[float32]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]int8, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]int16)
+		v, changed := fastpathTV.DecMapFloat32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]int16)
+		fastpathTV.DecMapFloat32Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Int16X(vp *map[float32]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[float32]int16, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]int32)
+		v, changed := fastpathTV.DecMapFloat32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]int32)
+		fastpathTV.DecMapFloat32Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Int32X(vp *map[float32]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]int32, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]int64)
+		v, changed := fastpathTV.DecMapFloat32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]int64)
+		fastpathTV.DecMapFloat32Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Int64X(vp *map[float32]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]int64, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]float32)
+		v, changed := fastpathTV.DecMapFloat32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]float32)
+		fastpathTV.DecMapFloat32Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Float32X(vp *map[float32]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]float32, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]float64)
+		v, changed := fastpathTV.DecMapFloat32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]float64)
+		fastpathTV.DecMapFloat32Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32Float64X(vp *map[float32]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]float64, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat32BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float32]bool)
+		v, changed := fastpathTV.DecMapFloat32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float32]bool)
+		fastpathTV.DecMapFloat32BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat32BoolX(vp *map[float32]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat32BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float32]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]bool, xlen)
+		changed = true
+	}
+
+	var mk float32
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = float32(dd.DecodeFloat(true))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]interface{})
+		v, changed := fastpathTV.DecMapFloat64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]interface{})
+		fastpathTV.DecMapFloat64IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64IntfX(vp *map[float64]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[float64]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk float64
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]string)
+		v, changed := fastpathTV.DecMapFloat64StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]string)
+		fastpathTV.DecMapFloat64StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64StringX(vp *map[float64]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[float64]string, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uint)
+		v, changed := fastpathTV.DecMapFloat64UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uint)
+		fastpathTV.DecMapFloat64UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64UintX(vp *map[float64]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]uint, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uint8)
+		v, changed := fastpathTV.DecMapFloat64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uint8)
+		fastpathTV.DecMapFloat64Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Uint8X(vp *map[float64]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]uint8, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uint16)
+		v, changed := fastpathTV.DecMapFloat64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uint16)
+		fastpathTV.DecMapFloat64Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Uint16X(vp *map[float64]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[float64]uint16, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uint32)
+		v, changed := fastpathTV.DecMapFloat64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uint32)
+		fastpathTV.DecMapFloat64Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Uint32X(vp *map[float64]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]uint32, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uint64)
+		v, changed := fastpathTV.DecMapFloat64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uint64)
+		fastpathTV.DecMapFloat64Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Uint64X(vp *map[float64]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]uint64, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]uintptr)
+		v, changed := fastpathTV.DecMapFloat64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]uintptr)
+		fastpathTV.DecMapFloat64UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64UintptrX(vp *map[float64]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]uintptr, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]int)
+		v, changed := fastpathTV.DecMapFloat64IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]int)
+		fastpathTV.DecMapFloat64IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64IntX(vp *map[float64]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]int, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]int8)
+		v, changed := fastpathTV.DecMapFloat64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]int8)
+		fastpathTV.DecMapFloat64Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Int8X(vp *map[float64]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]int8, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]int16)
+		v, changed := fastpathTV.DecMapFloat64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]int16)
+		fastpathTV.DecMapFloat64Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Int16X(vp *map[float64]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[float64]int16, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]int32)
+		v, changed := fastpathTV.DecMapFloat64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]int32)
+		fastpathTV.DecMapFloat64Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Int32X(vp *map[float64]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]int32, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]int64)
+		v, changed := fastpathTV.DecMapFloat64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]int64)
+		fastpathTV.DecMapFloat64Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Int64X(vp *map[float64]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]int64, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]float32)
+		v, changed := fastpathTV.DecMapFloat64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]float32)
+		fastpathTV.DecMapFloat64Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Float32X(vp *map[float64]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]float32, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]float64)
+		v, changed := fastpathTV.DecMapFloat64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]float64)
+		fastpathTV.DecMapFloat64Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64Float64X(vp *map[float64]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]float64, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapFloat64BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[float64]bool)
+		v, changed := fastpathTV.DecMapFloat64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[float64]bool)
+		fastpathTV.DecMapFloat64BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapFloat64BoolX(vp *map[float64]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapFloat64BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[float64]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]bool, xlen)
+		changed = true
+	}
+
+	var mk float64
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeFloat(false)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]interface{})
+		v, changed := fastpathTV.DecMapUintIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]interface{})
+		fastpathTV.DecMapUintIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintIntfX(vp *map[uint]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uint
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]string)
+		v, changed := fastpathTV.DecMapUintStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]string)
+		fastpathTV.DecMapUintStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintStringX(vp *map[uint]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint]string, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uint)
+		v, changed := fastpathTV.DecMapUintUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uint)
+		fastpathTV.DecMapUintUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUintX(vp *map[uint]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]uint, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uint8)
+		v, changed := fastpathTV.DecMapUintUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uint8)
+		fastpathTV.DecMapUintUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUint8X(vp *map[uint]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]uint8, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uint16)
+		v, changed := fastpathTV.DecMapUintUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uint16)
+		fastpathTV.DecMapUintUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUint16X(vp *map[uint]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint]uint16, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uint32)
+		v, changed := fastpathTV.DecMapUintUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uint32)
+		fastpathTV.DecMapUintUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUint32X(vp *map[uint]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]uint32, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uint64)
+		v, changed := fastpathTV.DecMapUintUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uint64)
+		fastpathTV.DecMapUintUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUint64X(vp *map[uint]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]uint64, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]uintptr)
+		v, changed := fastpathTV.DecMapUintUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]uintptr)
+		fastpathTV.DecMapUintUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintUintptrX(vp *map[uint]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]int)
+		v, changed := fastpathTV.DecMapUintIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]int)
+		fastpathTV.DecMapUintIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintIntX(vp *map[uint]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]int, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]int8)
+		v, changed := fastpathTV.DecMapUintInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]int8)
+		fastpathTV.DecMapUintInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintInt8X(vp *map[uint]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]int8, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]int16)
+		v, changed := fastpathTV.DecMapUintInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]int16)
+		fastpathTV.DecMapUintInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintInt16X(vp *map[uint]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint]int16, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]int32)
+		v, changed := fastpathTV.DecMapUintInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]int32)
+		fastpathTV.DecMapUintInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintInt32X(vp *map[uint]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]int32, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]int64)
+		v, changed := fastpathTV.DecMapUintInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]int64)
+		fastpathTV.DecMapUintInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintInt64X(vp *map[uint]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]int64, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]float32)
+		v, changed := fastpathTV.DecMapUintFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]float32)
+		fastpathTV.DecMapUintFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintFloat32X(vp *map[uint]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]float32, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]float64)
+		v, changed := fastpathTV.DecMapUintFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]float64)
+		fastpathTV.DecMapUintFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintFloat64X(vp *map[uint]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]float64, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint]bool)
+		v, changed := fastpathTV.DecMapUintBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint]bool)
+		fastpathTV.DecMapUintBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintBoolX(vp *map[uint]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]bool, xlen)
+		changed = true
+	}
+
+	var mk uint
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]interface{})
+		v, changed := fastpathTV.DecMapUint8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]interface{})
+		fastpathTV.DecMapUint8IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8IntfX(vp *map[uint8]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[uint8]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uint8
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]string)
+		v, changed := fastpathTV.DecMapUint8StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]string)
+		fastpathTV.DecMapUint8StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8StringX(vp *map[uint8]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[uint8]string, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uint)
+		v, changed := fastpathTV.DecMapUint8UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uint)
+		fastpathTV.DecMapUint8UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8UintX(vp *map[uint8]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]uint, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uint8)
+		v, changed := fastpathTV.DecMapUint8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uint8)
+		fastpathTV.DecMapUint8Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Uint8X(vp *map[uint8]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]uint8, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uint16)
+		v, changed := fastpathTV.DecMapUint8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uint16)
+		fastpathTV.DecMapUint8Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Uint16X(vp *map[uint8]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint8]uint16, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uint32)
+		v, changed := fastpathTV.DecMapUint8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uint32)
+		fastpathTV.DecMapUint8Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Uint32X(vp *map[uint8]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]uint32, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uint64)
+		v, changed := fastpathTV.DecMapUint8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uint64)
+		fastpathTV.DecMapUint8Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Uint64X(vp *map[uint8]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]uint64, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]uintptr)
+		v, changed := fastpathTV.DecMapUint8UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]uintptr)
+		fastpathTV.DecMapUint8UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8UintptrX(vp *map[uint8]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]int)
+		v, changed := fastpathTV.DecMapUint8IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]int)
+		fastpathTV.DecMapUint8IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8IntX(vp *map[uint8]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]int, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]int8)
+		v, changed := fastpathTV.DecMapUint8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]int8)
+		fastpathTV.DecMapUint8Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Int8X(vp *map[uint8]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]int8, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]int16)
+		v, changed := fastpathTV.DecMapUint8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]int16)
+		fastpathTV.DecMapUint8Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Int16X(vp *map[uint8]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint8]int16, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]int32)
+		v, changed := fastpathTV.DecMapUint8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]int32)
+		fastpathTV.DecMapUint8Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Int32X(vp *map[uint8]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]int32, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]int64)
+		v, changed := fastpathTV.DecMapUint8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]int64)
+		fastpathTV.DecMapUint8Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Int64X(vp *map[uint8]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]int64, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]float32)
+		v, changed := fastpathTV.DecMapUint8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]float32)
+		fastpathTV.DecMapUint8Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Float32X(vp *map[uint8]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]float32, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]float64)
+		v, changed := fastpathTV.DecMapUint8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]float64)
+		fastpathTV.DecMapUint8Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8Float64X(vp *map[uint8]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]float64, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint8BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint8]bool)
+		v, changed := fastpathTV.DecMapUint8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint8]bool)
+		fastpathTV.DecMapUint8BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint8BoolX(vp *map[uint8]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint8BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint8]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]bool, xlen)
+		changed = true
+	}
+
+	var mk uint8
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint8(dd.DecodeUint(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]interface{})
+		v, changed := fastpathTV.DecMapUint16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]interface{})
+		fastpathTV.DecMapUint16IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16IntfX(vp *map[uint16]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[uint16]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uint16
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]string)
+		v, changed := fastpathTV.DecMapUint16StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]string)
+		fastpathTV.DecMapUint16StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16StringX(vp *map[uint16]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[uint16]string, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uint)
+		v, changed := fastpathTV.DecMapUint16UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uint)
+		fastpathTV.DecMapUint16UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16UintX(vp *map[uint16]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]uint, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uint8)
+		v, changed := fastpathTV.DecMapUint16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uint8)
+		fastpathTV.DecMapUint16Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Uint8X(vp *map[uint16]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]uint8, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uint16)
+		v, changed := fastpathTV.DecMapUint16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uint16)
+		fastpathTV.DecMapUint16Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Uint16X(vp *map[uint16]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[uint16]uint16, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uint32)
+		v, changed := fastpathTV.DecMapUint16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uint32)
+		fastpathTV.DecMapUint16Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Uint32X(vp *map[uint16]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]uint32, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uint64)
+		v, changed := fastpathTV.DecMapUint16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uint64)
+		fastpathTV.DecMapUint16Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Uint64X(vp *map[uint16]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]uint64, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]uintptr)
+		v, changed := fastpathTV.DecMapUint16UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]uintptr)
+		fastpathTV.DecMapUint16UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16UintptrX(vp *map[uint16]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]int)
+		v, changed := fastpathTV.DecMapUint16IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]int)
+		fastpathTV.DecMapUint16IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16IntX(vp *map[uint16]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]int, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]int8)
+		v, changed := fastpathTV.DecMapUint16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]int8)
+		fastpathTV.DecMapUint16Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Int8X(vp *map[uint16]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]int8, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]int16)
+		v, changed := fastpathTV.DecMapUint16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]int16)
+		fastpathTV.DecMapUint16Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Int16X(vp *map[uint16]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[uint16]int16, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]int32)
+		v, changed := fastpathTV.DecMapUint16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]int32)
+		fastpathTV.DecMapUint16Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Int32X(vp *map[uint16]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]int32, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]int64)
+		v, changed := fastpathTV.DecMapUint16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]int64)
+		fastpathTV.DecMapUint16Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Int64X(vp *map[uint16]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]int64, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]float32)
+		v, changed := fastpathTV.DecMapUint16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]float32)
+		fastpathTV.DecMapUint16Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Float32X(vp *map[uint16]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]float32, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]float64)
+		v, changed := fastpathTV.DecMapUint16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]float64)
+		fastpathTV.DecMapUint16Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16Float64X(vp *map[uint16]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]float64, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint16BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint16]bool)
+		v, changed := fastpathTV.DecMapUint16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint16]bool)
+		fastpathTV.DecMapUint16BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint16BoolX(vp *map[uint16]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint16BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint16]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]bool, xlen)
+		changed = true
+	}
+
+	var mk uint16
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint16(dd.DecodeUint(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]interface{})
+		v, changed := fastpathTV.DecMapUint32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]interface{})
+		fastpathTV.DecMapUint32IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32IntfX(vp *map[uint32]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[uint32]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uint32
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]string)
+		v, changed := fastpathTV.DecMapUint32StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]string)
+		fastpathTV.DecMapUint32StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32StringX(vp *map[uint32]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[uint32]string, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uint)
+		v, changed := fastpathTV.DecMapUint32UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uint)
+		fastpathTV.DecMapUint32UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32UintX(vp *map[uint32]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]uint, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uint8)
+		v, changed := fastpathTV.DecMapUint32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uint8)
+		fastpathTV.DecMapUint32Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Uint8X(vp *map[uint32]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]uint8, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uint16)
+		v, changed := fastpathTV.DecMapUint32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uint16)
+		fastpathTV.DecMapUint32Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Uint16X(vp *map[uint32]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint32]uint16, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uint32)
+		v, changed := fastpathTV.DecMapUint32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uint32)
+		fastpathTV.DecMapUint32Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Uint32X(vp *map[uint32]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]uint32, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uint64)
+		v, changed := fastpathTV.DecMapUint32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uint64)
+		fastpathTV.DecMapUint32Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Uint64X(vp *map[uint32]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]uint64, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]uintptr)
+		v, changed := fastpathTV.DecMapUint32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]uintptr)
+		fastpathTV.DecMapUint32UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32UintptrX(vp *map[uint32]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]int)
+		v, changed := fastpathTV.DecMapUint32IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]int)
+		fastpathTV.DecMapUint32IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32IntX(vp *map[uint32]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]int, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]int8)
+		v, changed := fastpathTV.DecMapUint32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]int8)
+		fastpathTV.DecMapUint32Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Int8X(vp *map[uint32]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]int8, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]int16)
+		v, changed := fastpathTV.DecMapUint32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]int16)
+		fastpathTV.DecMapUint32Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Int16X(vp *map[uint32]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint32]int16, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]int32)
+		v, changed := fastpathTV.DecMapUint32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]int32)
+		fastpathTV.DecMapUint32Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Int32X(vp *map[uint32]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]int32, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]int64)
+		v, changed := fastpathTV.DecMapUint32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]int64)
+		fastpathTV.DecMapUint32Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Int64X(vp *map[uint32]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]int64, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]float32)
+		v, changed := fastpathTV.DecMapUint32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]float32)
+		fastpathTV.DecMapUint32Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Float32X(vp *map[uint32]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]float32, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]float64)
+		v, changed := fastpathTV.DecMapUint32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]float64)
+		fastpathTV.DecMapUint32Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32Float64X(vp *map[uint32]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]float64, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint32BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint32]bool)
+		v, changed := fastpathTV.DecMapUint32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint32]bool)
+		fastpathTV.DecMapUint32BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint32BoolX(vp *map[uint32]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint32BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint32]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]bool, xlen)
+		changed = true
+	}
+
+	var mk uint32
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uint32(dd.DecodeUint(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]interface{})
+		v, changed := fastpathTV.DecMapUint64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]interface{})
+		fastpathTV.DecMapUint64IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64IntfX(vp *map[uint64]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint64]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uint64
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]string)
+		v, changed := fastpathTV.DecMapUint64StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]string)
+		fastpathTV.DecMapUint64StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64StringX(vp *map[uint64]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint64]string, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uint)
+		v, changed := fastpathTV.DecMapUint64UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uint)
+		fastpathTV.DecMapUint64UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64UintX(vp *map[uint64]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]uint, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uint8)
+		v, changed := fastpathTV.DecMapUint64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uint8)
+		fastpathTV.DecMapUint64Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Uint8X(vp *map[uint64]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]uint8, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uint16)
+		v, changed := fastpathTV.DecMapUint64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uint16)
+		fastpathTV.DecMapUint64Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Uint16X(vp *map[uint64]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint64]uint16, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uint32)
+		v, changed := fastpathTV.DecMapUint64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uint32)
+		fastpathTV.DecMapUint64Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Uint32X(vp *map[uint64]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]uint32, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uint64)
+		v, changed := fastpathTV.DecMapUint64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uint64)
+		fastpathTV.DecMapUint64Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Uint64X(vp *map[uint64]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]uint64, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]uintptr)
+		v, changed := fastpathTV.DecMapUint64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]uintptr)
+		fastpathTV.DecMapUint64UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64UintptrX(vp *map[uint64]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]int)
+		v, changed := fastpathTV.DecMapUint64IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]int)
+		fastpathTV.DecMapUint64IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64IntX(vp *map[uint64]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]int, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]int8)
+		v, changed := fastpathTV.DecMapUint64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]int8)
+		fastpathTV.DecMapUint64Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Int8X(vp *map[uint64]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]int8, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]int16)
+		v, changed := fastpathTV.DecMapUint64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]int16)
+		fastpathTV.DecMapUint64Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Int16X(vp *map[uint64]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint64]int16, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]int32)
+		v, changed := fastpathTV.DecMapUint64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]int32)
+		fastpathTV.DecMapUint64Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Int32X(vp *map[uint64]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]int32, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]int64)
+		v, changed := fastpathTV.DecMapUint64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]int64)
+		fastpathTV.DecMapUint64Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Int64X(vp *map[uint64]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]int64, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]float32)
+		v, changed := fastpathTV.DecMapUint64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]float32)
+		fastpathTV.DecMapUint64Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Float32X(vp *map[uint64]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]float32, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]float64)
+		v, changed := fastpathTV.DecMapUint64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]float64)
+		fastpathTV.DecMapUint64Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64Float64X(vp *map[uint64]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]float64, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUint64BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uint64]bool)
+		v, changed := fastpathTV.DecMapUint64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uint64]bool)
+		fastpathTV.DecMapUint64BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUint64BoolX(vp *map[uint64]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUint64BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uint64]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]bool, xlen)
+		changed = true
+	}
+
+	var mk uint64
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeUint(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]interface{})
+		v, changed := fastpathTV.DecMapUintptrIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]interface{})
+		fastpathTV.DecMapUintptrIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrIntfX(vp *map[uintptr]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uintptr]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk uintptr
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]string)
+		v, changed := fastpathTV.DecMapUintptrStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]string)
+		fastpathTV.DecMapUintptrStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrStringX(vp *map[uintptr]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uintptr]string, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uint)
+		v, changed := fastpathTV.DecMapUintptrUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uint)
+		fastpathTV.DecMapUintptrUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUintX(vp *map[uintptr]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]uint, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uint8)
+		v, changed := fastpathTV.DecMapUintptrUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uint8)
+		fastpathTV.DecMapUintptrUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUint8X(vp *map[uintptr]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uintptr]uint8, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uint16)
+		v, changed := fastpathTV.DecMapUintptrUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uint16)
+		fastpathTV.DecMapUintptrUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUint16X(vp *map[uintptr]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uintptr]uint16, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uint32)
+		v, changed := fastpathTV.DecMapUintptrUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uint32)
+		fastpathTV.DecMapUintptrUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUint32X(vp *map[uintptr]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uintptr]uint32, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uint64)
+		v, changed := fastpathTV.DecMapUintptrUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uint64)
+		fastpathTV.DecMapUintptrUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUint64X(vp *map[uintptr]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]uint64, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]uintptr)
+		v, changed := fastpathTV.DecMapUintptrUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]uintptr)
+		fastpathTV.DecMapUintptrUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrUintptrX(vp *map[uintptr]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]uintptr, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]int)
+		v, changed := fastpathTV.DecMapUintptrIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]int)
+		fastpathTV.DecMapUintptrIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrIntX(vp *map[uintptr]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]int, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]int8)
+		v, changed := fastpathTV.DecMapUintptrInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]int8)
+		fastpathTV.DecMapUintptrInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrInt8X(vp *map[uintptr]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uintptr]int8, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]int16)
+		v, changed := fastpathTV.DecMapUintptrInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]int16)
+		fastpathTV.DecMapUintptrInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrInt16X(vp *map[uintptr]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uintptr]int16, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]int32)
+		v, changed := fastpathTV.DecMapUintptrInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]int32)
+		fastpathTV.DecMapUintptrInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrInt32X(vp *map[uintptr]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uintptr]int32, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]int64)
+		v, changed := fastpathTV.DecMapUintptrInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]int64)
+		fastpathTV.DecMapUintptrInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrInt64X(vp *map[uintptr]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]int64, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]float32)
+		v, changed := fastpathTV.DecMapUintptrFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]float32)
+		fastpathTV.DecMapUintptrFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrFloat32X(vp *map[uintptr]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uintptr]float32, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]float64)
+		v, changed := fastpathTV.DecMapUintptrFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]float64)
+		fastpathTV.DecMapUintptrFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrFloat64X(vp *map[uintptr]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uintptr]float64, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapUintptrBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[uintptr]bool)
+		v, changed := fastpathTV.DecMapUintptrBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[uintptr]bool)
+		fastpathTV.DecMapUintptrBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapUintptrBoolX(vp *map[uintptr]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapUintptrBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[uintptr]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uintptr]bool, xlen)
+		changed = true
+	}
+
+	var mk uintptr
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = uintptr(dd.DecodeUint(uintBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]interface{})
+		v, changed := fastpathTV.DecMapIntIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]interface{})
+		fastpathTV.DecMapIntIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntIntfX(vp *map[int]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk int
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]string)
+		v, changed := fastpathTV.DecMapIntStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]string)
+		fastpathTV.DecMapIntStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntStringX(vp *map[int]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int]string, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uint)
+		v, changed := fastpathTV.DecMapIntUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uint)
+		fastpathTV.DecMapIntUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUintX(vp *map[int]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]uint, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uint8)
+		v, changed := fastpathTV.DecMapIntUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uint8)
+		fastpathTV.DecMapIntUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUint8X(vp *map[int]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]uint8, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uint16)
+		v, changed := fastpathTV.DecMapIntUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uint16)
+		fastpathTV.DecMapIntUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUint16X(vp *map[int]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int]uint16, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uint32)
+		v, changed := fastpathTV.DecMapIntUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uint32)
+		fastpathTV.DecMapIntUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUint32X(vp *map[int]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]uint32, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uint64)
+		v, changed := fastpathTV.DecMapIntUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uint64)
+		fastpathTV.DecMapIntUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUint64X(vp *map[int]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]uint64, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]uintptr)
+		v, changed := fastpathTV.DecMapIntUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]uintptr)
+		fastpathTV.DecMapIntUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntUintptrX(vp *map[int]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]uintptr, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]int)
+		v, changed := fastpathTV.DecMapIntIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]int)
+		fastpathTV.DecMapIntIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntIntX(vp *map[int]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]int, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]int8)
+		v, changed := fastpathTV.DecMapIntInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]int8)
+		fastpathTV.DecMapIntInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntInt8X(vp *map[int]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]int8, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]int16)
+		v, changed := fastpathTV.DecMapIntInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]int16)
+		fastpathTV.DecMapIntInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntInt16X(vp *map[int]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int]int16, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]int32)
+		v, changed := fastpathTV.DecMapIntInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]int32)
+		fastpathTV.DecMapIntInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntInt32X(vp *map[int]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]int32, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]int64)
+		v, changed := fastpathTV.DecMapIntInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]int64)
+		fastpathTV.DecMapIntInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntInt64X(vp *map[int]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]int64, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]float32)
+		v, changed := fastpathTV.DecMapIntFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]float32)
+		fastpathTV.DecMapIntFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntFloat32X(vp *map[int]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]float32, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]float64)
+		v, changed := fastpathTV.DecMapIntFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]float64)
+		fastpathTV.DecMapIntFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntFloat64X(vp *map[int]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]float64, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapIntBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int]bool)
+		v, changed := fastpathTV.DecMapIntBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int]bool)
+		fastpathTV.DecMapIntBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapIntBoolX(vp *map[int]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapIntBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]bool, xlen)
+		changed = true
+	}
+
+	var mk int
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int(dd.DecodeInt(intBitsize))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]interface{})
+		v, changed := fastpathTV.DecMapInt8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]interface{})
+		fastpathTV.DecMapInt8IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8IntfX(vp *map[int8]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[int8]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk int8
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]string)
+		v, changed := fastpathTV.DecMapInt8StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]string)
+		fastpathTV.DecMapInt8StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8StringX(vp *map[int8]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[int8]string, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uint)
+		v, changed := fastpathTV.DecMapInt8UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uint)
+		fastpathTV.DecMapInt8UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8UintX(vp *map[int8]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]uint, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uint8)
+		v, changed := fastpathTV.DecMapInt8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uint8)
+		fastpathTV.DecMapInt8Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Uint8X(vp *map[int8]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]uint8, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uint16)
+		v, changed := fastpathTV.DecMapInt8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uint16)
+		fastpathTV.DecMapInt8Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Uint16X(vp *map[int8]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int8]uint16, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uint32)
+		v, changed := fastpathTV.DecMapInt8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uint32)
+		fastpathTV.DecMapInt8Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Uint32X(vp *map[int8]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]uint32, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uint64)
+		v, changed := fastpathTV.DecMapInt8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uint64)
+		fastpathTV.DecMapInt8Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Uint64X(vp *map[int8]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]uint64, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]uintptr)
+		v, changed := fastpathTV.DecMapInt8UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]uintptr)
+		fastpathTV.DecMapInt8UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8UintptrX(vp *map[int8]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]uintptr, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]int)
+		v, changed := fastpathTV.DecMapInt8IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]int)
+		fastpathTV.DecMapInt8IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8IntX(vp *map[int8]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]int, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]int8)
+		v, changed := fastpathTV.DecMapInt8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]int8)
+		fastpathTV.DecMapInt8Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Int8X(vp *map[int8]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]int8, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]int16)
+		v, changed := fastpathTV.DecMapInt8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]int16)
+		fastpathTV.DecMapInt8Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Int16X(vp *map[int8]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int8]int16, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]int32)
+		v, changed := fastpathTV.DecMapInt8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]int32)
+		fastpathTV.DecMapInt8Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Int32X(vp *map[int8]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]int32, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]int64)
+		v, changed := fastpathTV.DecMapInt8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]int64)
+		fastpathTV.DecMapInt8Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Int64X(vp *map[int8]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]int64, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]float32)
+		v, changed := fastpathTV.DecMapInt8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]float32)
+		fastpathTV.DecMapInt8Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Float32X(vp *map[int8]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]float32, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]float64)
+		v, changed := fastpathTV.DecMapInt8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]float64)
+		fastpathTV.DecMapInt8Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8Float64X(vp *map[int8]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]float64, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt8BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int8]bool)
+		v, changed := fastpathTV.DecMapInt8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int8]bool)
+		fastpathTV.DecMapInt8BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt8BoolX(vp *map[int8]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt8BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int8]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]bool, xlen)
+		changed = true
+	}
+
+	var mk int8
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int8(dd.DecodeInt(8))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]interface{})
+		v, changed := fastpathTV.DecMapInt16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]interface{})
+		fastpathTV.DecMapInt16IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16IntfX(vp *map[int16]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[int16]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk int16
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]string)
+		v, changed := fastpathTV.DecMapInt16StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]string)
+		fastpathTV.DecMapInt16StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16StringX(vp *map[int16]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[int16]string, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uint)
+		v, changed := fastpathTV.DecMapInt16UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uint)
+		fastpathTV.DecMapInt16UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16UintX(vp *map[int16]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]uint, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uint8)
+		v, changed := fastpathTV.DecMapInt16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uint8)
+		fastpathTV.DecMapInt16Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Uint8X(vp *map[int16]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]uint8, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uint16)
+		v, changed := fastpathTV.DecMapInt16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uint16)
+		fastpathTV.DecMapInt16Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Uint16X(vp *map[int16]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[int16]uint16, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uint32)
+		v, changed := fastpathTV.DecMapInt16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uint32)
+		fastpathTV.DecMapInt16Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Uint32X(vp *map[int16]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]uint32, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uint64)
+		v, changed := fastpathTV.DecMapInt16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uint64)
+		fastpathTV.DecMapInt16Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Uint64X(vp *map[int16]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]uint64, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]uintptr)
+		v, changed := fastpathTV.DecMapInt16UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]uintptr)
+		fastpathTV.DecMapInt16UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16UintptrX(vp *map[int16]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]uintptr, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]int)
+		v, changed := fastpathTV.DecMapInt16IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]int)
+		fastpathTV.DecMapInt16IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16IntX(vp *map[int16]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]int, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]int8)
+		v, changed := fastpathTV.DecMapInt16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]int8)
+		fastpathTV.DecMapInt16Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Int8X(vp *map[int16]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]int8, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]int16)
+		v, changed := fastpathTV.DecMapInt16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]int16)
+		fastpathTV.DecMapInt16Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Int16X(vp *map[int16]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[int16]int16, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]int32)
+		v, changed := fastpathTV.DecMapInt16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]int32)
+		fastpathTV.DecMapInt16Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Int32X(vp *map[int16]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]int32, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]int64)
+		v, changed := fastpathTV.DecMapInt16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]int64)
+		fastpathTV.DecMapInt16Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Int64X(vp *map[int16]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]int64, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]float32)
+		v, changed := fastpathTV.DecMapInt16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]float32)
+		fastpathTV.DecMapInt16Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Float32X(vp *map[int16]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]float32, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]float64)
+		v, changed := fastpathTV.DecMapInt16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]float64)
+		fastpathTV.DecMapInt16Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16Float64X(vp *map[int16]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]float64, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt16BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int16]bool)
+		v, changed := fastpathTV.DecMapInt16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int16]bool)
+		fastpathTV.DecMapInt16BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt16BoolX(vp *map[int16]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt16BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int16]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]bool, xlen)
+		changed = true
+	}
+
+	var mk int16
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int16(dd.DecodeInt(16))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]interface{})
+		v, changed := fastpathTV.DecMapInt32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]interface{})
+		fastpathTV.DecMapInt32IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32IntfX(vp *map[int32]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[int32]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk int32
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]string)
+		v, changed := fastpathTV.DecMapInt32StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]string)
+		fastpathTV.DecMapInt32StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32StringX(vp *map[int32]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[int32]string, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uint)
+		v, changed := fastpathTV.DecMapInt32UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uint)
+		fastpathTV.DecMapInt32UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32UintX(vp *map[int32]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]uint, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uint8)
+		v, changed := fastpathTV.DecMapInt32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uint8)
+		fastpathTV.DecMapInt32Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Uint8X(vp *map[int32]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]uint8, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uint16)
+		v, changed := fastpathTV.DecMapInt32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uint16)
+		fastpathTV.DecMapInt32Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Uint16X(vp *map[int32]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int32]uint16, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uint32)
+		v, changed := fastpathTV.DecMapInt32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uint32)
+		fastpathTV.DecMapInt32Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Uint32X(vp *map[int32]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]uint32, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uint64)
+		v, changed := fastpathTV.DecMapInt32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uint64)
+		fastpathTV.DecMapInt32Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Uint64X(vp *map[int32]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]uint64, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]uintptr)
+		v, changed := fastpathTV.DecMapInt32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]uintptr)
+		fastpathTV.DecMapInt32UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32UintptrX(vp *map[int32]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]uintptr, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]int)
+		v, changed := fastpathTV.DecMapInt32IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]int)
+		fastpathTV.DecMapInt32IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32IntX(vp *map[int32]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]int, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]int8)
+		v, changed := fastpathTV.DecMapInt32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]int8)
+		fastpathTV.DecMapInt32Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Int8X(vp *map[int32]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]int8, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]int16)
+		v, changed := fastpathTV.DecMapInt32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]int16)
+		fastpathTV.DecMapInt32Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Int16X(vp *map[int32]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int32]int16, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]int32)
+		v, changed := fastpathTV.DecMapInt32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]int32)
+		fastpathTV.DecMapInt32Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Int32X(vp *map[int32]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]int32, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]int64)
+		v, changed := fastpathTV.DecMapInt32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]int64)
+		fastpathTV.DecMapInt32Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Int64X(vp *map[int32]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]int64, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]float32)
+		v, changed := fastpathTV.DecMapInt32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]float32)
+		fastpathTV.DecMapInt32Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Float32X(vp *map[int32]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]float32, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]float64)
+		v, changed := fastpathTV.DecMapInt32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]float64)
+		fastpathTV.DecMapInt32Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32Float64X(vp *map[int32]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]float64, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt32BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int32]bool)
+		v, changed := fastpathTV.DecMapInt32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int32]bool)
+		fastpathTV.DecMapInt32BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt32BoolX(vp *map[int32]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt32BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int32]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]bool, xlen)
+		changed = true
+	}
+
+	var mk int32
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = int32(dd.DecodeInt(32))
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64IntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]interface{})
+		v, changed := fastpathTV.DecMapInt64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]interface{})
+		fastpathTV.DecMapInt64IntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64IntfX(vp *map[int64]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64IntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int64]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk int64
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64StringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]string)
+		v, changed := fastpathTV.DecMapInt64StringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]string)
+		fastpathTV.DecMapInt64StringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64StringX(vp *map[int64]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64StringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int64]string, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64UintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uint)
+		v, changed := fastpathTV.DecMapInt64UintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uint)
+		fastpathTV.DecMapInt64UintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64UintX(vp *map[int64]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64UintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]uint, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Uint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uint8)
+		v, changed := fastpathTV.DecMapInt64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uint8)
+		fastpathTV.DecMapInt64Uint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Uint8X(vp *map[int64]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Uint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]uint8, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Uint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uint16)
+		v, changed := fastpathTV.DecMapInt64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uint16)
+		fastpathTV.DecMapInt64Uint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Uint16X(vp *map[int64]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Uint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int64]uint16, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Uint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uint32)
+		v, changed := fastpathTV.DecMapInt64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uint32)
+		fastpathTV.DecMapInt64Uint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Uint32X(vp *map[int64]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Uint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]uint32, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Uint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uint64)
+		v, changed := fastpathTV.DecMapInt64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uint64)
+		fastpathTV.DecMapInt64Uint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Uint64X(vp *map[int64]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Uint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]uint64, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64UintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]uintptr)
+		v, changed := fastpathTV.DecMapInt64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]uintptr)
+		fastpathTV.DecMapInt64UintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64UintptrX(vp *map[int64]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64UintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]uintptr, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64IntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]int)
+		v, changed := fastpathTV.DecMapInt64IntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]int)
+		fastpathTV.DecMapInt64IntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64IntX(vp *map[int64]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64IntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]int, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Int8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]int8)
+		v, changed := fastpathTV.DecMapInt64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]int8)
+		fastpathTV.DecMapInt64Int8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Int8X(vp *map[int64]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Int8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]int8, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Int16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]int16)
+		v, changed := fastpathTV.DecMapInt64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]int16)
+		fastpathTV.DecMapInt64Int16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Int16X(vp *map[int64]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Int16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int64]int16, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Int32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]int32)
+		v, changed := fastpathTV.DecMapInt64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]int32)
+		fastpathTV.DecMapInt64Int32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Int32X(vp *map[int64]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Int32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]int32, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Int64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]int64)
+		v, changed := fastpathTV.DecMapInt64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]int64)
+		fastpathTV.DecMapInt64Int64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Int64X(vp *map[int64]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Int64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]int64, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Float32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]float32)
+		v, changed := fastpathTV.DecMapInt64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]float32)
+		fastpathTV.DecMapInt64Float32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Float32X(vp *map[int64]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Float32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]float32, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64Float64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]float64)
+		v, changed := fastpathTV.DecMapInt64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]float64)
+		fastpathTV.DecMapInt64Float64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64Float64X(vp *map[int64]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64Float64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]float64, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapInt64BoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[int64]bool)
+		v, changed := fastpathTV.DecMapInt64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[int64]bool)
+		fastpathTV.DecMapInt64BoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapInt64BoolX(vp *map[int64]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapInt64BoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[int64]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]bool, xlen)
+		changed = true
+	}
+
+	var mk int64
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeInt(64)
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolIntfR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]interface{})
+		v, changed := fastpathTV.DecMapBoolIntfV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]interface{})
+		fastpathTV.DecMapBoolIntfV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolIntfX(vp *map[bool]interface{}, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolIntfV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]interface{}, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[bool]interface{}, xlen)
+		changed = true
+	}
+	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
+	var mk bool
+	var mv interface{}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			if mapGet {
+				mv = v[mk]
+			} else {
+				mv = nil
+			}
+			d.decode(&mv)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolStringR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]string)
+		v, changed := fastpathTV.DecMapBoolStringV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]string)
+		fastpathTV.DecMapBoolStringV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolStringX(vp *map[bool]string, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolStringV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]string, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[bool]string, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv string
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeString()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUintR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uint)
+		v, changed := fastpathTV.DecMapBoolUintV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uint)
+		fastpathTV.DecMapBoolUintV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUintX(vp *map[bool]uint, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUintV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uint, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]uint, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uint
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUint8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uint8)
+		v, changed := fastpathTV.DecMapBoolUint8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uint8)
+		fastpathTV.DecMapBoolUint8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUint8X(vp *map[bool]uint8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUint8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uint8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]uint8, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uint8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint8(dd.DecodeUint(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUint16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uint16)
+		v, changed := fastpathTV.DecMapBoolUint16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uint16)
+		fastpathTV.DecMapBoolUint16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUint16X(vp *map[bool]uint16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUint16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uint16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[bool]uint16, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uint16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint16(dd.DecodeUint(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUint32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uint32)
+		v, changed := fastpathTV.DecMapBoolUint32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uint32)
+		fastpathTV.DecMapBoolUint32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUint32X(vp *map[bool]uint32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUint32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uint32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]uint32, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uint32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uint32(dd.DecodeUint(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUint64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uint64)
+		v, changed := fastpathTV.DecMapBoolUint64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uint64)
+		fastpathTV.DecMapBoolUint64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUint64X(vp *map[bool]uint64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUint64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uint64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]uint64, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uint64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeUint(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolUintptrR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]uintptr)
+		v, changed := fastpathTV.DecMapBoolUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]uintptr)
+		fastpathTV.DecMapBoolUintptrV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolUintptrX(vp *map[bool]uintptr, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolUintptrV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]uintptr, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]uintptr, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv uintptr
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = uintptr(dd.DecodeUint(uintBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolIntR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]int)
+		v, changed := fastpathTV.DecMapBoolIntV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]int)
+		fastpathTV.DecMapBoolIntV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolIntX(vp *map[bool]int, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolIntV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]int, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]int, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv int
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int(dd.DecodeInt(intBitsize))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolInt8R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]int8)
+		v, changed := fastpathTV.DecMapBoolInt8V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]int8)
+		fastpathTV.DecMapBoolInt8V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolInt8X(vp *map[bool]int8, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolInt8V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]int8, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]int8, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv int8
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int8(dd.DecodeInt(8))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolInt16R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]int16)
+		v, changed := fastpathTV.DecMapBoolInt16V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]int16)
+		fastpathTV.DecMapBoolInt16V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolInt16X(vp *map[bool]int16, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolInt16V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]int16, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[bool]int16, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv int16
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int16(dd.DecodeInt(16))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolInt32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]int32)
+		v, changed := fastpathTV.DecMapBoolInt32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]int32)
+		fastpathTV.DecMapBoolInt32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolInt32X(vp *map[bool]int32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolInt32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]int32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]int32, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv int32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = int32(dd.DecodeInt(32))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolInt64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]int64)
+		v, changed := fastpathTV.DecMapBoolInt64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]int64)
+		fastpathTV.DecMapBoolInt64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolInt64X(vp *map[bool]int64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolInt64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]int64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]int64, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv int64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeInt(64)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolFloat32R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]float32)
+		v, changed := fastpathTV.DecMapBoolFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]float32)
+		fastpathTV.DecMapBoolFloat32V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolFloat32X(vp *map[bool]float32, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolFloat32V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]float32, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]float32, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv float32
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = float32(dd.DecodeFloat(true))
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolFloat64R(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]float64)
+		v, changed := fastpathTV.DecMapBoolFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]float64)
+		fastpathTV.DecMapBoolFloat64V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolFloat64X(vp *map[bool]float64, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolFloat64V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]float64, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]float64, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv float64
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeFloat(false)
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}
+
+func (f *decFnInfo) fastpathDecMapBoolBoolR(rv reflect.Value) {
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[bool]bool)
+		v, changed := fastpathTV.DecMapBoolBoolV(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[bool]bool)
+		fastpathTV.DecMapBoolBoolV(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) DecMapBoolBoolX(vp *map[bool]bool, checkNil bool, d *Decoder) {
+	v, changed := f.DecMapBoolBoolV(*vp, checkNil, true, d)
+	if changed {
+		*vp = v
+	}
+}
+func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange bool,
+	d *Decoder) (_ map[bool]bool, changed bool) {
+	dd := d.d
+	cr := d.cr
+
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		}
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]bool, xlen)
+		changed = true
+	}
+
+	var mk bool
+	var mv bool
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil {
+				cr.sendContainerState(containerMapKey)
+			}
+			mk = dd.DecodeBool()
+			if cr != nil {
+				cr.sendContainerState(containerMapValue)
+			}
+			mv = dd.DecodeBool()
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil {
+		cr.sendContainerState(containerMapEnd)
+	}
+	return v, changed
+}

--- a/vendor/github.com/ugorji/go/codec/fast-path.go.tmpl
+++ b/vendor/github.com/ugorji/go/codec/fast-path.go.tmpl
@@ -1,0 +1,527 @@
+// +build !notfastpath
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// ************************************************************
+// DO NOT EDIT. 
+// THIS FILE IS AUTO-GENERATED from fast-path.go.tmpl
+// ************************************************************
+
+package codec
+
+// Fast path functions try to create a fast path encode or decode implementation
+// for common maps and slices.
+//
+// We define the functions and register then in this single file
+// so as not to pollute the encode.go and decode.go, and create a dependency in there.
+// This file can be omitted without causing a build failure.
+//
+// The advantage of fast paths is:
+//    - Many calls bypass reflection altogether
+// 
+// Currently support
+//    - slice of all builtin types,
+//    - map of all builtin types to string or interface value
+//    - symmetrical maps of all builtin types (e.g. str-str, uint8-uint8)
+// This should provide adequate "typical" implementations.
+// 
+// Note that fast track decode functions must handle values for which an address cannot be obtained.
+// For example: 
+//   m2 := map[string]int{}
+//   p2 := []interface{}{m2}
+//   // decoding into p2 will bomb if fast track functions do not treat like unaddressable.
+// 
+
+import (
+	"reflect"
+	"sort"
+)
+
+const fastpathEnabled = true
+
+const fastpathCheckNilFalse = false // for reflect
+const fastpathCheckNilTrue = true // for type switch
+
+type fastpathT struct {}
+
+var fastpathTV fastpathT
+
+type fastpathE struct {
+	rtid uintptr
+	rt reflect.Type 
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
+}
+
+type fastpathA [{{ .FastpathLen }}]fastpathE
+
+func (x *fastpathA) index(rtid uintptr) int {
+	// use binary search to grab the index (adapted from sort/search.go)
+	h, i, j := 0, 0, {{ .FastpathLen }} // len(x)
+	for i < j {
+		h = i + (j-i)/2
+		if x[h].rtid < rtid {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	if i < {{ .FastpathLen }} && x[i].rtid == rtid {
+		return i
+	}
+	return -1
+}
+
+type fastpathAslice []fastpathE
+
+func (x fastpathAslice) Len() int { return len(x) }
+func (x fastpathAslice) Less(i, j int) bool { return x[i].rtid < x[j].rtid }
+func (x fastpathAslice) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+var fastpathAV fastpathA
+
+// due to possible initialization loop error, make fastpath in an init()
+func init() {
+	i := 0
+	fn := func(v interface{}, fe func(*encFnInfo, reflect.Value), fd func(*decFnInfo, reflect.Value)) (f fastpathE) {
+		xrt := reflect.TypeOf(v)
+		xptr := reflect.ValueOf(xrt).Pointer()
+		fastpathAV[i] = fastpathE{xptr, xrt, fe, fd}
+		i++
+		return
+	}
+	
+	{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+	fn([]{{ .Elem }}(nil), (*encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (*decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
+	
+	{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
+	fn(map[{{ .MapKey }}]{{ .Elem }}(nil), (*encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (*decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
+	
+	sort.Sort(fastpathAslice(fastpathAV[:]))
+}
+
+// -- encode
+
+// -- -- fast path type switch
+func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+	case []{{ .Elem }}:{{else}}
+	case map[{{ .MapKey }}]{{ .Elem }}:{{end}}
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e){{if not .MapKey }}
+	case *[]{{ .Elem }}:{{else}}
+	case *map[{{ .MapKey }}]{{ .Elem }}:{{end}}
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
+{{end}}{{end}}
+	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+	case []{{ .Elem }}:
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e)
+	case *[]{{ .Elem }}:
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
+{{end}}{{end}}{{end}}
+	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
+	switch v := iv.(type) {
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
+	case map[{{ .MapKey }}]{{ .Elem }}:
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e)
+	case *map[{{ .MapKey }}]{{ .Elem }}:
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
+{{end}}{{end}}{{end}}
+	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+// -- -- fast path functions
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }} 
+
+func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
+	if f.ti.mbs {
+		fastpathTV.{{ .MethodNamePfx "EncAsMap" false }}V(rv.Interface().([]{{ .Elem }}), fastpathCheckNilFalse, f.e)
+	} else {
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(rv.Interface().([]{{ .Elem }}), fastpathCheckNilFalse, f.e)
+	}
+}
+func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v []{{ .Elem }}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeArrayStart(len(v))
+	for _, v2 := range v {
+		if cr != nil { cr.sendContainerState(containerArrayElem) }
+		{{ encmd .Elem "v2"}}
+	}
+	if cr != nil { cr.sendContainerState(containerArrayEnd) }{{/* ee.EncodeEnd() */}}
+}
+
+func (_ fastpathT) {{ .MethodNamePfx "EncAsMap" false }}V(v []{{ .Elem }}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	if len(v)%2 == 1 {
+		e.errorf("mapBySlice requires even slice length, but got %v", len(v))
+		return
+	}
+	ee.EncodeMapStart(len(v) / 2)
+	for j, v2 := range v {
+		if cr != nil {
+			if j%2 == 0 {
+				cr.sendContainerState(containerMapKey)
+			} else {
+				cr.sendContainerState(containerMapValue)
+			}
+		}
+		{{ encmd .Elem "v2"}}
+	}
+	if cr != nil { cr.sendContainerState(containerMapEnd) }
+}
+
+{{end}}{{end}}{{end}}
+
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
+
+func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
+	fastpathTV.{{ .MethodNamePfx "Enc" false }}V(rv.Interface().(map[{{ .MapKey }}]{{ .Elem }}), fastpathCheckNilFalse, f.e)
+}
+func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, e *Encoder) {
+	ee := e.e
+	cr := e.cr
+	if checkNil && v == nil {
+		ee.EncodeNil()
+		return
+	}
+	ee.EncodeMapStart(len(v))
+	{{if eq .MapKey "string"}}asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
+	{{end}}if e.h.Canonical {
+		{{if eq .MapKey "interface{}"}}{{/* out of band 
+		*/}}var mksv []byte = make([]byte, 0, len(v)*16) // temporary byte slice for the encoding
+		e2 := NewEncoderBytes(&mksv, e.hh)
+		v2 := make([]bytesI, len(v))
+		var i, l int
+		var vp *bytesI {{/* put loop variables outside. seems currently needed for better perf */}}
+		for k2, _ := range v {
+			l = len(mksv)
+			e2.MustEncode(k2)
+			vp = &v2[i]
+			vp.v = mksv[l:]
+			vp.i = k2 
+			i++
+		}
+		sort.Sort(bytesISlice(v2))
+		for j := range v2 {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
+			e.asis(v2[j].v)
+			if cr != nil { cr.sendContainerState(containerMapValue) }
+			e.encode(v[v2[j].i])
+		} {{else}}{{ $x := sorttype .MapKey true}}v2 := make([]{{ $x }}, len(v))
+		var i int 
+		for k, _ := range v {
+			v2[i] = {{ $x }}(k)
+			i++
+		}
+		sort.Sort({{ sorttype .MapKey false}}(v2))
+		for _, k2 := range v2 {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
+			{{if eq .MapKey "string"}}if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}{{else}}{{ $y := printf "%s(k2)" .MapKey }}{{ encmd .MapKey $y }}{{end}}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
+			{{ $y := printf "v[%s(k2)]" .MapKey }}{{ encmd .Elem $y }}
+		} {{end}}
+	} else {
+		for k2, v2 := range v {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
+			{{if eq .MapKey "string"}}if asSymbols {
+				ee.EncodeSymbol(k2)
+			} else {
+				ee.EncodeString(c_UTF8, k2)
+			}{{else}}{{ encmd .MapKey "k2"}}{{end}}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
+			{{ encmd .Elem "v2"}}
+		}
+	}
+	if cr != nil { cr.sendContainerState(containerMapEnd) }{{/* ee.EncodeEnd() */}}
+}
+
+{{end}}{{end}}{{end}}
+
+// -- decode
+
+// -- -- fast path type switch
+func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
+	switch v := iv.(type) {
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+	case []{{ .Elem }}:{{else}}
+	case map[{{ .MapKey }}]{{ .Elem }}:{{end}}
+		fastpathTV.{{ .MethodNamePfx "Dec" false }}V(v, fastpathCheckNilFalse, false, d){{if not .MapKey }}
+	case *[]{{ .Elem }}:{{else}}
+	case *map[{{ .MapKey }}]{{ .Elem }}:{{end}}
+		v2, changed2 := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*v, fastpathCheckNilFalse, true, d)
+		if changed2 {
+			*v = v2 
+		}
+{{end}}{{end}}
+	default:
+        _ = v // TODO: workaround https://github.com/golang/go/issues/12927 (remove after go 1.6 release)
+		return false
+	}
+	return true
+}
+
+// -- -- fast path functions
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+{{/*
+Slices can change if they 
+- did not come from an array
+- are addressable (from a ptr)
+- are settable (e.g. contained in an interface{})
+*/}}
+func (f *decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
+	array := f.seq == seqTypeArray
+	if !array && rv.CanAddr() { {{/* // CanSet => CanAddr + Exported */}}
+		vp := rv.Addr().Interface().(*[]{{ .Elem }})
+		v, changed := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*vp, fastpathCheckNilFalse, !array, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().([]{{ .Elem }})
+		fastpathTV.{{ .MethodNamePfx "Dec" false }}V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+
+func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *[]{{ .Elem }}, checkNil bool, d *Decoder) {
+	v, changed := f.{{ .MethodNamePfx "Dec" false }}V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v 
+	}
+}
+func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil bool, canChange bool, d *Decoder) (_ []{{ .Elem }}, changed bool) {
+	dd := d.d
+	{{/* // if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil() */}}
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true 
+		}
+		return nil, changed 
+	}
+
+	slh, containerLenS := d.decSliceHelperStart()
+	if containerLenS == 0 {
+		if canChange {
+			if v == nil {
+				v = []{{ .Elem }}{}
+			} else if len(v) != 0 {
+				v = v[:0]
+			}
+			changed = true
+		}
+		slh.End()
+		return v, changed
+	}
+	
+	if containerLenS > 0 {
+		x2read := containerLenS
+		var xtrunc bool 
+		if containerLenS > cap(v) {
+			if canChange { {{/*
+				// fast-path is for "basic" immutable types, so no need to copy them over
+				// s := make([]{{ .Elem }}, decInferLen(containerLenS, d.h.MaxInitLen))
+				// copy(s, v[:cap(v)])
+				// v = s */}}
+				var xlen int 
+                xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }})
+				if xtrunc {
+					if xlen <= cap(v) {
+						v = v[:xlen]
+					} else {
+						v = make([]{{ .Elem }}, xlen)
+					}
+				} else {
+					v = make([]{{ .Elem }}, xlen)
+				}
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), containerLenS)
+			}
+			x2read = len(v)
+		} else if containerLenS != len(v) {
+			if canChange {
+				v = v[:containerLenS]
+				changed = true
+			}
+		} {{/* // all checks done. cannot go past len. */}}
+		j := 0
+		for ; j < x2read; j++ {
+			slh.ElemContainerState(j)
+			{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
+		}
+		if xtrunc { {{/* // means canChange=true, changed=true already. */}}
+			for ; j < containerLenS; j++ {
+				v = append(v, {{ zerocmd .Elem }})
+				slh.ElemContainerState(j)
+				{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
+			}
+		} else if !canChange {
+			for ; j < containerLenS; j++ {
+				slh.ElemContainerState(j)
+				d.swallow()
+			}
+		}
+	} else {
+		breakFound := dd.CheckBreak() {{/* check break first, so we can initialize v with a capacity of 4 if necessary */}}
+		if breakFound {
+			if canChange {
+				if v == nil {
+					v = []{{ .Elem }}{}
+				} else if len(v) != 0 {
+					v = v[:0]
+				}
+				changed = true
+			}
+			slh.End()
+			return v, changed
+		}
+		if cap(v) == 0 {
+			v = make([]{{ .Elem }}, 1, 4)
+			changed = true
+		}
+		j := 0	
+		for ; !breakFound; j++ {
+			if j >= len(v) { 
+				if canChange {
+					v = append(v, {{ zerocmd .Elem }})
+					changed = true
+				} else {
+					d.arrayCannotExpand(len(v), j+1)
+				}
+			}
+			slh.ElemContainerState(j)
+			if j < len(v) { {{/* // all checks done. cannot go past len. */}}
+				{{ if eq .Elem "interface{}" }}d.decode(&v[j])
+				{{ else }}v[j] = {{ decmd .Elem }}{{ end }}
+			} else {
+				d.swallow()
+			}
+			breakFound = dd.CheckBreak()
+		}
+		if canChange && j < len(v) {
+			v = v[:j]
+			changed = true
+		}
+	}
+	slh.End() 
+	return v, changed 
+}
+
+{{end}}{{end}}{{end}}
+
+
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
+{{/*
+Maps can change if they are
+- addressable (from a ptr)
+- settable (e.g. contained in an interface{})
+*/}}
+func (f *decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
+	if rv.CanAddr() {
+		vp := rv.Addr().Interface().(*map[{{ .MapKey }}]{{ .Elem }})
+		v, changed := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*vp, fastpathCheckNilFalse, true, f.d)
+		if changed {
+			*vp = v
+		}
+	} else {
+		v := rv.Interface().(map[{{ .MapKey }}]{{ .Elem }})
+		fastpathTV.{{ .MethodNamePfx "Dec" false }}V(v, fastpathCheckNilFalse, false, f.d)
+	}
+}
+func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, d *Decoder) {
+	v, changed := f.{{ .MethodNamePfx "Dec" false }}V(*vp, checkNil, true, d)
+	if changed {
+		*vp = v 
+	}
+}
+func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, canChange bool, 
+	d *Decoder) (_ map[{{ .MapKey }}]{{ .Elem }}, changed bool) {
+	dd := d.d
+	cr := d.cr
+	{{/* // if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil() */}}
+	if checkNil && dd.TryDecodeAsNil() {
+		if v != nil {
+			changed = true
+		} 
+		return nil, changed
+	}
+
+	containerLen := dd.ReadMapStart()
+	if canChange && v == nil {
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, {{ .Size }})
+		v = make(map[{{ .MapKey }}]{{ .Elem }}, xlen)
+		changed = true
+	}
+	{{ if eq .Elem "interface{}" }}mapGet := !d.h.MapValueReset && !d.h.InterfaceReset{{end}}
+	var mk {{ .MapKey }}
+	var mv {{ .Elem }}
+	if containerLen > 0 {
+		for j := 0; j < containerLen; j++ {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
+			{{ if eq .MapKey "interface{}" }}mk = nil 
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
+			}{{ else }}mk = {{ decmd .MapKey }}{{ end }}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
+			{{ if eq .Elem "interface{}" }}if mapGet { mv = v[mk] } else { mv = nil }
+			d.decode(&mv){{ else }}mv = {{ decmd .Elem }}{{ end }}
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	} else if containerLen < 0 {
+		for j := 0; !dd.CheckBreak(); j++ {
+			if cr != nil { cr.sendContainerState(containerMapKey) }
+			{{ if eq .MapKey "interface{}" }}mk = nil 
+			d.decode(&mk)
+			if bv, bok := mk.([]byte); bok {
+				mk = d.string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
+			}{{ else }}mk = {{ decmd .MapKey }}{{ end }}
+			if cr != nil { cr.sendContainerState(containerMapValue) }
+			{{ if eq .Elem "interface{}" }}if mapGet { mv = v[mk] } else { mv = nil }
+			d.decode(&mv){{ else }}mv = {{ decmd .Elem }}{{ end }}
+			if v != nil {
+				v[mk] = mv
+			}
+		}
+	}
+	if cr != nil { cr.sendContainerState(containerMapEnd) }
+	return v, changed
+}
+
+{{end}}{{end}}{{end}}

--- a/vendor/github.com/ugorji/go/codec/fast-path.not.go
+++ b/vendor/github.com/ugorji/go/codec/fast-path.not.go
@@ -1,0 +1,34 @@
+// +build notfastpath
+
+package codec
+
+import "reflect"
+
+const fastpathEnabled = false
+
+// The generated fast-path code is very large, and adds a few seconds to the build time.
+// This causes test execution, execution of small tools which use codec, etc
+// to take a long time.
+//
+// To mitigate, we now support the notfastpath tag.
+// This tag disables fastpath during build, allowing for faster build, test execution,
+// short-program runs, etc.
+
+func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool      { return false }
+func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool      { return false }
+func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool { return false }
+func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool   { return false }
+
+type fastpathT struct{}
+type fastpathE struct {
+	rtid  uintptr
+	rt    reflect.Type
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
+}
+type fastpathA [0]fastpathE
+
+func (x fastpathA) index(rtid uintptr) int { return -1 }
+
+var fastpathAV fastpathA
+var fastpathTV fastpathT

--- a/vendor/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
+++ b/vendor/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
@@ -1,0 +1,104 @@
+{{var "v"}} := {{if not isArray}}*{{end}}{{ .Varname }}
+{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart() {{/* // helper, containerLenS */}}{{if not isArray}}
+var {{var "c"}} bool {{/* // changed */}}
+_ = {{var "c"}}{{end}}
+if {{var "l"}} == 0 {
+	{{if isSlice }}if {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	} else if len({{var "v"}}) != 0 {
+		{{var "v"}} = {{var "v"}}[:0]
+		{{var "c"}} = true
+	} {{end}} {{if isChan }}if {{var "v"}} == nil {
+		{{var "v"}} = make({{ .CTyp }}, 0)
+		{{var "c"}} = true
+	} {{end}}
+} else if {{var "l"}} > 0 {
+	{{if isChan }}if {{var "v"}} == nil {
+		{{var "rl"}}, _ = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
+		{{var "c"}} = true
+	}
+	for {{var "r"}} := 0; {{var "r"}} < {{var "l"}}; {{var "r"}}++ {
+		{{var "h"}}.ElemContainerState({{var "r"}})
+		var {{var "t"}} {{ .Typ }}
+		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
+		{{var "v"}} <- {{var "t"}}
+	}
+	{{ else }}	var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
+	var {{var "rt"}} bool {{/* truncated */}}
+	_, _ = {{var "rl"}}, {{var "rt"}}
+	{{var "rr"}} = {{var "l"}} // len({{var "v"}})
+	if {{var "l"}} > cap({{var "v"}}) {
+		{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
+		{{ else }}{{if not .Immutable }}
+		{{var "rg"}} := len({{var "v"}}) > 0
+		{{var "v2"}} := {{var "v"}} {{end}}
+		{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		if {{var "rt"}} {
+			if {{var "rl"}} <= cap({{var "v"}}) {
+				{{var "v"}} = {{var "v"}}[:{{var "rl"}}]
+			} else {
+				{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+			}
+		} else {
+			{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+		}
+		{{var "c"}} = true
+		{{var "rr"}} = len({{var "v"}}) {{if not .Immutable }}
+			if {{var "rg"}} { copy({{var "v"}}, {{var "v2"}}) } {{end}} {{end}}{{/* end not Immutable, isArray */}}
+	} {{if isSlice }} else if {{var "l"}} != len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "l"}}]
+		{{var "c"}} = true
+	} {{end}}	{{/* end isSlice:47 */}} 
+	{{var "j"}} := 0
+	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+	}
+	{{if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		z.DecSwallow()
+	}
+	{{ else }}if {{var "rt"}} {
+		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+			{{var "v"}} = append({{var "v"}}, {{ zero}})
+			{{var "h"}}.ElemContainerState({{var "j"}})
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		}
+	} {{end}} {{/* end isArray:56 */}}
+	{{end}} {{/* end isChan:16 */}}
+} else { {{/* len < 0 */}}
+	{{var "j"}} := 0
+	for ; !r.CheckBreak(); {{var "j"}}++ {
+		{{if isChan }}
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		var {{var "t"}} {{ .Typ }}
+		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
+		{{var "v"}} <- {{var "t"}} 
+		{{ else }}
+		if {{var "j"}} >= len({{var "v"}}) {
+			{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
+			{{ else }}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
+			{{var "c"}} = true {{end}}
+		}
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		if {{var "j"}} < len({{var "v"}}) {
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		} else {
+			z.DecSwallow()
+		}
+		{{end}}
+	}
+	{{if isSlice }}if {{var "j"}} < len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "j"}}]
+		{{var "c"}} = true
+	} else if {{var "j"}} == 0 && {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	}{{end}}
+}
+{{var "h"}}.End()
+{{if not isArray }}if {{var "c"}} { 
+	*{{ .Varname }} = {{var "v"}}
+}{{end}}

--- a/vendor/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
+++ b/vendor/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
@@ -1,0 +1,58 @@
+{{var "v"}} := *{{ .Varname }}
+{{var "l"}} := r.ReadMapStart()
+{{var "bh"}} := z.DecBasicHandle()
+if {{var "v"}} == nil {
+	{{var "rl"}}, _ := z.DecInferLen({{var "l"}}, {{var "bh"}}.MaxInitLen, {{ .Size }})
+	{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "rl"}})
+	*{{ .Varname }} = {{var "v"}}
+}
+var {{var "mk"}} {{ .KTyp }}
+var {{var "mv"}} {{ .Typ }}
+var {{var "mg"}} {{if decElemKindPtr}}, {{var "ms"}}, {{var "mok"}}{{end}} bool
+if {{var "bh"}}.MapValueReset {
+	{{if decElemKindPtr}}{{var "mg"}} = true
+	{{else if decElemKindIntf}}if !{{var "bh"}}.InterfaceReset { {{var "mg"}} = true }
+	{{else if not decElemKindImmutable}}{{var "mg"}} = true
+	{{end}} }
+if {{var "l"}} > 0  {
+for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
+{{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
+		{{var "mk"}} = string({{var "bv"}})
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true{{end}}
+	if {{var "mg"}} {
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
+	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
+		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
+	}
+}
+} else if {{var "l"}} < 0  {
+for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
+{{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
+		{{var "mk"}} = string({{var "bv"}})
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true {{ end }}
+	if {{var "mg"}} {
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
+	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
+		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
+	}
+}
+} // else len==0: TODO: Should we clear map entries?
+z.DecSendContainerState(codecSelfer_containerMapEnd{{ .Sfx }})

--- a/vendor/github.com/ugorji/go/codec/gen-helper.generated.go
+++ b/vendor/github.com/ugorji/go/codec/gen-helper.generated.go
@@ -1,0 +1,243 @@
+/* // +build ignore */
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// ************************************************************
+// DO NOT EDIT.
+// THIS FILE IS AUTO-GENERATED from gen-helper.go.tmpl
+// ************************************************************
+
+package codec
+
+import (
+	"encoding"
+	"reflect"
+)
+
+// This file is used to generate helper code for codecgen.
+// The values here i.e. genHelper(En|De)coder are not to be used directly by
+// library users. They WILL change continuously and without notice.
+//
+// To help enforce this, we create an unexported type with exported members.
+// The only way to get the type is via the one exported type that we control (somewhat).
+//
+// When static codecs are created for types, they will use this value
+// to perform encoding or decoding of primitives or known slice or map types.
+
+// GenHelperEncoder is exported so that it can be used externally by codecgen.
+// Library users: DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.
+func GenHelperEncoder(e *Encoder) (genHelperEncoder, encDriver) {
+	return genHelperEncoder{e: e}, e.e
+}
+
+// GenHelperDecoder is exported so that it can be used externally by codecgen.
+// Library users: DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.
+func GenHelperDecoder(d *Decoder) (genHelperDecoder, decDriver) {
+	return genHelperDecoder{d: d}, d.d
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+type genHelperEncoder struct {
+	e *Encoder
+	F fastpathT
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+type genHelperDecoder struct {
+	d *Decoder
+	F fastpathT
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBasicHandle() *BasicHandle {
+	return f.e.h
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinary() bool {
+	return f.e.be // f.e.hh.isBinaryEncoding()
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncFallback(iv interface{}) {
+	// println(">>>>>>>>> EncFallback")
+	f.e.encodeI(iv, false, false)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncTextMarshal(iv encoding.TextMarshaler) {
+	bs, fnerr := iv.MarshalText()
+	f.e.marshal(bs, fnerr, false, c_UTF8)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncJSONMarshal(iv jsonMarshaler) {
+	bs, fnerr := iv.MarshalJSON()
+	f.e.marshal(bs, fnerr, true, c_UTF8)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinaryMarshal(iv encoding.BinaryMarshaler) {
+	bs, fnerr := iv.MarshalBinary()
+	f.e.marshal(bs, fnerr, false, c_RAW)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncRaw(iv Raw) {
+	f.e.raw(iv)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.e.hh.(*BincHandle); ok {
+		return timeTypId
+	}
+	return 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) IsJSONHandle() bool {
+	return f.e.js
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) HasExtensions() bool {
+	return len(f.e.h.extHandle) != 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.e.h.getExt(rtid); xfFn != nil {
+		f.e.e.EncodeExt(v, xfFn.tag, xfFn.ext, f.e)
+		return true
+	}
+	return false
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncSendContainerState(c containerState) {
+	if f.e.cr != nil {
+		f.e.cr.sendContainerState(c)
+	}
+}
+
+// ---------------- DECODER FOLLOWS -----------------
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBasicHandle() *BasicHandle {
+	return f.d.h
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinary() bool {
+	return f.d.be // f.d.hh.isBinaryEncoding()
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSwallow() {
+	f.d.swallow()
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecScratchBuffer() []byte {
+	return f.d.b[:]
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecFallback(iv interface{}, chkPtr bool) {
+	// println(">>>>>>>>> DecFallback")
+	f.d.decodeI(iv, chkPtr, false, false, false)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSliceHelperStart() (decSliceHelper, int) {
+	return f.d.decSliceHelperStart()
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecStructFieldNotFound(index int, name string) {
+	f.d.structFieldNotFound(index, name)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecArrayCannotExpand(sliceLen, streamLen int) {
+	f.d.arrayCannotExpand(sliceLen, streamLen)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
+	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinaryUnmarshal(bm encoding.BinaryUnmarshaler) {
+	fnerr := bm.UnmarshalBinary(f.d.d.DecodeBytes(nil, false, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecRaw() []byte {
+	return f.d.raw()
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.d.hh.(*BincHandle); ok {
+		return timeTypId
+	}
+	return 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) IsJSONHandle() bool {
+	return f.d.js
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) HasExtensions() bool {
+	return len(f.d.h.extHandle) != 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v).Elem()
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.d.h.getExt(rtid); xfFn != nil {
+		f.d.d.DecodeExt(v, xfFn.tag, xfFn.ext)
+		return true
+	}
+	return false
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	return decInferLen(clen, maxlen, unit)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSendContainerState(c containerState) {
+	if f.d.cr != nil {
+		f.d.cr.sendContainerState(c)
+	}
+}

--- a/vendor/github.com/ugorji/go/codec/gen-helper.go.tmpl
+++ b/vendor/github.com/ugorji/go/codec/gen-helper.go.tmpl
@@ -1,0 +1,372 @@
+/* // +build ignore */
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// ************************************************************
+// DO NOT EDIT.
+// THIS FILE IS AUTO-GENERATED from gen-helper.go.tmpl
+// ************************************************************
+
+package codec
+
+import (
+	"encoding"
+	"reflect"
+)
+
+// This file is used to generate helper code for codecgen. 
+// The values here i.e. genHelper(En|De)coder are not to be used directly by 
+// library users. They WILL change continuously and without notice.
+// 
+// To help enforce this, we create an unexported type with exported members.
+// The only way to get the type is via the one exported type that we control (somewhat).
+// 
+// When static codecs are created for types, they will use this value
+// to perform encoding or decoding of primitives or known slice or map types.
+
+// GenHelperEncoder is exported so that it can be used externally by codecgen.
+// Library users: DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.
+func GenHelperEncoder(e *Encoder) (genHelperEncoder, encDriver) {
+	return genHelperEncoder{e:e}, e.e 
+}
+
+// GenHelperDecoder is exported so that it can be used externally by codecgen.
+// Library users: DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.
+func GenHelperDecoder(d *Decoder) (genHelperDecoder, decDriver) {
+	return genHelperDecoder{d:d}, d.d 
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+type genHelperEncoder struct {
+	e *Encoder
+	F fastpathT 
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+type genHelperDecoder struct {
+	d *Decoder
+	F fastpathT 
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBasicHandle() *BasicHandle {
+	return f.e.h
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinary() bool {
+	return f.e.be // f.e.hh.isBinaryEncoding()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncFallback(iv interface{}) {
+	// println(">>>>>>>>> EncFallback")
+	f.e.encodeI(iv, false, false)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncTextMarshal(iv encoding.TextMarshaler) {
+	bs, fnerr := iv.MarshalText()
+	f.e.marshal(bs, fnerr, false, c_UTF8)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncJSONMarshal(iv jsonMarshaler) {
+	bs, fnerr := iv.MarshalJSON()
+	f.e.marshal(bs, fnerr, true, c_UTF8)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinaryMarshal(iv encoding.BinaryMarshaler) {
+	bs, fnerr := iv.MarshalBinary()
+	f.e.marshal(bs, fnerr, false, c_RAW)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncRaw(iv Raw) {
+	f.e.raw(iv)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.e.hh.(*BincHandle); ok {
+		return timeTypId 
+	}
+	return 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) IsJSONHandle() bool {
+	return f.e.js
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) HasExtensions() bool {
+	return len(f.e.h.extHandle) != 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.e.h.getExt(rtid); xfFn != nil {
+		f.e.e.EncodeExt(v, xfFn.tag, xfFn.ext, f.e)
+		return true
+	}
+	return false 
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncSendContainerState(c containerState) {
+	if f.e.cr != nil {
+		f.e.cr.sendContainerState(c)
+	}
+}
+
+// ---------------- DECODER FOLLOWS -----------------
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBasicHandle() *BasicHandle {
+	return f.d.h
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinary() bool {
+     return f.d.be // f.d.hh.isBinaryEncoding()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSwallow() {
+	f.d.swallow()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecScratchBuffer() []byte {
+	return f.d.b[:]
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecFallback(iv interface{}, chkPtr bool) {
+	// println(">>>>>>>>> DecFallback")
+	f.d.decodeI(iv, chkPtr, false, false, false)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSliceHelperStart() (decSliceHelper, int) {
+	return f.d.decSliceHelperStart()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecStructFieldNotFound(index int, name string) {
+	f.d.structFieldNotFound(index, name)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecArrayCannotExpand(sliceLen, streamLen int) {
+	f.d.arrayCannotExpand(sliceLen, streamLen)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
+	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
+	// grab the bytes to be read, as UnmarshalJSON needs the full JSON so as to unmarshal it itself.
+	fnerr := tm.UnmarshalJSON(f.d.nextValueBytes())
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinaryUnmarshal(bm encoding.BinaryUnmarshaler) {
+	fnerr := bm.UnmarshalBinary(f.d.d.DecodeBytes(nil, false, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecRaw() []byte {
+	return f.d.raw()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.d.hh.(*BincHandle); ok {
+		return timeTypId 
+	}
+	return 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) IsJSONHandle() bool {
+	return f.d.js 
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) HasExtensions() bool {
+	return len(f.d.h.extHandle) != 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v).Elem()
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.d.h.getExt(rtid); xfFn != nil {
+		f.d.d.DecodeExt(v, xfFn.tag, xfFn.ext)
+		return true
+	}
+	return false 
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	return decInferLen(clen, maxlen, unit)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecSendContainerState(c containerState) {
+	if f.d.cr != nil {
+		f.d.cr.sendContainerState(c)
+	}
+}
+
+{{/*
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncDriver() encDriver {
+	return f.e.e
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecDriver() decDriver {
+     return f.d.d
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncNil() {
+	f.e.e.EncodeNil()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBytes(v []byte) {
+	f.e.e.EncodeStringBytes(c_RAW, v)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncArrayStart(length int) {
+	f.e.e.EncodeArrayStart(length)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncArrayEnd() {
+	f.e.e.EncodeArrayEnd()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncArrayEntrySeparator() {
+	f.e.e.EncodeArrayEntrySeparator()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncMapStart(length int) {
+	f.e.e.EncodeMapStart(length)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncMapEnd() {
+	f.e.e.EncodeMapEnd()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncMapEntrySeparator() {
+	f.e.e.EncodeMapEntrySeparator()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncMapKVSeparator() {
+	f.e.e.EncodeMapKVSeparator()
+}
+
+// ---------
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBytes(v *[]byte) {
+	*v = f.d.d.DecodeBytes(*v)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecTryNil() bool {
+	return f.d.d.TryDecodeAsNil()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecContainerIsNil() (b bool) {
+	return f.d.d.IsContainerType(valueTypeNil)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecContainerIsMap() (b bool) {
+	return f.d.d.IsContainerType(valueTypeMap)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecContainerIsArray() (b bool) {
+	return f.d.d.IsContainerType(valueTypeArray)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecCheckBreak() bool {
+	return f.d.d.CheckBreak()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecMapStart() int {
+	return f.d.d.ReadMapStart()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecArrayStart() int {
+	return f.d.d.ReadArrayStart()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecMapEnd() {
+	f.d.d.ReadMapEnd()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecArrayEnd() {
+	f.d.d.ReadArrayEnd()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecArrayEntrySeparator() {
+	f.d.d.ReadArrayEntrySeparator()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecMapEntrySeparator() {
+	f.d.d.ReadMapEntrySeparator()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecMapKVSeparator() {
+	f.d.d.ReadMapKVSeparator()
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) ReadStringAsBytes(bs []byte) []byte {
+	return f.d.d.DecodeStringAsBytes(bs)
+}
+
+
+// -- encode calls (primitives)
+{{range .Values}}{{if .Primitive }}{{if ne .Primitive "interface{}" }}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) {{ .MethodNamePfx "Enc" true }}(v {{ .Primitive }}) {
+	ee := f.e.e
+	{{ encmd .Primitive "v" }}
+}
+{{ end }}{{ end }}{{ end }}
+
+// -- decode calls (primitives)
+{{range .Values}}{{if .Primitive }}{{if ne .Primitive "interface{}" }}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) {{ .MethodNamePfx "Dec" true }}(vp *{{ .Primitive }}) {
+	dd := f.d.d
+	*vp = {{ decmd .Primitive }}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) {{ .MethodNamePfx "Read" true }}() (v {{ .Primitive }}) {
+	dd := f.d.d
+	v = {{ decmd .Primitive }}
+	return
+}
+{{ end }}{{ end }}{{ end }}
+
+
+// -- encode calls (slices/maps)
+{{range .Values}}{{if not .Primitive }}{{if .Slice }}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) {{ .MethodNamePfx "Enc" false }}(v []{{ .Elem }}) { {{ else }}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) {{ .MethodNamePfx "Enc" false }}(v map[{{ .MapKey }}]{{ .Elem }}) { {{end}}
+	f.F.{{ .MethodNamePfx "Enc" false }}V(v, false, f.e)
+}
+{{ end }}{{ end }}
+
+// -- decode calls (slices/maps) 
+{{range .Values}}{{if not .Primitive }}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+{{if .Slice }}func (f genHelperDecoder) {{ .MethodNamePfx "Dec" false }}(vp *[]{{ .Elem }}) { 
+{{else}}func (f genHelperDecoder) {{ .MethodNamePfx "Dec" false }}(vp *map[{{ .MapKey }}]{{ .Elem }}) { {{end}}
+	v, changed := f.F.{{ .MethodNamePfx "Dec" false }}V(*vp, false, true, f.d)
+	if changed {
+		*vp = v 
+	}
+}
+{{ end }}{{ end }}
+*/}}

--- a/vendor/github.com/ugorji/go/codec/gen.generated.go
+++ b/vendor/github.com/ugorji/go/codec/gen.generated.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// DO NOT EDIT. THIS FILE IS AUTO-GENERATED FROM gen-dec-(map|array).go.tmpl
+
+const genDecMapTmpl = `
+{{var "v"}} := *{{ .Varname }}
+{{var "l"}} := r.ReadMapStart()
+{{var "bh"}} := z.DecBasicHandle()
+if {{var "v"}} == nil {
+	{{var "rl"}}, _ := z.DecInferLen({{var "l"}}, {{var "bh"}}.MaxInitLen, {{ .Size }})
+	{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "rl"}})
+	*{{ .Varname }} = {{var "v"}}
+}
+var {{var "mk"}} {{ .KTyp }}
+var {{var "mv"}} {{ .Typ }}
+var {{var "mg"}} {{if decElemKindPtr}}, {{var "ms"}}, {{var "mok"}}{{end}} bool
+if {{var "bh"}}.MapValueReset {
+	{{if decElemKindPtr}}{{var "mg"}} = true
+	{{else if decElemKindIntf}}if !{{var "bh"}}.InterfaceReset { {{var "mg"}} = true }
+	{{else if not decElemKindImmutable}}{{var "mg"}} = true
+	{{end}} }
+if {{var "l"}} > 0  {
+for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
+{{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
+		{{var "mk"}} = string({{var "bv"}})
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true{{end}}
+	if {{var "mg"}} {
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
+	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
+		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
+	}
+}
+} else if {{var "l"}} < 0  {
+for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
+	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
+{{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
+		{{var "mk"}} = string({{var "bv"}})
+	}{{ end }}{{if decElemKindPtr}}
+	{{var "ms"}} = true {{ end }}
+	if {{var "mg"}} {
+		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
+		if {{var "mok"}} {
+			{{var "ms"}} = false
+		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
+	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
+	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
+	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
+		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
+	}
+}
+} // else len==0: TODO: Should we clear map entries?
+z.DecSendContainerState(codecSelfer_containerMapEnd{{ .Sfx }})
+`
+
+const genDecListTmpl = `
+{{var "v"}} := {{if not isArray}}*{{end}}{{ .Varname }}
+{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart() {{/* // helper, containerLenS */}}{{if not isArray}}
+var {{var "c"}} bool {{/* // changed */}}
+_ = {{var "c"}}{{end}}
+if {{var "l"}} == 0 {
+	{{if isSlice }}if {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	} else if len({{var "v"}}) != 0 {
+		{{var "v"}} = {{var "v"}}[:0]
+		{{var "c"}} = true
+	} {{end}} {{if isChan }}if {{var "v"}} == nil {
+		{{var "v"}} = make({{ .CTyp }}, 0)
+		{{var "c"}} = true
+	} {{end}}
+} else if {{var "l"}} > 0 {
+	{{if isChan }}if {{var "v"}} == nil {
+		{{var "rl"}}, _ = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
+		{{var "c"}} = true
+	}
+	for {{var "r"}} := 0; {{var "r"}} < {{var "l"}}; {{var "r"}}++ {
+		{{var "h"}}.ElemContainerState({{var "r"}})
+		var {{var "t"}} {{ .Typ }}
+		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
+		{{var "v"}} <- {{var "t"}}
+	}
+	{{ else }}	var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
+	var {{var "rt"}} bool {{/* truncated */}}
+	_, _ = {{var "rl"}}, {{var "rt"}}
+	{{var "rr"}} = {{var "l"}} // len({{var "v"}})
+	if {{var "l"}} > cap({{var "v"}}) {
+		{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
+		{{ else }}{{if not .Immutable }}
+		{{var "rg"}} := len({{var "v"}}) > 0
+		{{var "v2"}} := {{var "v"}} {{end}}
+		{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		if {{var "rt"}} {
+			if {{var "rl"}} <= cap({{var "v"}}) {
+				{{var "v"}} = {{var "v"}}[:{{var "rl"}}]
+			} else {
+				{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+			}
+		} else {
+			{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+		}
+		{{var "c"}} = true
+		{{var "rr"}} = len({{var "v"}}) {{if not .Immutable }}
+			if {{var "rg"}} { copy({{var "v"}}, {{var "v2"}}) } {{end}} {{end}}{{/* end not Immutable, isArray */}}
+	} {{if isSlice }} else if {{var "l"}} != len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "l"}}]
+		{{var "c"}} = true
+	} {{end}}	{{/* end isSlice:47 */}} 
+	{{var "j"}} := 0
+	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+	}
+	{{if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		z.DecSwallow()
+	}
+	{{ else }}if {{var "rt"}} {
+		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+			{{var "v"}} = append({{var "v"}}, {{ zero}})
+			{{var "h"}}.ElemContainerState({{var "j"}})
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		}
+	} {{end}} {{/* end isArray:56 */}}
+	{{end}} {{/* end isChan:16 */}}
+} else { {{/* len < 0 */}}
+	{{var "j"}} := 0
+	for ; !r.CheckBreak(); {{var "j"}}++ {
+		{{if isChan }}
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		var {{var "t"}} {{ .Typ }}
+		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
+		{{var "v"}} <- {{var "t"}} 
+		{{ else }}
+		if {{var "j"}} >= len({{var "v"}}) {
+			{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
+			{{ else }}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
+			{{var "c"}} = true {{end}}
+		}
+		{{var "h"}}.ElemContainerState({{var "j"}})
+		if {{var "j"}} < len({{var "v"}}) {
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		} else {
+			z.DecSwallow()
+		}
+		{{end}}
+	}
+	{{if isSlice }}if {{var "j"}} < len({{var "v"}}) {
+		{{var "v"}} = {{var "v"}}[:{{var "j"}}]
+		{{var "c"}} = true
+	} else if {{var "j"}} == 0 && {{var "v"}} == nil {
+		{{var "v"}} = []{{ .Typ }}{}
+		{{var "c"}} = true
+	}{{end}}
+}
+{{var "h"}}.End()
+{{if not isArray }}if {{var "c"}} { 
+	*{{ .Varname }} = {{var "v"}}
+}{{end}}
+`
+

--- a/vendor/github.com/ugorji/go/codec/gen.go
+++ b/vendor/github.com/ugorji/go/codec/gen.go
@@ -1,0 +1,2020 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"go/format"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ---------------------------------------------------
+// codecgen supports the full cycle of reflection-based codec:
+//    - RawExt
+//    - Raw
+//    - Builtins
+//    - Extensions
+//    - (Binary|Text|JSON)(Unm|M)arshal
+//    - generic by-kind
+//
+// This means that, for dynamic things, we MUST use reflection to at least get the reflect.Type.
+// In those areas, we try to only do reflection or interface-conversion when NECESSARY:
+//    - Extensions, only if Extensions are configured.
+//
+// However, codecgen doesn't support the following:
+//   - Canonical option. (codecgen IGNORES it currently)
+//     This is just because it has not been implemented.
+//
+// During encode/decode, Selfer takes precedence.
+// A type implementing Selfer will know how to encode/decode itself statically.
+//
+// The following field types are supported:
+//     array: [n]T
+//     slice: []T
+//     map: map[K]V
+//     primitive: [u]int[n], float(32|64), bool, string
+//     struct
+//
+// ---------------------------------------------------
+// Note that a Selfer cannot call (e|d).(En|De)code on itself,
+// as this will cause a circular reference, as (En|De)code will call Selfer methods.
+// Any type that implements Selfer must implement completely and not fallback to (En|De)code.
+//
+// In addition, code in this file manages the generation of fast-path implementations of
+// encode/decode of slices/maps of primitive keys/values.
+//
+// Users MUST re-generate their implementations whenever the code shape changes.
+// The generated code will panic if it was generated with a version older than the supporting library.
+// ---------------------------------------------------
+//
+// codec framework is very feature rich.
+// When encoding or decoding into an interface, it depends on the runtime type of the interface.
+// The type of the interface may be a named type, an extension, etc.
+// Consequently, we fallback to runtime codec for encoding/decoding interfaces.
+// In addition, we fallback for any value which cannot be guaranteed at runtime.
+// This allows us support ANY value, including any named types, specifically those which
+// do not implement our interfaces (e.g. Selfer).
+//
+// This explains some slowness compared to other code generation codecs (e.g. msgp).
+// This reduction in speed is only seen when your refers to interfaces,
+// e.g. type T struct { A interface{}; B []interface{}; C map[string]interface{} }
+//
+// codecgen will panic if the file was generated with an old version of the library in use.
+//
+// Note:
+//   It was a conscious decision to have gen.go always explicitly call EncodeNil or TryDecodeAsNil.
+//   This way, there isn't a function call overhead just to see that we should not enter a block of code.
+
+// GenVersion is the current version of codecgen.
+//
+// NOTE: Increment this value each time codecgen changes fundamentally.
+// Fundamental changes are:
+//   - helper methods change (signature change, new ones added, some removed, etc)
+//   - codecgen command line changes
+//
+// v1: Initial Version
+// v2:
+// v3: Changes for Kubernetes:
+//     changes in signature of some unpublished helper methods and codecgen cmdline arguments.
+// v4: Removed separator support from (en|de)cDriver, and refactored codec(gen)
+// v5: changes to support faster json decoding. Let encoder/decoder maintain state of collections.
+const GenVersion = 5
+
+const (
+	genCodecPkg        = "codec1978"
+	genTempVarPfx      = "yy"
+	genTopLevelVarName = "x"
+
+	// ignore canBeNil parameter, and always set to true.
+	// This is because nil can appear anywhere, so we should always check.
+	genAnythingCanBeNil = true
+
+	// if genUseOneFunctionForDecStructMap, make a single codecDecodeSelferFromMap function;
+	// else make codecDecodeSelferFromMap{LenPrefix,CheckBreak} so that conditionals
+	// are not executed a lot.
+	//
+	// From testing, it didn't make much difference in runtime, so keep as true (one function only)
+	genUseOneFunctionForDecStructMap = true
+)
+
+type genStructMapStyle uint8
+
+const (
+	genStructMapStyleConsolidated genStructMapStyle = iota
+	genStructMapStyleLenPrefix
+	genStructMapStyleCheckBreak
+)
+
+var (
+	genAllTypesSamePkgErr  = errors.New("All types must be in the same package")
+	genExpectArrayOrMapErr = errors.New("unexpected type. Expecting array/map/slice")
+	genBase64enc           = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789__")
+	genQNameRegex          = regexp.MustCompile(`[A-Za-z_.]+`)
+	genCheckVendor         bool
+)
+
+// genRunner holds some state used during a Gen run.
+type genRunner struct {
+	w io.Writer      // output
+	c uint64         // counter used for generating varsfx
+	t []reflect.Type // list of types to run selfer on
+
+	tc reflect.Type     // currently running selfer on this type
+	te map[uintptr]bool // types for which the encoder has been created
+	td map[uintptr]bool // types for which the decoder has been created
+	cp string           // codec import path
+
+	im  map[string]reflect.Type // imports to add
+	imn map[string]string       // package names of imports to add
+	imc uint64                  // counter for import numbers
+
+	is map[reflect.Type]struct{} // types seen during import search
+	bp string                    // base PkgPath, for which we are generating for
+
+	cpfx   string // codec package prefix
+	unsafe bool   // is unsafe to be used in generated code?
+
+	tm map[reflect.Type]struct{} // types for which enc/dec must be generated
+	ts []reflect.Type            // types for which enc/dec must be generated
+
+	xs string // top level variable/constant suffix
+	hn string // fn helper type name
+
+	ti *TypeInfos
+	// rr *rand.Rand // random generator for file-specific types
+}
+
+// Gen will write a complete go file containing Selfer implementations for each
+// type passed. All the types must be in the same package.
+//
+// Library users: *DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.*
+func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeInfos, typ ...reflect.Type) {
+	// All types passed to this method do not have a codec.Selfer method implemented directly.
+	// codecgen already checks the AST and skips any types that define the codec.Selfer methods.
+	// Consequently, there's no need to check and trim them if they implement codec.Selfer
+
+	if len(typ) == 0 {
+		return
+	}
+	x := genRunner{
+		unsafe: useUnsafe,
+		w:      w,
+		t:      typ,
+		te:     make(map[uintptr]bool),
+		td:     make(map[uintptr]bool),
+		im:     make(map[string]reflect.Type),
+		imn:    make(map[string]string),
+		is:     make(map[reflect.Type]struct{}),
+		tm:     make(map[reflect.Type]struct{}),
+		ts:     []reflect.Type{},
+		bp:     genImportPath(typ[0]),
+		xs:     uid,
+		ti:     ti,
+	}
+	if x.ti == nil {
+		x.ti = defTypeInfos
+	}
+	if x.xs == "" {
+		rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+		x.xs = strconv.FormatInt(rr.Int63n(9999), 10)
+	}
+
+	// gather imports first:
+	x.cp = genImportPath(reflect.TypeOf(x))
+	x.imn[x.cp] = genCodecPkg
+	for _, t := range typ {
+		// fmt.Printf("###########: PkgPath: '%v', Name: '%s'\n", genImportPath(t), t.Name())
+		if genImportPath(t) != x.bp {
+			panic(genAllTypesSamePkgErr)
+		}
+		x.genRefPkgs(t)
+	}
+	if buildTags != "" {
+		x.line("// +build " + buildTags)
+		x.line("")
+	}
+	x.line(`
+
+// ************************************************************
+// DO NOT EDIT.
+// THIS FILE IS AUTO-GENERATED BY codecgen.
+// ************************************************************
+
+`)
+	x.line("package " + pkgName)
+	x.line("")
+	x.line("import (")
+	if x.cp != x.bp {
+		x.cpfx = genCodecPkg + "."
+		x.linef("%s \"%s\"", genCodecPkg, x.cp)
+	}
+	// use a sorted set of im keys, so that we can get consistent output
+	imKeys := make([]string, 0, len(x.im))
+	for k, _ := range x.im {
+		imKeys = append(imKeys, k)
+	}
+	sort.Strings(imKeys)
+	for _, k := range imKeys { // for k, _ := range x.im {
+		x.linef("%s \"%s\"", x.imn[k], k)
+	}
+	// add required packages
+	for _, k := range [...]string{"reflect", "unsafe", "runtime", "fmt", "errors"} {
+		if _, ok := x.im[k]; !ok {
+			if k == "unsafe" && !x.unsafe {
+				continue
+			}
+			x.line("\"" + k + "\"")
+		}
+	}
+	x.line(")")
+	x.line("")
+
+	x.line("const (")
+	x.linef("// ----- content types ----")
+	x.linef("codecSelferC_UTF8%s = %v", x.xs, int64(c_UTF8))
+	x.linef("codecSelferC_RAW%s = %v", x.xs, int64(c_RAW))
+	x.linef("// ----- value types used ----")
+	x.linef("codecSelferValueTypeArray%s = %v", x.xs, int64(valueTypeArray))
+	x.linef("codecSelferValueTypeMap%s = %v", x.xs, int64(valueTypeMap))
+	x.linef("// ----- containerStateValues ----")
+	x.linef("codecSelfer_containerMapKey%s = %v", x.xs, int64(containerMapKey))
+	x.linef("codecSelfer_containerMapValue%s = %v", x.xs, int64(containerMapValue))
+	x.linef("codecSelfer_containerMapEnd%s = %v", x.xs, int64(containerMapEnd))
+	x.linef("codecSelfer_containerArrayElem%s = %v", x.xs, int64(containerArrayElem))
+	x.linef("codecSelfer_containerArrayEnd%s = %v", x.xs, int64(containerArrayEnd))
+	x.line(")")
+	x.line("var (")
+	x.line("codecSelferBitsize" + x.xs + " = uint8(reflect.TypeOf(uint(0)).Bits())")
+	x.line("codecSelferOnlyMapOrArrayEncodeToStructErr" + x.xs + " = errors.New(`only encoded map or array can be decoded into a struct`)")
+	x.line(")")
+	x.line("")
+
+	if x.unsafe {
+		x.line("type codecSelferUnsafeString" + x.xs + " struct { Data uintptr; Len int}")
+		x.line("")
+	}
+	x.hn = "codecSelfer" + x.xs
+	x.line("type " + x.hn + " struct{}")
+	x.line("")
+
+	x.varsfxreset()
+	x.line("func init() {")
+	x.linef("if %sGenVersion != %v {", x.cpfx, GenVersion)
+	x.line("_, file, _, _ := runtime.Caller(0)")
+	x.line(`err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v", `)
+	x.linef(`%v, %sGenVersion, file)`, GenVersion, x.cpfx)
+	x.line("panic(err)")
+	x.linef("}")
+	x.line("if false { // reference the types, but skip this branch at build/run time")
+	var n int
+	// for k, t := range x.im {
+	for _, k := range imKeys {
+		t := x.im[k]
+		x.linef("var v%v %s.%s", n, x.imn[k], t.Name())
+		n++
+	}
+	if x.unsafe {
+		x.linef("var v%v unsafe.Pointer", n)
+		n++
+	}
+	if n > 0 {
+		x.out("_")
+		for i := 1; i < n; i++ {
+			x.out(", _")
+		}
+		x.out(" = v0")
+		for i := 1; i < n; i++ {
+			x.outf(", v%v", i)
+		}
+	}
+	x.line("} ") // close if false
+	x.line("}")  // close init
+	x.line("")
+
+	// generate rest of type info
+	for _, t := range typ {
+		x.tc = t
+		x.selfer(true)
+		x.selfer(false)
+	}
+
+	for _, t := range x.ts {
+		rtid := reflect.ValueOf(t).Pointer()
+		// generate enc functions for all these slice/map types.
+		x.varsfxreset()
+		x.linef("func (x %s) enc%s(v %s%s, e *%sEncoder) {", x.hn, x.genMethodNameT(t), x.arr2str(t, "*"), x.genTypeName(t), x.cpfx)
+		x.genRequiredMethodVars(true)
+		switch t.Kind() {
+		case reflect.Array, reflect.Slice, reflect.Chan:
+			x.encListFallback("v", t)
+		case reflect.Map:
+			x.encMapFallback("v", t)
+		default:
+			panic(genExpectArrayOrMapErr)
+		}
+		x.line("}")
+		x.line("")
+
+		// generate dec functions for all these slice/map types.
+		x.varsfxreset()
+		x.linef("func (x %s) dec%s(v *%s, d *%sDecoder) {", x.hn, x.genMethodNameT(t), x.genTypeName(t), x.cpfx)
+		x.genRequiredMethodVars(false)
+		switch t.Kind() {
+		case reflect.Array, reflect.Slice, reflect.Chan:
+			x.decListFallback("v", rtid, t)
+		case reflect.Map:
+			x.decMapFallback("v", rtid, t)
+		default:
+			panic(genExpectArrayOrMapErr)
+		}
+		x.line("}")
+		x.line("")
+	}
+
+	x.line("")
+}
+
+func (x *genRunner) checkForSelfer(t reflect.Type, varname string) bool {
+	// return varname != genTopLevelVarName && t != x.tc
+	// the only time we checkForSelfer is if we are not at the TOP of the generated code.
+	return varname != genTopLevelVarName
+}
+
+func (x *genRunner) arr2str(t reflect.Type, s string) string {
+	if t.Kind() == reflect.Array {
+		return s
+	}
+	return ""
+}
+
+func (x *genRunner) genRequiredMethodVars(encode bool) {
+	x.line("var h " + x.hn)
+	if encode {
+		x.line("z, r := " + x.cpfx + "GenHelperEncoder(e)")
+	} else {
+		x.line("z, r := " + x.cpfx + "GenHelperDecoder(d)")
+	}
+	x.line("_, _, _ = h, z, r")
+}
+
+func (x *genRunner) genRefPkgs(t reflect.Type) {
+	if _, ok := x.is[t]; ok {
+		return
+	}
+	// fmt.Printf(">>>>>>: PkgPath: '%v', Name: '%s'\n", genImportPath(t), t.Name())
+	x.is[t] = struct{}{}
+	tpkg, tname := genImportPath(t), t.Name()
+	if tpkg != "" && tpkg != x.bp && tpkg != x.cp && tname != "" && tname[0] >= 'A' && tname[0] <= 'Z' {
+		if _, ok := x.im[tpkg]; !ok {
+			x.im[tpkg] = t
+			if idx := strings.LastIndex(tpkg, "/"); idx < 0 {
+				x.imn[tpkg] = tpkg
+			} else {
+				x.imc++
+				x.imn[tpkg] = "pkg" + strconv.FormatUint(x.imc, 10) + "_" + genGoIdentifier(tpkg[idx+1:], false)
+			}
+		}
+	}
+	switch t.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Ptr, reflect.Chan:
+		x.genRefPkgs(t.Elem())
+	case reflect.Map:
+		x.genRefPkgs(t.Elem())
+		x.genRefPkgs(t.Key())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if fname := t.Field(i).Name; fname != "" && fname[0] >= 'A' && fname[0] <= 'Z' {
+				x.genRefPkgs(t.Field(i).Type)
+			}
+		}
+	}
+}
+
+func (x *genRunner) line(s string) {
+	x.out(s)
+	if len(s) == 0 || s[len(s)-1] != '\n' {
+		x.out("\n")
+	}
+}
+
+func (x *genRunner) varsfx() string {
+	x.c++
+	return strconv.FormatUint(x.c, 10)
+}
+
+func (x *genRunner) varsfxreset() {
+	x.c = 0
+}
+
+func (x *genRunner) out(s string) {
+	if _, err := io.WriteString(x.w, s); err != nil {
+		panic(err)
+	}
+}
+
+func (x *genRunner) linef(s string, params ...interface{}) {
+	x.line(fmt.Sprintf(s, params...))
+}
+
+func (x *genRunner) outf(s string, params ...interface{}) {
+	x.out(fmt.Sprintf(s, params...))
+}
+
+func (x *genRunner) genTypeName(t reflect.Type) (n string) {
+	// defer func() { fmt.Printf(">>>> ####: genTypeName: t: %v, name: '%s'\n", t, n) }()
+
+	// if the type has a PkgPath, which doesn't match the current package,
+	// then include it.
+	// We cannot depend on t.String() because it includes current package,
+	// or t.PkgPath because it includes full import path,
+	//
+	var ptrPfx string
+	for t.Kind() == reflect.Ptr {
+		ptrPfx += "*"
+		t = t.Elem()
+	}
+	if tn := t.Name(); tn != "" {
+		return ptrPfx + x.genTypeNamePrim(t)
+	}
+	switch t.Kind() {
+	case reflect.Map:
+		return ptrPfx + "map[" + x.genTypeName(t.Key()) + "]" + x.genTypeName(t.Elem())
+	case reflect.Slice:
+		return ptrPfx + "[]" + x.genTypeName(t.Elem())
+	case reflect.Array:
+		return ptrPfx + "[" + strconv.FormatInt(int64(t.Len()), 10) + "]" + x.genTypeName(t.Elem())
+	case reflect.Chan:
+		return ptrPfx + t.ChanDir().String() + " " + x.genTypeName(t.Elem())
+	default:
+		if t == intfTyp {
+			return ptrPfx + "interface{}"
+		} else {
+			return ptrPfx + x.genTypeNamePrim(t)
+		}
+	}
+}
+
+func (x *genRunner) genTypeNamePrim(t reflect.Type) (n string) {
+	if t.Name() == "" {
+		return t.String()
+	} else if genImportPath(t) == "" || genImportPath(t) == genImportPath(x.tc) {
+		return t.Name()
+	} else {
+		return x.imn[genImportPath(t)] + "." + t.Name()
+		// return t.String() // best way to get the package name inclusive
+	}
+}
+
+func (x *genRunner) genZeroValueR(t reflect.Type) string {
+	// if t is a named type, w
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func,
+		reflect.Slice, reflect.Map, reflect.Invalid:
+		return "nil"
+	case reflect.Bool:
+		return "false"
+	case reflect.String:
+		return `""`
+	case reflect.Struct, reflect.Array:
+		return x.genTypeName(t) + "{}"
+	default: // all numbers
+		return "0"
+	}
+}
+
+func (x *genRunner) genMethodNameT(t reflect.Type) (s string) {
+	return genMethodNameT(t, x.tc)
+}
+
+func (x *genRunner) selfer(encode bool) {
+	t := x.tc
+	t0 := t
+	// always make decode use a pointer receiver,
+	// and structs always use a ptr receiver (encode|decode)
+	isptr := !encode || t.Kind() == reflect.Struct
+	x.varsfxreset()
+	fnSigPfx := "func (x "
+	if isptr {
+		fnSigPfx += "*"
+	}
+	fnSigPfx += x.genTypeName(t)
+
+	x.out(fnSigPfx)
+	if isptr {
+		t = reflect.PtrTo(t)
+	}
+	if encode {
+		x.line(") CodecEncodeSelf(e *" + x.cpfx + "Encoder) {")
+		x.genRequiredMethodVars(true)
+		// x.enc(genTopLevelVarName, t)
+		x.encVar(genTopLevelVarName, t)
+	} else {
+		x.line(") CodecDecodeSelf(d *" + x.cpfx + "Decoder) {")
+		x.genRequiredMethodVars(false)
+		// do not use decVar, as there is no need to check TryDecodeAsNil
+		// or way to elegantly handle that, and also setting it to a
+		// non-nil value doesn't affect the pointer passed.
+		// x.decVar(genTopLevelVarName, t, false)
+		x.dec(genTopLevelVarName, t0)
+	}
+	x.line("}")
+	x.line("")
+
+	if encode || t0.Kind() != reflect.Struct {
+		return
+	}
+
+	// write is containerMap
+	if genUseOneFunctionForDecStructMap {
+		x.out(fnSigPfx)
+		x.line(") codecDecodeSelfFromMap(l int, d *" + x.cpfx + "Decoder) {")
+		x.genRequiredMethodVars(false)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleConsolidated)
+		x.line("}")
+		x.line("")
+	} else {
+		x.out(fnSigPfx)
+		x.line(") codecDecodeSelfFromMapLenPrefix(l int, d *" + x.cpfx + "Decoder) {")
+		x.genRequiredMethodVars(false)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleLenPrefix)
+		x.line("}")
+		x.line("")
+
+		x.out(fnSigPfx)
+		x.line(") codecDecodeSelfFromMapCheckBreak(l int, d *" + x.cpfx + "Decoder) {")
+		x.genRequiredMethodVars(false)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleCheckBreak)
+		x.line("}")
+		x.line("")
+	}
+
+	// write containerArray
+	x.out(fnSigPfx)
+	x.line(") codecDecodeSelfFromArray(l int, d *" + x.cpfx + "Decoder) {")
+	x.genRequiredMethodVars(false)
+	x.decStructArray(genTopLevelVarName, "l", "return", reflect.ValueOf(t0).Pointer(), t0)
+	x.line("}")
+	x.line("")
+
+}
+
+// used for chan, array, slice, map
+func (x *genRunner) xtraSM(varname string, encode bool, t reflect.Type) {
+	if encode {
+		x.linef("h.enc%s((%s%s)(%s), e)", x.genMethodNameT(t), x.arr2str(t, "*"), x.genTypeName(t), varname)
+	} else {
+		x.linef("h.dec%s((*%s)(%s), d)", x.genMethodNameT(t), x.genTypeName(t), varname)
+	}
+	x.registerXtraT(t)
+}
+
+func (x *genRunner) registerXtraT(t reflect.Type) {
+	// recursively register the types
+	if _, ok := x.tm[t]; ok {
+		return
+	}
+	var tkey reflect.Type
+	switch t.Kind() {
+	case reflect.Chan, reflect.Slice, reflect.Array:
+	case reflect.Map:
+		tkey = t.Key()
+	default:
+		return
+	}
+	x.tm[t] = struct{}{}
+	x.ts = append(x.ts, t)
+	// check if this refers to any xtra types eg. a slice of array: add the array
+	x.registerXtraT(t.Elem())
+	if tkey != nil {
+		x.registerXtraT(tkey)
+	}
+}
+
+// encVar will encode a variable.
+// The parameter, t, is the reflect.Type of the variable itself
+func (x *genRunner) encVar(varname string, t reflect.Type) {
+	// fmt.Printf(">>>>>> varname: %s, t: %v\n", varname, t)
+	var checkNil bool
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan:
+		checkNil = true
+	}
+	if checkNil {
+		x.linef("if %s == nil { r.EncodeNil() } else { ", varname)
+	}
+	switch t.Kind() {
+	case reflect.Ptr:
+		switch t.Elem().Kind() {
+		case reflect.Struct, reflect.Array:
+			x.enc(varname, genNonPtr(t))
+		default:
+			i := x.varsfx()
+			x.line(genTempVarPfx + i + " := *" + varname)
+			x.enc(genTempVarPfx+i, genNonPtr(t))
+		}
+	case reflect.Struct, reflect.Array:
+		i := x.varsfx()
+		x.line(genTempVarPfx + i + " := &" + varname)
+		x.enc(genTempVarPfx+i, t)
+	default:
+		x.enc(varname, t)
+	}
+
+	if checkNil {
+		x.line("}")
+	}
+
+}
+
+// enc will encode a variable (varname) of type t,
+// except t is of kind reflect.Struct or reflect.Array, wherein varname is of type ptrTo(T) (to prevent copying)
+func (x *genRunner) enc(varname string, t reflect.Type) {
+	rtid := reflect.ValueOf(t).Pointer()
+	// We call CodecEncodeSelf if one of the following are honored:
+	//   - the type already implements Selfer, call that
+	//   - the type has a Selfer implementation just created, use that
+	//   - the type is in the list of the ones we will generate for, but it is not currently being generated
+
+	mi := x.varsfx()
+	tptr := reflect.PtrTo(t)
+	tk := t.Kind()
+	if x.checkForSelfer(t, varname) {
+		if tk == reflect.Array || tk == reflect.Struct { // varname is of type *T
+			if tptr.Implements(selferTyp) || t.Implements(selferTyp) {
+				x.line(varname + ".CodecEncodeSelf(e)")
+				return
+			}
+		} else { // varname is of type T
+			if t.Implements(selferTyp) {
+				x.line(varname + ".CodecEncodeSelf(e)")
+				return
+			} else if tptr.Implements(selferTyp) {
+				x.linef("%ssf%s := &%s", genTempVarPfx, mi, varname)
+				x.linef("%ssf%s.CodecEncodeSelf(e)", genTempVarPfx, mi)
+				return
+			}
+		}
+
+		if _, ok := x.te[rtid]; ok {
+			x.line(varname + ".CodecEncodeSelf(e)")
+			return
+		}
+	}
+
+	inlist := false
+	for _, t0 := range x.t {
+		if t == t0 {
+			inlist = true
+			if x.checkForSelfer(t, varname) {
+				x.line(varname + ".CodecEncodeSelf(e)")
+				return
+			}
+			break
+		}
+	}
+
+	var rtidAdded bool
+	if t == x.tc {
+		x.te[rtid] = true
+		rtidAdded = true
+	}
+
+	// check if
+	//   - type is RawExt, Raw
+	//   - the type implements (Text|JSON|Binary)(Unm|M)arshal
+	x.linef("%sm%s := z.EncBinary()", genTempVarPfx, mi)
+	x.linef("_ = %sm%s", genTempVarPfx, mi)
+	x.line("if false {")           //start if block
+	defer func() { x.line("}") }() //end if block
+
+	if t == rawTyp {
+		x.linef("} else { z.EncRaw(%v)", varname)
+		return
+	}
+	if t == rawExtTyp {
+		x.linef("} else { r.EncodeRawExt(%v, e)", varname)
+		return
+	}
+	// HACK: Support for Builtins.
+	//       Currently, only Binc supports builtins, and the only builtin type is time.Time.
+	//       Have a method that returns the rtid for time.Time if Handle is Binc.
+	if t == timeTyp {
+		vrtid := genTempVarPfx + "m" + x.varsfx()
+		x.linef("} else if %s := z.TimeRtidIfBinc(); %s != 0 { ", vrtid, vrtid)
+		x.linef("r.EncodeBuiltin(%s, %s)", vrtid, varname)
+	}
+	// only check for extensions if the type is named, and has a packagePath.
+	if genImportPath(t) != "" && t.Name() != "" {
+		// first check if extensions are configued, before doing the interface conversion
+		x.linef("} else if z.HasExtensions() && z.EncExt(%s) {", varname)
+	}
+	if tk == reflect.Array || tk == reflect.Struct { // varname is of type *T
+		if t.Implements(binaryMarshalerTyp) || tptr.Implements(binaryMarshalerTyp) {
+			x.linef("} else if %sm%s { z.EncBinaryMarshal(%v) ", genTempVarPfx, mi, varname)
+		}
+		if t.Implements(jsonMarshalerTyp) || tptr.Implements(jsonMarshalerTyp) {
+			x.linef("} else if !%sm%s && z.IsJSONHandle() { z.EncJSONMarshal(%v) ", genTempVarPfx, mi, varname)
+		} else if t.Implements(textMarshalerTyp) || tptr.Implements(textMarshalerTyp) {
+			x.linef("} else if !%sm%s { z.EncTextMarshal(%v) ", genTempVarPfx, mi, varname)
+		}
+	} else { // varname is of type T
+		if t.Implements(binaryMarshalerTyp) {
+			x.linef("} else if %sm%s { z.EncBinaryMarshal(%v) ", genTempVarPfx, mi, varname)
+		} else if tptr.Implements(binaryMarshalerTyp) {
+			x.linef("} else if %sm%s { z.EncBinaryMarshal(&%v) ", genTempVarPfx, mi, varname)
+		}
+		if t.Implements(jsonMarshalerTyp) {
+			x.linef("} else if !%sm%s && z.IsJSONHandle() { z.EncJSONMarshal(%v) ", genTempVarPfx, mi, varname)
+		} else if tptr.Implements(jsonMarshalerTyp) {
+			x.linef("} else if !%sm%s && z.IsJSONHandle() { z.EncJSONMarshal(&%v) ", genTempVarPfx, mi, varname)
+		} else if t.Implements(textMarshalerTyp) {
+			x.linef("} else if !%sm%s { z.EncTextMarshal(%v) ", genTempVarPfx, mi, varname)
+		} else if tptr.Implements(textMarshalerTyp) {
+			x.linef("} else if !%sm%s { z.EncTextMarshal(&%v) ", genTempVarPfx, mi, varname)
+		}
+	}
+	x.line("} else {")
+
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		x.line("r.EncodeInt(int64(" + varname + "))")
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		x.line("r.EncodeUint(uint64(" + varname + "))")
+	case reflect.Float32:
+		x.line("r.EncodeFloat32(float32(" + varname + "))")
+	case reflect.Float64:
+		x.line("r.EncodeFloat64(float64(" + varname + "))")
+	case reflect.Bool:
+		x.line("r.EncodeBool(bool(" + varname + "))")
+	case reflect.String:
+		x.line("r.EncodeString(codecSelferC_UTF8" + x.xs + ", string(" + varname + "))")
+	case reflect.Chan:
+		x.xtraSM(varname, true, t)
+		// x.encListFallback(varname, rtid, t)
+	case reflect.Array:
+		x.xtraSM(varname, true, t)
+	case reflect.Slice:
+		// if nil, call dedicated function
+		// if a []uint8, call dedicated function
+		// if a known fastpath slice, call dedicated function
+		// else write encode function in-line.
+		// - if elements are primitives or Selfers, call dedicated function on each member.
+		// - else call Encoder.encode(XXX) on it.
+		if rtid == uint8SliceTypId {
+			x.line("r.EncodeStringBytes(codecSelferC_RAW" + x.xs + ", []byte(" + varname + "))")
+		} else if fastpathAV.index(rtid) != -1 {
+			g := x.newGenV(t)
+			x.line("z.F." + g.MethodNamePfx("Enc", false) + "V(" + varname + ", false, e)")
+		} else {
+			x.xtraSM(varname, true, t)
+			// x.encListFallback(varname, rtid, t)
+		}
+	case reflect.Map:
+		// if nil, call dedicated function
+		// if a known fastpath map, call dedicated function
+		// else write encode function in-line.
+		// - if elements are primitives or Selfers, call dedicated function on each member.
+		// - else call Encoder.encode(XXX) on it.
+		// x.line("if " + varname + " == nil { \nr.EncodeNil()\n } else { ")
+		if fastpathAV.index(rtid) != -1 {
+			g := x.newGenV(t)
+			x.line("z.F." + g.MethodNamePfx("Enc", false) + "V(" + varname + ", false, e)")
+		} else {
+			x.xtraSM(varname, true, t)
+			// x.encMapFallback(varname, rtid, t)
+		}
+	case reflect.Struct:
+		if !inlist {
+			delete(x.te, rtid)
+			x.line("z.EncFallback(" + varname + ")")
+			break
+		}
+		x.encStruct(varname, rtid, t)
+	default:
+		if rtidAdded {
+			delete(x.te, rtid)
+		}
+		x.line("z.EncFallback(" + varname + ")")
+	}
+}
+
+func (x *genRunner) encZero(t reflect.Type) {
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		x.line("r.EncodeInt(0)")
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		x.line("r.EncodeUint(0)")
+	case reflect.Float32:
+		x.line("r.EncodeFloat32(0)")
+	case reflect.Float64:
+		x.line("r.EncodeFloat64(0)")
+	case reflect.Bool:
+		x.line("r.EncodeBool(false)")
+	case reflect.String:
+		x.line("r.EncodeString(codecSelferC_UTF8" + x.xs + `, "")`)
+	default:
+		x.line("r.EncodeNil()")
+	}
+}
+
+func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
+	// Use knowledge from structfieldinfo (mbs, encodable fields. Ignore omitempty. )
+	// replicate code in kStruct i.e. for each field, deref type to non-pointer, and call x.enc on it
+
+	// if t === type currently running selfer on, do for all
+	ti := x.ti.get(rtid, t)
+	i := x.varsfx()
+	sepVarname := genTempVarPfx + "sep" + i
+	numfieldsvar := genTempVarPfx + "q" + i
+	ti2arrayvar := genTempVarPfx + "r" + i
+	struct2arrvar := genTempVarPfx + "2arr" + i
+
+	x.line(sepVarname + " := !z.EncBinary()")
+	x.linef("%s := z.EncBasicHandle().StructToArray", struct2arrvar)
+	tisfi := ti.sfip // always use sequence from file. decStruct expects same thing.
+	// due to omitEmpty, we need to calculate the
+	// number of non-empty things we write out first.
+	// This is required as we need to pre-determine the size of the container,
+	// to support length-prefixing.
+	x.linef("var %s [%v]bool", numfieldsvar, len(tisfi))
+	x.linef("_, _, _ = %s, %s, %s", sepVarname, numfieldsvar, struct2arrvar)
+	x.linef("const %s bool = %v", ti2arrayvar, ti.toArray)
+	nn := 0
+	for j, si := range tisfi {
+		if !si.omitEmpty {
+			nn++
+			continue
+		}
+		var t2 reflect.StructField
+		var omitline string
+		if si.i != -1 {
+			t2 = t.Field(int(si.i))
+		} else {
+			t2typ := t
+			varname3 := varname
+			for _, ix := range si.is {
+				for t2typ.Kind() == reflect.Ptr {
+					t2typ = t2typ.Elem()
+				}
+				t2 = t2typ.Field(ix)
+				t2typ = t2.Type
+				varname3 = varname3 + "." + t2.Name
+				if t2typ.Kind() == reflect.Ptr {
+					omitline += varname3 + " != nil && "
+				}
+			}
+		}
+		// never check omitEmpty on a struct type, as it may contain uncomparable map/slice/etc.
+		// also, for maps/slices/arrays, check if len ! 0 (not if == zero value)
+		switch t2.Type.Kind() {
+		case reflect.Struct:
+			omitline += " true"
+		case reflect.Map, reflect.Slice, reflect.Array, reflect.Chan:
+			omitline += "len(" + varname + "." + t2.Name + ") != 0"
+		default:
+			omitline += varname + "." + t2.Name + " != " + x.genZeroValueR(t2.Type)
+		}
+		x.linef("%s[%v] = %s", numfieldsvar, j, omitline)
+	}
+	x.linef("var %snn%s int", genTempVarPfx, i)
+	x.linef("if %s || %s {", ti2arrayvar, struct2arrvar) // if ti.toArray {
+	x.line("r.EncodeArrayStart(" + strconv.FormatInt(int64(len(tisfi)), 10) + ")")
+	x.linef("} else {") // if not ti.toArray
+	x.linef("%snn%s = %v", genTempVarPfx, i, nn)
+	x.linef("for _, b := range %s { if b { %snn%s++ } }", numfieldsvar, genTempVarPfx, i)
+	x.linef("r.EncodeMapStart(%snn%s)", genTempVarPfx, i)
+	x.linef("%snn%s = %v", genTempVarPfx, i, 0)
+	// x.line("r.EncodeMapStart(" + strconv.FormatInt(int64(len(tisfi)), 10) + ")")
+	x.line("}") // close if not StructToArray
+
+	for j, si := range tisfi {
+		i := x.varsfx()
+		isNilVarName := genTempVarPfx + "n" + i
+		var labelUsed bool
+		var t2 reflect.StructField
+		if si.i != -1 {
+			t2 = t.Field(int(si.i))
+		} else {
+			t2typ := t
+			varname3 := varname
+			for _, ix := range si.is {
+				// fmt.Printf("%%%% %v, ix: %v\n", t2typ, ix)
+				for t2typ.Kind() == reflect.Ptr {
+					t2typ = t2typ.Elem()
+				}
+				t2 = t2typ.Field(ix)
+				t2typ = t2.Type
+				varname3 = varname3 + "." + t2.Name
+				if t2typ.Kind() == reflect.Ptr {
+					if !labelUsed {
+						x.line("var " + isNilVarName + " bool")
+					}
+					x.line("if " + varname3 + " == nil { " + isNilVarName + " = true ")
+					x.line("goto LABEL" + i)
+					x.line("}")
+					labelUsed = true
+					// "varname3 = new(" + x.genTypeName(t3.Elem()) + ") }")
+				}
+			}
+			// t2 = t.FieldByIndex(si.is)
+		}
+		if labelUsed {
+			x.line("LABEL" + i + ":")
+		}
+		// if the type of the field is a Selfer, or one of the ones
+
+		x.linef("if %s || %s {", ti2arrayvar, struct2arrvar) // if ti.toArray
+		if labelUsed {
+			x.line("if " + isNilVarName + " { r.EncodeNil() } else { ")
+		}
+		x.linef("z.EncSendContainerState(codecSelfer_containerArrayElem%s)", x.xs)
+		if si.omitEmpty {
+			x.linef("if %s[%v] {", numfieldsvar, j)
+		}
+		x.encVar(varname+"."+t2.Name, t2.Type)
+		if si.omitEmpty {
+			x.linef("} else {")
+			x.encZero(t2.Type)
+			x.linef("}")
+		}
+		if labelUsed {
+			x.line("}")
+		}
+
+		x.linef("} else {") // if not ti.toArray
+
+		if si.omitEmpty {
+			x.linef("if %s[%v] {", numfieldsvar, j)
+		}
+		x.linef("z.EncSendContainerState(codecSelfer_containerMapKey%s)", x.xs)
+		x.line("r.EncodeString(codecSelferC_UTF8" + x.xs + ", string(\"" + si.encName + "\"))")
+		x.linef("z.EncSendContainerState(codecSelfer_containerMapValue%s)", x.xs)
+		if labelUsed {
+			x.line("if " + isNilVarName + " { r.EncodeNil() } else { ")
+			x.encVar(varname+"."+t2.Name, t2.Type)
+			x.line("}")
+		} else {
+			x.encVar(varname+"."+t2.Name, t2.Type)
+		}
+		if si.omitEmpty {
+			x.line("}")
+		}
+		x.linef("} ") // end if/else ti.toArray
+	}
+	x.linef("if %s || %s {", ti2arrayvar, struct2arrvar) // if ti.toArray {
+	x.linef("z.EncSendContainerState(codecSelfer_containerArrayEnd%s)", x.xs)
+	x.line("} else {")
+	x.linef("z.EncSendContainerState(codecSelfer_containerMapEnd%s)", x.xs)
+	x.line("}")
+
+}
+
+func (x *genRunner) encListFallback(varname string, t reflect.Type) {
+	if t.AssignableTo(uint8SliceTyp) {
+		x.linef("r.EncodeStringBytes(codecSelferC_RAW%s, []byte(%s))", x.xs, varname)
+		return
+	}
+	if t.Kind() == reflect.Array && t.Elem().Kind() == reflect.Uint8 {
+		x.linef("r.EncodeStringBytes(codecSelferC_RAW%s, ([%v]byte(%s))[:])", x.xs, t.Len(), varname)
+		return
+	}
+	i := x.varsfx()
+	g := genTempVarPfx
+	x.line("r.EncodeArrayStart(len(" + varname + "))")
+	if t.Kind() == reflect.Chan {
+		x.linef("for %si%s, %si2%s := 0, len(%s); %si%s < %si2%s; %si%s++ {", g, i, g, i, varname, g, i, g, i, g, i)
+		x.linef("z.EncSendContainerState(codecSelfer_containerArrayElem%s)", x.xs)
+		x.linef("%sv%s := <-%s", g, i, varname)
+	} else {
+		// x.linef("for %si%s, %sv%s := range %s {", genTempVarPfx, i, genTempVarPfx, i, varname)
+		x.linef("for _, %sv%s := range %s {", genTempVarPfx, i, varname)
+		x.linef("z.EncSendContainerState(codecSelfer_containerArrayElem%s)", x.xs)
+	}
+	x.encVar(genTempVarPfx+"v"+i, t.Elem())
+	x.line("}")
+	x.linef("z.EncSendContainerState(codecSelfer_containerArrayEnd%s)", x.xs)
+}
+
+func (x *genRunner) encMapFallback(varname string, t reflect.Type) {
+	// TODO: expand this to handle canonical.
+	i := x.varsfx()
+	x.line("r.EncodeMapStart(len(" + varname + "))")
+	x.linef("for %sk%s, %sv%s := range %s {", genTempVarPfx, i, genTempVarPfx, i, varname)
+	// x.line("for " + genTempVarPfx + "k" + i + ", " + genTempVarPfx + "v" + i + " := range " + varname + " {")
+	x.linef("z.EncSendContainerState(codecSelfer_containerMapKey%s)", x.xs)
+	x.encVar(genTempVarPfx+"k"+i, t.Key())
+	x.linef("z.EncSendContainerState(codecSelfer_containerMapValue%s)", x.xs)
+	x.encVar(genTempVarPfx+"v"+i, t.Elem())
+	x.line("}")
+	x.linef("z.EncSendContainerState(codecSelfer_containerMapEnd%s)", x.xs)
+}
+
+func (x *genRunner) decVar(varname string, t reflect.Type, canBeNil bool) {
+	// We only encode as nil if a nillable value.
+	// This removes some of the wasted checks for TryDecodeAsNil.
+	// We need to think about this more, to see what happens if omitempty, etc
+	// cause a nil value to be stored when something is expected.
+	// This could happen when decoding from a struct encoded as an array.
+	// For that, decVar should be called with canNil=true, to force true as its value.
+	i := x.varsfx()
+	if !canBeNil {
+		canBeNil = genAnythingCanBeNil || !genIsImmutable(t)
+	}
+	if canBeNil {
+		x.line("if r.TryDecodeAsNil() {")
+		if t.Kind() == reflect.Ptr {
+			x.line("if " + varname + " != nil { ")
+
+			// if varname is a field of a struct (has a dot in it),
+			// then just set it to nil
+			if strings.IndexByte(varname, '.') != -1 {
+				x.line(varname + " = nil")
+			} else {
+				x.line("*" + varname + " = " + x.genZeroValueR(t.Elem()))
+			}
+			x.line("}")
+		} else {
+			x.line(varname + " = " + x.genZeroValueR(t))
+		}
+		x.line("} else {")
+	} else {
+		x.line("// cannot be nil")
+	}
+	if t.Kind() != reflect.Ptr {
+		if x.decTryAssignPrimitive(varname, t) {
+			x.line(genTempVarPfx + "v" + i + " := &" + varname)
+			x.dec(genTempVarPfx+"v"+i, t)
+		}
+	} else {
+		x.linef("if %s == nil { %s = new(%s) }", varname, varname, x.genTypeName(t.Elem()))
+		// Ensure we set underlying ptr to a non-nil value (so we can deref to it later).
+		// There's a chance of a **T in here which is nil.
+		var ptrPfx string
+		for t = t.Elem(); t.Kind() == reflect.Ptr; t = t.Elem() {
+			ptrPfx += "*"
+			x.linef("if %s%s == nil { %s%s = new(%s)}",
+				ptrPfx, varname, ptrPfx, varname, x.genTypeName(t))
+		}
+		// if varname has [ in it, then create temp variable for this ptr thingie
+		if strings.Index(varname, "[") >= 0 {
+			varname2 := genTempVarPfx + "w" + i
+			x.line(varname2 + " := " + varname)
+			varname = varname2
+		}
+
+		if ptrPfx == "" {
+			x.dec(varname, t)
+		} else {
+			x.line(genTempVarPfx + "z" + i + " := " + ptrPfx + varname)
+			x.dec(genTempVarPfx+"z"+i, t)
+		}
+
+	}
+
+	if canBeNil {
+		x.line("} ")
+	}
+}
+
+// dec will decode a variable (varname) of type ptrTo(t).
+// t is always a basetype (i.e. not of kind reflect.Ptr).
+func (x *genRunner) dec(varname string, t reflect.Type) {
+	// assumptions:
+	//   - the varname is to a pointer already. No need to take address of it
+	//   - t is always a baseType T (not a *T, etc).
+	rtid := reflect.ValueOf(t).Pointer()
+	tptr := reflect.PtrTo(t)
+	if x.checkForSelfer(t, varname) {
+		if t.Implements(selferTyp) || tptr.Implements(selferTyp) {
+			x.line(varname + ".CodecDecodeSelf(d)")
+			return
+		}
+		if _, ok := x.td[rtid]; ok {
+			x.line(varname + ".CodecDecodeSelf(d)")
+			return
+		}
+	}
+
+	inlist := false
+	for _, t0 := range x.t {
+		if t == t0 {
+			inlist = true
+			if x.checkForSelfer(t, varname) {
+				x.line(varname + ".CodecDecodeSelf(d)")
+				return
+			}
+			break
+		}
+	}
+
+	var rtidAdded bool
+	if t == x.tc {
+		x.td[rtid] = true
+		rtidAdded = true
+	}
+
+	// check if
+	//   - type is Raw, RawExt
+	//   - the type implements (Text|JSON|Binary)(Unm|M)arshal
+	mi := x.varsfx()
+	x.linef("%sm%s := z.DecBinary()", genTempVarPfx, mi)
+	x.linef("_ = %sm%s", genTempVarPfx, mi)
+	x.line("if false {")           //start if block
+	defer func() { x.line("}") }() //end if block
+
+	if t == rawTyp {
+		x.linef("} else { *%v = z.DecRaw()", varname)
+		return
+	}
+	if t == rawExtTyp {
+		x.linef("} else { r.DecodeExt(%v, 0, nil)", varname)
+		return
+	}
+
+	// HACK: Support for Builtins.
+	//       Currently, only Binc supports builtins, and the only builtin type is time.Time.
+	//       Have a method that returns the rtid for time.Time if Handle is Binc.
+	if t == timeTyp {
+		vrtid := genTempVarPfx + "m" + x.varsfx()
+		x.linef("} else if %s := z.TimeRtidIfBinc(); %s != 0 { ", vrtid, vrtid)
+		x.linef("r.DecodeBuiltin(%s, %s)", vrtid, varname)
+	}
+	// only check for extensions if the type is named, and has a packagePath.
+	if genImportPath(t) != "" && t.Name() != "" {
+		// first check if extensions are configued, before doing the interface conversion
+		x.linef("} else if z.HasExtensions() && z.DecExt(%s) {", varname)
+	}
+
+	if t.Implements(binaryUnmarshalerTyp) || tptr.Implements(binaryUnmarshalerTyp) {
+		x.linef("} else if %sm%s { z.DecBinaryUnmarshal(%v) ", genTempVarPfx, mi, varname)
+	}
+	if t.Implements(jsonUnmarshalerTyp) || tptr.Implements(jsonUnmarshalerTyp) {
+		x.linef("} else if !%sm%s && z.IsJSONHandle() { z.DecJSONUnmarshal(%v)", genTempVarPfx, mi, varname)
+	} else if t.Implements(textUnmarshalerTyp) || tptr.Implements(textUnmarshalerTyp) {
+		x.linef("} else if !%sm%s { z.DecTextUnmarshal(%v)", genTempVarPfx, mi, varname)
+	}
+
+	x.line("} else {")
+
+	// Since these are pointers, we cannot share, and have to use them one by one
+	switch t.Kind() {
+	case reflect.Int:
+		x.line("*((*int)(" + varname + ")) = int(r.DecodeInt(codecSelferBitsize" + x.xs + "))")
+		// x.line("z.DecInt((*int)(" + varname + "))")
+	case reflect.Int8:
+		x.line("*((*int8)(" + varname + ")) = int8(r.DecodeInt(8))")
+		// x.line("z.DecInt8((*int8)(" + varname + "))")
+	case reflect.Int16:
+		x.line("*((*int16)(" + varname + ")) = int16(r.DecodeInt(16))")
+		// x.line("z.DecInt16((*int16)(" + varname + "))")
+	case reflect.Int32:
+		x.line("*((*int32)(" + varname + ")) = int32(r.DecodeInt(32))")
+		// x.line("z.DecInt32((*int32)(" + varname + "))")
+	case reflect.Int64:
+		x.line("*((*int64)(" + varname + ")) = int64(r.DecodeInt(64))")
+		// x.line("z.DecInt64((*int64)(" + varname + "))")
+
+	case reflect.Uint:
+		x.line("*((*uint)(" + varname + ")) = uint(r.DecodeUint(codecSelferBitsize" + x.xs + "))")
+		// x.line("z.DecUint((*uint)(" + varname + "))")
+	case reflect.Uint8:
+		x.line("*((*uint8)(" + varname + ")) = uint8(r.DecodeUint(8))")
+		// x.line("z.DecUint8((*uint8)(" + varname + "))")
+	case reflect.Uint16:
+		x.line("*((*uint16)(" + varname + ")) = uint16(r.DecodeUint(16))")
+		//x.line("z.DecUint16((*uint16)(" + varname + "))")
+	case reflect.Uint32:
+		x.line("*((*uint32)(" + varname + ")) = uint32(r.DecodeUint(32))")
+		//x.line("z.DecUint32((*uint32)(" + varname + "))")
+	case reflect.Uint64:
+		x.line("*((*uint64)(" + varname + ")) = uint64(r.DecodeUint(64))")
+		//x.line("z.DecUint64((*uint64)(" + varname + "))")
+	case reflect.Uintptr:
+		x.line("*((*uintptr)(" + varname + ")) = uintptr(r.DecodeUint(codecSelferBitsize" + x.xs + "))")
+
+	case reflect.Float32:
+		x.line("*((*float32)(" + varname + ")) = float32(r.DecodeFloat(true))")
+		//x.line("z.DecFloat32((*float32)(" + varname + "))")
+	case reflect.Float64:
+		x.line("*((*float64)(" + varname + ")) = float64(r.DecodeFloat(false))")
+		// x.line("z.DecFloat64((*float64)(" + varname + "))")
+
+	case reflect.Bool:
+		x.line("*((*bool)(" + varname + ")) = r.DecodeBool()")
+		// x.line("z.DecBool((*bool)(" + varname + "))")
+	case reflect.String:
+		x.line("*((*string)(" + varname + ")) = r.DecodeString()")
+		// x.line("z.DecString((*string)(" + varname + "))")
+	case reflect.Array, reflect.Chan:
+		x.xtraSM(varname, false, t)
+		// x.decListFallback(varname, rtid, true, t)
+	case reflect.Slice:
+		// if a []uint8, call dedicated function
+		// if a known fastpath slice, call dedicated function
+		// else write encode function in-line.
+		// - if elements are primitives or Selfers, call dedicated function on each member.
+		// - else call Encoder.encode(XXX) on it.
+		if rtid == uint8SliceTypId {
+			x.line("*" + varname + " = r.DecodeBytes(*(*[]byte)(" + varname + "), false, false)")
+		} else if fastpathAV.index(rtid) != -1 {
+			g := x.newGenV(t)
+			x.line("z.F." + g.MethodNamePfx("Dec", false) + "X(" + varname + ", false, d)")
+		} else {
+			x.xtraSM(varname, false, t)
+			// x.decListFallback(varname, rtid, false, t)
+		}
+	case reflect.Map:
+		// if a known fastpath map, call dedicated function
+		// else write encode function in-line.
+		// - if elements are primitives or Selfers, call dedicated function on each member.
+		// - else call Encoder.encode(XXX) on it.
+		if fastpathAV.index(rtid) != -1 {
+			g := x.newGenV(t)
+			x.line("z.F." + g.MethodNamePfx("Dec", false) + "X(" + varname + ", false, d)")
+		} else {
+			x.xtraSM(varname, false, t)
+			// x.decMapFallback(varname, rtid, t)
+		}
+	case reflect.Struct:
+		if inlist {
+			x.decStruct(varname, rtid, t)
+		} else {
+			// delete(x.td, rtid)
+			x.line("z.DecFallback(" + varname + ", false)")
+		}
+	default:
+		if rtidAdded {
+			delete(x.te, rtid)
+		}
+		x.line("z.DecFallback(" + varname + ", true)")
+	}
+}
+
+func (x *genRunner) decTryAssignPrimitive(varname string, t reflect.Type) (tryAsPtr bool) {
+	// This should only be used for exact primitives (ie un-named types).
+	// Named types may be implementations of Selfer, Unmarshaler, etc.
+	// They should be handled by dec(...)
+
+	if t.Name() != "" {
+		tryAsPtr = true
+		return
+	}
+
+	switch t.Kind() {
+	case reflect.Int:
+		x.linef("%s = r.DecodeInt(codecSelferBitsize%s)", varname, x.xs)
+	case reflect.Int8:
+		x.linef("%s = r.DecodeInt(8)", varname)
+	case reflect.Int16:
+		x.linef("%s = r.DecodeInt(16)", varname)
+	case reflect.Int32:
+		x.linef("%s = r.DecodeInt(32)", varname)
+	case reflect.Int64:
+		x.linef("%s = r.DecodeInt(64)", varname)
+
+	case reflect.Uint:
+		x.linef("%s = r.DecodeUint(codecSelferBitsize%s)", varname, x.xs)
+	case reflect.Uint8:
+		x.linef("%s = r.DecodeUint(8)", varname)
+	case reflect.Uint16:
+		x.linef("%s = r.DecodeUint(16)", varname)
+	case reflect.Uint32:
+		x.linef("%s = r.DecodeUint(32)", varname)
+	case reflect.Uint64:
+		x.linef("%s = r.DecodeUint(64)", varname)
+	case reflect.Uintptr:
+		x.linef("%s = r.DecodeUint(codecSelferBitsize%s)", varname, x.xs)
+
+	case reflect.Float32:
+		x.linef("%s = r.DecodeFloat(true)", varname)
+	case reflect.Float64:
+		x.linef("%s = r.DecodeFloat(false)", varname)
+
+	case reflect.Bool:
+		x.linef("%s = r.DecodeBool()", varname)
+	case reflect.String:
+		x.linef("%s = r.DecodeString()", varname)
+	default:
+		tryAsPtr = true
+	}
+	return
+}
+
+func (x *genRunner) decListFallback(varname string, rtid uintptr, t reflect.Type) {
+	if t.AssignableTo(uint8SliceTyp) {
+		x.line("*" + varname + " = r.DecodeBytes(*((*[]byte)(" + varname + ")), false, false)")
+		return
+	}
+	if t.Kind() == reflect.Array && t.Elem().Kind() == reflect.Uint8 {
+		x.linef("r.DecodeBytes( ((*[%s]byte)(%s))[:], false, true)", t.Len(), varname)
+		return
+	}
+	type tstruc struct {
+		TempVar   string
+		Rand      string
+		Varname   string
+		CTyp      string
+		Typ       string
+		Immutable bool
+		Size      int
+	}
+	telem := t.Elem()
+	ts := tstruc{genTempVarPfx, x.varsfx(), varname, x.genTypeName(t), x.genTypeName(telem), genIsImmutable(telem), int(telem.Size())}
+
+	funcs := make(template.FuncMap)
+
+	funcs["decLineVar"] = func(varname string) string {
+		x.decVar(varname, telem, false)
+		return ""
+	}
+	funcs["decLine"] = func(pfx string) string {
+		x.decVar(ts.TempVar+pfx+ts.Rand, reflect.PtrTo(telem), false)
+		return ""
+	}
+	funcs["var"] = func(s string) string {
+		return ts.TempVar + s + ts.Rand
+	}
+	funcs["zero"] = func() string {
+		return x.genZeroValueR(telem)
+	}
+	funcs["isArray"] = func() bool {
+		return t.Kind() == reflect.Array
+	}
+	funcs["isSlice"] = func() bool {
+		return t.Kind() == reflect.Slice
+	}
+	funcs["isChan"] = func() bool {
+		return t.Kind() == reflect.Chan
+	}
+	tm, err := template.New("").Funcs(funcs).Parse(genDecListTmpl)
+	if err != nil {
+		panic(err)
+	}
+	if err = tm.Execute(x.w, &ts); err != nil {
+		panic(err)
+	}
+}
+
+func (x *genRunner) decMapFallback(varname string, rtid uintptr, t reflect.Type) {
+	type tstruc struct {
+		TempVar string
+		Sfx     string
+		Rand    string
+		Varname string
+		KTyp    string
+		Typ     string
+		Size    int
+	}
+	telem := t.Elem()
+	tkey := t.Key()
+	ts := tstruc{
+		genTempVarPfx, x.xs, x.varsfx(), varname, x.genTypeName(tkey),
+		x.genTypeName(telem), int(telem.Size() + tkey.Size()),
+	}
+
+	funcs := make(template.FuncMap)
+	funcs["decElemZero"] = func() string {
+		return x.genZeroValueR(telem)
+	}
+	funcs["decElemKindImmutable"] = func() bool {
+		return genIsImmutable(telem)
+	}
+	funcs["decElemKindPtr"] = func() bool {
+		return telem.Kind() == reflect.Ptr
+	}
+	funcs["decElemKindIntf"] = func() bool {
+		return telem.Kind() == reflect.Interface
+	}
+	funcs["decLineVarK"] = func(varname string) string {
+		x.decVar(varname, tkey, false)
+		return ""
+	}
+	funcs["decLineVar"] = func(varname string) string {
+		x.decVar(varname, telem, false)
+		return ""
+	}
+	funcs["decLineK"] = func(pfx string) string {
+		x.decVar(ts.TempVar+pfx+ts.Rand, reflect.PtrTo(tkey), false)
+		return ""
+	}
+	funcs["decLine"] = func(pfx string) string {
+		x.decVar(ts.TempVar+pfx+ts.Rand, reflect.PtrTo(telem), false)
+		return ""
+	}
+	funcs["var"] = func(s string) string {
+		return ts.TempVar + s + ts.Rand
+	}
+
+	tm, err := template.New("").Funcs(funcs).Parse(genDecMapTmpl)
+	if err != nil {
+		panic(err)
+	}
+	if err = tm.Execute(x.w, &ts); err != nil {
+		panic(err)
+	}
+}
+
+func (x *genRunner) decStructMapSwitch(kName string, varname string, rtid uintptr, t reflect.Type) {
+	ti := x.ti.get(rtid, t)
+	tisfi := ti.sfip // always use sequence from file. decStruct expects same thing.
+	x.line("switch (" + kName + ") {")
+	for _, si := range tisfi {
+		x.line("case \"" + si.encName + "\":")
+		var t2 reflect.StructField
+		if si.i != -1 {
+			t2 = t.Field(int(si.i))
+		} else {
+			//we must accommodate anonymous fields, where the embedded field is a nil pointer in the value.
+			// t2 = t.FieldByIndex(si.is)
+			t2typ := t
+			varname3 := varname
+			for _, ix := range si.is {
+				for t2typ.Kind() == reflect.Ptr {
+					t2typ = t2typ.Elem()
+				}
+				t2 = t2typ.Field(ix)
+				t2typ = t2.Type
+				varname3 = varname3 + "." + t2.Name
+				if t2typ.Kind() == reflect.Ptr {
+					x.linef("if %s == nil { %s = new(%s) }", varname3, varname3, x.genTypeName(t2typ.Elem()))
+				}
+			}
+		}
+		x.decVar(varname+"."+t2.Name, t2.Type, false)
+	}
+	x.line("default:")
+	// pass the slice here, so that the string will not escape, and maybe save allocation
+	x.line("z.DecStructFieldNotFound(-1, " + kName + ")")
+	x.line("} // end switch " + kName)
+}
+
+func (x *genRunner) decStructMap(varname, lenvarname string, rtid uintptr, t reflect.Type, style genStructMapStyle) {
+	tpfx := genTempVarPfx
+	i := x.varsfx()
+	kName := tpfx + "s" + i
+
+	// We thought to use ReadStringAsBytes, as go compiler might optimize the copy out.
+	// However, using that was more expensive, as it seems that the switch expression
+	// is evaluated each time.
+	//
+	// We could depend on decodeString using a temporary/shared buffer internally.
+	// However, this model of creating a byte array, and using explicitly is faster,
+	// and allows optional use of unsafe []byte->string conversion without alloc.
+
+	// Also, ensure that the slice array doesn't escape.
+	// That will help escape analysis prevent allocation when it gets better.
+
+	// x.line("var " + kName + "Arr = [32]byte{} // default string to decode into")
+	// x.line("var " + kName + "Slc = " + kName + "Arr[:] // default slice to decode into")
+	// use the scratch buffer to avoid allocation (most field names are < 32).
+
+	x.line("var " + kName + "Slc = z.DecScratchBuffer() // default slice to decode into")
+
+	x.line("_ = " + kName + "Slc")
+	switch style {
+	case genStructMapStyleLenPrefix:
+		x.linef("for %sj%s := 0; %sj%s < %s; %sj%s++ {", tpfx, i, tpfx, i, lenvarname, tpfx, i)
+	case genStructMapStyleCheckBreak:
+		x.linef("for %sj%s := 0; !r.CheckBreak(); %sj%s++ {", tpfx, i, tpfx, i)
+	default: // 0, otherwise.
+		x.linef("var %shl%s bool = %s >= 0", tpfx, i, lenvarname) // has length
+		x.linef("for %sj%s := 0; ; %sj%s++ {", tpfx, i, tpfx, i)
+		x.linef("if %shl%s { if %sj%s >= %s { break }", tpfx, i, tpfx, i, lenvarname)
+		x.line("} else { if r.CheckBreak() { break }; }")
+	}
+	x.linef("z.DecSendContainerState(codecSelfer_containerMapKey%s)", x.xs)
+	x.line(kName + "Slc = r.DecodeBytes(" + kName + "Slc, true, true)")
+	// let string be scoped to this loop alone, so it doesn't escape.
+	if x.unsafe {
+		x.line(kName + "SlcHdr := codecSelferUnsafeString" + x.xs + "{uintptr(unsafe.Pointer(&" +
+			kName + "Slc[0])), len(" + kName + "Slc)}")
+		x.line(kName + " := *(*string)(unsafe.Pointer(&" + kName + "SlcHdr))")
+	} else {
+		x.line(kName + " := string(" + kName + "Slc)")
+	}
+	x.linef("z.DecSendContainerState(codecSelfer_containerMapValue%s)", x.xs)
+	x.decStructMapSwitch(kName, varname, rtid, t)
+
+	x.line("} // end for " + tpfx + "j" + i)
+	x.linef("z.DecSendContainerState(codecSelfer_containerMapEnd%s)", x.xs)
+}
+
+func (x *genRunner) decStructArray(varname, lenvarname, breakString string, rtid uintptr, t reflect.Type) {
+	tpfx := genTempVarPfx
+	i := x.varsfx()
+	ti := x.ti.get(rtid, t)
+	tisfi := ti.sfip // always use sequence from file. decStruct expects same thing.
+	x.linef("var %sj%s int", tpfx, i)
+	x.linef("var %sb%s bool", tpfx, i)                        // break
+	x.linef("var %shl%s bool = %s >= 0", tpfx, i, lenvarname) // has length
+	for _, si := range tisfi {
+		var t2 reflect.StructField
+		if si.i != -1 {
+			t2 = t.Field(int(si.i))
+		} else {
+			//we must accommodate anonymous fields, where the embedded field is a nil pointer in the value.
+			// t2 = t.FieldByIndex(si.is)
+			t2typ := t
+			varname3 := varname
+			for _, ix := range si.is {
+				for t2typ.Kind() == reflect.Ptr {
+					t2typ = t2typ.Elem()
+				}
+				t2 = t2typ.Field(ix)
+				t2typ = t2.Type
+				varname3 = varname3 + "." + t2.Name
+				if t2typ.Kind() == reflect.Ptr {
+					x.linef("if %s == nil { %s = new(%s) }", varname3, varname3, x.genTypeName(t2typ.Elem()))
+				}
+			}
+		}
+
+		x.linef("%sj%s++; if %shl%s { %sb%s = %sj%s > %s } else { %sb%s = r.CheckBreak() }",
+			tpfx, i, tpfx, i, tpfx, i,
+			tpfx, i, lenvarname, tpfx, i)
+		x.linef("if %sb%s { z.DecSendContainerState(codecSelfer_containerArrayEnd%s); %s }",
+			tpfx, i, x.xs, breakString)
+		x.linef("z.DecSendContainerState(codecSelfer_containerArrayElem%s)", x.xs)
+		x.decVar(varname+"."+t2.Name, t2.Type, true)
+	}
+	// read remaining values and throw away.
+	x.line("for {")
+	x.linef("%sj%s++; if %shl%s { %sb%s = %sj%s > %s } else { %sb%s = r.CheckBreak() }",
+		tpfx, i, tpfx, i, tpfx, i,
+		tpfx, i, lenvarname, tpfx, i)
+	x.linef("if %sb%s { break }", tpfx, i)
+	x.linef("z.DecSendContainerState(codecSelfer_containerArrayElem%s)", x.xs)
+	x.linef(`z.DecStructFieldNotFound(%sj%s - 1, "")`, tpfx, i)
+	x.line("}")
+	x.linef("z.DecSendContainerState(codecSelfer_containerArrayEnd%s)", x.xs)
+}
+
+func (x *genRunner) decStruct(varname string, rtid uintptr, t reflect.Type) {
+	// if container is map
+	i := x.varsfx()
+	x.linef("%sct%s := r.ContainerType()", genTempVarPfx, i)
+	x.linef("if %sct%s == codecSelferValueTypeMap%s {", genTempVarPfx, i, x.xs)
+	x.line(genTempVarPfx + "l" + i + " := r.ReadMapStart()")
+	x.linef("if %sl%s == 0 {", genTempVarPfx, i)
+	x.linef("z.DecSendContainerState(codecSelfer_containerMapEnd%s)", x.xs)
+	if genUseOneFunctionForDecStructMap {
+		x.line("} else { ")
+		x.linef("x.codecDecodeSelfFromMap(%sl%s, d)", genTempVarPfx, i)
+	} else {
+		x.line("} else if " + genTempVarPfx + "l" + i + " > 0 { ")
+		x.line("x.codecDecodeSelfFromMapLenPrefix(" + genTempVarPfx + "l" + i + ", d)")
+		x.line("} else {")
+		x.line("x.codecDecodeSelfFromMapCheckBreak(" + genTempVarPfx + "l" + i + ", d)")
+	}
+	x.line("}")
+
+	// else if container is array
+	x.linef("} else if %sct%s == codecSelferValueTypeArray%s {", genTempVarPfx, i, x.xs)
+	x.line(genTempVarPfx + "l" + i + " := r.ReadArrayStart()")
+	x.linef("if %sl%s == 0 {", genTempVarPfx, i)
+	x.linef("z.DecSendContainerState(codecSelfer_containerArrayEnd%s)", x.xs)
+	x.line("} else { ")
+	x.linef("x.codecDecodeSelfFromArray(%sl%s, d)", genTempVarPfx, i)
+	x.line("}")
+	// else panic
+	x.line("} else { ")
+	x.line("panic(codecSelferOnlyMapOrArrayEncodeToStructErr" + x.xs + ")")
+	x.line("} ")
+}
+
+// --------
+
+type genV struct {
+	// genV is either a primitive (Primitive != "") or a map (MapKey != "") or a slice
+	MapKey    string
+	Elem      string
+	Primitive string
+	Size      int
+}
+
+func (x *genRunner) newGenV(t reflect.Type) (v genV) {
+	switch t.Kind() {
+	case reflect.Slice, reflect.Array:
+		te := t.Elem()
+		v.Elem = x.genTypeName(te)
+		v.Size = int(te.Size())
+	case reflect.Map:
+		te, tk := t.Elem(), t.Key()
+		v.Elem = x.genTypeName(te)
+		v.MapKey = x.genTypeName(tk)
+		v.Size = int(te.Size() + tk.Size())
+	default:
+		panic("unexpected type for newGenV. Requires map or slice type")
+	}
+	return
+}
+
+func (x *genV) MethodNamePfx(prefix string, prim bool) string {
+	var name []byte
+	if prefix != "" {
+		name = append(name, prefix...)
+	}
+	if prim {
+		name = append(name, genTitleCaseName(x.Primitive)...)
+	} else {
+		if x.MapKey == "" {
+			name = append(name, "Slice"...)
+		} else {
+			name = append(name, "Map"...)
+			name = append(name, genTitleCaseName(x.MapKey)...)
+		}
+		name = append(name, genTitleCaseName(x.Elem)...)
+	}
+	return string(name)
+
+}
+
+// genImportPath returns import path of a non-predeclared named typed, or an empty string otherwise.
+//
+// This handles the misbehaviour that occurs when 1.5-style vendoring is enabled,
+// where PkgPath returns the full path, including the vendoring pre-fix that should have been stripped.
+// We strip it here.
+func genImportPath(t reflect.Type) (s string) {
+	s = t.PkgPath()
+	if genCheckVendor {
+		// HACK: always handle vendoring. It should be typically on in go 1.6, 1.7
+		s = stripVendor(s)
+	}
+	return
+}
+
+// A go identifier is (letter|_)[letter|number|_]*
+func genGoIdentifier(s string, checkFirstChar bool) string {
+	b := make([]byte, 0, len(s))
+	t := make([]byte, 4)
+	var n int
+	for i, r := range s {
+		if checkFirstChar && i == 0 && !unicode.IsLetter(r) {
+			b = append(b, '_')
+		}
+		// r must be unicode_letter, unicode_digit or _
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			n = utf8.EncodeRune(t, r)
+			b = append(b, t[:n]...)
+		} else {
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
+func genNonPtr(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+func genTitleCaseName(s string) string {
+	switch s {
+	case "interface{}", "interface {}":
+		return "Intf"
+	default:
+		return strings.ToUpper(s[0:1]) + s[1:]
+	}
+}
+
+func genMethodNameT(t reflect.Type, tRef reflect.Type) (n string) {
+	var ptrPfx string
+	for t.Kind() == reflect.Ptr {
+		ptrPfx += "Ptrto"
+		t = t.Elem()
+	}
+	tstr := t.String()
+	if tn := t.Name(); tn != "" {
+		if tRef != nil && genImportPath(t) == genImportPath(tRef) {
+			return ptrPfx + tn
+		} else {
+			if genQNameRegex.MatchString(tstr) {
+				return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
+			} else {
+				return ptrPfx + genCustomTypeName(tstr)
+			}
+		}
+	}
+	switch t.Kind() {
+	case reflect.Map:
+		return ptrPfx + "Map" + genMethodNameT(t.Key(), tRef) + genMethodNameT(t.Elem(), tRef)
+	case reflect.Slice:
+		return ptrPfx + "Slice" + genMethodNameT(t.Elem(), tRef)
+	case reflect.Array:
+		return ptrPfx + "Array" + strconv.FormatInt(int64(t.Len()), 10) + genMethodNameT(t.Elem(), tRef)
+	case reflect.Chan:
+		var cx string
+		switch t.ChanDir() {
+		case reflect.SendDir:
+			cx = "ChanSend"
+		case reflect.RecvDir:
+			cx = "ChanRecv"
+		default:
+			cx = "Chan"
+		}
+		return ptrPfx + cx + genMethodNameT(t.Elem(), tRef)
+	default:
+		if t == intfTyp {
+			return ptrPfx + "Interface"
+		} else {
+			if tRef != nil && genImportPath(t) == genImportPath(tRef) {
+				if t.Name() != "" {
+					return ptrPfx + t.Name()
+				} else {
+					return ptrPfx + genCustomTypeName(tstr)
+				}
+			} else {
+				// best way to get the package name inclusive
+				// return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
+				// return ptrPfx + genBase64enc.EncodeToString([]byte(tstr))
+				if t.Name() != "" && genQNameRegex.MatchString(tstr) {
+					return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
+				} else {
+					return ptrPfx + genCustomTypeName(tstr)
+				}
+			}
+		}
+	}
+}
+
+// genCustomNameForType base64encodes the t.String() value in such a way
+// that it can be used within a function name.
+func genCustomTypeName(tstr string) string {
+	len2 := genBase64enc.EncodedLen(len(tstr))
+	bufx := make([]byte, len2)
+	genBase64enc.Encode(bufx, []byte(tstr))
+	for i := len2 - 1; i >= 0; i-- {
+		if bufx[i] == '=' {
+			len2--
+		} else {
+			break
+		}
+	}
+	return string(bufx[:len2])
+}
+
+func genIsImmutable(t reflect.Type) (v bool) {
+	return isImmutableKind(t.Kind())
+}
+
+type genInternal struct {
+	Values []genV
+	Unsafe bool
+}
+
+func (x genInternal) FastpathLen() (l int) {
+	for _, v := range x.Values {
+		if v.Primitive == "" {
+			l++
+		}
+	}
+	return
+}
+
+func genInternalZeroValue(s string) string {
+	switch s {
+	case "interface{}", "interface {}":
+		return "nil"
+	case "bool":
+		return "false"
+	case "string":
+		return `""`
+	default:
+		return "0"
+	}
+}
+
+func genInternalEncCommandAsString(s string, vname string) string {
+	switch s {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return "ee.EncodeUint(uint64(" + vname + "))"
+	case "int", "int8", "int16", "int32", "int64":
+		return "ee.EncodeInt(int64(" + vname + "))"
+	case "string":
+		return "ee.EncodeString(c_UTF8, " + vname + ")"
+	case "float32":
+		return "ee.EncodeFloat32(" + vname + ")"
+	case "float64":
+		return "ee.EncodeFloat64(" + vname + ")"
+	case "bool":
+		return "ee.EncodeBool(" + vname + ")"
+	case "symbol":
+		return "ee.EncodeSymbol(" + vname + ")"
+	default:
+		return "e.encode(" + vname + ")"
+	}
+}
+
+func genInternalDecCommandAsString(s string) string {
+	switch s {
+	case "uint":
+		return "uint(dd.DecodeUint(uintBitsize))"
+	case "uint8":
+		return "uint8(dd.DecodeUint(8))"
+	case "uint16":
+		return "uint16(dd.DecodeUint(16))"
+	case "uint32":
+		return "uint32(dd.DecodeUint(32))"
+	case "uint64":
+		return "dd.DecodeUint(64)"
+	case "uintptr":
+		return "uintptr(dd.DecodeUint(uintBitsize))"
+	case "int":
+		return "int(dd.DecodeInt(intBitsize))"
+	case "int8":
+		return "int8(dd.DecodeInt(8))"
+	case "int16":
+		return "int16(dd.DecodeInt(16))"
+	case "int32":
+		return "int32(dd.DecodeInt(32))"
+	case "int64":
+		return "dd.DecodeInt(64)"
+
+	case "string":
+		return "dd.DecodeString()"
+	case "float32":
+		return "float32(dd.DecodeFloat(true))"
+	case "float64":
+		return "dd.DecodeFloat(false)"
+	case "bool":
+		return "dd.DecodeBool()"
+	default:
+		panic(errors.New("gen internal: unknown type for decode: " + s))
+	}
+}
+
+func genInternalSortType(s string, elem bool) string {
+	for _, v := range [...]string{"int", "uint", "float", "bool", "string"} {
+		if strings.HasPrefix(s, v) {
+			if elem {
+				if v == "int" || v == "uint" || v == "float" {
+					return v + "64"
+				} else {
+					return v
+				}
+			}
+			return v + "Slice"
+		}
+	}
+	panic("sorttype: unexpected type: " + s)
+}
+
+func stripVendor(s string) string {
+	// HACK: Misbehaviour occurs in go 1.5. May have to re-visit this later.
+	// if s contains /vendor/ OR startsWith vendor/, then return everything after it.
+	const vendorStart = "vendor/"
+	const vendorInline = "/vendor/"
+	if i := strings.LastIndex(s, vendorInline); i >= 0 {
+		s = s[i+len(vendorInline):]
+	} else if strings.HasPrefix(s, vendorStart) {
+		s = s[len(vendorStart):]
+	}
+	return s
+}
+
+// var genInternalMu sync.Mutex
+var genInternalV genInternal
+var genInternalTmplFuncs template.FuncMap
+var genInternalOnce sync.Once
+
+func genInternalInit() {
+	types := [...]string{
+		"interface{}",
+		"string",
+		"float32",
+		"float64",
+		"uint",
+		"uint8",
+		"uint16",
+		"uint32",
+		"uint64",
+		"uintptr",
+		"int",
+		"int8",
+		"int16",
+		"int32",
+		"int64",
+		"bool",
+	}
+	// keep as slice, so it is in specific iteration order.
+	// Initial order was uint64, string, interface{}, int, int64
+	mapvaltypes := [...]string{
+		"interface{}",
+		"string",
+		"uint",
+		"uint8",
+		"uint16",
+		"uint32",
+		"uint64",
+		"uintptr",
+		"int",
+		"int8",
+		"int16",
+		"int32",
+		"int64",
+		"float32",
+		"float64",
+		"bool",
+	}
+	wordSizeBytes := int(intBitsize) / 8
+
+	mapvaltypes2 := map[string]int{
+		"interface{}": 2 * wordSizeBytes,
+		"string":      2 * wordSizeBytes,
+		"uint":        1 * wordSizeBytes,
+		"uint8":       1,
+		"uint16":      2,
+		"uint32":      4,
+		"uint64":      8,
+		"uintptr":     1 * wordSizeBytes,
+		"int":         1 * wordSizeBytes,
+		"int8":        1,
+		"int16":       2,
+		"int32":       4,
+		"int64":       8,
+		"float32":     4,
+		"float64":     8,
+		"bool":        1,
+	}
+	var gt genInternal
+
+	// For each slice or map type, there must be a (symmetrical) Encode and Decode fast-path function
+	for _, s := range types {
+		gt.Values = append(gt.Values, genV{Primitive: s, Size: mapvaltypes2[s]})
+		if s != "uint8" { // do not generate fast path for slice of bytes. Treat specially already.
+			gt.Values = append(gt.Values, genV{Elem: s, Size: mapvaltypes2[s]})
+		}
+		if _, ok := mapvaltypes2[s]; !ok {
+			gt.Values = append(gt.Values, genV{MapKey: s, Elem: s, Size: 2 * mapvaltypes2[s]})
+		}
+		for _, ms := range mapvaltypes {
+			gt.Values = append(gt.Values, genV{MapKey: s, Elem: ms, Size: mapvaltypes2[s] + mapvaltypes2[ms]})
+		}
+	}
+
+	funcs := make(template.FuncMap)
+	// funcs["haspfx"] = strings.HasPrefix
+	funcs["encmd"] = genInternalEncCommandAsString
+	funcs["decmd"] = genInternalDecCommandAsString
+	funcs["zerocmd"] = genInternalZeroValue
+	funcs["hasprefix"] = strings.HasPrefix
+	funcs["sorttype"] = genInternalSortType
+
+	genInternalV = gt
+	genInternalTmplFuncs = funcs
+}
+
+// genInternalGoFile is used to generate source files from templates.
+// It is run by the program author alone.
+// Unfortunately, it has to be exported so that it can be called from a command line tool.
+// *** DO NOT USE ***
+func genInternalGoFile(r io.Reader, w io.Writer, safe bool) (err error) {
+	genInternalOnce.Do(genInternalInit)
+
+	gt := genInternalV
+	gt.Unsafe = !safe
+
+	t := template.New("").Funcs(genInternalTmplFuncs)
+
+	tmplstr, err := ioutil.ReadAll(r)
+	if err != nil {
+		return
+	}
+
+	if t, err = t.Parse(string(tmplstr)); err != nil {
+		return
+	}
+
+	var out bytes.Buffer
+	err = t.Execute(&out, gt)
+	if err != nil {
+		return
+	}
+
+	bout, err := format.Source(out.Bytes())
+	if err != nil {
+		w.Write(out.Bytes()) // write out if error, so we can still see.
+		// w.Write(bout) // write out if error, as much as possible, so we can still see.
+		return
+	}
+	w.Write(bout)
+	return
+}

--- a/vendor/github.com/ugorji/go/codec/gen_15.go
+++ b/vendor/github.com/ugorji/go/codec/gen_15.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build go1.5,!go1.6
+
+package codec
+
+import "os"
+
+func init() {
+	genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") == "1"
+}

--- a/vendor/github.com/ugorji/go/codec/gen_16.go
+++ b/vendor/github.com/ugorji/go/codec/gen_16.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build go1.6
+
+package codec
+
+import "os"
+
+func init() {
+	genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") != "0"
+}

--- a/vendor/github.com/ugorji/go/codec/gen_17.go
+++ b/vendor/github.com/ugorji/go/codec/gen_17.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build go1.7
+
+package codec
+
+func init() {
+	genCheckVendor = true
+}

--- a/vendor/github.com/ugorji/go/codec/helper.go
+++ b/vendor/github.com/ugorji/go/codec/helper.go
@@ -1,0 +1,1314 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// Contains code shared by both encode and decode.
+
+// Some shared ideas around encoding/decoding
+// ------------------------------------------
+//
+// If an interface{} is passed, we first do a type assertion to see if it is
+// a primitive type or a map/slice of primitive types, and use a fastpath to handle it.
+//
+// If we start with a reflect.Value, we are already in reflect.Value land and
+// will try to grab the function for the underlying Type and directly call that function.
+// This is more performant than calling reflect.Value.Interface().
+//
+// This still helps us bypass many layers of reflection, and give best performance.
+//
+// Containers
+// ------------
+// Containers in the stream are either associative arrays (key-value pairs) or
+// regular arrays (indexed by incrementing integers).
+//
+// Some streams support indefinite-length containers, and use a breaking
+// byte-sequence to denote that the container has come to an end.
+//
+// Some streams also are text-based, and use explicit separators to denote the
+// end/beginning of different values.
+//
+// During encode, we use a high-level condition to determine how to iterate through
+// the container. That decision is based on whether the container is text-based (with
+// separators) or binary (without separators). If binary, we do not even call the
+// encoding of separators.
+//
+// During decode, we use a different high-level condition to determine how to iterate
+// through the containers. That decision is based on whether the stream contained
+// a length prefix, or if it used explicit breaks. If length-prefixed, we assume that
+// it has to be binary, and we do not even try to read separators.
+//
+// Philosophy
+// ------------
+// On decode, this codec will update containers appropriately:
+//    - If struct, update fields from stream into fields of struct.
+//      If field in stream not found in struct, handle appropriately (based on option).
+//      If a struct field has no corresponding value in the stream, leave it AS IS.
+//      If nil in stream, set value to nil/zero value.
+//    - If map, update map from stream.
+//      If the stream value is NIL, set the map to nil.
+//    - if slice, try to update up to length of array in stream.
+//      if container len is less than stream array length,
+//      and container cannot be expanded, handled (based on option).
+//      This means you can decode 4-element stream array into 1-element array.
+//
+// ------------------------------------
+// On encode, user can specify omitEmpty. This means that the value will be omitted
+// if the zero value. The problem may occur during decode, where omitted values do not affect
+// the value being decoded into. This means that if decoding into a struct with an
+// int field with current value=5, and the field is omitted in the stream, then after
+// decoding, the value will still be 5 (not 0).
+// omitEmpty only works if you guarantee that you always decode into zero-values.
+//
+// ------------------------------------
+// We could have truncated a map to remove keys not available in the stream,
+// or set values in the struct which are not in the stream to their zero values.
+// We decided against it because there is no efficient way to do it.
+// We may introduce it as an option later.
+// However, that will require enabling it for both runtime and code generation modes.
+//
+// To support truncate, we need to do 2 passes over the container:
+//   map
+//   - first collect all keys (e.g. in k1)
+//   - for each key in stream, mark k1 that the key should not be removed
+//   - after updating map, do second pass and call delete for all keys in k1 which are not marked
+//   struct:
+//   - for each field, track the *typeInfo s1
+//   - iterate through all s1, and for each one not marked, set value to zero
+//   - this involves checking the possible anonymous fields which are nil ptrs.
+//     too much work.
+//
+// ------------------------------------------
+// Error Handling is done within the library using panic.
+//
+// This way, the code doesn't have to keep checking if an error has happened,
+// and we don't have to keep sending the error value along with each call
+// or storing it in the En|Decoder and checking it constantly along the way.
+//
+// The disadvantage is that small functions which use panics cannot be inlined.
+// The code accounts for that by only using panics behind an interface;
+// since interface calls cannot be inlined, this is irrelevant.
+//
+// We considered storing the error is En|Decoder.
+//   - once it has its err field set, it cannot be used again.
+//   - panicing will be optional, controlled by const flag.
+//   - code should always check error first and return early.
+// We eventually decided against it as it makes the code clumsier to always
+// check for these error conditions.
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	scratchByteArrayLen = 32
+	initCollectionCap   = 32 // 32 is defensive. 16 is preferred.
+
+	// Support encoding.(Binary|Text)(Unm|M)arshaler.
+	// This constant flag will enable or disable it.
+	supportMarshalInterfaces = true
+
+	// Each Encoder or Decoder uses a cache of functions based on conditionals,
+	// so that the conditionals are not run every time.
+	//
+	// Either a map or a slice is used to keep track of the functions.
+	// The map is more natural, but has a higher cost than a slice/array.
+	// This flag (useMapForCodecCache) controls which is used.
+	//
+	// From benchmarks, slices with linear search perform better with < 32 entries.
+	// We have typically seen a high threshold of about 24 entries.
+	useMapForCodecCache = false
+
+	// for debugging, set this to false, to catch panic traces.
+	// Note that this will always cause rpc tests to fail, since they need io.EOF sent via panic.
+	recoverPanicToErr = true
+
+	// if resetSliceElemToZeroValue, then on decoding a slice, reset the element to a zero value first.
+	// Only concern is that, if the slice already contained some garbage, we will decode into that garbage.
+	// The chances of this are slim, so leave this "optimization".
+	// TODO: should this be true, to ensure that we always decode into a "zero" "empty" value?
+	resetSliceElemToZeroValue bool = false
+)
+
+var (
+	oneByteArr    = [1]byte{0}
+	zeroByteSlice = oneByteArr[:0:0]
+)
+
+type charEncoding uint8
+
+const (
+	c_RAW charEncoding = iota
+	c_UTF8
+	c_UTF16LE
+	c_UTF16BE
+	c_UTF32LE
+	c_UTF32BE
+)
+
+// valueType is the stream type
+type valueType uint8
+
+const (
+	valueTypeUnset valueType = iota
+	valueTypeNil
+	valueTypeInt
+	valueTypeUint
+	valueTypeFloat
+	valueTypeBool
+	valueTypeString
+	valueTypeSymbol
+	valueTypeBytes
+	valueTypeMap
+	valueTypeArray
+	valueTypeTimestamp
+	valueTypeExt
+
+	// valueTypeInvalid = 0xff
+)
+
+type seqType uint8
+
+const (
+	_ seqType = iota
+	seqTypeArray
+	seqTypeSlice
+	seqTypeChan
+)
+
+// note that containerMapStart and containerArraySend are not sent.
+// This is because the ReadXXXStart and EncodeXXXStart already does these.
+type containerState uint8
+
+const (
+	_ containerState = iota
+
+	containerMapStart // slot left open, since Driver method already covers it
+	containerMapKey
+	containerMapValue
+	containerMapEnd
+	containerArrayStart // slot left open, since Driver methods already cover it
+	containerArrayElem
+	containerArrayEnd
+)
+
+// sfiIdx used for tracking where a (field/enc)Name is seen in a []*structFieldInfo
+type sfiIdx struct {
+	name  string
+	index int
+}
+
+// do not recurse if a containing type refers to an embedded type
+// which refers back to its containing type (via a pointer).
+// The second time this back-reference happens, break out,
+// so as not to cause an infinite loop.
+const rgetMaxRecursion = 2
+
+// Anecdotally, we believe most types have <= 12 fields.
+// Java's PMD rules set TooManyFields threshold to 15.
+const rgetPoolTArrayLen = 12
+
+type rgetT struct {
+	fNames   []string
+	encNames []string
+	etypes   []uintptr
+	sfis     []*structFieldInfo
+}
+
+type rgetPoolT struct {
+	fNames   [rgetPoolTArrayLen]string
+	encNames [rgetPoolTArrayLen]string
+	etypes   [rgetPoolTArrayLen]uintptr
+	sfis     [rgetPoolTArrayLen]*structFieldInfo
+	sfiidx   [rgetPoolTArrayLen]sfiIdx
+}
+
+var rgetPool = sync.Pool{
+	New: func() interface{} { return new(rgetPoolT) },
+}
+
+type containerStateRecv interface {
+	sendContainerState(containerState)
+}
+
+// mirror json.Marshaler and json.Unmarshaler here,
+// so we don't import the encoding/json package
+type jsonMarshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+type jsonUnmarshaler interface {
+	UnmarshalJSON([]byte) error
+}
+
+var (
+	bigen               = binary.BigEndian
+	structInfoFieldName = "_struct"
+
+	mapStrIntfTyp  = reflect.TypeOf(map[string]interface{}(nil))
+	mapIntfIntfTyp = reflect.TypeOf(map[interface{}]interface{}(nil))
+	intfSliceTyp   = reflect.TypeOf([]interface{}(nil))
+	intfTyp        = intfSliceTyp.Elem()
+
+	stringTyp     = reflect.TypeOf("")
+	timeTyp       = reflect.TypeOf(time.Time{})
+	rawExtTyp     = reflect.TypeOf(RawExt{})
+	rawTyp        = reflect.TypeOf(Raw{})
+	uint8SliceTyp = reflect.TypeOf([]uint8(nil))
+
+	mapBySliceTyp = reflect.TypeOf((*MapBySlice)(nil)).Elem()
+
+	binaryMarshalerTyp   = reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
+	binaryUnmarshalerTyp = reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
+
+	textMarshalerTyp   = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	textUnmarshalerTyp = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+
+	jsonMarshalerTyp   = reflect.TypeOf((*jsonMarshaler)(nil)).Elem()
+	jsonUnmarshalerTyp = reflect.TypeOf((*jsonUnmarshaler)(nil)).Elem()
+
+	selferTyp = reflect.TypeOf((*Selfer)(nil)).Elem()
+
+	uint8SliceTypId = reflect.ValueOf(uint8SliceTyp).Pointer()
+	rawExtTypId     = reflect.ValueOf(rawExtTyp).Pointer()
+	rawTypId        = reflect.ValueOf(rawTyp).Pointer()
+	intfTypId       = reflect.ValueOf(intfTyp).Pointer()
+	timeTypId       = reflect.ValueOf(timeTyp).Pointer()
+	stringTypId     = reflect.ValueOf(stringTyp).Pointer()
+
+	mapStrIntfTypId  = reflect.ValueOf(mapStrIntfTyp).Pointer()
+	mapIntfIntfTypId = reflect.ValueOf(mapIntfIntfTyp).Pointer()
+	intfSliceTypId   = reflect.ValueOf(intfSliceTyp).Pointer()
+	// mapBySliceTypId  = reflect.ValueOf(mapBySliceTyp).Pointer()
+
+	intBitsize  uint8 = uint8(reflect.TypeOf(int(0)).Bits())
+	uintBitsize uint8 = uint8(reflect.TypeOf(uint(0)).Bits())
+
+	bsAll0x00 = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	bsAll0xff = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+	chkOvf checkOverflow
+
+	noFieldNameToStructFieldInfoErr = errors.New("no field name passed to parseStructFieldInfo")
+)
+
+var defTypeInfos = NewTypeInfos([]string{"codec", "json"})
+
+// Selfer defines methods by which a value can encode or decode itself.
+//
+// Any type which implements Selfer will be able to encode or decode itself.
+// Consequently, during (en|de)code, this takes precedence over
+// (text|binary)(M|Unm)arshal or extension support.
+type Selfer interface {
+	CodecEncodeSelf(*Encoder)
+	CodecDecodeSelf(*Decoder)
+}
+
+// MapBySlice represents a slice which should be encoded as a map in the stream.
+// The slice contains a sequence of key-value pairs.
+// This affords storing a map in a specific sequence in the stream.
+//
+// The support of MapBySlice affords the following:
+//   - A slice type which implements MapBySlice will be encoded as a map
+//   - A slice can be decoded from a map in the stream
+type MapBySlice interface {
+	MapBySlice()
+}
+
+// WARNING: DO NOT USE DIRECTLY. EXPORTED FOR GODOC BENEFIT. WILL BE REMOVED.
+//
+// BasicHandle encapsulates the common options and extension functions.
+type BasicHandle struct {
+	// TypeInfos is used to get the type info for any type.
+	//
+	// If not configured, the default TypeInfos is used, which uses struct tag keys: codec, json
+	TypeInfos *TypeInfos
+
+	extHandle
+	EncodeOptions
+	DecodeOptions
+}
+
+func (x *BasicHandle) getBasicHandle() *BasicHandle {
+	return x
+}
+
+func (x *BasicHandle) getTypeInfo(rtid uintptr, rt reflect.Type) (pti *typeInfo) {
+	if x.TypeInfos != nil {
+		return x.TypeInfos.get(rtid, rt)
+	}
+	return defTypeInfos.get(rtid, rt)
+}
+
+// Handle is the interface for a specific encoding format.
+//
+// Typically, a Handle is pre-configured before first time use,
+// and not modified while in use. Such a pre-configured Handle
+// is safe for concurrent access.
+type Handle interface {
+	getBasicHandle() *BasicHandle
+	newEncDriver(w *Encoder) encDriver
+	newDecDriver(r *Decoder) decDriver
+	isBinary() bool
+}
+
+// Raw represents raw formatted bytes.
+// We "blindly" store it during encode and store the raw bytes during decode.
+// Note: it is dangerous during encode, so we may gate the behaviour behind an Encode flag which must be explicitly set.
+type Raw []byte
+
+// RawExt represents raw unprocessed extension data.
+// Some codecs will decode extension data as a *RawExt if there is no registered extension for the tag.
+//
+// Only one of Data or Value is nil. If Data is nil, then the content of the RawExt is in the Value.
+type RawExt struct {
+	Tag uint64
+	// Data is the []byte which represents the raw ext. If Data is nil, ext is exposed in Value.
+	// Data is used by codecs (e.g. binc, msgpack, simple) which do custom serialization of the types
+	Data []byte
+	// Value represents the extension, if Data is nil.
+	// Value is used by codecs (e.g. cbor, json) which use the format to do custom serialization of the types.
+	Value interface{}
+}
+
+// BytesExt handles custom (de)serialization of types to/from []byte.
+// It is used by codecs (e.g. binc, msgpack, simple) which do custom serialization of the types.
+type BytesExt interface {
+	// WriteExt converts a value to a []byte.
+	//
+	// Note: v *may* be a pointer to the extension type, if the extension type was a struct or array.
+	WriteExt(v interface{}) []byte
+
+	// ReadExt updates a value from a []byte.
+	ReadExt(dst interface{}, src []byte)
+}
+
+// InterfaceExt handles custom (de)serialization of types to/from another interface{} value.
+// The Encoder or Decoder will then handle the further (de)serialization of that known type.
+//
+// It is used by codecs (e.g. cbor, json) which use the format to do custom serialization of the types.
+type InterfaceExt interface {
+	// ConvertExt converts a value into a simpler interface for easy encoding e.g. convert time.Time to int64.
+	//
+	// Note: v *may* be a pointer to the extension type, if the extension type was a struct or array.
+	ConvertExt(v interface{}) interface{}
+
+	// UpdateExt updates a value from a simpler interface for easy decoding e.g. convert int64 to time.Time.
+	UpdateExt(dst interface{}, src interface{})
+}
+
+// Ext handles custom (de)serialization of custom types / extensions.
+type Ext interface {
+	BytesExt
+	InterfaceExt
+}
+
+// addExtWrapper is a wrapper implementation to support former AddExt exported method.
+type addExtWrapper struct {
+	encFn func(reflect.Value) ([]byte, error)
+	decFn func(reflect.Value, []byte) error
+}
+
+func (x addExtWrapper) WriteExt(v interface{}) []byte {
+	bs, err := x.encFn(reflect.ValueOf(v))
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+func (x addExtWrapper) ReadExt(v interface{}, bs []byte) {
+	if err := x.decFn(reflect.ValueOf(v), bs); err != nil {
+		panic(err)
+	}
+}
+
+func (x addExtWrapper) ConvertExt(v interface{}) interface{} {
+	return x.WriteExt(v)
+}
+
+func (x addExtWrapper) UpdateExt(dest interface{}, v interface{}) {
+	x.ReadExt(dest, v.([]byte))
+}
+
+type setExtWrapper struct {
+	b BytesExt
+	i InterfaceExt
+}
+
+func (x *setExtWrapper) WriteExt(v interface{}) []byte {
+	if x.b == nil {
+		panic("BytesExt.WriteExt is not supported")
+	}
+	return x.b.WriteExt(v)
+}
+
+func (x *setExtWrapper) ReadExt(v interface{}, bs []byte) {
+	if x.b == nil {
+		panic("BytesExt.WriteExt is not supported")
+
+	}
+	x.b.ReadExt(v, bs)
+}
+
+func (x *setExtWrapper) ConvertExt(v interface{}) interface{} {
+	if x.i == nil {
+		panic("InterfaceExt.ConvertExt is not supported")
+
+	}
+	return x.i.ConvertExt(v)
+}
+
+func (x *setExtWrapper) UpdateExt(dest interface{}, v interface{}) {
+	if x.i == nil {
+		panic("InterfaceExxt.UpdateExt is not supported")
+
+	}
+	x.i.UpdateExt(dest, v)
+}
+
+// type errorString string
+// func (x errorString) Error() string { return string(x) }
+
+type binaryEncodingType struct{}
+
+func (_ binaryEncodingType) isBinary() bool { return true }
+
+type textEncodingType struct{}
+
+func (_ textEncodingType) isBinary() bool { return false }
+
+// noBuiltInTypes is embedded into many types which do not support builtins
+// e.g. msgpack, simple, cbor.
+type noBuiltInTypes struct{}
+
+func (_ noBuiltInTypes) IsBuiltinType(rt uintptr) bool           { return false }
+func (_ noBuiltInTypes) EncodeBuiltin(rt uintptr, v interface{}) {}
+func (_ noBuiltInTypes) DecodeBuiltin(rt uintptr, v interface{}) {}
+
+type noStreamingCodec struct{}
+
+func (_ noStreamingCodec) CheckBreak() bool { return false }
+
+// bigenHelper.
+// Users must already slice the x completely, because we will not reslice.
+type bigenHelper struct {
+	x []byte // must be correctly sliced to appropriate len. slicing is a cost.
+	w encWriter
+}
+
+func (z bigenHelper) writeUint16(v uint16) {
+	bigen.PutUint16(z.x, v)
+	z.w.writeb(z.x)
+}
+
+func (z bigenHelper) writeUint32(v uint32) {
+	bigen.PutUint32(z.x, v)
+	z.w.writeb(z.x)
+}
+
+func (z bigenHelper) writeUint64(v uint64) {
+	bigen.PutUint64(z.x, v)
+	z.w.writeb(z.x)
+}
+
+type extTypeTagFn struct {
+	rtid uintptr
+	rt   reflect.Type
+	tag  uint64
+	ext  Ext
+}
+
+type extHandle []extTypeTagFn
+
+// DEPRECATED: Use SetBytesExt or SetInterfaceExt on the Handle instead.
+//
+// AddExt registes an encode and decode function for a reflect.Type.
+// AddExt internally calls SetExt.
+// To deregister an Ext, call AddExt with nil encfn and/or nil decfn.
+func (o *extHandle) AddExt(
+	rt reflect.Type, tag byte,
+	encfn func(reflect.Value) ([]byte, error), decfn func(reflect.Value, []byte) error,
+) (err error) {
+	if encfn == nil || decfn == nil {
+		return o.SetExt(rt, uint64(tag), nil)
+	}
+	return o.SetExt(rt, uint64(tag), addExtWrapper{encfn, decfn})
+}
+
+// DEPRECATED: Use SetBytesExt or SetInterfaceExt on the Handle instead.
+//
+// Note that the type must be a named type, and specifically not
+// a pointer or Interface. An error is returned if that is not honored.
+//
+// To Deregister an ext, call SetExt with nil Ext
+func (o *extHandle) SetExt(rt reflect.Type, tag uint64, ext Ext) (err error) {
+	// o is a pointer, because we may need to initialize it
+	if rt.PkgPath() == "" || rt.Kind() == reflect.Interface {
+		err = fmt.Errorf("codec.Handle.AddExt: Takes named type, not a pointer or interface: %T",
+			reflect.Zero(rt).Interface())
+		return
+	}
+
+	rtid := reflect.ValueOf(rt).Pointer()
+	for _, v := range *o {
+		if v.rtid == rtid {
+			v.tag, v.ext = tag, ext
+			return
+		}
+	}
+
+	if *o == nil {
+		*o = make([]extTypeTagFn, 0, 4)
+	}
+	*o = append(*o, extTypeTagFn{rtid, rt, tag, ext})
+	return
+}
+
+func (o extHandle) getExt(rtid uintptr) *extTypeTagFn {
+	var v *extTypeTagFn
+	for i := range o {
+		v = &o[i]
+		if v.rtid == rtid {
+			return v
+		}
+	}
+	return nil
+}
+
+func (o extHandle) getExtForTag(tag uint64) *extTypeTagFn {
+	var v *extTypeTagFn
+	for i := range o {
+		v = &o[i]
+		if v.tag == tag {
+			return v
+		}
+	}
+	return nil
+}
+
+type structFieldInfo struct {
+	encName   string // encode name
+	fieldName string // field name
+
+	// only one of 'i' or 'is' can be set. If 'i' is -1, then 'is' has been set.
+
+	is        []int // (recursive/embedded) field index in struct
+	i         int16 // field index in struct
+	omitEmpty bool
+	toArray   bool // if field is _struct, is the toArray set?
+}
+
+// func (si *structFieldInfo) isZero() bool {
+// 	return si.encName == "" && len(si.is) == 0 && si.i == 0 && !si.omitEmpty && !si.toArray
+// }
+
+// rv returns the field of the struct.
+// If anonymous, it returns an Invalid
+func (si *structFieldInfo) field(v reflect.Value, update bool) (rv2 reflect.Value) {
+	if si.i != -1 {
+		v = v.Field(int(si.i))
+		return v
+	}
+	// replicate FieldByIndex
+	for _, x := range si.is {
+		for v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				if !update {
+					return
+				}
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v
+}
+
+func (si *structFieldInfo) setToZeroValue(v reflect.Value) {
+	if si.i != -1 {
+		v = v.Field(int(si.i))
+		v.Set(reflect.Zero(v.Type()))
+		// v.Set(reflect.New(v.Type()).Elem())
+		// v.Set(reflect.New(v.Type()))
+	} else {
+		// replicate FieldByIndex
+		for _, x := range si.is {
+			for v.Kind() == reflect.Ptr {
+				if v.IsNil() {
+					return
+				}
+				v = v.Elem()
+			}
+			v = v.Field(x)
+		}
+		v.Set(reflect.Zero(v.Type()))
+	}
+}
+
+func parseStructFieldInfo(fname string, stag string) *structFieldInfo {
+	// if fname == "" {
+	// 	panic(noFieldNameToStructFieldInfoErr)
+	// }
+	si := structFieldInfo{
+		encName: fname,
+	}
+
+	if stag != "" {
+		for i, s := range strings.Split(stag, ",") {
+			if i == 0 {
+				if s != "" {
+					si.encName = s
+				}
+			} else {
+				if s == "omitempty" {
+					si.omitEmpty = true
+				} else if s == "toarray" {
+					si.toArray = true
+				}
+			}
+		}
+	}
+	// si.encNameBs = []byte(si.encName)
+	return &si
+}
+
+type sfiSortedByEncName []*structFieldInfo
+
+func (p sfiSortedByEncName) Len() int {
+	return len(p)
+}
+
+func (p sfiSortedByEncName) Less(i, j int) bool {
+	return p[i].encName < p[j].encName
+}
+
+func (p sfiSortedByEncName) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+// typeInfo keeps information about each type referenced in the encode/decode sequence.
+//
+// During an encode/decode sequence, we work as below:
+//   - If base is a built in type, en/decode base value
+//   - If base is registered as an extension, en/decode base value
+//   - If type is binary(M/Unm)arshaler, call Binary(M/Unm)arshal method
+//   - If type is text(M/Unm)arshaler, call Text(M/Unm)arshal method
+//   - Else decode appropriately based on the reflect.Kind
+type typeInfo struct {
+	sfi  []*structFieldInfo // sorted. Used when enc/dec struct to map.
+	sfip []*structFieldInfo // unsorted. Used when enc/dec struct to array.
+
+	rt   reflect.Type
+	rtid uintptr
+
+	numMeth uint16 // number of methods
+
+	// baseId gives pointer to the base reflect.Type, after deferencing
+	// the pointers. E.g. base type of ***time.Time is time.Time.
+	base      reflect.Type
+	baseId    uintptr
+	baseIndir int8 // number of indirections to get to base
+
+	mbs bool // base type (T or *T) is a MapBySlice
+
+	bm        bool // base type (T or *T) is a binaryMarshaler
+	bunm      bool // base type (T or *T) is a binaryUnmarshaler
+	bmIndir   int8 // number of indirections to get to binaryMarshaler type
+	bunmIndir int8 // number of indirections to get to binaryUnmarshaler type
+
+	tm        bool // base type (T or *T) is a textMarshaler
+	tunm      bool // base type (T or *T) is a textUnmarshaler
+	tmIndir   int8 // number of indirections to get to textMarshaler type
+	tunmIndir int8 // number of indirections to get to textUnmarshaler type
+
+	jm        bool // base type (T or *T) is a jsonMarshaler
+	junm      bool // base type (T or *T) is a jsonUnmarshaler
+	jmIndir   int8 // number of indirections to get to jsonMarshaler type
+	junmIndir int8 // number of indirections to get to jsonUnmarshaler type
+
+	cs      bool // base type (T or *T) is a Selfer
+	csIndir int8 // number of indirections to get to Selfer type
+
+	toArray bool // whether this (struct) type should be encoded as an array
+}
+
+func (ti *typeInfo) indexForEncName(name string) int {
+	// NOTE: name may be a stringView, so don't pass it to another function.
+	//tisfi := ti.sfi
+	const binarySearchThreshold = 16
+	if sfilen := len(ti.sfi); sfilen < binarySearchThreshold {
+		// linear search. faster than binary search in my testing up to 16-field structs.
+		for i, si := range ti.sfi {
+			if si.encName == name {
+				return i
+			}
+		}
+	} else {
+		// binary search. adapted from sort/search.go.
+		h, i, j := 0, 0, sfilen
+		for i < j {
+			h = i + (j-i)/2
+			if ti.sfi[h].encName < name {
+				i = h + 1
+			} else {
+				j = h
+			}
+		}
+		if i < sfilen && ti.sfi[i].encName == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// TypeInfos caches typeInfo for each type on first inspection.
+//
+// It is configured with a set of tag keys, which are used to get
+// configuration for the type.
+type TypeInfos struct {
+	infos map[uintptr]*typeInfo
+	mu    sync.RWMutex
+	tags  []string
+}
+
+// NewTypeInfos creates a TypeInfos given a set of struct tags keys.
+//
+// This allows users customize the struct tag keys which contain configuration
+// of their types.
+func NewTypeInfos(tags []string) *TypeInfos {
+	return &TypeInfos{tags: tags, infos: make(map[uintptr]*typeInfo, 64)}
+}
+
+func (x *TypeInfos) structTag(t reflect.StructTag) (s string) {
+	// check for tags: codec, json, in that order.
+	// this allows seamless support for many configured structs.
+	for _, x := range x.tags {
+		s = t.Get(x)
+		if s != "" {
+			return s
+		}
+	}
+	return
+}
+
+func (x *TypeInfos) get(rtid uintptr, rt reflect.Type) (pti *typeInfo) {
+	var ok bool
+	x.mu.RLock()
+	pti, ok = x.infos[rtid]
+	x.mu.RUnlock()
+	if ok {
+		return
+	}
+
+	// do not hold lock while computing this.
+	// it may lead to duplication, but that's ok.
+	ti := typeInfo{rt: rt, rtid: rtid}
+	ti.numMeth = uint16(rt.NumMethod())
+
+	var indir int8
+	if ok, indir = implementsIntf(rt, binaryMarshalerTyp); ok {
+		ti.bm, ti.bmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, binaryUnmarshalerTyp); ok {
+		ti.bunm, ti.bunmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, textMarshalerTyp); ok {
+		ti.tm, ti.tmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, textUnmarshalerTyp); ok {
+		ti.tunm, ti.tunmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, jsonMarshalerTyp); ok {
+		ti.jm, ti.jmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, jsonUnmarshalerTyp); ok {
+		ti.junm, ti.junmIndir = true, indir
+	}
+	if ok, indir = implementsIntf(rt, selferTyp); ok {
+		ti.cs, ti.csIndir = true, indir
+	}
+	if ok, _ = implementsIntf(rt, mapBySliceTyp); ok {
+		ti.mbs = true
+	}
+
+	pt := rt
+	var ptIndir int8
+	// for ; pt.Kind() == reflect.Ptr; pt, ptIndir = pt.Elem(), ptIndir+1 { }
+	for pt.Kind() == reflect.Ptr {
+		pt = pt.Elem()
+		ptIndir++
+	}
+	if ptIndir == 0 {
+		ti.base = rt
+		ti.baseId = rtid
+	} else {
+		ti.base = pt
+		ti.baseId = reflect.ValueOf(pt).Pointer()
+		ti.baseIndir = ptIndir
+	}
+
+	if rt.Kind() == reflect.Struct {
+		var omitEmpty bool
+		if f, ok := rt.FieldByName(structInfoFieldName); ok {
+			siInfo := parseStructFieldInfo(structInfoFieldName, x.structTag(f.Tag))
+			ti.toArray = siInfo.toArray
+			omitEmpty = siInfo.omitEmpty
+		}
+		pi := rgetPool.Get()
+		pv := pi.(*rgetPoolT)
+		pv.etypes[0] = ti.baseId
+		vv := rgetT{pv.fNames[:0], pv.encNames[:0], pv.etypes[:1], pv.sfis[:0]}
+		x.rget(rt, rtid, omitEmpty, nil, &vv)
+		ti.sfip, ti.sfi = rgetResolveSFI(vv.sfis, pv.sfiidx[:0])
+		rgetPool.Put(pi)
+	}
+	// sfi = sfip
+
+	x.mu.Lock()
+	if pti, ok = x.infos[rtid]; !ok {
+		pti = &ti
+		x.infos[rtid] = pti
+	}
+	x.mu.Unlock()
+	return
+}
+
+func (x *TypeInfos) rget(rt reflect.Type, rtid uintptr, omitEmpty bool,
+	indexstack []int, pv *rgetT,
+) {
+	// Read up fields and store how to access the value.
+	//
+	// It uses go's rules for message selectors,
+	// which say that the field with the shallowest depth is selected.
+	//
+	// Note: we consciously use slices, not a map, to simulate a set.
+	//       Typically, types have < 16 fields,
+	//       and iteration using equals is faster than maps there
+
+LOOP:
+	for j, jlen := 0, rt.NumField(); j < jlen; j++ {
+		f := rt.Field(j)
+		fkind := f.Type.Kind()
+		// skip if a func type, or is unexported, or structTag value == "-"
+		switch fkind {
+		case reflect.Func, reflect.Complex64, reflect.Complex128, reflect.UnsafePointer:
+			continue LOOP
+		}
+
+		// if r1, _ := utf8.DecodeRuneInString(f.Name);
+		// r1 == utf8.RuneError || !unicode.IsUpper(r1) {
+		if f.PkgPath != "" && !f.Anonymous { // unexported, not embedded
+			continue
+		}
+		stag := x.structTag(f.Tag)
+		if stag == "-" {
+			continue
+		}
+		var si *structFieldInfo
+		// if anonymous and no struct tag (or it's blank),
+		// and a struct (or pointer to struct), inline it.
+		if f.Anonymous && fkind != reflect.Interface {
+			doInline := stag == ""
+			if !doInline {
+				si = parseStructFieldInfo("", stag)
+				doInline = si.encName == ""
+				// doInline = si.isZero()
+			}
+			if doInline {
+				ft := f.Type
+				for ft.Kind() == reflect.Ptr {
+					ft = ft.Elem()
+				}
+				if ft.Kind() == reflect.Struct {
+					// if etypes contains this, don't call rget again (as fields are already seen here)
+					ftid := reflect.ValueOf(ft).Pointer()
+					// We cannot recurse forever, but we need to track other field depths.
+					// So - we break if we see a type twice (not the first time).
+					// This should be sufficient to handle an embedded type that refers to its
+					// owning type, which then refers to its embedded type.
+					processIt := true
+					numk := 0
+					for _, k := range pv.etypes {
+						if k == ftid {
+							numk++
+							if numk == rgetMaxRecursion {
+								processIt = false
+								break
+							}
+						}
+					}
+					if processIt {
+						pv.etypes = append(pv.etypes, ftid)
+						indexstack2 := make([]int, len(indexstack)+1)
+						copy(indexstack2, indexstack)
+						indexstack2[len(indexstack)] = j
+						// indexstack2 := append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
+						x.rget(ft, ftid, omitEmpty, indexstack2, pv)
+					}
+					continue
+				}
+			}
+		}
+
+		// after the anonymous dance: if an unexported field, skip
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+
+		if f.Name == "" {
+			panic(noFieldNameToStructFieldInfoErr)
+		}
+
+		pv.fNames = append(pv.fNames, f.Name)
+
+		if si == nil {
+			si = parseStructFieldInfo(f.Name, stag)
+		} else if si.encName == "" {
+			si.encName = f.Name
+		}
+		si.fieldName = f.Name
+
+		pv.encNames = append(pv.encNames, si.encName)
+
+		// si.ikind = int(f.Type.Kind())
+		if len(indexstack) == 0 {
+			si.i = int16(j)
+		} else {
+			si.i = -1
+			si.is = make([]int, len(indexstack)+1)
+			copy(si.is, indexstack)
+			si.is[len(indexstack)] = j
+			// si.is = append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
+		}
+
+		if omitEmpty {
+			si.omitEmpty = true
+		}
+		pv.sfis = append(pv.sfis, si)
+	}
+}
+
+// resolves the struct field info got from a call to rget.
+// Returns a trimmed, unsorted and sorted []*structFieldInfo.
+func rgetResolveSFI(x []*structFieldInfo, pv []sfiIdx) (y, z []*structFieldInfo) {
+	var n int
+	for i, v := range x {
+		xn := v.encName //TODO: fieldName or encName? use encName for now.
+		var found bool
+		for j, k := range pv {
+			if k.name == xn {
+				// one of them must be reset to nil, and the index updated appropriately to the other one
+				if len(v.is) == len(x[k.index].is) {
+				} else if len(v.is) < len(x[k.index].is) {
+					pv[j].index = i
+					if x[k.index] != nil {
+						x[k.index] = nil
+						n++
+					}
+				} else {
+					if x[i] != nil {
+						x[i] = nil
+						n++
+					}
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			pv = append(pv, sfiIdx{xn, i})
+		}
+	}
+
+	// remove all the nils
+	y = make([]*structFieldInfo, len(x)-n)
+	n = 0
+	for _, v := range x {
+		if v == nil {
+			continue
+		}
+		y[n] = v
+		n++
+	}
+
+	z = make([]*structFieldInfo, len(y))
+	copy(z, y)
+	sort.Sort(sfiSortedByEncName(z))
+	return
+}
+
+func panicToErr(err *error) {
+	if recoverPanicToErr {
+		if x := recover(); x != nil {
+			//debug.PrintStack()
+			panicValToErr(x, err)
+		}
+	}
+}
+
+// func doPanic(tag string, format string, params ...interface{}) {
+// 	params2 := make([]interface{}, len(params)+1)
+// 	params2[0] = tag
+// 	copy(params2[1:], params)
+// 	panic(fmt.Errorf("%s: "+format, params2...))
+// }
+
+func isImmutableKind(k reflect.Kind) (v bool) {
+	return false ||
+		k == reflect.Int ||
+		k == reflect.Int8 ||
+		k == reflect.Int16 ||
+		k == reflect.Int32 ||
+		k == reflect.Int64 ||
+		k == reflect.Uint ||
+		k == reflect.Uint8 ||
+		k == reflect.Uint16 ||
+		k == reflect.Uint32 ||
+		k == reflect.Uint64 ||
+		k == reflect.Uintptr ||
+		k == reflect.Float32 ||
+		k == reflect.Float64 ||
+		k == reflect.Bool ||
+		k == reflect.String
+}
+
+// these functions must be inlinable, and not call anybody
+type checkOverflow struct{}
+
+func (_ checkOverflow) Float32(f float64) (overflow bool) {
+	if f < 0 {
+		f = -f
+	}
+	return math.MaxFloat32 < f && f <= math.MaxFloat64
+}
+
+func (_ checkOverflow) Uint(v uint64, bitsize uint8) (overflow bool) {
+	if bitsize == 0 || bitsize >= 64 || v == 0 {
+		return
+	}
+	if trunc := (v << (64 - bitsize)) >> (64 - bitsize); v != trunc {
+		overflow = true
+	}
+	return
+}
+
+func (_ checkOverflow) Int(v int64, bitsize uint8) (overflow bool) {
+	if bitsize == 0 || bitsize >= 64 || v == 0 {
+		return
+	}
+	if trunc := (v << (64 - bitsize)) >> (64 - bitsize); v != trunc {
+		overflow = true
+	}
+	return
+}
+
+func (_ checkOverflow) SignedInt(v uint64) (i int64, overflow bool) {
+	//e.g. -127 to 128 for int8
+	pos := (v >> 63) == 0
+	ui2 := v & 0x7fffffffffffffff
+	if pos {
+		if ui2 > math.MaxInt64 {
+			overflow = true
+			return
+		}
+	} else {
+		if ui2 > math.MaxInt64-1 {
+			overflow = true
+			return
+		}
+	}
+	i = int64(v)
+	return
+}
+
+// ------------------ SORT -----------------
+
+func isNaN(f float64) bool { return f != f }
+
+// -----------------------
+
+type intSlice []int64
+type uintSlice []uint64
+type floatSlice []float64
+type boolSlice []bool
+type stringSlice []string
+type bytesSlice [][]byte
+
+func (p intSlice) Len() int           { return len(p) }
+func (p intSlice) Less(i, j int) bool { return p[i] < p[j] }
+func (p intSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p uintSlice) Len() int           { return len(p) }
+func (p uintSlice) Less(i, j int) bool { return p[i] < p[j] }
+func (p uintSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p floatSlice) Len() int { return len(p) }
+func (p floatSlice) Less(i, j int) bool {
+	return p[i] < p[j] || isNaN(p[i]) && !isNaN(p[j])
+}
+func (p floatSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func (p stringSlice) Len() int           { return len(p) }
+func (p stringSlice) Less(i, j int) bool { return p[i] < p[j] }
+func (p stringSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p bytesSlice) Len() int           { return len(p) }
+func (p bytesSlice) Less(i, j int) bool { return bytes.Compare(p[i], p[j]) == -1 }
+func (p bytesSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p boolSlice) Len() int           { return len(p) }
+func (p boolSlice) Less(i, j int) bool { return !p[i] && p[j] }
+func (p boolSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// ---------------------
+
+type intRv struct {
+	v int64
+	r reflect.Value
+}
+type intRvSlice []intRv
+type uintRv struct {
+	v uint64
+	r reflect.Value
+}
+type uintRvSlice []uintRv
+type floatRv struct {
+	v float64
+	r reflect.Value
+}
+type floatRvSlice []floatRv
+type boolRv struct {
+	v bool
+	r reflect.Value
+}
+type boolRvSlice []boolRv
+type stringRv struct {
+	v string
+	r reflect.Value
+}
+type stringRvSlice []stringRv
+type bytesRv struct {
+	v []byte
+	r reflect.Value
+}
+type bytesRvSlice []bytesRv
+
+func (p intRvSlice) Len() int           { return len(p) }
+func (p intRvSlice) Less(i, j int) bool { return p[i].v < p[j].v }
+func (p intRvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p uintRvSlice) Len() int           { return len(p) }
+func (p uintRvSlice) Less(i, j int) bool { return p[i].v < p[j].v }
+func (p uintRvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p floatRvSlice) Len() int { return len(p) }
+func (p floatRvSlice) Less(i, j int) bool {
+	return p[i].v < p[j].v || isNaN(p[i].v) && !isNaN(p[j].v)
+}
+func (p floatRvSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func (p stringRvSlice) Len() int           { return len(p) }
+func (p stringRvSlice) Less(i, j int) bool { return p[i].v < p[j].v }
+func (p stringRvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p bytesRvSlice) Len() int           { return len(p) }
+func (p bytesRvSlice) Less(i, j int) bool { return bytes.Compare(p[i].v, p[j].v) == -1 }
+func (p bytesRvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p boolRvSlice) Len() int           { return len(p) }
+func (p boolRvSlice) Less(i, j int) bool { return !p[i].v && p[j].v }
+func (p boolRvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// -----------------
+
+type bytesI struct {
+	v []byte
+	i interface{}
+}
+
+type bytesISlice []bytesI
+
+func (p bytesISlice) Len() int           { return len(p) }
+func (p bytesISlice) Less(i, j int) bool { return bytes.Compare(p[i].v, p[j].v) == -1 }
+func (p bytesISlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// -----------------
+
+type set []uintptr
+
+func (s *set) add(v uintptr) (exists bool) {
+	// e.ci is always nil, or len >= 1
+	// defer func() { fmt.Printf("$$$$$$$$$$$ cirRef Add: %v, exists: %v\n", v, exists) }()
+	x := *s
+	if x == nil {
+		x = make([]uintptr, 1, 8)
+		x[0] = v
+		*s = x
+		return
+	}
+	// typically, length will be 1. make this perform.
+	if len(x) == 1 {
+		if j := x[0]; j == 0 {
+			x[0] = v
+		} else if j == v {
+			exists = true
+		} else {
+			x = append(x, v)
+			*s = x
+		}
+		return
+	}
+	// check if it exists
+	for _, j := range x {
+		if j == v {
+			exists = true
+			return
+		}
+	}
+	// try to replace a "deleted" slot
+	for i, j := range x {
+		if j == 0 {
+			x[i] = v
+			return
+		}
+	}
+	// if unable to replace deleted slot, just append it.
+	x = append(x, v)
+	*s = x
+	return
+}
+
+func (s *set) remove(v uintptr) (exists bool) {
+	// defer func() { fmt.Printf("$$$$$$$$$$$ cirRef Rm: %v, exists: %v\n", v, exists) }()
+	x := *s
+	if len(x) == 0 {
+		return
+	}
+	if len(x) == 1 {
+		if x[0] == v {
+			x[0] = 0
+		}
+		return
+	}
+	for i, j := range x {
+		if j == v {
+			exists = true
+			x[i] = 0 // set it to 0, as way to delete it.
+			// copy(x[i:], x[i+1:])
+			// x = x[:len(x)-1]
+			return
+		}
+	}
+	return
+}

--- a/vendor/github.com/ugorji/go/codec/helper_internal.go
+++ b/vendor/github.com/ugorji/go/codec/helper_internal.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// All non-std package dependencies live in this file,
+// so porting to different environment is easy (just update functions).
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+func panicValToErr(panicVal interface{}, err *error) {
+	if panicVal == nil {
+		return
+	}
+	// case nil
+	switch xerr := panicVal.(type) {
+	case error:
+		*err = xerr
+	case string:
+		*err = errors.New(xerr)
+	default:
+		*err = fmt.Errorf("%v", panicVal)
+	}
+	return
+}
+
+func hIsEmptyValue(v reflect.Value, deref, checkStruct bool) bool {
+	switch v.Kind() {
+	case reflect.Invalid:
+		return true
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		if deref {
+			if v.IsNil() {
+				return true
+			}
+			return hIsEmptyValue(v.Elem(), deref, checkStruct)
+		} else {
+			return v.IsNil()
+		}
+	case reflect.Struct:
+		if !checkStruct {
+			return false
+		}
+		// return true if all fields are empty. else return false.
+		// we cannot use equality check, because some fields may be maps/slices/etc
+		// and consequently the structs are not comparable.
+		// return v.Interface() == reflect.Zero(v.Type()).Interface()
+		for i, n := 0, v.NumField(); i < n; i++ {
+			if !hIsEmptyValue(v.Field(i), deref, checkStruct) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func isEmptyValue(v reflect.Value, deref, checkStruct bool) bool {
+	return hIsEmptyValue(v, deref, checkStruct)
+}
+
+func pruneSignExt(v []byte, pos bool) (n int) {
+	if len(v) < 2 {
+	} else if pos && v[0] == 0 {
+		for ; v[n] == 0 && n+1 < len(v) && (v[n+1]&(1<<7) == 0); n++ {
+		}
+	} else if !pos && v[0] == 0xff {
+		for ; v[n] == 0xff && n+1 < len(v) && (v[n+1]&(1<<7) != 0); n++ {
+		}
+	}
+	return
+}
+
+func implementsIntf(typ, iTyp reflect.Type) (success bool, indir int8) {
+	if typ == nil {
+		return
+	}
+	rt := typ
+	// The type might be a pointer and we need to keep
+	// dereferencing to the base type until we find an implementation.
+	for {
+		if rt.Implements(iTyp) {
+			return true, indir
+		}
+		if p := rt; p.Kind() == reflect.Ptr {
+			indir++
+			if indir >= math.MaxInt8 { // insane number of indirections
+				return false, 0
+			}
+			rt = p.Elem()
+			continue
+		}
+		break
+	}
+	// No luck yet, but if this is a base type (non-pointer), the pointer might satisfy.
+	if typ.Kind() != reflect.Ptr {
+		// Not a pointer, but does the pointer work?
+		if reflect.PtrTo(typ).Implements(iTyp) {
+			return true, -1
+		}
+	}
+	return false, 0
+}
+
+// validate that this function is correct ...
+// culled from OGRE (Object-Oriented Graphics Rendering Engine)
+// function: halfToFloatI (http://stderr.org/doc/ogre-doc/api/OgreBitwise_8h-source.html)
+func halfFloatToFloatBits(yy uint16) (d uint32) {
+	y := uint32(yy)
+	s := (y >> 15) & 0x01
+	e := (y >> 10) & 0x1f
+	m := y & 0x03ff
+
+	if e == 0 {
+		if m == 0 { // plu or minus 0
+			return s << 31
+		} else { // Denormalized number -- renormalize it
+			for (m & 0x00000400) == 0 {
+				m <<= 1
+				e -= 1
+			}
+			e += 1
+			const zz uint32 = 0x0400
+			m &= ^zz
+		}
+	} else if e == 31 {
+		if m == 0 { // Inf
+			return (s << 31) | 0x7f800000
+		} else { // NaN
+			return (s << 31) | 0x7f800000 | (m << 13)
+		}
+	}
+	e = e + (127 - 15)
+	m = m << 13
+	return (s << 31) | (e << 23) | m
+}
+
+// GrowCap will return a new capacity for a slice, given the following:
+//   - oldCap: current capacity
+//   - unit: in-memory size of an element
+//   - num: number of elements to add
+func growCap(oldCap, unit, num int) (newCap int) {
+	// appendslice logic (if cap < 1024, *2, else *1.25):
+	//   leads to many copy calls, especially when copying bytes.
+	//   bytes.Buffer model (2*cap + n): much better for bytes.
+	// smarter way is to take the byte-size of the appended element(type) into account
+
+	// maintain 3 thresholds:
+	// t1: if cap <= t1, newcap = 2x
+	// t2: if cap <= t2, newcap = 1.75x
+	// t3: if cap <= t3, newcap = 1.5x
+	//     else          newcap = 1.25x
+	//
+	// t1, t2, t3 >= 1024 always.
+	// i.e. if unit size >= 16, then always do 2x or 1.25x (ie t1, t2, t3 are all same)
+	//
+	// With this, appending for bytes increase by:
+	//    100% up to 4K
+	//     75% up to 8K
+	//     50% up to 16K
+	//     25% beyond that
+
+	// unit can be 0 e.g. for struct{}{}; handle that appropriately
+	var t1, t2, t3 int // thresholds
+	if unit <= 1 {
+		t1, t2, t3 = 4*1024, 8*1024, 16*1024
+	} else if unit < 16 {
+		t3 = 16 / unit * 1024
+		t1 = t3 * 1 / 4
+		t2 = t3 * 2 / 4
+	} else {
+		t1, t2, t3 = 1024, 1024, 1024
+	}
+
+	var x int // temporary variable
+
+	// x is multiplier here: one of 5, 6, 7 or 8; incr of 25%, 50%, 75% or 100% respectively
+	if oldCap <= t1 { // [0,t1]
+		x = 8
+	} else if oldCap > t3 { // (t3,infinity]
+		x = 5
+	} else if oldCap <= t2 { // (t1,t2]
+		x = 7
+	} else { // (t2,t3]
+		x = 6
+	}
+	newCap = x * oldCap / 4
+
+	if num > 0 {
+		newCap += num
+	}
+
+	// ensure newCap is a multiple of 64 (if it is > 64) or 16.
+	if newCap > 64 {
+		if x = newCap % 64; x != 0 {
+			x = newCap / 64
+			newCap = 64 * (x + 1)
+		}
+	} else {
+		if x = newCap % 16; x != 0 {
+			x = newCap / 16
+			newCap = 16 * (x + 1)
+		}
+	}
+	return
+}
+
+func expandSliceValue(s reflect.Value, num int) reflect.Value {
+	if num <= 0 {
+		return s
+	}
+	l0 := s.Len()
+	l1 := l0 + num // new slice length
+	if l1 < l0 {
+		panic("ExpandSlice: slice overflow")
+	}
+	c0 := s.Cap()
+	if l1 <= c0 {
+		return s.Slice(0, l1)
+	}
+	st := s.Type()
+	c1 := growCap(c0, int(st.Elem().Size()), num)
+	s2 := reflect.MakeSlice(st, l1, c1)
+	// println("expandslicevalue: cap-old: ", c0, ", cap-new: ", c1, ", len-new: ", l1)
+	reflect.Copy(s2, s)
+	return s2
+}

--- a/vendor/github.com/ugorji/go/codec/helper_not_unsafe.go
+++ b/vendor/github.com/ugorji/go/codec/helper_not_unsafe.go
@@ -1,0 +1,36 @@
+// +build !unsafe
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// stringView returns a view of the []byte as a string.
+// In unsafe mode, it doesn't incur allocation and copying caused by conversion.
+// In regular safe mode, it is an allocation and copy.
+//
+// Usage: Always maintain a reference to v while result of this call is in use,
+//        and call keepAlive4BytesView(v) at point where done with view.
+func stringView(v []byte) string {
+	return string(v)
+}
+
+// bytesView returns a view of the string as a []byte.
+// In unsafe mode, it doesn't incur allocation and copying caused by conversion.
+// In regular safe mode, it is an allocation and copy.
+//
+// Usage: Always maintain a reference to v while result of this call is in use,
+//        and call keepAlive4BytesView(v) at point where done with view.
+func bytesView(v string) []byte {
+	return []byte(v)
+}
+
+// keepAlive4BytesView maintains a reference to the input parameter for bytesView.
+//
+// Usage: call this at point where done with the bytes view.
+func keepAlive4BytesView(v string) {}
+
+// keepAlive4BytesView maintains a reference to the input parameter for stringView.
+//
+// Usage: call this at point where done with the string view.
+func keepAlive4StringView(v []byte) {}

--- a/vendor/github.com/ugorji/go/codec/helper_test.go
+++ b/vendor/github.com/ugorji/go/codec/helper_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// All non-std package dependencies related to testing live in this file,
+// so porting to different environment is easy (just update functions).
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// ----- functions below are used only by tests (not benchmarks)
+
+const (
+	testLogToT    = true
+	failNowOnFail = true
+)
+
+func checkErrT(t *testing.T, err error) {
+	if err != nil {
+		logT(t, err.Error())
+		failT(t)
+	}
+}
+
+func checkEqualT(t *testing.T, v1 interface{}, v2 interface{}, desc string) (err error) {
+	if err = deepEqual(v1, v2); err != nil {
+		logT(t, "Not Equal: %s: %v. v1: %v, v2: %v", desc, err, v1, v2)
+		failT(t)
+	}
+	return
+}
+
+func failT(t *testing.T) {
+	if failNowOnFail {
+		t.FailNow()
+	} else {
+		t.Fail()
+	}
+}
+
+// --- these functions are used by both benchmarks and tests
+
+func deepEqual(v1, v2 interface{}) (err error) {
+	if !reflect.DeepEqual(v1, v2) {
+		err = errors.New("Not Match")
+	}
+	return
+}
+
+func logT(x interface{}, format string, args ...interface{}) {
+	if t, ok := x.(*testing.T); ok && t != nil && testLogToT {
+		if testVerbose {
+			t.Logf(format, args...)
+		}
+	} else if b, ok := x.(*testing.B); ok && b != nil && testLogToT {
+		b.Logf(format, args...)
+	} else {
+		if len(format) == 0 || format[len(format)-1] != '\n' {
+			format = format + "\n"
+		}
+		fmt.Printf(format, args...)
+	}
+}
+
+func approxDataSize(rv reflect.Value) (sum int) {
+	switch rk := rv.Kind(); rk {
+	case reflect.Invalid:
+	case reflect.Ptr, reflect.Interface:
+		sum += int(rv.Type().Size())
+		sum += approxDataSize(rv.Elem())
+	case reflect.Slice:
+		sum += int(rv.Type().Size())
+		for j := 0; j < rv.Len(); j++ {
+			sum += approxDataSize(rv.Index(j))
+		}
+	case reflect.String:
+		sum += int(rv.Type().Size())
+		sum += rv.Len()
+	case reflect.Map:
+		sum += int(rv.Type().Size())
+		for _, mk := range rv.MapKeys() {
+			sum += approxDataSize(mk)
+			sum += approxDataSize(rv.MapIndex(mk))
+		}
+	case reflect.Struct:
+		//struct size already includes the full data size.
+		//sum += int(rv.Type().Size())
+		for j := 0; j < rv.NumField(); j++ {
+			sum += approxDataSize(rv.Field(j))
+		}
+	default:
+		//pure value types
+		sum += int(rv.Type().Size())
+	}
+	return
+}

--- a/vendor/github.com/ugorji/go/codec/helper_unsafe.go
+++ b/vendor/github.com/ugorji/go/codec/helper_unsafe.go
@@ -1,0 +1,53 @@
+// +build unsafe
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// This file has unsafe variants of some helper methods.
+// NOTE: See helper_not_unsafe.go for the usage information.
+
+type unsafeString struct {
+	Data uintptr
+	Len  int
+}
+
+type unsafeSlice struct {
+	Data uintptr
+	Len  int
+	Cap  int
+}
+
+func stringView(v []byte) string {
+	if len(v) == 0 {
+		return ""
+	}
+
+	bx := (*unsafeSlice)(unsafe.Pointer(&v))
+	sx := unsafeString{bx.Data, bx.Len}
+	return *(*string)(unsafe.Pointer(&sx))
+}
+
+func bytesView(v string) []byte {
+	if len(v) == 0 {
+		return zeroByteSlice
+	}
+
+	sx := (*unsafeString)(unsafe.Pointer(&v))
+	bx := unsafeSlice{sx.Data, sx.Len, sx.Len}
+	return *(*[]byte)(unsafe.Pointer(&bx))
+}
+
+func keepAlive4BytesView(v string) {
+	runtime.KeepAlive(v)
+}
+
+func keepAlive4StringView(v []byte) {
+	runtime.KeepAlive(v)
+}

--- a/vendor/github.com/ugorji/go/codec/json.go
+++ b/vendor/github.com/ugorji/go/codec/json.go
@@ -1,0 +1,1264 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// By default, this json support uses base64 encoding for bytes, because you cannot
+// store and read any arbitrary string in json (only unicode).
+// However, the user can configre how to encode/decode bytes.
+//
+// This library specifically supports UTF-8 for encoding and decoding only.
+//
+// Note that the library will happily encode/decode things which are not valid
+// json e.g. a map[int64]string. We do it for consistency. With valid json,
+// we will encode and decode appropriately.
+// Users can specify their map type if necessary to force it.
+//
+// Note:
+//   - we cannot use strconv.Quote and strconv.Unquote because json quotes/unquotes differently.
+//     We implement it here.
+//   - Also, strconv.ParseXXX for floats and integers
+//     - only works on strings resulting in unnecessary allocation and []byte-string conversion.
+//     - it does a lot of redundant checks, because json numbers are simpler that what it supports.
+//   - We parse numbers (floats and integers) directly here.
+//     We only delegate parsing floats if it is a hairy float which could cause a loss of precision.
+//     In that case, we delegate to strconv.ParseFloat.
+//
+// Note:
+//   - encode does not beautify. There is no whitespace when encoding.
+//   - rpc calls which take single integer arguments or write single numeric arguments will need care.
+
+// Top-level methods of json(End|Dec)Driver (which are implementations of (en|de)cDriver
+// MUST not call one-another.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"strconv"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+//--------------------------------
+
+var (
+	jsonLiterals = [...]byte{'t', 'r', 'u', 'e', 'f', 'a', 'l', 's', 'e', 'n', 'u', 'l', 'l'}
+
+	jsonFloat64Pow10 = [...]float64{
+		1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+		1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+		1e20, 1e21, 1e22,
+	}
+
+	jsonUint64Pow10 = [...]uint64{
+		1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+		1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+	}
+
+	// jsonTabs and jsonSpaces are used as caches for indents
+	jsonTabs, jsonSpaces string
+)
+
+const (
+	// jsonUnreadAfterDecNum controls whether we unread after decoding a number.
+	//
+	// instead of unreading, just update d.tok (iff it's not a whitespace char)
+	// However, doing this means that we may HOLD onto some data which belongs to another stream.
+	// Thus, it is safest to unread the data when done.
+	// keep behind a constant flag for now.
+	jsonUnreadAfterDecNum = true
+
+	// If !jsonValidateSymbols, decoding will be faster, by skipping some checks:
+	//   - If we see first character of null, false or true,
+	//     do not validate subsequent characters.
+	//   - e.g. if we see a n, assume null and skip next 3 characters,
+	//     and do not validate they are ull.
+	// P.S. Do not expect a significant decoding boost from this.
+	jsonValidateSymbols = true
+
+	// if jsonTruncateMantissa, truncate mantissa if trailing 0's.
+	// This is important because it could allow some floats to be decoded without
+	// deferring to strconv.ParseFloat.
+	jsonTruncateMantissa = true
+
+	// if mantissa >= jsonNumUintCutoff before multiplying by 10, this is an overflow
+	jsonNumUintCutoff = (1<<64-1)/uint64(10) + 1 // cutoff64(base)
+
+	// if mantissa >= jsonNumUintMaxVal, this is an overflow
+	jsonNumUintMaxVal = 1<<uint64(64) - 1
+
+	// jsonNumDigitsUint64Largest = 19
+
+	jsonSpacesOrTabsLen = 128
+)
+
+func init() {
+	var bs [jsonSpacesOrTabsLen]byte
+	for i := 0; i < jsonSpacesOrTabsLen; i++ {
+		bs[i] = ' '
+	}
+	jsonSpaces = string(bs[:])
+
+	for i := 0; i < jsonSpacesOrTabsLen; i++ {
+		bs[i] = '\t'
+	}
+	jsonTabs = string(bs[:])
+}
+
+type jsonEncDriver struct {
+	e  *Encoder
+	w  encWriter
+	h  *JsonHandle
+	b  [64]byte // scratch
+	bs []byte   // scratch
+	se setExtWrapper
+	ds string // indent string
+	dl uint16 // indent level
+	dt bool   // indent using tabs
+	d  bool   // indent
+	c  containerState
+	noBuiltInTypes
+}
+
+// indent is done as below:
+//   - newline and indent are added before each mapKey or arrayElem
+//   - newline and indent are added before each ending,
+//     except there was no entry (so we can have {} or [])
+
+func (e *jsonEncDriver) sendContainerState(c containerState) {
+	// determine whether to output separators
+	if c == containerMapKey {
+		if e.c != containerMapStart {
+			e.w.writen1(',')
+		}
+		if e.d {
+			e.writeIndent()
+		}
+	} else if c == containerMapValue {
+		if e.d {
+			e.w.writen2(':', ' ')
+		} else {
+			e.w.writen1(':')
+		}
+	} else if c == containerMapEnd {
+		if e.d {
+			e.dl--
+			if e.c != containerMapStart {
+				e.writeIndent()
+			}
+		}
+		e.w.writen1('}')
+	} else if c == containerArrayElem {
+		if e.c != containerArrayStart {
+			e.w.writen1(',')
+		}
+		if e.d {
+			e.writeIndent()
+		}
+	} else if c == containerArrayEnd {
+		if e.d {
+			e.dl--
+			if e.c != containerArrayStart {
+				e.writeIndent()
+			}
+		}
+		e.w.writen1(']')
+	}
+	e.c = c
+}
+
+func (e *jsonEncDriver) writeIndent() {
+	e.w.writen1('\n')
+	if x := len(e.ds) * int(e.dl); x <= jsonSpacesOrTabsLen {
+		if e.dt {
+			e.w.writestr(jsonTabs[:x])
+		} else {
+			e.w.writestr(jsonSpaces[:x])
+		}
+	} else {
+		for i := uint16(0); i < e.dl; i++ {
+			e.w.writestr(e.ds)
+		}
+	}
+}
+
+func (e *jsonEncDriver) EncodeNil() {
+	e.w.writeb(jsonLiterals[9:13]) // null
+}
+
+func (e *jsonEncDriver) EncodeBool(b bool) {
+	if b {
+		e.w.writeb(jsonLiterals[0:4]) // true
+	} else {
+		e.w.writeb(jsonLiterals[4:9]) // false
+	}
+}
+
+func (e *jsonEncDriver) EncodeFloat32(f float32) {
+	e.encodeFloat(float64(f), 32)
+}
+
+func (e *jsonEncDriver) EncodeFloat64(f float64) {
+	// e.w.writestr(strconv.FormatFloat(f, 'E', -1, 64))
+	e.encodeFloat(f, 64)
+}
+
+func (e *jsonEncDriver) encodeFloat(f float64, numbits int) {
+	x := strconv.AppendFloat(e.b[:0], f, 'G', -1, numbits)
+	e.w.writeb(x)
+	if bytes.IndexByte(x, 'E') == -1 && bytes.IndexByte(x, '.') == -1 {
+		e.w.writen2('.', '0')
+	}
+}
+
+func (e *jsonEncDriver) EncodeInt(v int64) {
+	if x := e.h.IntegerAsString; x == 'A' || x == 'L' && (v > 1<<53 || v < -(1<<53)) {
+		e.w.writen1('"')
+		e.w.writeb(strconv.AppendInt(e.b[:0], v, 10))
+		e.w.writen1('"')
+		return
+	}
+	e.w.writeb(strconv.AppendInt(e.b[:0], v, 10))
+}
+
+func (e *jsonEncDriver) EncodeUint(v uint64) {
+	if x := e.h.IntegerAsString; x == 'A' || x == 'L' && v > 1<<53 {
+		e.w.writen1('"')
+		e.w.writeb(strconv.AppendUint(e.b[:0], v, 10))
+		e.w.writen1('"')
+		return
+	}
+	e.w.writeb(strconv.AppendUint(e.b[:0], v, 10))
+}
+
+func (e *jsonEncDriver) EncodeExt(rv interface{}, xtag uint64, ext Ext, en *Encoder) {
+	if v := ext.ConvertExt(rv); v == nil {
+		e.w.writeb(jsonLiterals[9:13]) // null // e.EncodeNil()
+	} else {
+		en.encode(v)
+	}
+}
+
+func (e *jsonEncDriver) EncodeRawExt(re *RawExt, en *Encoder) {
+	// only encodes re.Value (never re.Data)
+	if re.Value == nil {
+		e.w.writeb(jsonLiterals[9:13]) // null // e.EncodeNil()
+	} else {
+		en.encode(re.Value)
+	}
+}
+
+func (e *jsonEncDriver) EncodeArrayStart(length int) {
+	if e.d {
+		e.dl++
+	}
+	e.w.writen1('[')
+	e.c = containerArrayStart
+}
+
+func (e *jsonEncDriver) EncodeMapStart(length int) {
+	if e.d {
+		e.dl++
+	}
+	e.w.writen1('{')
+	e.c = containerMapStart
+}
+
+func (e *jsonEncDriver) EncodeString(c charEncoding, v string) {
+	// e.w.writestr(strconv.Quote(v))
+	e.quoteStr(v)
+}
+
+func (e *jsonEncDriver) EncodeSymbol(v string) {
+	// e.EncodeString(c_UTF8, v)
+	e.quoteStr(v)
+}
+
+func (e *jsonEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
+	// if encoding raw bytes and RawBytesExt is configured, use it to encode
+	if c == c_RAW && e.se.i != nil {
+		e.EncodeExt(v, 0, &e.se, e.e)
+		return
+	}
+	if c == c_RAW {
+		slen := base64.StdEncoding.EncodedLen(len(v))
+		if cap(e.bs) >= slen {
+			e.bs = e.bs[:slen]
+		} else {
+			e.bs = make([]byte, slen)
+		}
+		base64.StdEncoding.Encode(e.bs, v)
+		e.w.writen1('"')
+		e.w.writeb(e.bs)
+		e.w.writen1('"')
+	} else {
+		// e.EncodeString(c, string(v))
+		e.quoteStr(stringView(v))
+	}
+}
+
+func (e *jsonEncDriver) EncodeAsis(v []byte) {
+	e.w.writeb(v)
+}
+
+func (e *jsonEncDriver) quoteStr(s string) {
+	// adapted from std pkg encoding/json
+	const hex = "0123456789abcdef"
+	w := e.w
+	w.writen1('"')
+	start := 0
+	for i := 0; i < len(s); {
+		// encode all bytes < 0x20 (except \r, \n).
+		// also encode < > & to prevent security holes when served to some browsers.
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+				i++
+				continue
+			}
+			if start < i {
+				w.writestr(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				w.writen2('\\', b)
+			case '\n':
+				w.writen2('\\', 'n')
+			case '\r':
+				w.writen2('\\', 'r')
+			case '\b':
+				w.writen2('\\', 'b')
+			case '\f':
+				w.writen2('\\', 'f')
+			case '\t':
+				w.writen2('\\', 't')
+			case '<', '>', '&':
+				if e.h.HTMLCharsAsIs {
+					w.writen1(b)
+				} else {
+					w.writestr(`\u00`)
+					w.writen2(hex[b>>4], hex[b&0xF])
+				}
+			default:
+				w.writestr(`\u00`)
+				w.writen2(hex[b>>4], hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				w.writestr(s[start:i])
+			}
+			w.writestr(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR. U+2029 is PARAGRAPH SEPARATOR.
+		// Both technically valid JSON, but bomb on JSONP, so fix here unconditionally.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				w.writestr(s[start:i])
+			}
+			w.writestr(`\u202`)
+			w.writen1(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		w.writestr(s[start:])
+	}
+	w.writen1('"')
+}
+
+//--------------------------------
+
+type jsonNum struct {
+	// bytes            []byte // may have [+-.eE0-9]
+	mantissa         uint64 // where mantissa ends, and maybe dot begins.
+	exponent         int16  // exponent value.
+	manOverflow      bool
+	neg              bool // started with -. No initial sign in the bytes above.
+	dot              bool // has dot
+	explicitExponent bool // explicit exponent
+}
+
+func (x *jsonNum) reset() {
+	x.manOverflow = false
+	x.neg = false
+	x.dot = false
+	x.explicitExponent = false
+	x.mantissa = 0
+	x.exponent = 0
+}
+
+// uintExp is called only if exponent > 0.
+func (x *jsonNum) uintExp() (n uint64, overflow bool) {
+	n = x.mantissa
+	e := x.exponent
+	if e >= int16(len(jsonUint64Pow10)) {
+		overflow = true
+		return
+	}
+	n *= jsonUint64Pow10[e]
+	if n < x.mantissa || n > jsonNumUintMaxVal {
+		overflow = true
+		return
+	}
+	return
+	// for i := int16(0); i < e; i++ {
+	// 	if n >= jsonNumUintCutoff {
+	// 		overflow = true
+	// 		return
+	// 	}
+	// 	n *= 10
+	// }
+	// return
+}
+
+// these constants are only used withn floatVal.
+// They are brought out, so that floatVal can be inlined.
+const (
+	jsonUint64MantissaBits = 52
+	jsonMaxExponent        = int16(len(jsonFloat64Pow10)) - 1
+)
+
+func (x *jsonNum) floatVal() (f float64, parseUsingStrConv bool) {
+	// We do not want to lose precision.
+	// Consequently, we will delegate to strconv.ParseFloat if any of the following happen:
+	//    - There are more digits than in math.MaxUint64: 18446744073709551615 (20 digits)
+	//      We expect up to 99.... (19 digits)
+	//    - The mantissa cannot fit into a 52 bits of uint64
+	//    - The exponent is beyond our scope ie beyong 22.
+	parseUsingStrConv = x.manOverflow ||
+		x.exponent > jsonMaxExponent ||
+		(x.exponent < 0 && -(x.exponent) > jsonMaxExponent) ||
+		x.mantissa>>jsonUint64MantissaBits != 0
+
+	if parseUsingStrConv {
+		return
+	}
+
+	// all good. so handle parse here.
+	f = float64(x.mantissa)
+	// fmt.Printf(".Float: uint64 value: %v, float: %v\n", m, f)
+	if x.neg {
+		f = -f
+	}
+	if x.exponent > 0 {
+		f *= jsonFloat64Pow10[x.exponent]
+	} else if x.exponent < 0 {
+		f /= jsonFloat64Pow10[-x.exponent]
+	}
+	return
+}
+
+type jsonDecDriver struct {
+	noBuiltInTypes
+	d *Decoder
+	h *JsonHandle
+	r decReader
+
+	c containerState
+	// tok is used to store the token read right after skipWhiteSpace.
+	tok uint8
+
+	bstr [8]byte  // scratch used for string \UXXX parsing
+	b    [64]byte // scratch, used for parsing strings or numbers
+	b2   [64]byte // scratch, used only for decodeBytes (after base64)
+	bs   []byte   // scratch. Initialized from b. Used for parsing strings or numbers.
+
+	se setExtWrapper
+
+	n jsonNum
+}
+
+func jsonIsWS(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+}
+
+// // This will skip whitespace characters and return the next byte to read.
+// // The next byte determines what the value will be one of.
+// func (d *jsonDecDriver) skipWhitespace() {
+// 	// fast-path: do not enter loop. Just check first (in case no whitespace).
+// 	b := d.r.readn1()
+// 	if jsonIsWS(b) {
+// 		r := d.r
+// 		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+// 		}
+// 	}
+// 	d.tok = b
+// }
+
+func (d *jsonDecDriver) uncacheRead() {
+	if d.tok != 0 {
+		d.r.unreadn1()
+		d.tok = 0
+	}
+}
+
+func (d *jsonDecDriver) sendContainerState(c containerState) {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	var xc uint8 // char expected
+	if c == containerMapKey {
+		if d.c != containerMapStart {
+			xc = ','
+		}
+	} else if c == containerMapValue {
+		xc = ':'
+	} else if c == containerMapEnd {
+		xc = '}'
+	} else if c == containerArrayElem {
+		if d.c != containerArrayStart {
+			xc = ','
+		}
+	} else if c == containerArrayEnd {
+		xc = ']'
+	}
+	if xc != 0 {
+		if d.tok != xc {
+			d.d.errorf("json: expect char '%c' but got char '%c'", xc, d.tok)
+		}
+		d.tok = 0
+	}
+	d.c = c
+}
+
+func (d *jsonDecDriver) CheckBreak() bool {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if d.tok == '}' || d.tok == ']' {
+		// d.tok = 0 // only checking, not consuming
+		return true
+	}
+	return false
+}
+
+func (d *jsonDecDriver) readStrIdx(fromIdx, toIdx uint8) {
+	bs := d.r.readx(int(toIdx - fromIdx))
+	d.tok = 0
+	if jsonValidateSymbols {
+		if !bytes.Equal(bs, jsonLiterals[fromIdx:toIdx]) {
+			d.d.errorf("json: expecting %s: got %s", jsonLiterals[fromIdx:toIdx], bs)
+			return
+		}
+	}
+}
+
+func (d *jsonDecDriver) TryDecodeAsNil() bool {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if d.tok == 'n' {
+		d.readStrIdx(10, 13) // ull
+		return true
+	}
+	return false
+}
+
+func (d *jsonDecDriver) DecodeBool() bool {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if d.tok == 'f' {
+		d.readStrIdx(5, 9) // alse
+		return false
+	}
+	if d.tok == 't' {
+		d.readStrIdx(1, 4) // rue
+		return true
+	}
+	d.d.errorf("json: decode bool: got first char %c", d.tok)
+	return false // "unreachable"
+}
+
+func (d *jsonDecDriver) ReadMapStart() int {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if d.tok != '{' {
+		d.d.errorf("json: expect char '%c' but got char '%c'", '{', d.tok)
+	}
+	d.tok = 0
+	d.c = containerMapStart
+	return -1
+}
+
+func (d *jsonDecDriver) ReadArrayStart() int {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if d.tok != '[' {
+		d.d.errorf("json: expect char '%c' but got char '%c'", '[', d.tok)
+	}
+	d.tok = 0
+	d.c = containerArrayStart
+	return -1
+}
+
+func (d *jsonDecDriver) ContainerType() (vt valueType) {
+	// check container type by checking the first char
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	if b := d.tok; b == '{' {
+		return valueTypeMap
+	} else if b == '[' {
+		return valueTypeArray
+	} else if b == 'n' {
+		return valueTypeNil
+	} else if b == '"' {
+		return valueTypeString
+	}
+	return valueTypeUnset
+	// d.d.errorf("isContainerType: unsupported parameter: %v", vt)
+	// return false // "unreachable"
+}
+
+func (d *jsonDecDriver) decNum(storeBytes bool) {
+	// If it is has a . or an e|E, decode as a float; else decode as an int.
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	b := d.tok
+	var str bool
+	if b == '"' {
+		str = true
+		b = d.r.readn1()
+	}
+	if !(b == '+' || b == '-' || b == '.' || (b >= '0' && b <= '9')) {
+		d.d.errorf("json: decNum: got first char '%c'", b)
+		return
+	}
+	d.tok = 0
+
+	const cutoff = (1<<64-1)/uint64(10) + 1 // cutoff64(base)
+	const jsonNumUintMaxVal = 1<<uint64(64) - 1
+
+	n := &d.n
+	r := d.r
+	n.reset()
+	d.bs = d.bs[:0]
+
+	if str && storeBytes {
+		d.bs = append(d.bs, '"')
+	}
+
+	// The format of a number is as below:
+	// parsing:     sign? digit* dot? digit* e?  sign? digit*
+	// states:  0   1*    2      3*   4      5*  6     7
+	// We honor this state so we can break correctly.
+	var state uint8 = 0
+	var eNeg bool
+	var e int16
+	var eof bool
+LOOP:
+	for !eof {
+		// fmt.Printf("LOOP: b: %q\n", b)
+		switch b {
+		case '+':
+			switch state {
+			case 0:
+				state = 2
+				if storeBytes {
+					d.bs = append(d.bs, b)
+				}
+				b, eof = r.readn1eof()
+				continue
+			case 6: // typ = jsonNumFloat
+				state = 7
+			default:
+				break LOOP
+			}
+		case '-':
+			switch state {
+			case 0:
+				state = 2
+				n.neg = true
+				if storeBytes {
+					d.bs = append(d.bs, b)
+				}
+				b, eof = r.readn1eof()
+				continue
+			case 6: // typ = jsonNumFloat
+				eNeg = true
+				state = 7
+			default:
+				break LOOP
+			}
+		case '.':
+			switch state {
+			case 0, 2: // typ = jsonNumFloat
+				state = 4
+				n.dot = true
+			default:
+				break LOOP
+			}
+		case 'e', 'E':
+			switch state {
+			case 0, 2, 4: // typ = jsonNumFloat
+				state = 6
+				// n.mantissaEndIndex = int16(len(n.bytes))
+				n.explicitExponent = true
+			default:
+				break LOOP
+			}
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			switch state {
+			case 0:
+				state = 2
+				fallthrough
+			case 2:
+				fallthrough
+			case 4:
+				if n.dot {
+					n.exponent--
+				}
+				if n.mantissa >= jsonNumUintCutoff {
+					n.manOverflow = true
+					break
+				}
+				v := uint64(b - '0')
+				n.mantissa *= 10
+				if v != 0 {
+					n1 := n.mantissa + v
+					if n1 < n.mantissa || n1 > jsonNumUintMaxVal {
+						n.manOverflow = true // n+v overflows
+						break
+					}
+					n.mantissa = n1
+				}
+			case 6:
+				state = 7
+				fallthrough
+			case 7:
+				if !(b == '0' && e == 0) {
+					e = e*10 + int16(b-'0')
+				}
+			default:
+				break LOOP
+			}
+		case '"':
+			if str {
+				if storeBytes {
+					d.bs = append(d.bs, '"')
+				}
+				b, eof = r.readn1eof()
+			}
+			break LOOP
+		default:
+			break LOOP
+		}
+		if storeBytes {
+			d.bs = append(d.bs, b)
+		}
+		b, eof = r.readn1eof()
+	}
+
+	if jsonTruncateMantissa && n.mantissa != 0 {
+		for n.mantissa%10 == 0 {
+			n.mantissa /= 10
+			n.exponent++
+		}
+	}
+
+	if e != 0 {
+		if eNeg {
+			n.exponent -= e
+		} else {
+			n.exponent += e
+		}
+	}
+
+	// d.n = n
+
+	if !eof {
+		if jsonUnreadAfterDecNum {
+			r.unreadn1()
+		} else {
+			if !jsonIsWS(b) {
+				d.tok = b
+			}
+		}
+	}
+	// fmt.Printf("1: n: bytes: %s, neg: %v, dot: %v, exponent: %v, mantissaEndIndex: %v\n",
+	// 	n.bytes, n.neg, n.dot, n.exponent, n.mantissaEndIndex)
+	return
+}
+
+func (d *jsonDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	d.decNum(false)
+	n := &d.n
+	if n.manOverflow {
+		d.d.errorf("json: overflow integer after: %v", n.mantissa)
+		return
+	}
+	var u uint64
+	if n.exponent == 0 {
+		u = n.mantissa
+	} else if n.exponent < 0 {
+		d.d.errorf("json: fractional integer")
+		return
+	} else if n.exponent > 0 {
+		var overflow bool
+		if u, overflow = n.uintExp(); overflow {
+			d.d.errorf("json: overflow integer")
+			return
+		}
+	}
+	i = int64(u)
+	if n.neg {
+		i = -i
+	}
+	if chkOvf.Int(i, bitsize) {
+		d.d.errorf("json: overflow %v bits: %s", bitsize, d.bs)
+		return
+	}
+	// fmt.Printf("DecodeInt: %v\n", i)
+	return
+}
+
+// floatVal MUST only be called after a decNum, as d.bs now contains the bytes of the number
+func (d *jsonDecDriver) floatVal() (f float64) {
+	f, useStrConv := d.n.floatVal()
+	if useStrConv {
+		var err error
+		if f, err = strconv.ParseFloat(stringView(d.bs), 64); err != nil {
+			panic(fmt.Errorf("parse float: %s, %v", d.bs, err))
+		}
+		if d.n.neg {
+			f = -f
+		}
+	}
+	return
+}
+
+func (d *jsonDecDriver) DecodeUint(bitsize uint8) (u uint64) {
+	d.decNum(false)
+	n := &d.n
+	if n.neg {
+		d.d.errorf("json: unsigned integer cannot be negative")
+		return
+	}
+	if n.manOverflow {
+		d.d.errorf("json: overflow integer after: %v", n.mantissa)
+		return
+	}
+	if n.exponent == 0 {
+		u = n.mantissa
+	} else if n.exponent < 0 {
+		d.d.errorf("json: fractional integer")
+		return
+	} else if n.exponent > 0 {
+		var overflow bool
+		if u, overflow = n.uintExp(); overflow {
+			d.d.errorf("json: overflow integer")
+			return
+		}
+	}
+	if chkOvf.Uint(u, bitsize) {
+		d.d.errorf("json: overflow %v bits: %s", bitsize, d.bs)
+		return
+	}
+	// fmt.Printf("DecodeUint: %v\n", u)
+	return
+}
+
+func (d *jsonDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	d.decNum(true)
+	f = d.floatVal()
+	if chkOverflow32 && chkOvf.Float32(f) {
+		d.d.errorf("json: overflow float32: %v, %s", f, d.bs)
+		return
+	}
+	return
+}
+
+func (d *jsonDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	if ext == nil {
+		re := rv.(*RawExt)
+		re.Tag = xtag
+		d.d.decode(&re.Value)
+	} else {
+		var v interface{}
+		d.d.decode(&v)
+		ext.UpdateExt(rv, v)
+	}
+	return
+}
+
+func (d *jsonDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+	// if decoding into raw bytes, and the RawBytesExt is configured, use it to decode.
+	if !isstring && d.se.i != nil {
+		bsOut = bs
+		d.DecodeExt(&bsOut, 0, &d.se)
+		return
+	}
+	d.appendStringAsBytes()
+	// if isstring, then just return the bytes, even if it is using the scratch buffer.
+	// the bytes will be converted to a string as needed.
+	if isstring {
+		return d.bs
+	}
+	// if appendStringAsBytes returned a zero-len slice, then treat as nil.
+	// This should only happen for null, and "".
+	if len(d.bs) == 0 {
+		return nil
+	}
+	bs0 := d.bs
+	slen := base64.StdEncoding.DecodedLen(len(bs0))
+	if slen <= cap(bs) {
+		bsOut = bs[:slen]
+	} else if zerocopy && slen <= cap(d.b2) {
+		bsOut = d.b2[:slen]
+	} else {
+		bsOut = make([]byte, slen)
+	}
+	slen2, err := base64.StdEncoding.Decode(bsOut, bs0)
+	if err != nil {
+		d.d.errorf("json: error decoding base64 binary '%s': %v", bs0, err)
+		return nil
+	}
+	if slen != slen2 {
+		bsOut = bsOut[:slen2]
+	}
+	return
+}
+
+func (d *jsonDecDriver) DecodeString() (s string) {
+	d.appendStringAsBytes()
+	// if x := d.s.sc; x != nil && x.so && x.st == '}' { // map key
+	if d.c == containerMapKey {
+		return d.d.string(d.bs)
+	}
+	return string(d.bs)
+}
+
+func (d *jsonDecDriver) appendStringAsBytes() {
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+
+	if d.tok != '"' {
+		// d.d.errorf("json: expect char '%c' but got char '%c'", '"', d.tok)
+		// handle non-string scalar: null, true, false or a number
+		switch d.tok {
+		case 'n':
+			d.readStrIdx(10, 13) // ull
+			d.bs = d.bs[:0]
+		case 'f':
+			d.readStrIdx(5, 9) // alse
+			d.bs = d.bs[:5]
+			copy(d.bs, "false")
+		case 't':
+			d.readStrIdx(1, 4) // rue
+			d.bs = d.bs[:4]
+			copy(d.bs, "true")
+		default:
+			// try to parse a valid number
+			d.decNum(true)
+		}
+		return
+	}
+
+	d.tok = 0
+
+	v := d.bs[:0]
+	var c uint8
+	r := d.r
+	for {
+		c = r.readn1()
+		if c == '"' {
+			break
+		} else if c == '\\' {
+			c = r.readn1()
+			switch c {
+			case '"', '\\', '/', '\'':
+				v = append(v, c)
+			case 'b':
+				v = append(v, '\b')
+			case 'f':
+				v = append(v, '\f')
+			case 'n':
+				v = append(v, '\n')
+			case 'r':
+				v = append(v, '\r')
+			case 't':
+				v = append(v, '\t')
+			case 'u':
+				rr := d.jsonU4(false)
+				// fmt.Printf("$$$$$$$$$: is surrogate: %v\n", utf16.IsSurrogate(rr))
+				if utf16.IsSurrogate(rr) {
+					rr = utf16.DecodeRune(rr, d.jsonU4(true))
+				}
+				w2 := utf8.EncodeRune(d.bstr[:], rr)
+				v = append(v, d.bstr[:w2]...)
+			default:
+				d.d.errorf("json: unsupported escaped value: %c", c)
+			}
+		} else {
+			v = append(v, c)
+		}
+	}
+	d.bs = v
+}
+
+func (d *jsonDecDriver) jsonU4(checkSlashU bool) rune {
+	r := d.r
+	if checkSlashU && !(r.readn1() == '\\' && r.readn1() == 'u') {
+		d.d.errorf(`json: unquoteStr: invalid unicode sequence. Expecting \u`)
+		return 0
+	}
+	// u, _ := strconv.ParseUint(string(d.bstr[:4]), 16, 64)
+	var u uint32
+	for i := 0; i < 4; i++ {
+		v := r.readn1()
+		if '0' <= v && v <= '9' {
+			v = v - '0'
+		} else if 'a' <= v && v <= 'z' {
+			v = v - 'a' + 10
+		} else if 'A' <= v && v <= 'Z' {
+			v = v - 'A' + 10
+		} else {
+			d.d.errorf(`json: unquoteStr: invalid hex char in \u unicode sequence: %q`, v)
+			return 0
+		}
+		u = u*16 + uint32(v)
+	}
+	return rune(u)
+}
+
+func (d *jsonDecDriver) DecodeNaked() {
+	z := &d.d.n
+	// var decodeFurther bool
+
+	if d.tok == 0 {
+		var b byte
+		r := d.r
+		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
+		}
+		d.tok = b
+	}
+	switch d.tok {
+	case 'n':
+		d.readStrIdx(10, 13) // ull
+		z.v = valueTypeNil
+	case 'f':
+		d.readStrIdx(5, 9) // alse
+		z.v = valueTypeBool
+		z.b = false
+	case 't':
+		d.readStrIdx(1, 4) // rue
+		z.v = valueTypeBool
+		z.b = true
+	case '{':
+		z.v = valueTypeMap
+		// d.tok = 0 // don't consume. kInterfaceNaked will call ReadMapStart
+		// decodeFurther = true
+	case '[':
+		z.v = valueTypeArray
+		// d.tok = 0 // don't consume. kInterfaceNaked will call ReadArrayStart
+		// decodeFurther = true
+	case '"':
+		z.v = valueTypeString
+		z.s = d.DecodeString()
+	default: // number
+		d.decNum(true)
+		n := &d.n
+		// if the string had a any of [.eE], then decode as float.
+		switch {
+		case n.explicitExponent, n.dot, n.exponent < 0, n.manOverflow:
+			z.v = valueTypeFloat
+			z.f = d.floatVal()
+		case n.exponent == 0:
+			u := n.mantissa
+			switch {
+			case n.neg:
+				z.v = valueTypeInt
+				z.i = -int64(u)
+			case d.h.SignedInteger:
+				z.v = valueTypeInt
+				z.i = int64(u)
+			default:
+				z.v = valueTypeUint
+				z.u = u
+			}
+		default:
+			u, overflow := n.uintExp()
+			switch {
+			case overflow:
+				z.v = valueTypeFloat
+				z.f = d.floatVal()
+			case n.neg:
+				z.v = valueTypeInt
+				z.i = -int64(u)
+			case d.h.SignedInteger:
+				z.v = valueTypeInt
+				z.i = int64(u)
+			default:
+				z.v = valueTypeUint
+				z.u = u
+			}
+		}
+		// fmt.Printf("DecodeNaked: Number: %T, %v\n", v, v)
+	}
+	// if decodeFurther {
+	// 	d.s.sc.retryRead()
+	// }
+	return
+}
+
+//----------------------
+
+// JsonHandle is a handle for JSON encoding format.
+//
+// Json is comprehensively supported:
+//    - decodes numbers into interface{} as int, uint or float64
+//    - configurable way to encode/decode []byte .
+//      by default, encodes and decodes []byte using base64 Std Encoding
+//    - UTF-8 support for encoding and decoding
+//
+// It has better performance than the json library in the standard library,
+// by leveraging the performance improvements of the codec library and
+// minimizing allocations.
+//
+// In addition, it doesn't read more bytes than necessary during a decode, which allows
+// reading multiple values from a stream containing json and non-json content.
+// For example, a user can read a json value, then a cbor value, then a msgpack value,
+// all from the same stream in sequence.
+type JsonHandle struct {
+	textEncodingType
+	BasicHandle
+
+	// RawBytesExt, if configured, is used to encode and decode raw bytes in a custom way.
+	// If not configured, raw bytes are encoded to/from base64 text.
+	RawBytesExt InterfaceExt
+
+	// Indent indicates how a value is encoded.
+	//   - If positive, indent by that number of spaces.
+	//   - If negative, indent by that number of tabs.
+	Indent int8
+
+	// IntegerAsString controls how integers (signed and unsigned) are encoded.
+	//
+	// Per the JSON Spec, JSON numbers are 64-bit floating point numbers.
+	// Consequently, integers > 2^53 cannot be represented as a JSON number without losing precision.
+	// This can be mitigated by configuring how to encode integers.
+	//
+	// IntegerAsString interpretes the following values:
+	//   - if 'L', then encode integers > 2^53 as a json string.
+	//   - if 'A', then encode all integers as a json string
+	//             containing the exact integer representation as a decimal.
+	//   - else    encode all integers as a json number (default)
+	IntegerAsString uint8
+
+	// HTMLCharsAsIs controls how to encode some special characters to html: < > &
+	//
+	// By default, we encode them as \uXXX
+	// to prevent security holes when served from some browsers.
+	HTMLCharsAsIs bool
+}
+
+func (h *JsonHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{i: ext})
+}
+
+func (h *JsonHandle) newEncDriver(e *Encoder) encDriver {
+	hd := jsonEncDriver{e: e, h: h}
+	hd.bs = hd.b[:0]
+
+	hd.reset()
+
+	return &hd
+}
+
+func (h *JsonHandle) newDecDriver(d *Decoder) decDriver {
+	// d := jsonDecDriver{r: r.(*bytesDecReader), h: h}
+	hd := jsonDecDriver{d: d, h: h}
+	hd.bs = hd.b[:0]
+	hd.reset()
+	return &hd
+}
+
+func (e *jsonEncDriver) reset() {
+	e.w = e.e.w
+	e.se.i = e.h.RawBytesExt
+	if e.bs != nil {
+		e.bs = e.bs[:0]
+	}
+	e.d, e.dt, e.dl, e.ds = false, false, 0, ""
+	e.c = 0
+	if e.h.Indent > 0 {
+		e.d = true
+		e.ds = jsonSpaces[:e.h.Indent]
+	} else if e.h.Indent < 0 {
+		e.d = true
+		e.dt = true
+		e.ds = jsonTabs[:-(e.h.Indent)]
+	}
+}
+
+func (d *jsonDecDriver) reset() {
+	d.r = d.d.r
+	d.se.i = d.h.RawBytesExt
+	if d.bs != nil {
+		d.bs = d.bs[:0]
+	}
+	d.c, d.tok = 0, 0
+	d.n.reset()
+}
+
+var jsonEncodeTerminate = []byte{' '}
+
+func (h *JsonHandle) rpcEncodeTerminate() []byte {
+	return jsonEncodeTerminate
+}
+
+var _ decDriver = (*jsonDecDriver)(nil)
+var _ encDriver = (*jsonEncDriver)(nil)

--- a/vendor/github.com/ugorji/go/codec/msgpack.go
+++ b/vendor/github.com/ugorji/go/codec/msgpack.go
@@ -1,0 +1,861 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+/*
+MSGPACK
+
+Msgpack-c implementation powers the c, c++, python, ruby, etc libraries.
+We need to maintain compatibility with it and how it encodes integer values
+without caring about the type.
+
+For compatibility with behaviour of msgpack-c reference implementation:
+  - Go intX (>0) and uintX
+       IS ENCODED AS
+    msgpack +ve fixnum, unsigned
+  - Go intX (<0)
+       IS ENCODED AS
+    msgpack -ve fixnum, signed
+
+*/
+package codec
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net/rpc"
+	"reflect"
+)
+
+const (
+	mpPosFixNumMin byte = 0x00
+	mpPosFixNumMax      = 0x7f
+	mpFixMapMin         = 0x80
+	mpFixMapMax         = 0x8f
+	mpFixArrayMin       = 0x90
+	mpFixArrayMax       = 0x9f
+	mpFixStrMin         = 0xa0
+	mpFixStrMax         = 0xbf
+	mpNil               = 0xc0
+	_                   = 0xc1
+	mpFalse             = 0xc2
+	mpTrue              = 0xc3
+	mpFloat             = 0xca
+	mpDouble            = 0xcb
+	mpUint8             = 0xcc
+	mpUint16            = 0xcd
+	mpUint32            = 0xce
+	mpUint64            = 0xcf
+	mpInt8              = 0xd0
+	mpInt16             = 0xd1
+	mpInt32             = 0xd2
+	mpInt64             = 0xd3
+
+	// extensions below
+	mpBin8     = 0xc4
+	mpBin16    = 0xc5
+	mpBin32    = 0xc6
+	mpExt8     = 0xc7
+	mpExt16    = 0xc8
+	mpExt32    = 0xc9
+	mpFixExt1  = 0xd4
+	mpFixExt2  = 0xd5
+	mpFixExt4  = 0xd6
+	mpFixExt8  = 0xd7
+	mpFixExt16 = 0xd8
+
+	mpStr8  = 0xd9 // new
+	mpStr16 = 0xda
+	mpStr32 = 0xdb
+
+	mpArray16 = 0xdc
+	mpArray32 = 0xdd
+
+	mpMap16 = 0xde
+	mpMap32 = 0xdf
+
+	mpNegFixNumMin = 0xe0
+	mpNegFixNumMax = 0xff
+)
+
+// MsgpackSpecRpcMultiArgs is a special type which signifies to the MsgpackSpecRpcCodec
+// that the backend RPC service takes multiple arguments, which have been arranged
+// in sequence in the slice.
+//
+// The Codec then passes it AS-IS to the rpc service (without wrapping it in an
+// array of 1 element).
+type MsgpackSpecRpcMultiArgs []interface{}
+
+// A MsgpackContainer type specifies the different types of msgpackContainers.
+type msgpackContainerType struct {
+	fixCutoff                   int
+	bFixMin, b8, b16, b32       byte
+	hasFixMin, has8, has8Always bool
+}
+
+var (
+	msgpackContainerStr  = msgpackContainerType{32, mpFixStrMin, mpStr8, mpStr16, mpStr32, true, true, false}
+	msgpackContainerBin  = msgpackContainerType{0, 0, mpBin8, mpBin16, mpBin32, false, true, true}
+	msgpackContainerList = msgpackContainerType{16, mpFixArrayMin, 0, mpArray16, mpArray32, true, false, false}
+	msgpackContainerMap  = msgpackContainerType{16, mpFixMapMin, 0, mpMap16, mpMap32, true, false, false}
+)
+
+//---------------------------------------------
+
+type msgpackEncDriver struct {
+	noBuiltInTypes
+	encNoSeparator
+	e *Encoder
+	w encWriter
+	h *MsgpackHandle
+	x [8]byte
+}
+
+func (e *msgpackEncDriver) EncodeNil() {
+	e.w.writen1(mpNil)
+}
+
+func (e *msgpackEncDriver) EncodeInt(i int64) {
+	if i >= 0 {
+		e.EncodeUint(uint64(i))
+	} else if i >= -32 {
+		e.w.writen1(byte(i))
+	} else if i >= math.MinInt8 {
+		e.w.writen2(mpInt8, byte(i))
+	} else if i >= math.MinInt16 {
+		e.w.writen1(mpInt16)
+		bigenHelper{e.x[:2], e.w}.writeUint16(uint16(i))
+	} else if i >= math.MinInt32 {
+		e.w.writen1(mpInt32)
+		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(i))
+	} else {
+		e.w.writen1(mpInt64)
+		bigenHelper{e.x[:8], e.w}.writeUint64(uint64(i))
+	}
+}
+
+func (e *msgpackEncDriver) EncodeUint(i uint64) {
+	if i <= math.MaxInt8 {
+		e.w.writen1(byte(i))
+	} else if i <= math.MaxUint8 {
+		e.w.writen2(mpUint8, byte(i))
+	} else if i <= math.MaxUint16 {
+		e.w.writen1(mpUint16)
+		bigenHelper{e.x[:2], e.w}.writeUint16(uint16(i))
+	} else if i <= math.MaxUint32 {
+		e.w.writen1(mpUint32)
+		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(i))
+	} else {
+		e.w.writen1(mpUint64)
+		bigenHelper{e.x[:8], e.w}.writeUint64(uint64(i))
+	}
+}
+
+func (e *msgpackEncDriver) EncodeBool(b bool) {
+	if b {
+		e.w.writen1(mpTrue)
+	} else {
+		e.w.writen1(mpFalse)
+	}
+}
+
+func (e *msgpackEncDriver) EncodeFloat32(f float32) {
+	e.w.writen1(mpFloat)
+	bigenHelper{e.x[:4], e.w}.writeUint32(math.Float32bits(f))
+}
+
+func (e *msgpackEncDriver) EncodeFloat64(f float64) {
+	e.w.writen1(mpDouble)
+	bigenHelper{e.x[:8], e.w}.writeUint64(math.Float64bits(f))
+}
+
+func (e *msgpackEncDriver) EncodeExt(v interface{}, xtag uint64, ext Ext, _ *Encoder) {
+	bs := ext.WriteExt(v)
+	if bs == nil {
+		e.EncodeNil()
+		return
+	}
+	if e.h.WriteExt {
+		e.encodeExtPreamble(uint8(xtag), len(bs))
+		e.w.writeb(bs)
+	} else {
+		e.EncodeStringBytes(c_RAW, bs)
+	}
+}
+
+func (e *msgpackEncDriver) EncodeRawExt(re *RawExt, _ *Encoder) {
+	e.encodeExtPreamble(uint8(re.Tag), len(re.Data))
+	e.w.writeb(re.Data)
+}
+
+func (e *msgpackEncDriver) encodeExtPreamble(xtag byte, l int) {
+	if l == 1 {
+		e.w.writen2(mpFixExt1, xtag)
+	} else if l == 2 {
+		e.w.writen2(mpFixExt2, xtag)
+	} else if l == 4 {
+		e.w.writen2(mpFixExt4, xtag)
+	} else if l == 8 {
+		e.w.writen2(mpFixExt8, xtag)
+	} else if l == 16 {
+		e.w.writen2(mpFixExt16, xtag)
+	} else if l < 256 {
+		e.w.writen2(mpExt8, byte(l))
+		e.w.writen1(xtag)
+	} else if l < 65536 {
+		e.w.writen1(mpExt16)
+		bigenHelper{e.x[:2], e.w}.writeUint16(uint16(l))
+		e.w.writen1(xtag)
+	} else {
+		e.w.writen1(mpExt32)
+		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(l))
+		e.w.writen1(xtag)
+	}
+}
+
+func (e *msgpackEncDriver) EncodeArrayStart(length int) {
+	e.writeContainerLen(msgpackContainerList, length)
+}
+
+func (e *msgpackEncDriver) EncodeMapStart(length int) {
+	e.writeContainerLen(msgpackContainerMap, length)
+}
+
+func (e *msgpackEncDriver) EncodeString(c charEncoding, s string) {
+	if c == c_RAW && e.h.WriteExt {
+		e.writeContainerLen(msgpackContainerBin, len(s))
+	} else {
+		e.writeContainerLen(msgpackContainerStr, len(s))
+	}
+	if len(s) > 0 {
+		e.w.writestr(s)
+	}
+}
+
+func (e *msgpackEncDriver) EncodeSymbol(v string) {
+	e.EncodeString(c_UTF8, v)
+}
+
+func (e *msgpackEncDriver) EncodeStringBytes(c charEncoding, bs []byte) {
+	if c == c_RAW && e.h.WriteExt {
+		e.writeContainerLen(msgpackContainerBin, len(bs))
+	} else {
+		e.writeContainerLen(msgpackContainerStr, len(bs))
+	}
+	if len(bs) > 0 {
+		e.w.writeb(bs)
+	}
+}
+
+func (e *msgpackEncDriver) writeContainerLen(ct msgpackContainerType, l int) {
+	if ct.hasFixMin && l < ct.fixCutoff {
+		e.w.writen1(ct.bFixMin | byte(l))
+	} else if ct.has8 && l < 256 && (ct.has8Always || e.h.WriteExt) {
+		e.w.writen2(ct.b8, uint8(l))
+	} else if l < 65536 {
+		e.w.writen1(ct.b16)
+		bigenHelper{e.x[:2], e.w}.writeUint16(uint16(l))
+	} else {
+		e.w.writen1(ct.b32)
+		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(l))
+	}
+}
+
+//---------------------------------------------
+
+type msgpackDecDriver struct {
+	d      *Decoder
+	r      decReader // *Decoder decReader decReaderT
+	h      *MsgpackHandle
+	b      [scratchByteArrayLen]byte
+	bd     byte
+	bdRead bool
+	br     bool // bytes reader
+	noBuiltInTypes
+	noStreamingCodec
+	decNoSeparator
+}
+
+// Note: This returns either a primitive (int, bool, etc) for non-containers,
+// or a containerType, or a specific type denoting nil or extension.
+// It is called when a nil interface{} is passed, leaving it up to the DecDriver
+// to introspect the stream and decide how best to decode.
+// It deciphers the value by looking at the stream first.
+func (d *msgpackDecDriver) DecodeNaked() {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	bd := d.bd
+	n := &d.d.n
+	var decodeFurther bool
+
+	switch bd {
+	case mpNil:
+		n.v = valueTypeNil
+		d.bdRead = false
+	case mpFalse:
+		n.v = valueTypeBool
+		n.b = false
+	case mpTrue:
+		n.v = valueTypeBool
+		n.b = true
+
+	case mpFloat:
+		n.v = valueTypeFloat
+		n.f = float64(math.Float32frombits(bigen.Uint32(d.r.readx(4))))
+	case mpDouble:
+		n.v = valueTypeFloat
+		n.f = math.Float64frombits(bigen.Uint64(d.r.readx(8)))
+
+	case mpUint8:
+		n.v = valueTypeUint
+		n.u = uint64(d.r.readn1())
+	case mpUint16:
+		n.v = valueTypeUint
+		n.u = uint64(bigen.Uint16(d.r.readx(2)))
+	case mpUint32:
+		n.v = valueTypeUint
+		n.u = uint64(bigen.Uint32(d.r.readx(4)))
+	case mpUint64:
+		n.v = valueTypeUint
+		n.u = uint64(bigen.Uint64(d.r.readx(8)))
+
+	case mpInt8:
+		n.v = valueTypeInt
+		n.i = int64(int8(d.r.readn1()))
+	case mpInt16:
+		n.v = valueTypeInt
+		n.i = int64(int16(bigen.Uint16(d.r.readx(2))))
+	case mpInt32:
+		n.v = valueTypeInt
+		n.i = int64(int32(bigen.Uint32(d.r.readx(4))))
+	case mpInt64:
+		n.v = valueTypeInt
+		n.i = int64(int64(bigen.Uint64(d.r.readx(8))))
+
+	default:
+		switch {
+		case bd >= mpPosFixNumMin && bd <= mpPosFixNumMax:
+			// positive fixnum (always signed)
+			n.v = valueTypeInt
+			n.i = int64(int8(bd))
+		case bd >= mpNegFixNumMin && bd <= mpNegFixNumMax:
+			// negative fixnum
+			n.v = valueTypeInt
+			n.i = int64(int8(bd))
+		case bd == mpStr8, bd == mpStr16, bd == mpStr32, bd >= mpFixStrMin && bd <= mpFixStrMax:
+			if d.h.RawToString {
+				n.v = valueTypeString
+				n.s = d.DecodeString()
+			} else {
+				n.v = valueTypeBytes
+				n.l = d.DecodeBytes(nil, false, false)
+			}
+		case bd == mpBin8, bd == mpBin16, bd == mpBin32:
+			n.v = valueTypeBytes
+			n.l = d.DecodeBytes(nil, false, false)
+		case bd == mpArray16, bd == mpArray32, bd >= mpFixArrayMin && bd <= mpFixArrayMax:
+			n.v = valueTypeArray
+			decodeFurther = true
+		case bd == mpMap16, bd == mpMap32, bd >= mpFixMapMin && bd <= mpFixMapMax:
+			n.v = valueTypeMap
+			decodeFurther = true
+		case bd >= mpFixExt1 && bd <= mpFixExt16, bd >= mpExt8 && bd <= mpExt32:
+			n.v = valueTypeExt
+			clen := d.readExtLen()
+			n.u = uint64(d.r.readn1())
+			n.l = d.r.readx(clen)
+		default:
+			d.d.errorf("Nil-Deciphered DecodeValue: %s: hex: %x, dec: %d", msgBadDesc, bd, bd)
+		}
+	}
+	if !decodeFurther {
+		d.bdRead = false
+	}
+	if n.v == valueTypeUint && d.h.SignedInteger {
+		n.v = valueTypeInt
+		n.i = int64(n.u)
+	}
+	return
+}
+
+// int can be decoded from msgpack type: intXXX or uintXXX
+func (d *msgpackDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	switch d.bd {
+	case mpUint8:
+		i = int64(uint64(d.r.readn1()))
+	case mpUint16:
+		i = int64(uint64(bigen.Uint16(d.r.readx(2))))
+	case mpUint32:
+		i = int64(uint64(bigen.Uint32(d.r.readx(4))))
+	case mpUint64:
+		i = int64(bigen.Uint64(d.r.readx(8)))
+	case mpInt8:
+		i = int64(int8(d.r.readn1()))
+	case mpInt16:
+		i = int64(int16(bigen.Uint16(d.r.readx(2))))
+	case mpInt32:
+		i = int64(int32(bigen.Uint32(d.r.readx(4))))
+	case mpInt64:
+		i = int64(bigen.Uint64(d.r.readx(8)))
+	default:
+		switch {
+		case d.bd >= mpPosFixNumMin && d.bd <= mpPosFixNumMax:
+			i = int64(int8(d.bd))
+		case d.bd >= mpNegFixNumMin && d.bd <= mpNegFixNumMax:
+			i = int64(int8(d.bd))
+		default:
+			d.d.errorf("Unhandled single-byte unsigned integer value: %s: %x", msgBadDesc, d.bd)
+			return
+		}
+	}
+	// check overflow (logic adapted from std pkg reflect/value.go OverflowUint()
+	if bitsize > 0 {
+		if trunc := (i << (64 - bitsize)) >> (64 - bitsize); i != trunc {
+			d.d.errorf("Overflow int value: %v", i)
+			return
+		}
+	}
+	d.bdRead = false
+	return
+}
+
+// uint can be decoded from msgpack type: intXXX or uintXXX
+func (d *msgpackDecDriver) DecodeUint(bitsize uint8) (ui uint64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	switch d.bd {
+	case mpUint8:
+		ui = uint64(d.r.readn1())
+	case mpUint16:
+		ui = uint64(bigen.Uint16(d.r.readx(2)))
+	case mpUint32:
+		ui = uint64(bigen.Uint32(d.r.readx(4)))
+	case mpUint64:
+		ui = bigen.Uint64(d.r.readx(8))
+	case mpInt8:
+		if i := int64(int8(d.r.readn1())); i >= 0 {
+			ui = uint64(i)
+		} else {
+			d.d.errorf("Assigning negative signed value: %v, to unsigned type", i)
+			return
+		}
+	case mpInt16:
+		if i := int64(int16(bigen.Uint16(d.r.readx(2)))); i >= 0 {
+			ui = uint64(i)
+		} else {
+			d.d.errorf("Assigning negative signed value: %v, to unsigned type", i)
+			return
+		}
+	case mpInt32:
+		if i := int64(int32(bigen.Uint32(d.r.readx(4)))); i >= 0 {
+			ui = uint64(i)
+		} else {
+			d.d.errorf("Assigning negative signed value: %v, to unsigned type", i)
+			return
+		}
+	case mpInt64:
+		if i := int64(bigen.Uint64(d.r.readx(8))); i >= 0 {
+			ui = uint64(i)
+		} else {
+			d.d.errorf("Assigning negative signed value: %v, to unsigned type", i)
+			return
+		}
+	default:
+		switch {
+		case d.bd >= mpPosFixNumMin && d.bd <= mpPosFixNumMax:
+			ui = uint64(d.bd)
+		case d.bd >= mpNegFixNumMin && d.bd <= mpNegFixNumMax:
+			d.d.errorf("Assigning negative signed value: %v, to unsigned type", int(d.bd))
+			return
+		default:
+			d.d.errorf("Unhandled single-byte unsigned integer value: %s: %x", msgBadDesc, d.bd)
+			return
+		}
+	}
+	// check overflow (logic adapted from std pkg reflect/value.go OverflowUint()
+	if bitsize > 0 {
+		if trunc := (ui << (64 - bitsize)) >> (64 - bitsize); ui != trunc {
+			d.d.errorf("Overflow uint value: %v", ui)
+			return
+		}
+	}
+	d.bdRead = false
+	return
+}
+
+// float can either be decoded from msgpack type: float, double or intX
+func (d *msgpackDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == mpFloat {
+		f = float64(math.Float32frombits(bigen.Uint32(d.r.readx(4))))
+	} else if d.bd == mpDouble {
+		f = math.Float64frombits(bigen.Uint64(d.r.readx(8)))
+	} else {
+		f = float64(d.DecodeInt(0))
+	}
+	if chkOverflow32 && chkOvf.Float32(f) {
+		d.d.errorf("msgpack: float32 overflow: %v", f)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+// bool can be decoded from bool, fixnum 0 or 1.
+func (d *msgpackDecDriver) DecodeBool() (b bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == mpFalse || d.bd == 0 {
+		// b = false
+	} else if d.bd == mpTrue || d.bd == 1 {
+		b = true
+	} else {
+		d.d.errorf("Invalid single-byte value for bool: %s: %x", msgBadDesc, d.bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *msgpackDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	var clen int
+	// ignore isstring. Expect that the bytes may be found from msgpackContainerStr or msgpackContainerBin
+	if bd := d.bd; bd == mpBin8 || bd == mpBin16 || bd == mpBin32 {
+		clen = d.readContainerLen(msgpackContainerBin)
+	} else {
+		clen = d.readContainerLen(msgpackContainerStr)
+	}
+	// println("DecodeBytes: clen: ", clen)
+	d.bdRead = false
+	// bytes may be nil, so handle it. if nil, clen=-1.
+	if clen < 0 {
+		return nil
+	}
+	if zerocopy {
+		if d.br {
+			return d.r.readx(clen)
+		} else if len(bs) == 0 {
+			bs = d.b[:]
+		}
+	}
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
+}
+
+func (d *msgpackDecDriver) DecodeString() (s string) {
+	return string(d.DecodeBytes(d.b[:], true, true))
+}
+
+func (d *msgpackDecDriver) readNextBd() {
+	d.bd = d.r.readn1()
+	d.bdRead = true
+}
+
+func (d *msgpackDecDriver) uncacheRead() {
+	if d.bdRead {
+		d.r.unreadn1()
+		d.bdRead = false
+	}
+}
+
+func (d *msgpackDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	bd := d.bd
+	if bd == mpNil {
+		return valueTypeNil
+	} else if bd == mpBin8 || bd == mpBin16 || bd == mpBin32 ||
+		(!d.h.RawToString &&
+			(bd == mpStr8 || bd == mpStr16 || bd == mpStr32 || (bd >= mpFixStrMin && bd <= mpFixStrMax))) {
+		return valueTypeBytes
+	} else if d.h.RawToString &&
+		(bd == mpStr8 || bd == mpStr16 || bd == mpStr32 || (bd >= mpFixStrMin && bd <= mpFixStrMax)) {
+		return valueTypeString
+	} else if bd == mpArray16 || bd == mpArray32 || (bd >= mpFixArrayMin && bd <= mpFixArrayMax) {
+		return valueTypeArray
+	} else if bd == mpMap16 || bd == mpMap32 || (bd >= mpFixMapMin && bd <= mpFixMapMax) {
+		return valueTypeMap
+	} else {
+		// d.d.errorf("isContainerType: unsupported parameter: %v", vt)
+	}
+	return valueTypeUnset
+}
+
+func (d *msgpackDecDriver) TryDecodeAsNil() (v bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == mpNil {
+		d.bdRead = false
+		v = true
+	}
+	return
+}
+
+func (d *msgpackDecDriver) readContainerLen(ct msgpackContainerType) (clen int) {
+	bd := d.bd
+	if bd == mpNil {
+		clen = -1 // to represent nil
+	} else if bd == ct.b8 {
+		clen = int(d.r.readn1())
+	} else if bd == ct.b16 {
+		clen = int(bigen.Uint16(d.r.readx(2)))
+	} else if bd == ct.b32 {
+		clen = int(bigen.Uint32(d.r.readx(4)))
+	} else if (ct.bFixMin & bd) == ct.bFixMin {
+		clen = int(ct.bFixMin ^ bd)
+	} else {
+		d.d.errorf("readContainerLen: %s: hex: %x, decimal: %d", msgBadDesc, bd, bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *msgpackDecDriver) ReadMapStart() int {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	return d.readContainerLen(msgpackContainerMap)
+}
+
+func (d *msgpackDecDriver) ReadArrayStart() int {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	return d.readContainerLen(msgpackContainerList)
+}
+
+func (d *msgpackDecDriver) readExtLen() (clen int) {
+	switch d.bd {
+	case mpNil:
+		clen = -1 // to represent nil
+	case mpFixExt1:
+		clen = 1
+	case mpFixExt2:
+		clen = 2
+	case mpFixExt4:
+		clen = 4
+	case mpFixExt8:
+		clen = 8
+	case mpFixExt16:
+		clen = 16
+	case mpExt8:
+		clen = int(d.r.readn1())
+	case mpExt16:
+		clen = int(bigen.Uint16(d.r.readx(2)))
+	case mpExt32:
+		clen = int(bigen.Uint32(d.r.readx(4)))
+	default:
+		d.d.errorf("decoding ext bytes: found unexpected byte: %x", d.bd)
+		return
+	}
+	return
+}
+
+func (d *msgpackDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	if xtag > 0xff {
+		d.d.errorf("decodeExt: tag must be <= 0xff; got: %v", xtag)
+		return
+	}
+	realxtag1, xbs := d.decodeExtV(ext != nil, uint8(xtag))
+	realxtag = uint64(realxtag1)
+	if ext == nil {
+		re := rv.(*RawExt)
+		re.Tag = realxtag
+		re.Data = detachZeroCopyBytes(d.br, re.Data, xbs)
+	} else {
+		ext.ReadExt(rv, xbs)
+	}
+	return
+}
+
+func (d *msgpackDecDriver) decodeExtV(verifyTag bool, tag byte) (xtag byte, xbs []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	xbd := d.bd
+	if xbd == mpBin8 || xbd == mpBin16 || xbd == mpBin32 {
+		xbs = d.DecodeBytes(nil, false, true)
+	} else if xbd == mpStr8 || xbd == mpStr16 || xbd == mpStr32 ||
+		(xbd >= mpFixStrMin && xbd <= mpFixStrMax) {
+		xbs = d.DecodeBytes(nil, true, true)
+	} else {
+		clen := d.readExtLen()
+		xtag = d.r.readn1()
+		if verifyTag && xtag != tag {
+			d.d.errorf("Wrong extension tag. Got %b. Expecting: %v", xtag, tag)
+			return
+		}
+		xbs = d.r.readx(clen)
+	}
+	d.bdRead = false
+	return
+}
+
+//--------------------------------------------------
+
+//MsgpackHandle is a Handle for the Msgpack Schema-Free Encoding Format.
+type MsgpackHandle struct {
+	BasicHandle
+
+	// RawToString controls how raw bytes are decoded into a nil interface{}.
+	RawToString bool
+
+	// WriteExt flag supports encoding configured extensions with extension tags.
+	// It also controls whether other elements of the new spec are encoded (ie Str8).
+	//
+	// With WriteExt=false, configured extensions are serialized as raw bytes
+	// and Str8 is not encoded.
+	//
+	// A stream can still be decoded into a typed value, provided an appropriate value
+	// is provided, but the type cannot be inferred from the stream. If no appropriate
+	// type is provided (e.g. decoding into a nil interface{}), you get back
+	// a []byte or string based on the setting of RawToString.
+	WriteExt bool
+	binaryEncodingType
+}
+
+func (h *MsgpackHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
+}
+
+func (h *MsgpackHandle) newEncDriver(e *Encoder) encDriver {
+	return &msgpackEncDriver{e: e, w: e.w, h: h}
+}
+
+func (h *MsgpackHandle) newDecDriver(d *Decoder) decDriver {
+	return &msgpackDecDriver{d: d, h: h, r: d.r, br: d.bytes}
+}
+
+func (e *msgpackEncDriver) reset() {
+	e.w = e.e.w
+}
+
+func (d *msgpackDecDriver) reset() {
+	d.r, d.br = d.d.r, d.d.bytes
+	d.bd, d.bdRead = 0, false
+}
+
+//--------------------------------------------------
+
+type msgpackSpecRpcCodec struct {
+	rpcCodec
+}
+
+// /////////////// Spec RPC Codec ///////////////////
+func (c *msgpackSpecRpcCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	// WriteRequest can write to both a Go service, and other services that do
+	// not abide by the 1 argument rule of a Go service.
+	// We discriminate based on if the body is a MsgpackSpecRpcMultiArgs
+	var bodyArr []interface{}
+	if m, ok := body.(MsgpackSpecRpcMultiArgs); ok {
+		bodyArr = ([]interface{})(m)
+	} else {
+		bodyArr = []interface{}{body}
+	}
+	r2 := []interface{}{0, uint32(r.Seq), r.ServiceMethod, bodyArr}
+	return c.write(r2, nil, false, true)
+}
+
+func (c *msgpackSpecRpcCodec) WriteResponse(r *rpc.Response, body interface{}) error {
+	var moe interface{}
+	if r.Error != "" {
+		moe = r.Error
+	}
+	if moe != nil && body != nil {
+		body = nil
+	}
+	r2 := []interface{}{1, uint32(r.Seq), moe, body}
+	return c.write(r2, nil, false, true)
+}
+
+func (c *msgpackSpecRpcCodec) ReadResponseHeader(r *rpc.Response) error {
+	return c.parseCustomHeader(1, &r.Seq, &r.Error)
+}
+
+func (c *msgpackSpecRpcCodec) ReadRequestHeader(r *rpc.Request) error {
+	return c.parseCustomHeader(0, &r.Seq, &r.ServiceMethod)
+}
+
+func (c *msgpackSpecRpcCodec) ReadRequestBody(body interface{}) error {
+	if body == nil { // read and discard
+		return c.read(nil)
+	}
+	bodyArr := []interface{}{body}
+	return c.read(&bodyArr)
+}
+
+func (c *msgpackSpecRpcCodec) parseCustomHeader(expectTypeByte byte, msgid *uint64, methodOrError *string) (err error) {
+
+	if c.isClosed() {
+		return io.EOF
+	}
+
+	// We read the response header by hand
+	// so that the body can be decoded on its own from the stream at a later time.
+
+	const fia byte = 0x94 //four item array descriptor value
+	// Not sure why the panic of EOF is swallowed above.
+	// if bs1 := c.dec.r.readn1(); bs1 != fia {
+	// 	err = fmt.Errorf("Unexpected value for array descriptor: Expecting %v. Received %v", fia, bs1)
+	// 	return
+	// }
+	var b byte
+	b, err = c.br.ReadByte()
+	if err != nil {
+		return
+	}
+	if b != fia {
+		err = fmt.Errorf("Unexpected value for array descriptor: Expecting %v. Received %v", fia, b)
+		return
+	}
+
+	if err = c.read(&b); err != nil {
+		return
+	}
+	if b != expectTypeByte {
+		err = fmt.Errorf("Unexpected byte descriptor in header. Expecting %v. Received %v", expectTypeByte, b)
+		return
+	}
+	if err = c.read(msgid); err != nil {
+		return
+	}
+	if err = c.read(methodOrError); err != nil {
+		return
+	}
+	return
+}
+
+//--------------------------------------------------
+
+// msgpackSpecRpc is the implementation of Rpc that uses custom communication protocol
+// as defined in the msgpack spec at https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md
+type msgpackSpecRpc struct{}
+
+// MsgpackSpecRpc implements Rpc using the communication protocol defined in
+// the msgpack spec at https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md .
+// Its methods (ServerCodec and ClientCodec) return values that implement RpcCodecBuffered.
+var MsgpackSpecRpc msgpackSpecRpc
+
+func (x msgpackSpecRpc) ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec {
+	return &msgpackSpecRpcCodec{newRPCCodec(conn, h)}
+}
+
+func (x msgpackSpecRpc) ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec {
+	return &msgpackSpecRpcCodec{newRPCCodec(conn, h)}
+}
+
+var _ decDriver = (*msgpackDecDriver)(nil)
+var _ encDriver = (*msgpackEncDriver)(nil)

--- a/vendor/github.com/ugorji/go/codec/noop.go
+++ b/vendor/github.com/ugorji/go/codec/noop.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"math/rand"
+	"time"
+)
+
+// NoopHandle returns a no-op handle. It basically does nothing.
+// It is only useful for benchmarking, as it gives an idea of the
+// overhead from the codec framework.
+//
+// LIBRARY USERS: *** DO NOT USE ***
+func NoopHandle(slen int) *noopHandle {
+	h := noopHandle{}
+	h.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	h.B = make([][]byte, slen)
+	h.S = make([]string, slen)
+	for i := 0; i < len(h.S); i++ {
+		b := make([]byte, i+1)
+		for j := 0; j < len(b); j++ {
+			b[j] = 'a' + byte(i)
+		}
+		h.B[i] = b
+		h.S[i] = string(b)
+	}
+	return &h
+}
+
+// noopHandle does nothing.
+// It is used to simulate the overhead of the codec framework.
+type noopHandle struct {
+	BasicHandle
+	binaryEncodingType
+	noopDrv // noopDrv is unexported here, so we can get a copy of it when needed.
+}
+
+type noopDrv struct {
+	d    *Decoder
+	e    *Encoder
+	i    int
+	S    []string
+	B    [][]byte
+	mks  []bool    // stack. if map (true), else if array (false)
+	mk   bool      // top of stack. what container are we on? map or array?
+	ct   valueType // last response for IsContainerType.
+	cb   int       // counter for ContainerType
+	rand *rand.Rand
+}
+
+func (h *noopDrv) r(v int) int { return h.rand.Intn(v) }
+func (h *noopDrv) m(v int) int { h.i++; return h.i % v }
+
+func (h *noopDrv) newEncDriver(e *Encoder) encDriver { h.e = e; return h }
+func (h *noopDrv) newDecDriver(d *Decoder) decDriver { h.d = d; return h }
+
+func (h *noopDrv) reset()       {}
+func (h *noopDrv) uncacheRead() {}
+
+// --- encDriver
+
+// stack functions (for map and array)
+func (h *noopDrv) start(b bool) {
+	// println("start", len(h.mks)+1)
+	h.mks = append(h.mks, b)
+	h.mk = b
+}
+func (h *noopDrv) end() {
+	// println("end: ", len(h.mks)-1)
+	h.mks = h.mks[:len(h.mks)-1]
+	if len(h.mks) > 0 {
+		h.mk = h.mks[len(h.mks)-1]
+	} else {
+		h.mk = false
+	}
+}
+
+func (h *noopDrv) EncodeBuiltin(rt uintptr, v interface{}) {}
+func (h *noopDrv) EncodeNil()                              {}
+func (h *noopDrv) EncodeInt(i int64)                       {}
+func (h *noopDrv) EncodeUint(i uint64)                     {}
+func (h *noopDrv) EncodeBool(b bool)                       {}
+func (h *noopDrv) EncodeFloat32(f float32)                 {}
+func (h *noopDrv) EncodeFloat64(f float64)                 {}
+func (h *noopDrv) EncodeRawExt(re *RawExt, e *Encoder)     {}
+func (h *noopDrv) EncodeArrayStart(length int)             { h.start(true) }
+func (h *noopDrv) EncodeMapStart(length int)               { h.start(false) }
+func (h *noopDrv) EncodeEnd()                              { h.end() }
+
+func (h *noopDrv) EncodeString(c charEncoding, v string)      {}
+func (h *noopDrv) EncodeSymbol(v string)                      {}
+func (h *noopDrv) EncodeStringBytes(c charEncoding, v []byte) {}
+
+func (h *noopDrv) EncodeExt(rv interface{}, xtag uint64, ext Ext, e *Encoder) {}
+
+// ---- decDriver
+func (h *noopDrv) initReadNext()                              {}
+func (h *noopDrv) CheckBreak() bool                           { return false }
+func (h *noopDrv) IsBuiltinType(rt uintptr) bool              { return false }
+func (h *noopDrv) DecodeBuiltin(rt uintptr, v interface{})    {}
+func (h *noopDrv) DecodeInt(bitsize uint8) (i int64)          { return int64(h.m(15)) }
+func (h *noopDrv) DecodeUint(bitsize uint8) (ui uint64)       { return uint64(h.m(35)) }
+func (h *noopDrv) DecodeFloat(chkOverflow32 bool) (f float64) { return float64(h.m(95)) }
+func (h *noopDrv) DecodeBool() (b bool)                       { return h.m(2) == 0 }
+func (h *noopDrv) DecodeString() (s string)                   { return h.S[h.m(8)] }
+
+// func (h *noopDrv) DecodeStringAsBytes(bs []byte) []byte       { return h.DecodeBytes(bs) }
+
+func (h *noopDrv) DecodeBytes(bs []byte, isstring, zerocopy bool) []byte { return h.B[h.m(len(h.B))] }
+
+func (h *noopDrv) ReadEnd() { h.end() }
+
+// toggle map/slice
+func (h *noopDrv) ReadMapStart() int   { h.start(true); return h.m(10) }
+func (h *noopDrv) ReadArrayStart() int { h.start(false); return h.m(10) }
+
+func (h *noopDrv) ContainerType() (vt valueType) {
+	// return h.m(2) == 0
+	// handle kStruct, which will bomb is it calls this and doesn't get back a map or array.
+	// consequently, if the return value is not map or array, reset it to one of them based on h.m(7) % 2
+	// for kstruct: at least one out of every 2 times, return one of valueTypeMap or Array (else kstruct bombs)
+	// however, every 10th time it is called, we just return something else.
+	var vals = [...]valueType{valueTypeArray, valueTypeMap}
+	//  ------------ TAKE ------------
+	// if h.cb%2 == 0 {
+	// 	if h.ct == valueTypeMap || h.ct == valueTypeArray {
+	// 	} else {
+	// 		h.ct = vals[h.m(2)]
+	// 	}
+	// } else if h.cb%5 == 0 {
+	// 	h.ct = valueType(h.m(8))
+	// } else {
+	// 	h.ct = vals[h.m(2)]
+	// }
+	//  ------------ TAKE ------------
+	// if h.cb%16 == 0 {
+	// 	h.ct = valueType(h.cb % 8)
+	// } else {
+	// 	h.ct = vals[h.cb%2]
+	// }
+	h.ct = vals[h.cb%2]
+	h.cb++
+	return h.ct
+
+	// if h.ct == valueTypeNil || h.ct == valueTypeString || h.ct == valueTypeBytes {
+	// 	return h.ct
+	// }
+	// return valueTypeUnset
+	// TODO: may need to tweak this so it works.
+	// if h.ct == valueTypeMap && vt == valueTypeArray || h.ct == valueTypeArray && vt == valueTypeMap {
+	// 	h.cb = !h.cb
+	// 	h.ct = vt
+	// 	return h.cb
+	// }
+	// // go in a loop and check it.
+	// h.ct = vt
+	// h.cb = h.m(7) == 0
+	// return h.cb
+}
+func (h *noopDrv) TryDecodeAsNil() bool {
+	if h.mk {
+		return false
+	} else {
+		return h.m(8) == 0
+	}
+}
+func (h *noopDrv) DecodeExt(rv interface{}, xtag uint64, ext Ext) uint64 {
+	return 0
+}
+
+func (h *noopDrv) DecodeNaked() {
+	// use h.r (random) not h.m() because h.m() could cause the same value to be given.
+	var sk int
+	if h.mk {
+		// if mapkey, do not support values of nil OR bytes, array, map or rawext
+		sk = h.r(7) + 1
+	} else {
+		sk = h.r(12)
+	}
+	n := &h.d.n
+	switch sk {
+	case 0:
+		n.v = valueTypeNil
+	case 1:
+		n.v, n.b = valueTypeBool, false
+	case 2:
+		n.v, n.b = valueTypeBool, true
+	case 3:
+		n.v, n.i = valueTypeInt, h.DecodeInt(64)
+	case 4:
+		n.v, n.u = valueTypeUint, h.DecodeUint(64)
+	case 5:
+		n.v, n.f = valueTypeFloat, h.DecodeFloat(true)
+	case 6:
+		n.v, n.f = valueTypeFloat, h.DecodeFloat(false)
+	case 7:
+		n.v, n.s = valueTypeString, h.DecodeString()
+	case 8:
+		n.v, n.l = valueTypeBytes, h.B[h.m(len(h.B))]
+	case 9:
+		n.v = valueTypeArray
+	case 10:
+		n.v = valueTypeMap
+	default:
+		n.v = valueTypeExt
+		n.u = h.DecodeUint(64)
+		n.l = h.B[h.m(len(h.B))]
+	}
+	h.ct = n.v
+	return
+}

--- a/vendor/github.com/ugorji/go/codec/prebuild.go
+++ b/vendor/github.com/ugorji/go/codec/prebuild.go
@@ -1,0 +1,3 @@
+package codec
+
+//go:generate bash prebuild.sh

--- a/vendor/github.com/ugorji/go/codec/prebuild.sh
+++ b/vendor/github.com/ugorji/go/codec/prebuild.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# _needgen is a helper function to tell if we need to generate files for msgp, codecgen.
+_needgen() {
+    local a="$1"
+    zneedgen=0
+    if [[ ! -e "$a" ]]
+    then
+        zneedgen=1
+        echo 1
+        return 0
+    fi 
+    for i in `ls -1 *.go.tmpl gen.go values_test.go`
+    do
+        if [[ "$a" -ot "$i" ]]
+        then
+            zneedgen=1
+            echo 1
+            return 0
+        fi 
+    done 
+    echo 0
+}
+
+# _build generates fast-path.go and gen-helper.go.
+# 
+# It is needed because there is some dependency between the generated code
+# and the other classes. Consequently, we have to totally remove the 
+# generated files and put stubs in place, before calling "go run" again
+# to recreate them.
+_build() {
+    if ! [[ "${zforce}" == "1" ||
+                "1" == $( _needgen "fast-path.generated.go" ) ||
+                "1" == $( _needgen "gen-helper.generated.go" ) ||
+                "1" == $( _needgen "gen.generated.go" ) ||
+                1 == 0 ]]
+    then
+        return 0
+    fi 
+
+    # echo "Running prebuild"
+    if [ "${zbak}" == "1" ] 
+    then
+        # echo "Backing up old generated files"
+        _zts=`date '+%m%d%Y_%H%M%S'`
+        _gg=".generated.go"
+        [ -e "gen-helper${_gg}" ] && mv gen-helper${_gg} gen-helper${_gg}__${_zts}.bak
+        [ -e "fast-path${_gg}" ] && mv fast-path${_gg} fast-path${_gg}__${_zts}.bak
+        [ -e "gen${_gg}" ] && mv gen${_gg} gen${_gg}__${_zts}.bak
+        # [ -e "safe${_gg}" ] && mv safe${_gg} safe${_gg}__${_zts}.bak
+        # [ -e "unsafe${_gg}" ] && mv unsafe${_gg} unsafe${_gg}__${_zts}.bak
+    fi 
+    rm -f gen-helper.generated.go fast-path.generated.go \
+       gen.generated.go \
+       *safe.generated.go *_generated_test.go *.generated_ffjson_expose.go
+
+    cat > gen.generated.go <<EOF
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// DO NOT EDIT. THIS FILE IS AUTO-GENERATED FROM gen-dec-(map|array).go.tmpl
+
+const genDecMapTmpl = \`
+EOF
+
+    cat >> gen.generated.go < gen-dec-map.go.tmpl
+
+    cat >> gen.generated.go <<EOF
+\`
+
+const genDecListTmpl = \`
+EOF
+
+    cat >> gen.generated.go < gen-dec-array.go.tmpl
+
+    cat >> gen.generated.go <<EOF
+\`
+
+EOF
+
+    cat > gen-from-tmpl.codec.generated.go <<EOF
+package codec 
+import "io"
+func GenInternalGoFile(r io.Reader, w io.Writer, safe bool) error {
+return genInternalGoFile(r, w, safe)
+}
+EOF
+    
+    cat > gen-from-tmpl.generated.go <<EOF
+//+build ignore
+
+package main
+
+//import "flag"
+import "${zpkg}"
+import "os"
+
+func run(fnameIn, fnameOut string, safe bool) {
+fin, err := os.Open(fnameIn)
+if err != nil { panic(err) }
+defer fin.Close()
+fout, err := os.Create(fnameOut)
+if err != nil { panic(err) }
+defer fout.Close()
+err = codec.GenInternalGoFile(fin, fout, safe)
+if err != nil { panic(err) }
+}
+
+func main() {
+// do not make safe/unsafe variants. 
+// Instead, depend on escape analysis, and place string creation and usage appropriately.
+// run("unsafe.go.tmpl", "safe.generated.go", true)
+// run("unsafe.go.tmpl", "unsafe.generated.go", false)
+run("fast-path.go.tmpl", "fast-path.generated.go", false)
+run("gen-helper.go.tmpl", "gen-helper.generated.go", false)
+}
+
+EOF
+    go run -tags=notfastpath gen-from-tmpl.generated.go && \
+        rm -f gen-from-tmpl.*generated.go 
+}
+
+_codegenerators() {
+    if [[ $zforce == "1" || 
+                "1" == $( _needgen "values_codecgen${zsfx}" ) ||
+                "1" == $( _needgen "values_msgp${zsfx}" ) ||
+                "1" == $( _needgen "values_ffjson${zsfx}" ) ||
+                1 == 0 ]] 
+    then
+        # codecgen creates some temporary files in the directory (main, pkg).
+        # Consequently, we should start msgp and ffjson first, and also put a small time latency before
+        # starting codecgen.
+        # Without this, ffjson chokes on one of the temporary files from codecgen.
+        if [[ $zexternal == "1" ]]
+        then 
+            echo "ffjson ... " && \
+                ffjson -w values_ffjson${zsfx} $zfin &
+            zzzIdFF=$!
+            echo "msgp ... " && \
+                msgp -tests=false -o=values_msgp${zsfx} -file=$zfin &
+            zzzIdMsgp=$!
+            
+            sleep 1 # give ffjson and msgp some buffer time. see note above.
+        fi
+        
+        echo "codecgen - !unsafe ... " && \
+            $zgobase/bin/codecgen -rt codecgen -t 'x,codecgen,!unsafe' -o values_codecgen${zsfx} -d 19780 $zfin &
+        zzzIdC=$!
+        echo "codecgen - unsafe ... " && \
+            $zgobase/bin/codecgen  -u -rt codecgen -t 'x,codecgen,unsafe' -o values_codecgen_unsafe${zsfx} -d 19781 $zfin &
+        zzzIdCU=$!
+        wait $zzzIdC $zzzIdCU $zzzIdMsgp $zzzIdFF && \
+            # remove (M|Unm)arshalJSON implementations, so they don't conflict with encoding/json bench \
+            if [[ $zexternal == "1" ]]
+            then
+                sed -i '' -e 's+ MarshalJSON(+ _MarshalJSON(+g' values_ffjson${zsfx} && \
+                    sed -i '' -e 's+ UnmarshalJSON(+ _UnmarshalJSON(+g' values_ffjson${zsfx}
+            fi && \
+            echo "generators done!" && \
+            true
+    fi 
+}
+
+# _init reads the arguments and sets up the flags
+_init() {
+OPTIND=1
+while getopts "fbxp:" flag
+do
+    case "x$flag" in 
+        'xf') zforce=1;;
+        'xb') zbak=1;;
+        'xx') zexternal=1;;
+        'xp') zpkg="${OPTARG}" ;;
+        *) echo "prebuild.sh accepts [-fbx] [-p basepkgname] only"; return 1;;
+    esac
+done
+shift $((OPTIND-1))
+OPTIND=1
+}
+
+# main script.
+# First ensure that this is being run from the basedir (i.e. dirname of script is .)
+# Sample usage:
+if [ "." = `dirname $0` ]
+then
+    zmydir=`pwd`
+    zfin="test_values.generated.go"
+    zsfx="_generated_test.go"
+    # zpkg="ugorji.net/codec"
+    zpkg=${zmydir##*/src/}
+    zgobase=${zmydir%%/src/*}
+    # rm -f *_generated_test.go 
+    rm -f codecgen-*.go && \
+        _init "$@" && \
+        _build && \
+        cp $zmydir/values_test.go $zmydir/$zfin && \
+        _codegenerators && \
+        echo prebuild done successfully
+    rm -f $zmydir/$zfin
+else
+    echo "Script must be run from the directory it resides in"
+fi 
+

--- a/vendor/github.com/ugorji/go/codec/py_test.go
+++ b/vendor/github.com/ugorji/go/codec/py_test.go
@@ -1,0 +1,30 @@
+// +build x
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// These tests are used to verify msgpack and cbor implementations against their python libraries.
+// If you have the library installed, you can enable the tests back by running: go test -tags=x .
+// Look at test.py for how to setup your environment.
+
+import (
+	"testing"
+)
+
+func TestMsgpackPythonGenStreams(t *testing.T) {
+	doTestPythonGenStreams(t, "msgpack", testMsgpackH)
+}
+
+func TestCborPythonGenStreams(t *testing.T) {
+	doTestPythonGenStreams(t, "cbor", testCborH)
+}
+
+func TestMsgpackRpcSpecGoClientToPythonSvc(t *testing.T) {
+	doTestMsgpackRpcSpecGoClientToPythonSvc(t)
+}
+
+func TestMsgpackRpcSpecPythonClientToGoSvc(t *testing.T) {
+	doTestMsgpackRpcSpecPythonClientToGoSvc(t)
+}

--- a/vendor/github.com/ugorji/go/codec/rpc.go
+++ b/vendor/github.com/ugorji/go/codec/rpc.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"bufio"
+	"io"
+	"net/rpc"
+	"sync"
+)
+
+// rpcEncodeTerminator allows a handler specify a []byte terminator to send after each Encode.
+//
+// Some codecs like json need to put a space after each encoded value, to serve as a
+// delimiter for things like numbers (else json codec will continue reading till EOF).
+type rpcEncodeTerminator interface {
+	rpcEncodeTerminate() []byte
+}
+
+// Rpc provides a rpc Server or Client Codec for rpc communication.
+type Rpc interface {
+	ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec
+	ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec
+}
+
+// RpcCodecBuffered allows access to the underlying bufio.Reader/Writer
+// used by the rpc connection. It accommodates use-cases where the connection
+// should be used by rpc and non-rpc functions, e.g. streaming a file after
+// sending an rpc response.
+type RpcCodecBuffered interface {
+	BufferedReader() *bufio.Reader
+	BufferedWriter() *bufio.Writer
+}
+
+// -------------------------------------
+
+// rpcCodec defines the struct members and common methods.
+type rpcCodec struct {
+	rwc io.ReadWriteCloser
+	dec *Decoder
+	enc *Encoder
+	bw  *bufio.Writer
+	br  *bufio.Reader
+	mu  sync.Mutex
+	h   Handle
+
+	cls   bool
+	clsmu sync.RWMutex
+}
+
+func newRPCCodec(conn io.ReadWriteCloser, h Handle) rpcCodec {
+	bw := bufio.NewWriter(conn)
+	br := bufio.NewReader(conn)
+	return rpcCodec{
+		rwc: conn,
+		bw:  bw,
+		br:  br,
+		enc: NewEncoder(bw, h),
+		dec: NewDecoder(br, h),
+		h:   h,
+	}
+}
+
+func (c *rpcCodec) BufferedReader() *bufio.Reader {
+	return c.br
+}
+
+func (c *rpcCodec) BufferedWriter() *bufio.Writer {
+	return c.bw
+}
+
+func (c *rpcCodec) write(obj1, obj2 interface{}, writeObj2, doFlush bool) (err error) {
+	if c.isClosed() {
+		return io.EOF
+	}
+	if err = c.enc.Encode(obj1); err != nil {
+		return
+	}
+	t, tOk := c.h.(rpcEncodeTerminator)
+	if tOk {
+		c.bw.Write(t.rpcEncodeTerminate())
+	}
+	if writeObj2 {
+		if err = c.enc.Encode(obj2); err != nil {
+			return
+		}
+		if tOk {
+			c.bw.Write(t.rpcEncodeTerminate())
+		}
+	}
+	if doFlush {
+		return c.bw.Flush()
+	}
+	return
+}
+
+func (c *rpcCodec) read(obj interface{}) (err error) {
+	if c.isClosed() {
+		return io.EOF
+	}
+	//If nil is passed in, we should still attempt to read content to nowhere.
+	if obj == nil {
+		var obj2 interface{}
+		return c.dec.Decode(&obj2)
+	}
+	return c.dec.Decode(obj)
+}
+
+func (c *rpcCodec) isClosed() bool {
+	c.clsmu.RLock()
+	x := c.cls
+	c.clsmu.RUnlock()
+	return x
+}
+
+func (c *rpcCodec) Close() error {
+	if c.isClosed() {
+		return io.EOF
+	}
+	c.clsmu.Lock()
+	c.cls = true
+	c.clsmu.Unlock()
+	return c.rwc.Close()
+}
+
+func (c *rpcCodec) ReadResponseBody(body interface{}) error {
+	return c.read(body)
+}
+
+// -------------------------------------
+
+type goRpcCodec struct {
+	rpcCodec
+}
+
+func (c *goRpcCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	// Must protect for concurrent access as per API
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.write(r, body, true, true)
+}
+
+func (c *goRpcCodec) WriteResponse(r *rpc.Response, body interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.write(r, body, true, true)
+}
+
+func (c *goRpcCodec) ReadResponseHeader(r *rpc.Response) error {
+	return c.read(r)
+}
+
+func (c *goRpcCodec) ReadRequestHeader(r *rpc.Request) error {
+	return c.read(r)
+}
+
+func (c *goRpcCodec) ReadRequestBody(body interface{}) error {
+	return c.read(body)
+}
+
+// -------------------------------------
+
+// goRpc is the implementation of Rpc that uses the communication protocol
+// as defined in net/rpc package.
+type goRpc struct{}
+
+// GoRpc implements Rpc using the communication protocol defined in net/rpc package.
+// Its methods (ServerCodec and ClientCodec) return values that implement RpcCodecBuffered.
+var GoRpc goRpc
+
+func (x goRpc) ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec {
+	return &goRpcCodec{newRPCCodec(conn, h)}
+}
+
+func (x goRpc) ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec {
+	return &goRpcCodec{newRPCCodec(conn, h)}
+}
+
+var _ RpcCodecBuffered = (*rpcCodec)(nil) // ensure *rpcCodec implements RpcCodecBuffered

--- a/vendor/github.com/ugorji/go/codec/shared_test.go
+++ b/vendor/github.com/ugorji/go/codec/shared_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// This file sets up the variables used, including testInitFns.
+// Each file should add initialization that should be performed
+// after flags are parsed.
+//
+// init is a multi-step process:
+//   - setup vars (handled by init functions in each file)
+//   - parse flags
+//   - setup derived vars (handled by pre-init registered functions - registered in init function)
+//   - post init (handled by post-init registered functions - registered in init function)
+// This way, no one has to manage carefully control the initialization
+// using file names, etc.
+//
+// Tests which require external dependencies need the -tag=x parameter.
+// They should be run as:
+//    go test -tags=x -run=. <other parameters ...>
+// Benchmarks should also take this parameter, to include the sereal, xdr, etc.
+// To run against codecgen, etc, make sure you pass extra parameters.
+// Example usage:
+//    go test "-tags=x codecgen unsafe" -bench=. <other parameters ...>
+//
+// To fully test everything:
+//    go test -tags=x -benchtime=100ms -tv -bg -bi  -brw -bu -v -run=. -bench=.
+
+// Handling flags
+// codec_test.go will define a set of global flags for testing, including:
+//   - Use Reset
+//   - Use IO reader/writer (vs direct bytes)
+//   - Set Canonical
+//   - Set InternStrings
+//   - Use Symbols
+//
+// This way, we can test them all by running same set of tests with a different
+// set of flags.
+//
+// Following this, all the benchmarks will utilize flags set by codec_test.go
+// and will not redefine these "global" flags.
+
+import (
+	"bytes"
+	"flag"
+	"sync"
+)
+
+// DO NOT REMOVE - replacement line for go-codec-bench import declaration tag //
+
+type testHED struct {
+	H Handle
+	E *Encoder
+	D *Decoder
+}
+
+var (
+	testNoopH    = NoopHandle(8)
+	testMsgpackH = &MsgpackHandle{}
+	testBincH    = &BincHandle{}
+	testSimpleH  = &SimpleHandle{}
+	testCborH    = &CborHandle{}
+	testJsonH    = &JsonHandle{}
+
+	testHandles     []Handle
+	testPreInitFns  []func()
+	testPostInitFns []func()
+
+	testOnce sync.Once
+
+	testHEDs []testHED
+)
+
+// flag variables used by tests (and bench)
+var (
+	testVerbose        bool
+	testInitDebug      bool
+	testUseIoEncDec    bool
+	testStructToArray  bool
+	testCanonical      bool
+	testUseReset       bool
+	testWriteNoSymbols bool
+	testSkipIntf       bool
+	testInternStr      bool
+	testUseMust        bool
+	testCheckCircRef   bool
+	testJsonIndent     int
+	testMaxInitLen     int
+
+	testJsonHTMLCharsAsIs bool
+)
+
+// flag variables used by bench
+var (
+	benchDoInitBench      bool
+	benchVerify           bool
+	benchUnscientificRes  bool = false
+	benchMapStringKeyOnly bool
+	//depth of 0 maps to ~400bytes json-encoded string, 1 maps to ~1400 bytes, etc
+	//For depth>1, we likely trigger stack growth for encoders, making benchmarking unreliable.
+	benchDepth     int
+	benchInitDebug bool
+)
+
+func init() {
+	testHEDs = make([]testHED, 0, 32)
+	testHandles = append(testHandles,
+		testNoopH, testMsgpackH, testBincH, testSimpleH,
+		testCborH, testJsonH)
+	testInitFlags()
+	benchInitFlags()
+}
+
+func testInitFlags() {
+	// delete(testDecOpts.ExtFuncs, timeTyp)
+	flag.BoolVar(&testVerbose, "tv", false, "Test Verbose")
+	flag.BoolVar(&testInitDebug, "tg", false, "Test Init Debug")
+	flag.BoolVar(&testUseIoEncDec, "ti", false, "Use IO Reader/Writer for Marshal/Unmarshal")
+	flag.BoolVar(&testStructToArray, "ts", false, "Set StructToArray option")
+	flag.BoolVar(&testWriteNoSymbols, "tn", false, "Set NoSymbols option")
+	flag.BoolVar(&testCanonical, "tc", false, "Set Canonical option")
+	flag.BoolVar(&testInternStr, "te", false, "Set InternStr option")
+	flag.BoolVar(&testSkipIntf, "tf", false, "Skip Interfaces")
+	flag.BoolVar(&testUseReset, "tr", false, "Use Reset")
+	flag.IntVar(&testJsonIndent, "td", 0, "Use JSON Indent")
+	flag.IntVar(&testMaxInitLen, "tx", 0, "Max Init Len")
+	flag.BoolVar(&testUseMust, "tm", true, "Use Must(En|De)code")
+	flag.BoolVar(&testCheckCircRef, "tl", false, "Use Check Circular Ref")
+	flag.BoolVar(&testJsonHTMLCharsAsIs, "tas", false, "Set JSON HTMLCharsAsIs")
+}
+
+func benchInitFlags() {
+	flag.BoolVar(&benchMapStringKeyOnly, "bs", false, "Bench use maps with string keys only")
+	flag.BoolVar(&benchInitDebug, "bg", false, "Bench Debug")
+	flag.IntVar(&benchDepth, "bd", 1, "Bench Depth")
+	flag.BoolVar(&benchDoInitBench, "bi", false, "Run Bench Init")
+	flag.BoolVar(&benchVerify, "bv", false, "Verify Decoded Value during Benchmark")
+	flag.BoolVar(&benchUnscientificRes, "bu", false, "Show Unscientific Results during Benchmark")
+}
+
+func testHEDGet(h Handle) *testHED {
+	for i := range testHEDs {
+		v := &testHEDs[i]
+		if v.H == h {
+			return v
+		}
+	}
+	testHEDs = append(testHEDs, testHED{h, NewEncoder(nil, h), NewDecoder(nil, h)})
+	return &testHEDs[len(testHEDs)-1]
+}
+
+func testInitAll() {
+	flag.Parse()
+	for _, f := range testPreInitFns {
+		f()
+	}
+	for _, f := range testPostInitFns {
+		f()
+	}
+}
+
+func testCodecEncode(ts interface{}, bsIn []byte,
+	fn func([]byte) *bytes.Buffer, h Handle) (bs []byte, err error) {
+	// bs = make([]byte, 0, approxSize)
+	var e *Encoder
+	var buf *bytes.Buffer
+	if testUseReset {
+		e = testHEDGet(h).E
+	} else {
+		e = NewEncoder(nil, h)
+	}
+	if testUseIoEncDec {
+		buf = fn(bsIn)
+		e.Reset(buf)
+	} else {
+		bs = bsIn
+		e.ResetBytes(&bs)
+	}
+	if testUseMust {
+		e.MustEncode(ts)
+	} else {
+		err = e.Encode(ts)
+	}
+	if testUseIoEncDec {
+		bs = buf.Bytes()
+	}
+	return
+}
+
+func testCodecDecode(bs []byte, ts interface{}, h Handle) (err error) {
+	var d *Decoder
+	var buf *bytes.Reader
+	if testUseReset {
+		d = testHEDGet(h).D
+	} else {
+		d = NewDecoder(nil, h)
+	}
+	if testUseIoEncDec {
+		buf = bytes.NewReader(bs)
+		d.Reset(buf)
+	} else {
+		d.ResetBytes(bs)
+	}
+	if testUseMust {
+		d.MustDecode(ts)
+	} else {
+		err = d.Decode(ts)
+	}
+	return
+}
+
+// ----- functions below are used only by benchmarks alone
+
+func fnBenchmarkByteBuf(bsIn []byte) (buf *bytes.Buffer) {
+	// var buf bytes.Buffer
+	// buf.Grow(approxSize)
+	buf = bytes.NewBuffer(bsIn)
+	buf.Truncate(0)
+	return
+}
+
+func benchFnCodecEncode(ts interface{}, bsIn []byte, h Handle) (bs []byte, err error) {
+	return testCodecEncode(ts, bsIn, fnBenchmarkByteBuf, h)
+}
+
+func benchFnCodecDecode(bs []byte, ts interface{}, h Handle) (err error) {
+	return testCodecDecode(bs, ts, h)
+}

--- a/vendor/github.com/ugorji/go/codec/simple.go
+++ b/vendor/github.com/ugorji/go/codec/simple.go
@@ -1,0 +1,535 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"math"
+	"reflect"
+)
+
+const (
+	_               uint8 = iota
+	simpleVdNil           = 1
+	simpleVdFalse         = 2
+	simpleVdTrue          = 3
+	simpleVdFloat32       = 4
+	simpleVdFloat64       = 5
+
+	// each lasts for 4 (ie n, n+1, n+2, n+3)
+	simpleVdPosInt = 8
+	simpleVdNegInt = 12
+
+	// containers: each lasts for 4 (ie n, n+1, n+2, ... n+7)
+	simpleVdString    = 216
+	simpleVdByteArray = 224
+	simpleVdArray     = 232
+	simpleVdMap       = 240
+	simpleVdExt       = 248
+)
+
+type simpleEncDriver struct {
+	noBuiltInTypes
+	encNoSeparator
+	e *Encoder
+	h *SimpleHandle
+	w encWriter
+	b [8]byte
+}
+
+func (e *simpleEncDriver) EncodeNil() {
+	e.w.writen1(simpleVdNil)
+}
+
+func (e *simpleEncDriver) EncodeBool(b bool) {
+	if b {
+		e.w.writen1(simpleVdTrue)
+	} else {
+		e.w.writen1(simpleVdFalse)
+	}
+}
+
+func (e *simpleEncDriver) EncodeFloat32(f float32) {
+	e.w.writen1(simpleVdFloat32)
+	bigenHelper{e.b[:4], e.w}.writeUint32(math.Float32bits(f))
+}
+
+func (e *simpleEncDriver) EncodeFloat64(f float64) {
+	e.w.writen1(simpleVdFloat64)
+	bigenHelper{e.b[:8], e.w}.writeUint64(math.Float64bits(f))
+}
+
+func (e *simpleEncDriver) EncodeInt(v int64) {
+	if v < 0 {
+		e.encUint(uint64(-v), simpleVdNegInt)
+	} else {
+		e.encUint(uint64(v), simpleVdPosInt)
+	}
+}
+
+func (e *simpleEncDriver) EncodeUint(v uint64) {
+	e.encUint(v, simpleVdPosInt)
+}
+
+func (e *simpleEncDriver) encUint(v uint64, bd uint8) {
+	if v <= math.MaxUint8 {
+		e.w.writen2(bd, uint8(v))
+	} else if v <= math.MaxUint16 {
+		e.w.writen1(bd + 1)
+		bigenHelper{e.b[:2], e.w}.writeUint16(uint16(v))
+	} else if v <= math.MaxUint32 {
+		e.w.writen1(bd + 2)
+		bigenHelper{e.b[:4], e.w}.writeUint32(uint32(v))
+	} else { // if v <= math.MaxUint64 {
+		e.w.writen1(bd + 3)
+		bigenHelper{e.b[:8], e.w}.writeUint64(v)
+	}
+}
+
+func (e *simpleEncDriver) encLen(bd byte, length int) {
+	if length == 0 {
+		e.w.writen1(bd)
+	} else if length <= math.MaxUint8 {
+		e.w.writen1(bd + 1)
+		e.w.writen1(uint8(length))
+	} else if length <= math.MaxUint16 {
+		e.w.writen1(bd + 2)
+		bigenHelper{e.b[:2], e.w}.writeUint16(uint16(length))
+	} else if int64(length) <= math.MaxUint32 {
+		e.w.writen1(bd + 3)
+		bigenHelper{e.b[:4], e.w}.writeUint32(uint32(length))
+	} else {
+		e.w.writen1(bd + 4)
+		bigenHelper{e.b[:8], e.w}.writeUint64(uint64(length))
+	}
+}
+
+func (e *simpleEncDriver) EncodeExt(rv interface{}, xtag uint64, ext Ext, _ *Encoder) {
+	bs := ext.WriteExt(rv)
+	if bs == nil {
+		e.EncodeNil()
+		return
+	}
+	e.encodeExtPreamble(uint8(xtag), len(bs))
+	e.w.writeb(bs)
+}
+
+func (e *simpleEncDriver) EncodeRawExt(re *RawExt, _ *Encoder) {
+	e.encodeExtPreamble(uint8(re.Tag), len(re.Data))
+	e.w.writeb(re.Data)
+}
+
+func (e *simpleEncDriver) encodeExtPreamble(xtag byte, length int) {
+	e.encLen(simpleVdExt, length)
+	e.w.writen1(xtag)
+}
+
+func (e *simpleEncDriver) EncodeArrayStart(length int) {
+	e.encLen(simpleVdArray, length)
+}
+
+func (e *simpleEncDriver) EncodeMapStart(length int) {
+	e.encLen(simpleVdMap, length)
+}
+
+func (e *simpleEncDriver) EncodeString(c charEncoding, v string) {
+	e.encLen(simpleVdString, len(v))
+	e.w.writestr(v)
+}
+
+func (e *simpleEncDriver) EncodeSymbol(v string) {
+	e.EncodeString(c_UTF8, v)
+}
+
+func (e *simpleEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
+	e.encLen(simpleVdByteArray, len(v))
+	e.w.writeb(v)
+}
+
+//------------------------------------
+
+type simpleDecDriver struct {
+	d      *Decoder
+	h      *SimpleHandle
+	r      decReader
+	bdRead bool
+	bd     byte
+	br     bool // bytes reader
+	noBuiltInTypes
+	noStreamingCodec
+	decNoSeparator
+	b [scratchByteArrayLen]byte
+}
+
+func (d *simpleDecDriver) readNextBd() {
+	d.bd = d.r.readn1()
+	d.bdRead = true
+}
+
+func (d *simpleDecDriver) uncacheRead() {
+	if d.bdRead {
+		d.r.unreadn1()
+		d.bdRead = false
+	}
+}
+
+func (d *simpleDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == simpleVdNil {
+		return valueTypeNil
+	} else if d.bd == simpleVdByteArray || d.bd == simpleVdByteArray+1 ||
+		d.bd == simpleVdByteArray+2 || d.bd == simpleVdByteArray+3 || d.bd == simpleVdByteArray+4 {
+		return valueTypeBytes
+	} else if d.bd == simpleVdString || d.bd == simpleVdString+1 ||
+		d.bd == simpleVdString+2 || d.bd == simpleVdString+3 || d.bd == simpleVdString+4 {
+		return valueTypeString
+	} else if d.bd == simpleVdArray || d.bd == simpleVdArray+1 ||
+		d.bd == simpleVdArray+2 || d.bd == simpleVdArray+3 || d.bd == simpleVdArray+4 {
+		return valueTypeArray
+	} else if d.bd == simpleVdMap || d.bd == simpleVdMap+1 ||
+		d.bd == simpleVdMap+2 || d.bd == simpleVdMap+3 || d.bd == simpleVdMap+4 {
+		return valueTypeMap
+	} else {
+		// d.d.errorf("isContainerType: unsupported parameter: %v", vt)
+	}
+	return valueTypeUnset
+}
+
+func (d *simpleDecDriver) TryDecodeAsNil() bool {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == simpleVdNil {
+		d.bdRead = false
+		return true
+	}
+	return false
+}
+
+func (d *simpleDecDriver) decCheckInteger() (ui uint64, neg bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	switch d.bd {
+	case simpleVdPosInt:
+		ui = uint64(d.r.readn1())
+	case simpleVdPosInt + 1:
+		ui = uint64(bigen.Uint16(d.r.readx(2)))
+	case simpleVdPosInt + 2:
+		ui = uint64(bigen.Uint32(d.r.readx(4)))
+	case simpleVdPosInt + 3:
+		ui = uint64(bigen.Uint64(d.r.readx(8)))
+	case simpleVdNegInt:
+		ui = uint64(d.r.readn1())
+		neg = true
+	case simpleVdNegInt + 1:
+		ui = uint64(bigen.Uint16(d.r.readx(2)))
+		neg = true
+	case simpleVdNegInt + 2:
+		ui = uint64(bigen.Uint32(d.r.readx(4)))
+		neg = true
+	case simpleVdNegInt + 3:
+		ui = uint64(bigen.Uint64(d.r.readx(8)))
+		neg = true
+	default:
+		d.d.errorf("decIntAny: Integer only valid from pos/neg integer1..8. Invalid descriptor: %v", d.bd)
+		return
+	}
+	// don't do this check, because callers may only want the unsigned value.
+	// if ui > math.MaxInt64 {
+	// 	d.d.errorf("decIntAny: Integer out of range for signed int64: %v", ui)
+	//		return
+	// }
+	return
+}
+
+func (d *simpleDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	ui, neg := d.decCheckInteger()
+	i, overflow := chkOvf.SignedInt(ui)
+	if overflow {
+		d.d.errorf("simple: overflow converting %v to signed integer", ui)
+		return
+	}
+	if neg {
+		i = -i
+	}
+	if chkOvf.Int(i, bitsize) {
+		d.d.errorf("simple: overflow integer: %v", i)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *simpleDecDriver) DecodeUint(bitsize uint8) (ui uint64) {
+	ui, neg := d.decCheckInteger()
+	if neg {
+		d.d.errorf("Assigning negative signed value to unsigned type")
+		return
+	}
+	if chkOvf.Uint(ui, bitsize) {
+		d.d.errorf("simple: overflow integer: %v", ui)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *simpleDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == simpleVdFloat32 {
+		f = float64(math.Float32frombits(bigen.Uint32(d.r.readx(4))))
+	} else if d.bd == simpleVdFloat64 {
+		f = math.Float64frombits(bigen.Uint64(d.r.readx(8)))
+	} else {
+		if d.bd >= simpleVdPosInt && d.bd <= simpleVdNegInt+3 {
+			f = float64(d.DecodeInt(64))
+		} else {
+			d.d.errorf("Float only valid from float32/64: Invalid descriptor: %v", d.bd)
+			return
+		}
+	}
+	if chkOverflow32 && chkOvf.Float32(f) {
+		d.d.errorf("msgpack: float32 overflow: %v", f)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+// bool can be decoded from bool only (single byte).
+func (d *simpleDecDriver) DecodeBool() (b bool) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == simpleVdTrue {
+		b = true
+	} else if d.bd == simpleVdFalse {
+	} else {
+		d.d.errorf("Invalid single-byte value for bool: %s: %x", msgBadDesc, d.bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *simpleDecDriver) ReadMapStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	d.bdRead = false
+	return d.decLen()
+}
+
+func (d *simpleDecDriver) ReadArrayStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	d.bdRead = false
+	return d.decLen()
+}
+
+func (d *simpleDecDriver) decLen() int {
+	switch d.bd % 8 {
+	case 0:
+		return 0
+	case 1:
+		return int(d.r.readn1())
+	case 2:
+		return int(bigen.Uint16(d.r.readx(2)))
+	case 3:
+		ui := uint64(bigen.Uint32(d.r.readx(4)))
+		if chkOvf.Uint(ui, intBitsize) {
+			d.d.errorf("simple: overflow integer: %v", ui)
+			return 0
+		}
+		return int(ui)
+	case 4:
+		ui := bigen.Uint64(d.r.readx(8))
+		if chkOvf.Uint(ui, intBitsize) {
+			d.d.errorf("simple: overflow integer: %v", ui)
+			return 0
+		}
+		return int(ui)
+	}
+	d.d.errorf("decLen: Cannot read length: bd%%8 must be in range 0..4. Got: %d", d.bd%8)
+	return -1
+}
+
+func (d *simpleDecDriver) DecodeString() (s string) {
+	return string(d.DecodeBytes(d.b[:], true, true))
+}
+
+func (d *simpleDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	if d.bd == simpleVdNil {
+		d.bdRead = false
+		return
+	}
+	clen := d.decLen()
+	d.bdRead = false
+	if zerocopy {
+		if d.br {
+			return d.r.readx(clen)
+		} else if len(bs) == 0 {
+			bs = d.b[:]
+		}
+	}
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
+}
+
+func (d *simpleDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	if xtag > 0xff {
+		d.d.errorf("decodeExt: tag must be <= 0xff; got: %v", xtag)
+		return
+	}
+	realxtag1, xbs := d.decodeExtV(ext != nil, uint8(xtag))
+	realxtag = uint64(realxtag1)
+	if ext == nil {
+		re := rv.(*RawExt)
+		re.Tag = realxtag
+		re.Data = detachZeroCopyBytes(d.br, re.Data, xbs)
+	} else {
+		ext.ReadExt(rv, xbs)
+	}
+	return
+}
+
+func (d *simpleDecDriver) decodeExtV(verifyTag bool, tag byte) (xtag byte, xbs []byte) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+	switch d.bd {
+	case simpleVdExt, simpleVdExt + 1, simpleVdExt + 2, simpleVdExt + 3, simpleVdExt + 4:
+		l := d.decLen()
+		xtag = d.r.readn1()
+		if verifyTag && xtag != tag {
+			d.d.errorf("Wrong extension tag. Got %b. Expecting: %v", xtag, tag)
+			return
+		}
+		xbs = d.r.readx(l)
+	case simpleVdByteArray, simpleVdByteArray + 1, simpleVdByteArray + 2, simpleVdByteArray + 3, simpleVdByteArray + 4:
+		xbs = d.DecodeBytes(nil, false, true)
+	default:
+		d.d.errorf("Invalid d.bd for extensions (Expecting extensions or byte array). Got: 0x%x", d.bd)
+		return
+	}
+	d.bdRead = false
+	return
+}
+
+func (d *simpleDecDriver) DecodeNaked() {
+	if !d.bdRead {
+		d.readNextBd()
+	}
+
+	n := &d.d.n
+	var decodeFurther bool
+
+	switch d.bd {
+	case simpleVdNil:
+		n.v = valueTypeNil
+	case simpleVdFalse:
+		n.v = valueTypeBool
+		n.b = false
+	case simpleVdTrue:
+		n.v = valueTypeBool
+		n.b = true
+	case simpleVdPosInt, simpleVdPosInt + 1, simpleVdPosInt + 2, simpleVdPosInt + 3:
+		if d.h.SignedInteger {
+			n.v = valueTypeInt
+			n.i = d.DecodeInt(64)
+		} else {
+			n.v = valueTypeUint
+			n.u = d.DecodeUint(64)
+		}
+	case simpleVdNegInt, simpleVdNegInt + 1, simpleVdNegInt + 2, simpleVdNegInt + 3:
+		n.v = valueTypeInt
+		n.i = d.DecodeInt(64)
+	case simpleVdFloat32:
+		n.v = valueTypeFloat
+		n.f = d.DecodeFloat(true)
+	case simpleVdFloat64:
+		n.v = valueTypeFloat
+		n.f = d.DecodeFloat(false)
+	case simpleVdString, simpleVdString + 1, simpleVdString + 2, simpleVdString + 3, simpleVdString + 4:
+		n.v = valueTypeString
+		n.s = d.DecodeString()
+	case simpleVdByteArray, simpleVdByteArray + 1, simpleVdByteArray + 2, simpleVdByteArray + 3, simpleVdByteArray + 4:
+		n.v = valueTypeBytes
+		n.l = d.DecodeBytes(nil, false, false)
+	case simpleVdExt, simpleVdExt + 1, simpleVdExt + 2, simpleVdExt + 3, simpleVdExt + 4:
+		n.v = valueTypeExt
+		l := d.decLen()
+		n.u = uint64(d.r.readn1())
+		n.l = d.r.readx(l)
+	case simpleVdArray, simpleVdArray + 1, simpleVdArray + 2, simpleVdArray + 3, simpleVdArray + 4:
+		n.v = valueTypeArray
+		decodeFurther = true
+	case simpleVdMap, simpleVdMap + 1, simpleVdMap + 2, simpleVdMap + 3, simpleVdMap + 4:
+		n.v = valueTypeMap
+		decodeFurther = true
+	default:
+		d.d.errorf("decodeNaked: Unrecognized d.bd: 0x%x", d.bd)
+	}
+
+	if !decodeFurther {
+		d.bdRead = false
+	}
+	return
+}
+
+//------------------------------------
+
+// SimpleHandle is a Handle for a very simple encoding format.
+//
+// simple is a simplistic codec similar to binc, but not as compact.
+//   - Encoding of a value is always preceded by the descriptor byte (bd)
+//   - True, false, nil are encoded fully in 1 byte (the descriptor)
+//   - Integers (intXXX, uintXXX) are encoded in 1, 2, 4 or 8 bytes (plus a descriptor byte).
+//     There are positive (uintXXX and intXXX >= 0) and negative (intXXX < 0) integers.
+//   - Floats are encoded in 4 or 8 bytes (plus a descriptor byte)
+//   - Lenght of containers (strings, bytes, array, map, extensions)
+//     are encoded in 0, 1, 2, 4 or 8 bytes.
+//     Zero-length containers have no length encoded.
+//     For others, the number of bytes is given by pow(2, bd%3)
+//   - maps are encoded as [bd] [length] [[key][value]]...
+//   - arrays are encoded as [bd] [length] [value]...
+//   - extensions are encoded as [bd] [length] [tag] [byte]...
+//   - strings/bytearrays are encoded as [bd] [length] [byte]...
+//
+// The full spec will be published soon.
+type SimpleHandle struct {
+	BasicHandle
+	binaryEncodingType
+}
+
+func (h *SimpleHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
+}
+
+func (h *SimpleHandle) newEncDriver(e *Encoder) encDriver {
+	return &simpleEncDriver{e: e, w: e.w, h: h}
+}
+
+func (h *SimpleHandle) newDecDriver(d *Decoder) decDriver {
+	return &simpleDecDriver{d: d, h: h, r: d.r, br: d.bytes}
+}
+
+func (e *simpleEncDriver) reset() {
+	e.w = e.e.w
+}
+
+func (d *simpleDecDriver) reset() {
+	d.r, d.br = d.d.r, d.d.bytes
+	d.bd, d.bdRead = 0, false
+}
+
+var _ decDriver = (*simpleDecDriver)(nil)
+var _ encDriver = (*simpleEncDriver)(nil)

--- a/vendor/github.com/ugorji/go/codec/test-cbor-goldens.json
+++ b/vendor/github.com/ugorji/go/codec/test-cbor-goldens.json
@@ -1,0 +1,639 @@
+[
+  {
+    "cbor": "AA==",
+    "hex": "00",
+    "roundtrip": true,
+    "decoded": 0
+  },
+  {
+    "cbor": "AQ==",
+    "hex": "01",
+    "roundtrip": true,
+    "decoded": 1
+  },
+  {
+    "cbor": "Cg==",
+    "hex": "0a",
+    "roundtrip": true,
+    "decoded": 10
+  },
+  {
+    "cbor": "Fw==",
+    "hex": "17",
+    "roundtrip": true,
+    "decoded": 23
+  },
+  {
+    "cbor": "GBg=",
+    "hex": "1818",
+    "roundtrip": true,
+    "decoded": 24
+  },
+  {
+    "cbor": "GBk=",
+    "hex": "1819",
+    "roundtrip": true,
+    "decoded": 25
+  },
+  {
+    "cbor": "GGQ=",
+    "hex": "1864",
+    "roundtrip": true,
+    "decoded": 100
+  },
+  {
+    "cbor": "GQPo",
+    "hex": "1903e8",
+    "roundtrip": true,
+    "decoded": 1000
+  },
+  {
+    "cbor": "GgAPQkA=",
+    "hex": "1a000f4240",
+    "roundtrip": true,
+    "decoded": 1000000
+  },
+  {
+    "cbor": "GwAAAOjUpRAA",
+    "hex": "1b000000e8d4a51000",
+    "roundtrip": true,
+    "decoded": 1000000000000
+  },
+  {
+    "cbor": "G///////////",
+    "hex": "1bffffffffffffffff",
+    "roundtrip": true,
+    "decoded": 18446744073709551615
+  },
+  {
+    "cbor": "wkkBAAAAAAAAAAA=",
+    "hex": "c249010000000000000000",
+    "roundtrip": true,
+    "decoded": 18446744073709551616
+  },
+  {
+    "cbor": "O///////////",
+    "hex": "3bffffffffffffffff",
+    "roundtrip": true,
+    "decoded": -18446744073709551616,
+    "skip": true
+  },
+  {
+    "cbor": "w0kBAAAAAAAAAAA=",
+    "hex": "c349010000000000000000",
+    "roundtrip": true,
+    "decoded": -18446744073709551617
+  },
+  {
+    "cbor": "IA==",
+    "hex": "20",
+    "roundtrip": true,
+    "decoded": -1
+  },
+  {
+    "cbor": "KQ==",
+    "hex": "29",
+    "roundtrip": true,
+    "decoded": -10
+  },
+  {
+    "cbor": "OGM=",
+    "hex": "3863",
+    "roundtrip": true,
+    "decoded": -100
+  },
+  {
+    "cbor": "OQPn",
+    "hex": "3903e7",
+    "roundtrip": true,
+    "decoded": -1000
+  },
+  {
+    "cbor": "+QAA",
+    "hex": "f90000",
+    "roundtrip": true,
+    "decoded": 0.0
+  },
+  {
+    "cbor": "+YAA",
+    "hex": "f98000",
+    "roundtrip": true,
+    "decoded": -0.0
+  },
+  {
+    "cbor": "+TwA",
+    "hex": "f93c00",
+    "roundtrip": true,
+    "decoded": 1.0
+  },
+  {
+    "cbor": "+z/xmZmZmZma",
+    "hex": "fb3ff199999999999a",
+    "roundtrip": true,
+    "decoded": 1.1
+  },
+  {
+    "cbor": "+T4A",
+    "hex": "f93e00",
+    "roundtrip": true,
+    "decoded": 1.5
+  },
+  {
+    "cbor": "+Xv/",
+    "hex": "f97bff",
+    "roundtrip": true,
+    "decoded": 65504.0
+  },
+  {
+    "cbor": "+kfDUAA=",
+    "hex": "fa47c35000",
+    "roundtrip": true,
+    "decoded": 100000.0
+  },
+  {
+    "cbor": "+n9///8=",
+    "hex": "fa7f7fffff",
+    "roundtrip": true,
+    "decoded": 3.4028234663852886e+38
+  },
+  {
+    "cbor": "+3435DyIAHWc",
+    "hex": "fb7e37e43c8800759c",
+    "roundtrip": true,
+    "decoded": 1.0e+300
+  },
+  {
+    "cbor": "+QAB",
+    "hex": "f90001",
+    "roundtrip": true,
+    "decoded": 5.960464477539063e-08
+  },
+  {
+    "cbor": "+QQA",
+    "hex": "f90400",
+    "roundtrip": true,
+    "decoded": 6.103515625e-05
+  },
+  {
+    "cbor": "+cQA",
+    "hex": "f9c400",
+    "roundtrip": true,
+    "decoded": -4.0
+  },
+  {
+    "cbor": "+8AQZmZmZmZm",
+    "hex": "fbc010666666666666",
+    "roundtrip": true,
+    "decoded": -4.1
+  },
+  {
+    "cbor": "+XwA",
+    "hex": "f97c00",
+    "roundtrip": true,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+X4A",
+    "hex": "f97e00",
+    "roundtrip": true,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+fwA",
+    "hex": "f9fc00",
+    "roundtrip": true,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "+n+AAAA=",
+    "hex": "fa7f800000",
+    "roundtrip": false,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+n/AAAA=",
+    "hex": "fa7fc00000",
+    "roundtrip": false,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+v+AAAA=",
+    "hex": "faff800000",
+    "roundtrip": false,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "+3/wAAAAAAAA",
+    "hex": "fb7ff0000000000000",
+    "roundtrip": false,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+3/4AAAAAAAA",
+    "hex": "fb7ff8000000000000",
+    "roundtrip": false,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+//wAAAAAAAA",
+    "hex": "fbfff0000000000000",
+    "roundtrip": false,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "9A==",
+    "hex": "f4",
+    "roundtrip": true,
+    "decoded": false
+  },
+  {
+    "cbor": "9Q==",
+    "hex": "f5",
+    "roundtrip": true,
+    "decoded": true
+  },
+  {
+    "cbor": "9g==",
+    "hex": "f6",
+    "roundtrip": true,
+    "decoded": null
+  },
+  {
+    "cbor": "9w==",
+    "hex": "f7",
+    "roundtrip": true,
+    "diagnostic": "undefined"
+  },
+  {
+    "cbor": "8A==",
+    "hex": "f0",
+    "roundtrip": true,
+    "diagnostic": "simple(16)"
+  },
+  {
+    "cbor": "+Bg=",
+    "hex": "f818",
+    "roundtrip": true,
+    "diagnostic": "simple(24)"
+  },
+  {
+    "cbor": "+P8=",
+    "hex": "f8ff",
+    "roundtrip": true,
+    "diagnostic": "simple(255)"
+  },
+  {
+    "cbor": "wHQyMDEzLTAzLTIxVDIwOjA0OjAwWg==",
+    "hex": "c074323031332d30332d32315432303a30343a30305a",
+    "roundtrip": true,
+    "diagnostic": "0(\"2013-03-21T20:04:00Z\")"
+  },
+  {
+    "cbor": "wRpRS2ew",
+    "hex": "c11a514b67b0",
+    "roundtrip": true,
+    "diagnostic": "1(1363896240)"
+  },
+  {
+    "cbor": "wftB1FLZ7CAAAA==",
+    "hex": "c1fb41d452d9ec200000",
+    "roundtrip": true,
+    "diagnostic": "1(1363896240.5)"
+  },
+  {
+    "cbor": "10QBAgME",
+    "hex": "d74401020304",
+    "roundtrip": true,
+    "diagnostic": "23(h'01020304')"
+  },
+  {
+    "cbor": "2BhFZElFVEY=",
+    "hex": "d818456449455446",
+    "roundtrip": true,
+    "diagnostic": "24(h'6449455446')"
+  },
+  {
+    "cbor": "2CB2aHR0cDovL3d3dy5leGFtcGxlLmNvbQ==",
+    "hex": "d82076687474703a2f2f7777772e6578616d706c652e636f6d",
+    "roundtrip": true,
+    "diagnostic": "32(\"http://www.example.com\")"
+  },
+  {
+    "cbor": "QA==",
+    "hex": "40",
+    "roundtrip": true,
+    "diagnostic": "h''"
+  },
+  {
+    "cbor": "RAECAwQ=",
+    "hex": "4401020304",
+    "roundtrip": true,
+    "diagnostic": "h'01020304'"
+  },
+  {
+    "cbor": "YA==",
+    "hex": "60",
+    "roundtrip": true,
+    "decoded": ""
+  },
+  {
+    "cbor": "YWE=",
+    "hex": "6161",
+    "roundtrip": true,
+    "decoded": "a"
+  },
+  {
+    "cbor": "ZElFVEY=",
+    "hex": "6449455446",
+    "roundtrip": true,
+    "decoded": "IETF"
+  },
+  {
+    "cbor": "YiJc",
+    "hex": "62225c",
+    "roundtrip": true,
+    "decoded": "\"\\"
+  },
+  {
+    "cbor": "YsO8",
+    "hex": "62c3bc",
+    "roundtrip": true,
+    "decoded": "ü"
+  },
+  {
+    "cbor": "Y+awtA==",
+    "hex": "63e6b0b4",
+    "roundtrip": true,
+    "decoded": "水"
+  },
+  {
+    "cbor": "ZPCQhZE=",
+    "hex": "64f0908591",
+    "roundtrip": true,
+    "decoded": "𐅑"
+  },
+  {
+    "cbor": "gA==",
+    "hex": "80",
+    "roundtrip": true,
+    "decoded": [
+
+    ]
+  },
+  {
+    "cbor": "gwECAw==",
+    "hex": "83010203",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      2,
+      3
+    ]
+  },
+  {
+    "cbor": "gwGCAgOCBAU=",
+    "hex": "8301820203820405",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "mBkBAgMEBQYHCAkKCwwNDg8QERITFBUWFxgYGBk=",
+    "hex": "98190102030405060708090a0b0c0d0e0f101112131415161718181819",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25
+    ]
+  },
+  {
+    "cbor": "oA==",
+    "hex": "a0",
+    "roundtrip": true,
+    "decoded": {
+    }
+  },
+  {
+    "cbor": "ogECAwQ=",
+    "hex": "a201020304",
+    "roundtrip": true,
+    "skip": true,
+    "diagnostic": "{1: 2, 3: 4}"
+  },
+  {
+    "cbor": "omFhAWFiggID",
+    "hex": "a26161016162820203",
+    "roundtrip": true,
+    "decoded": {
+      "a": 1,
+      "b": [
+        2,
+        3
+      ]
+    }
+  },
+  {
+    "cbor": "gmFhoWFiYWM=",
+    "hex": "826161a161626163",
+    "roundtrip": true,
+    "decoded": [
+      "a",
+      {
+        "b": "c"
+      }
+    ]
+  },
+  {
+    "cbor": "pWFhYUFhYmFCYWNhQ2FkYURhZWFF",
+    "hex": "a56161614161626142616361436164614461656145",
+    "roundtrip": true,
+    "decoded": {
+      "a": "A",
+      "b": "B",
+      "c": "C",
+      "d": "D",
+      "e": "E"
+    }
+  },
+  {
+    "cbor": "X0IBAkMDBAX/",
+    "hex": "5f42010243030405ff",
+    "roundtrip": false,
+    "skip": true,
+    "diagnostic": "(_ h'0102', h'030405')"
+  },
+  {
+    "cbor": "f2VzdHJlYWRtaW5n/w==",
+    "hex": "7f657374726561646d696e67ff",
+    "roundtrip": false,
+    "decoded": "streaming"
+  },
+  {
+    "cbor": "n/8=",
+    "hex": "9fff",
+    "roundtrip": false,
+    "decoded": [
+
+    ]
+  },
+  {
+    "cbor": "nwGCAgOfBAX//w==",
+    "hex": "9f018202039f0405ffff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "nwGCAgOCBAX/",
+    "hex": "9f01820203820405ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "gwGCAgOfBAX/",
+    "hex": "83018202039f0405ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "gwGfAgP/ggQF",
+    "hex": "83019f0203ff820405",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "nwECAwQFBgcICQoLDA0ODxAREhMUFRYXGBgYGf8=",
+    "hex": "9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25
+    ]
+  },
+  {
+    "cbor": "v2FhAWFinwID//8=",
+    "hex": "bf61610161629f0203ffff",
+    "roundtrip": false,
+    "decoded": {
+      "a": 1,
+      "b": [
+        2,
+        3
+      ]
+    }
+  },
+  {
+    "cbor": "gmFhv2FiYWP/",
+    "hex": "826161bf61626163ff",
+    "roundtrip": false,
+    "decoded": [
+      "a",
+      {
+        "b": "c"
+      }
+    ]
+  },
+  {
+    "cbor": "v2NGdW71Y0FtdCH/",
+    "hex": "bf6346756ef563416d7421ff",
+    "roundtrip": false,
+    "decoded": {
+      "Fun": true,
+      "Amt": -2
+    }
+  }
+]

--- a/vendor/github.com/ugorji/go/codec/test.py
+++ b/vendor/github.com/ugorji/go/codec/test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+# This will create golden files in a directory passed to it.
+# A Test calls this internally to create the golden files
+# So it can process them (so we don't have to checkin the files).
+
+# Ensure msgpack-python and cbor are installed first, using:
+#   sudo apt-get install python-dev
+#   sudo apt-get install python-pip
+#   pip install --user msgpack-python msgpack-rpc-python cbor
+
+# Ensure all "string" keys are utf strings (else encoded as bytes)
+
+import cbor, msgpack, msgpackrpc, sys, os, threading
+
+def get_test_data_list():
+    # get list with all primitive types, and a combo type
+    l0 = [ 
+        -8,
+         -1616,
+         -32323232,
+         -6464646464646464,
+         192,
+         1616,
+         32323232,
+         6464646464646464,
+         192,
+         -3232.0,
+         -6464646464.0,
+         3232.0,
+         6464.0,
+         6464646464.0,
+         False,
+         True,
+         u"null",
+         None,
+         u"some&day>some<day",
+         1328176922000002000,
+         u"",
+         -2206187877999998000,
+         u"bytestring",
+         270,
+         u"none",
+        -2013855847999995777,
+         #-6795364578871345152,
+         ]
+    l1 = [
+        { "true": True,
+          "false": False },
+        { "true": u"True",
+          "false": False,
+          "uint16(1616)": 1616 },
+        { "list": [1616, 32323232, True, -3232.0, {"TRUE":True, "FALSE":False}, [True, False] ],
+          "int32":32323232, "bool": True, 
+          "LONG STRING": u"123456789012345678901234567890123456789012345678901234567890",
+          "SHORT STRING": u"1234567890" },
+        { True: "true", 138: False, "false": 200 }
+        ]
+    
+    l = []
+    l.extend(l0)
+    l.append(l0)
+    l.append(1)
+    l.extend(l1)
+    return l
+
+def build_test_data(destdir):
+    l = get_test_data_list()
+    for i in range(len(l)):
+        # packer = msgpack.Packer()
+        serialized = msgpack.dumps(l[i])
+        f = open(os.path.join(destdir, str(i) + '.msgpack.golden'), 'wb')
+        f.write(serialized)
+        f.close()
+        serialized = cbor.dumps(l[i])
+        f = open(os.path.join(destdir, str(i) + '.cbor.golden'), 'wb')
+        f.write(serialized)
+        f.close()
+
+def doRpcServer(port, stopTimeSec):
+    class EchoHandler(object):
+        def Echo123(self, msg1, msg2, msg3):
+            return ("1:%s 2:%s 3:%s" % (msg1, msg2, msg3))
+        def EchoStruct(self, msg):
+            return ("%s" % msg)
+    
+    addr = msgpackrpc.Address('127.0.0.1', port)
+    server = msgpackrpc.Server(EchoHandler())
+    server.listen(addr)
+    # run thread to stop it after stopTimeSec seconds if > 0
+    if stopTimeSec > 0:
+        def myStopRpcServer():
+            server.stop()
+        t = threading.Timer(stopTimeSec, myStopRpcServer)
+        t.start()
+    server.start()
+
+def doRpcClientToPythonSvc(port):
+    address = msgpackrpc.Address('127.0.0.1', port)
+    client = msgpackrpc.Client(address, unpack_encoding='utf-8')
+    print client.call("Echo123", "A1", "B2", "C3")
+    print client.call("EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+   
+def doRpcClientToGoSvc(port):
+    # print ">>>> port: ", port, " <<<<<"
+    address = msgpackrpc.Address('127.0.0.1', port)
+    client = msgpackrpc.Client(address, unpack_encoding='utf-8')
+    print client.call("TestRpcInt.Echo123", ["A1", "B2", "C3"])
+    print client.call("TestRpcInt.EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+
+def doMain(args):
+    if len(args) == 2 and args[0] == "testdata":
+        build_test_data(args[1])
+    elif len(args) == 3 and args[0] == "rpc-server":
+        doRpcServer(int(args[1]), int(args[2]))
+    elif len(args) == 2 and args[0] == "rpc-client-python-service":
+        doRpcClientToPythonSvc(int(args[1]))
+    elif len(args) == 2 and args[0] == "rpc-client-go-service":
+        doRpcClientToGoSvc(int(args[1]))
+    else:
+        print("Usage: test.py " + 
+              "[testdata|rpc-server|rpc-client-python-service|rpc-client-go-service] ...")
+    
+if __name__ == "__main__":
+    doMain(sys.argv[1:])
+

--- a/vendor/github.com/ugorji/go/codec/tests.sh
+++ b/vendor/github.com/ugorji/go/codec/tests.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Run all the different permutations of all the tests.
+# This helps ensure that nothing gets broken.
+
+_run() {
+    # 1. VARIATIONS: regular (t), canonical (c), IO R/W (i),
+    #                binc-nosymbols (n), struct2array (s), intern string (e),
+    #                json-indent (d), circular (l)
+    # 2. MODE: reflection (r), external (x), codecgen (g), unsafe (u), notfastpath (f)
+    # 3. OPTIONS: verbose (v), reset (z), must (m),
+    # 
+    # Use combinations of mode to get exactly what you want,
+    # and then pass the variations you need.
+
+    ztags=""
+    zargs=""
+    local OPTIND 
+    OPTIND=1
+    # "_xurtcinsvgzmefdl" ===  "_cdefgilmnrtsuvxz"
+    while getopts "_cdefgilmnrtsuvwxz" flag
+    do
+        case "x$flag" in 
+            'xr')  ;;
+            'xf') ztags="$ztags notfastpath" ;;
+            'xg') ztags="$ztags codecgen" ;;
+            'xx') ztags="$ztags x" ;;
+            'xu') ztags="$ztags unsafe" ;;
+            'xv') zargs="$zargs -tv" ;;
+            'xz') zargs="$zargs -tr" ;;
+            'xm') zargs="$zargs -tm" ;;
+            'xl') zargs="$zargs -tl" ;;
+            'xw') zargs="$zargs -tx=10" ;;
+            *) ;;
+        esac
+    done
+    # shift $((OPTIND-1))
+    printf '............. TAGS: %s .............\n' "$ztags"
+    # echo ">>>>>>> TAGS: $ztags"
+    
+    OPTIND=1
+    while getopts "_cdefgilmnrtsuvwxz" flag
+    do
+        case "x$flag" in 
+            'xt') printf ">>>>>>> REGULAR    : "; go test "-tags=$ztags" $zargs ; sleep 2 ;;
+            'xc') printf ">>>>>>> CANONICAL  : "; go test "-tags=$ztags" $zargs -tc; sleep 2 ;;
+            'xi') printf ">>>>>>> I/O        : "; go test "-tags=$ztags" $zargs -ti; sleep 2 ;;
+            'xn') printf ">>>>>>> NO_SYMBOLS : "; go test "-tags=$ztags" -run=Binc $zargs -tn; sleep 2 ;;
+            'xs') printf ">>>>>>> TO_ARRAY   : "; go test "-tags=$ztags" $zargs -ts; sleep 2 ;;
+            'xe') printf ">>>>>>> INTERN     : "; go test "-tags=$ztags" $zargs -te; sleep 2 ;;
+            'xd') printf ">>>>>>> INDENT     : ";
+                  go test "-tags=$ztags" -run=JsonCodecsTable -td=-1 $zargs;
+                  go test "-tags=$ztags" -run=JsonCodecsTable -td=8 $zargs;
+                  sleep 2 ;;
+            *) ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    OPTIND=1
+}
+
+# echo ">>>>>>> RUNNING VARIATIONS OF TESTS"    
+if [[ "x$@" = "x"  || "x$@" = "x-A" ]]; then
+    # All: r, x, g, gu
+    _run "-_tcinsed_ml"  # regular
+    _run "-_tcinsed_ml_z" # regular with reset
+    _run "-w_tcinsed_ml"  # regular with max init len
+    _run "-_tcinsed_ml_f" # regular with no fastpath (notfastpath)
+    _run "-x_tcinsed_ml" # external
+    _run "-gx_tcinsed_ml" # codecgen: requires external
+    _run "-gxu_tcinsed_ml" # codecgen + unsafe
+elif [[ "x$@" = "x-Z" ]]; then
+    # Regular
+    _run "-_tcinsed_ml"  # regular
+    _run "-_tcinsed_ml_z" # regular with reset
+elif [[ "x$@" = "x-F" ]]; then
+    # regular with notfastpath
+    _run "-_tcinsed_ml_f"  # regular
+    _run "-_tcinsed_ml_zf" # regular with reset
+elif [[ "x$@" = "x-C" ]]; then
+    # codecgen
+    _run "-gx_tcinsed_ml" # codecgen: requires external
+    _run "-gxu_tcinsed_ml" # codecgen + unsafe
+    _run "-gxuw_tcinsed_ml" # codecgen + unsafe + maxinitlen
+elif [[ "x$@" = "x-X" ]]; then
+    # external
+    _run "-x_tcinsed_ml" # external
+elif [[ "x$@" = "x-h" || "x$@" = "x-?" ]]; then
+    cat <<EOF
+Usage: tests.sh [options...]
+  -A run through all tests (regular, external, codecgen)
+  -Z regular tests only 
+  -F regular tests only (without fastpath, so they run quickly)
+  -C codecgen only 
+  -X external only 
+  -h show help (usage)
+  -? same as -h
+  (no options) 
+      same as -A
+  (unrecognized options)
+      just pass on the options from the command line 
+EOF
+else
+    # e.g. ./tests.sh "-w_tcinsed_ml"
+    _run "$@"
+fi

--- a/vendor/github.com/ugorji/go/codec/time.go
+++ b/vendor/github.com/ugorji/go/codec/time.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+var (
+	timeDigits   = [...]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	timeExtEncFn = func(rv reflect.Value) (bs []byte, err error) {
+		defer panicToErr(&err)
+		bs = timeExt{}.WriteExt(rv.Interface())
+		return
+	}
+	timeExtDecFn = func(rv reflect.Value, bs []byte) (err error) {
+		defer panicToErr(&err)
+		timeExt{}.ReadExt(rv.Interface(), bs)
+		return
+	}
+)
+
+type timeExt struct{}
+
+func (x timeExt) WriteExt(v interface{}) (bs []byte) {
+	switch v2 := v.(type) {
+	case time.Time:
+		bs = encodeTime(v2)
+	case *time.Time:
+		bs = encodeTime(*v2)
+	default:
+		panic(fmt.Errorf("unsupported format for time conversion: expecting time.Time; got %T", v2))
+	}
+	return
+}
+func (x timeExt) ReadExt(v interface{}, bs []byte) {
+	tt, err := decodeTime(bs)
+	if err != nil {
+		panic(err)
+	}
+	*(v.(*time.Time)) = tt
+}
+
+func (x timeExt) ConvertExt(v interface{}) interface{} {
+	return x.WriteExt(v)
+}
+func (x timeExt) UpdateExt(v interface{}, src interface{}) {
+	x.ReadExt(v, src.([]byte))
+}
+
+// EncodeTime encodes a time.Time as a []byte, including
+// information on the instant in time and UTC offset.
+//
+// Format Description
+//
+//   A timestamp is composed of 3 components:
+//
+//   - secs: signed integer representing seconds since unix epoch
+//   - nsces: unsigned integer representing fractional seconds as a
+//     nanosecond offset within secs, in the range 0 <= nsecs < 1e9
+//   - tz: signed integer representing timezone offset in minutes east of UTC,
+//     and a dst (daylight savings time) flag
+//
+//   When encoding a timestamp, the first byte is the descriptor, which
+//   defines which components are encoded and how many bytes are used to
+//   encode secs and nsecs components. *If secs/nsecs is 0 or tz is UTC, it
+//   is not encoded in the byte array explicitly*.
+//
+//       Descriptor 8 bits are of the form `A B C DDD EE`:
+//           A:   Is secs component encoded? 1 = true
+//           B:   Is nsecs component encoded? 1 = true
+//           C:   Is tz component encoded? 1 = true
+//           DDD: Number of extra bytes for secs (range 0-7).
+//                If A = 1, secs encoded in DDD+1 bytes.
+//                    If A = 0, secs is not encoded, and is assumed to be 0.
+//                    If A = 1, then we need at least 1 byte to encode secs.
+//                    DDD says the number of extra bytes beyond that 1.
+//                    E.g. if DDD=0, then secs is represented in 1 byte.
+//                         if DDD=2, then secs is represented in 3 bytes.
+//           EE:  Number of extra bytes for nsecs (range 0-3).
+//                If B = 1, nsecs encoded in EE+1 bytes (similar to secs/DDD above)
+//
+//   Following the descriptor bytes, subsequent bytes are:
+//
+//       secs component encoded in `DDD + 1` bytes (if A == 1)
+//       nsecs component encoded in `EE + 1` bytes (if B == 1)
+//       tz component encoded in 2 bytes (if C == 1)
+//
+//   secs and nsecs components are integers encoded in a BigEndian
+//   2-complement encoding format.
+//
+//   tz component is encoded as 2 bytes (16 bits). Most significant bit 15 to
+//   Least significant bit 0 are described below:
+//
+//       Timezone offset has a range of -12:00 to +14:00 (ie -720 to +840 minutes).
+//       Bit 15 = have\_dst: set to 1 if we set the dst flag.
+//       Bit 14 = dst\_on: set to 1 if dst is in effect at the time, or 0 if not.
+//       Bits 13..0 = timezone offset in minutes. It is a signed integer in Big Endian format.
+//
+func encodeTime(t time.Time) []byte {
+	//t := rv.Interface().(time.Time)
+	tsecs, tnsecs := t.Unix(), t.Nanosecond()
+	var (
+		bd   byte
+		btmp [8]byte
+		bs   [16]byte
+		i    int = 1
+	)
+	l := t.Location()
+	if l == time.UTC {
+		l = nil
+	}
+	if tsecs != 0 {
+		bd = bd | 0x80
+		bigen.PutUint64(btmp[:], uint64(tsecs))
+		f := pruneSignExt(btmp[:], tsecs >= 0)
+		bd = bd | (byte(7-f) << 2)
+		copy(bs[i:], btmp[f:])
+		i = i + (8 - f)
+	}
+	if tnsecs != 0 {
+		bd = bd | 0x40
+		bigen.PutUint32(btmp[:4], uint32(tnsecs))
+		f := pruneSignExt(btmp[:4], true)
+		bd = bd | byte(3-f)
+		copy(bs[i:], btmp[f:4])
+		i = i + (4 - f)
+	}
+	if l != nil {
+		bd = bd | 0x20
+		// Note that Go Libs do not give access to dst flag.
+		_, zoneOffset := t.Zone()
+		//zoneName, zoneOffset := t.Zone()
+		zoneOffset /= 60
+		z := uint16(zoneOffset)
+		bigen.PutUint16(btmp[:2], z)
+		// clear dst flags
+		bs[i] = btmp[0] & 0x3f
+		bs[i+1] = btmp[1]
+		i = i + 2
+	}
+	bs[0] = bd
+	return bs[0:i]
+}
+
+// DecodeTime decodes a []byte into a time.Time.
+func decodeTime(bs []byte) (tt time.Time, err error) {
+	bd := bs[0]
+	var (
+		tsec  int64
+		tnsec uint32
+		tz    uint16
+		i     byte = 1
+		i2    byte
+		n     byte
+	)
+	if bd&(1<<7) != 0 {
+		var btmp [8]byte
+		n = ((bd >> 2) & 0x7) + 1
+		i2 = i + n
+		copy(btmp[8-n:], bs[i:i2])
+		//if first bit of bs[i] is set, then fill btmp[0..8-n] with 0xff (ie sign extend it)
+		if bs[i]&(1<<7) != 0 {
+			copy(btmp[0:8-n], bsAll0xff)
+			//for j,k := byte(0), 8-n; j < k; j++ {	btmp[j] = 0xff }
+		}
+		i = i2
+		tsec = int64(bigen.Uint64(btmp[:]))
+	}
+	if bd&(1<<6) != 0 {
+		var btmp [4]byte
+		n = (bd & 0x3) + 1
+		i2 = i + n
+		copy(btmp[4-n:], bs[i:i2])
+		i = i2
+		tnsec = bigen.Uint32(btmp[:])
+	}
+	if bd&(1<<5) == 0 {
+		tt = time.Unix(tsec, int64(tnsec)).UTC()
+		return
+	}
+	// In stdlib time.Parse, when a date is parsed without a zone name, it uses "" as zone name.
+	// However, we need name here, so it can be shown when time is printed.
+	// Zone name is in form: UTC-08:00.
+	// Note that Go Libs do not give access to dst flag, so we ignore dst bits
+
+	i2 = i + 2
+	tz = bigen.Uint16(bs[i:i2])
+	i = i2
+	// sign extend sign bit into top 2 MSB (which were dst bits):
+	if tz&(1<<13) == 0 { // positive
+		tz = tz & 0x3fff //clear 2 MSBs: dst bits
+	} else { // negative
+		tz = tz | 0xc000 //set 2 MSBs: dst bits
+		//tzname[3] = '-' (TODO: verify. this works here)
+	}
+	tzint := int16(tz)
+	if tzint == 0 {
+		tt = time.Unix(tsec, int64(tnsec)).UTC()
+	} else {
+		// For Go Time, do not use a descriptive timezone.
+		// It's unnecessary, and makes it harder to do a reflect.DeepEqual.
+		// The Offset already tells what the offset should be, if not on UTC and unknown zone name.
+		// var zoneName = timeLocUTCName(tzint)
+		tt = time.Unix(tsec, int64(tnsec)).In(time.FixedZone("", int(tzint)*60))
+	}
+	return
+}
+
+func timeLocUTCName(tzint int16) string {
+	if tzint == 0 {
+		return "UTC"
+	}
+	var tzname = []byte("UTC+00:00")
+	//tzname := fmt.Sprintf("UTC%s%02d:%02d", tzsign, tz/60, tz%60) //perf issue using Sprintf. inline below.
+	//tzhr, tzmin := tz/60, tz%60 //faster if u convert to int first
+	var tzhr, tzmin int16
+	if tzint < 0 {
+		tzname[3] = '-' // (TODO: verify. this works here)
+		tzhr, tzmin = -tzint/60, (-tzint)%60
+	} else {
+		tzhr, tzmin = tzint/60, tzint%60
+	}
+	tzname[4] = timeDigits[tzhr/10]
+	tzname[5] = timeDigits[tzhr%10]
+	tzname[7] = timeDigits[tzmin/10]
+	tzname[8] = timeDigits[tzmin%10]
+	return string(tzname)
+	//return time.FixedZone(string(tzname), int(tzint)*60)
+}

--- a/vendor/github.com/ugorji/go/codec/values_test.go
+++ b/vendor/github.com/ugorji/go/codec/values_test.go
@@ -1,0 +1,203 @@
+/* // +build testing */
+
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+// This file contains values used by tests and benchmarks.
+// JSON/BSON do not like maps with keys that are not strings,
+// so we only use maps with string keys here.
+
+import (
+	"math"
+	"time"
+)
+
+var testStrucTime = time.Date(2012, 2, 2, 2, 2, 2, 2000, time.UTC).UTC()
+
+type AnonInTestStruc struct {
+	AS        string
+	AI64      int64
+	AI16      int16
+	AUi64     uint64
+	ASslice   []string
+	AI64slice []int64
+	AF64slice []float64
+	// AMI32U32  map[int32]uint32
+	// AMU32F64 map[uint32]float64 // json/bson do not like it
+	AMSU16 map[string]uint16
+}
+
+type AnonInTestStrucIntf struct {
+	Islice []interface{}
+	Ms     map[string]interface{}
+	Nintf  interface{} //don't set this, so we can test for nil
+	T      time.Time
+}
+
+type TestStruc struct {
+	_struct struct{} `codec:",omitempty"` //set omitempty for every field
+
+	S    string
+	I64  int64
+	I16  int16
+	Ui64 uint64
+	Ui8  uint8
+	B    bool
+	By   uint8 // byte: msgp doesn't like byte
+
+	Sslice    []string
+	I64slice  []int64
+	I16slice  []int16
+	Ui64slice []uint64
+	Ui8slice  []uint8
+	Bslice    []bool
+	Byslice   []byte
+
+	Iptrslice []*int64
+
+	// TODO: test these separately, specifically for reflection and codecgen.
+	// Unfortunately, ffjson doesn't support these. Its compilation even fails.
+	// Ui64array      [4]uint64
+	// Ui64slicearray [][4]uint64
+
+	AnonInTestStruc
+
+	//M map[interface{}]interface{}  `json:"-",bson:"-"`
+	Msi64 map[string]int64
+
+	// make this a ptr, so that it could be set or not.
+	// for comparison (e.g. with msgp), give it a struct tag (so it is not inlined),
+	// make this one omitempty (so it is included if nil).
+	*AnonInTestStrucIntf `codec:",omitempty"`
+
+	Nmap       map[string]bool //don't set this, so we can test for nil
+	Nslice     []byte          //don't set this, so we can test for nil
+	Nint64     *int64          //don't set this, so we can test for nil
+	Mtsptr     map[string]*TestStruc
+	Mts        map[string]TestStruc
+	Its        []*TestStruc
+	Nteststruc *TestStruc
+}
+
+// small struct for testing that codecgen works for unexported types
+type tLowerFirstLetter struct {
+	I int
+	u uint64
+	S string
+	b []byte
+}
+
+func newTestStruc(depth int, bench bool, useInterface, useStringKeyOnly bool) (ts *TestStruc) {
+	var i64a, i64b, i64c, i64d int64 = 64, 6464, 646464, 64646464
+
+	ts = &TestStruc{
+		S:    "some string",
+		I64:  math.MaxInt64 * 2 / 3, // 64,
+		I16:  1616,
+		Ui64: uint64(int64(math.MaxInt64 * 2 / 3)), // 64, //don't use MaxUint64, as bson can't write it
+		Ui8:  160,
+		B:    true,
+		By:   5,
+
+		Sslice:    []string{"one", "two", "three"},
+		I64slice:  []int64{1111, 2222, 3333},
+		I16slice:  []int16{44, 55, 66},
+		Ui64slice: []uint64{12121212, 34343434, 56565656},
+		Ui8slice:  []uint8{210, 211, 212},
+		Bslice:    []bool{true, false, true, false},
+		Byslice:   []byte{13, 14, 15},
+
+		Msi64: map[string]int64{
+			"one": 1,
+			"two": 2,
+		},
+		AnonInTestStruc: AnonInTestStruc{
+			// There's more leeway in altering this.
+			AS:    "A-String",
+			AI64:  -64646464,
+			AI16:  1616,
+			AUi64: 64646464,
+			// (U+1D11E)G-clef character may be represented in json as "\uD834\uDD1E".
+			// single reverse solidus character may be represented in json as "\u005C".
+			// include these in ASslice below.
+			ASslice: []string{"Aone", "Atwo", "Athree",
+				"Afour.reverse_solidus.\u005c", "Afive.Gclef.\U0001d11E"},
+			AI64slice: []int64{1, -22, 333, -4444, 55555, -666666},
+			AMSU16:    map[string]uint16{"1": 1, "22": 2, "333": 3, "4444": 4},
+			AF64slice: []float64{11.11e-11, 22.22E+22, 33.33E-33, 44.44e+44, 555.55E-6, 666.66E6},
+		},
+	}
+	if useInterface {
+		ts.AnonInTestStrucIntf = &AnonInTestStrucIntf{
+			Islice: []interface{}{"true", true, "no", false, uint64(288), float64(0.4)},
+			Ms: map[string]interface{}{
+				"true":     "true",
+				"int64(9)": false,
+			},
+			T: testStrucTime,
+		}
+	}
+
+	//For benchmarks, some things will not work.
+	if !bench {
+		//json and bson require string keys in maps
+		//ts.M = map[interface{}]interface{}{
+		//	true: "true",
+		//	int8(9): false,
+		//}
+		//gob cannot encode nil in element in array (encodeArray: nil element)
+		ts.Iptrslice = []*int64{nil, &i64a, nil, &i64b, nil, &i64c, nil, &i64d, nil}
+		// ts.Iptrslice = nil
+	}
+	if !useStringKeyOnly {
+		// ts.AnonInTestStruc.AMU32F64 = map[uint32]float64{1: 1, 2: 2, 3: 3} // Json/Bson barf
+	}
+	if depth > 0 {
+		depth--
+		if ts.Mtsptr == nil {
+			ts.Mtsptr = make(map[string]*TestStruc)
+		}
+		if ts.Mts == nil {
+			ts.Mts = make(map[string]TestStruc)
+		}
+		ts.Mtsptr["0"] = newTestStruc(depth, bench, useInterface, useStringKeyOnly)
+		ts.Mts["0"] = *(ts.Mtsptr["0"])
+		ts.Its = append(ts.Its, ts.Mtsptr["0"])
+	}
+	return
+}
+
+// Some other types
+
+type Sstring string
+type Bbool bool
+type Sstructsmall struct {
+	A int
+}
+
+type Sstructbig struct {
+	A int
+	B bool
+	c string
+	// Sval Sstruct
+	Ssmallptr *Sstructsmall
+	Ssmall    *Sstructsmall
+	Sptr      *Sstructbig
+}
+
+type SstructbigMapBySlice struct {
+	_struct struct{} `codec:",toarray"`
+	A       int
+	B       bool
+	c       string
+	// Sval Sstruct
+	Ssmallptr *Sstructsmall
+	Ssmall    *Sstructsmall
+	Sptr      *Sstructbig
+}
+
+type Sinterface interface {
+	Noop()
+}

--- a/vendor/github.com/ugorji/go/msgpack.org.md
+++ b/vendor/github.com/ugorji/go/msgpack.org.md
@@ -1,0 +1,47 @@
+**MessagePack and [Binc](http://github.com/ugorji/binc) Codec for [Go](http://golang.org) Language.**
+
+*A High Performance, Feature-Rich, Idiomatic encode/decode and rpc library*.
+
+To install:
+
+    go get github.com/ugorji/go/codec
+
+Source: [http://github.com/ugorji/go]  
+Online documentation: [http://godoc.org/github.com/ugorji/go/codec]  
+
+Typical usage:
+
+```go
+    // create and use decoder/encoder
+    var (
+        v interface{} // value to decode/encode into
+        r io.Reader
+        w io.Writer
+        b []byte
+        mh codec.MsgpackHandle
+    )
+    
+    dec = codec.NewDecoder(r, &mh)
+    dec = codec.NewDecoderBytes(b, &mh)
+    err = dec.Decode(&v) 
+    
+    enc = codec.NewEncoder(w, &mh)
+    enc = codec.NewEncoderBytes(&b, &mh)
+    err = enc.Encode(v)
+    
+    //RPC Server
+    go func() {
+        for {
+            conn, err := listener.Accept()
+            rpcCodec := codec.GoRpc.ServerCodec(conn, h)
+            //OR rpcCodec := codec.MsgpackSpecRpc.ServerCodec(conn, h)
+            rpc.ServeCodec(rpcCodec)
+        }
+    }()
+    
+    //RPC Communication (client side)
+    conn, err = net.Dial("tcp", "localhost:5555")
+    rpcCodec := codec.GoRpc.ClientCodec(conn, h)
+    //OR rpcCodec := codec.MsgpackSpecRpc.ClientCodec(conn, h)
+    client := rpc.NewClientWithCodec(rpcCodec)
+```


### PR DESCRIPTION
Most [recent commit](https://github.com/ugorji/go/commit/54210f4e076c57f351166f0ed60e67d3fca57a36) of [ugorji/go](https://github.com/ugorji/go) changes an API, so breaks compilation of our vendored etcd code.  So vendor in ugorji/go as of 54210f4e076c^, which is [8c0409fcbb70](https://github.com/ugorji/go/commit/8c0409fcbb70).