### PR TITLE
Make trillian.Tree.PrivateKey a mutable field

### DIFF
--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -228,6 +228,8 @@ func applyUpdateMask(from, to *trillian.Tree, mask *field_mask.FieldMask) error 
 			to.StorageSettings = from.StorageSettings
 		case "max_root_duration":
 			to.MaxRootDuration = from.MaxRootDuration
+		case "private_key":
+			to.PrivateKey = from.PrivateKey
 		default:
 			return status.Errorf(codes.InvalidArgument, "invalid update_mask path: %q", path)
 		}

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -132,7 +132,7 @@ func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trilli
 }
 
 func (t *adminTX) CreateTree(ctx context.Context, tr *trillian.Tree) (*trillian.Tree, error) {
-	if err := storage.ValidateTreeForCreation(tr); err != nil {
+	if err := storage.ValidateTreeForCreation(ctx, tr); err != nil {
 		return nil, err
 	}
 	if err := validateStorageSettings(tr); err != nil {
@@ -174,7 +174,7 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	tree := mTree.meta
 	beforeUpdate := *tree
 	updateFunc(tree)
-	if err := storage.ValidateTreeForUpdate(&beforeUpdate, tree); err != nil {
+	if err := storage.ValidateTreeForUpdate(ctx, &beforeUpdate, tree); err != nil {
 		return nil, err
 	}
 	if err := validateStorageSettings(tree); err != nil {

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -35,7 +35,9 @@ import (
 	spb "github.com/google/trillian/crypto/sigpb"
 	ttestonly "github.com/google/trillian/testonly"
 
-	_ "github.com/google/trillian/merkle/maphasher" // TEST_MAP_HASHER
+	_ "github.com/google/trillian/crypto/keys/der/proto" // PrivateKey proto handler
+	_ "github.com/google/trillian/crypto/keys/pem/proto" // PEMKeyFile proto handler
+	_ "github.com/google/trillian/merkle/maphasher"      // TEST_MAP_HASHER
 )
 
 // mustMarshalAny panics if ptypes.MarshalAny fails.

--- a/storage/tools/dump_tree/dumplib/nochange_test.go
+++ b/storage/tools/dump_tree/dumplib/nochange_test.go
@@ -18,6 +18,8 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	_ "github.com/google/trillian/crypto/keys/der/proto"
 )
 
 // TestDBFormatNoChange ensures that the prefix, suffix, and protos stored in the database do not change.

--- a/trillian.proto
+++ b/trillian.proto
@@ -139,9 +139,9 @@ message Tree {
   // This can be any type of message to accommodate different key management
   // systems, e.g. PEM files, HSMs, etc.
   // Private keys are write-only: they're never returned by RPCs.
-  // TODO(RJPercival): Implement sufficient validation to allow this field to be
-  // mutable. It should be mutable in the sense that the key can be migrated to
-  // a different key management system, but the key itself should never change.
+  // The private_key message can be changed after a tree is created, but the
+  // underlying key must remain the same - this is to enable migrating a key
+  // from one provider to another.
   google.protobuf.Any private_key = 12;
 
   // Storage-specific settings.


### PR DESCRIPTION
Checks are performed to ensure that the underlying key material is not changed; only the protobuf message that communicates how to obtain it. This makes it possible to migrate a tree from one key management system to another.