### PR TITLE
Tree garbage collection

### DIFF
--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -256,7 +256,6 @@ func TestInclusion(t *testing.T) {
 				continue
 			}
 
-
 			if _, err := env.MapClient.SetLeaves(ctx, &trillian.SetMapLeavesRequest{
 				MapId:  tree.TreeId,
 				Leaves: tc.leaves,

--- a/server/admin/tree_gc.go
+++ b/server/admin/tree_gc.go
@@ -43,7 +43,7 @@ type DeletedTreeGC struct {
 	Admin storage.AdminStorage
 
 	// DeleteThreshold defines the minimum time a tree has to remain in the soft-deleted state
-	// before its eligible for garbage collection.
+	// before it's eligible for garbage collection.
 	DeleteThreshold time.Duration
 
 	// MinRunInterval defines how frequently sweeps for deleted trees are performed.
@@ -51,9 +51,15 @@ type DeletedTreeGC struct {
 	MinRunInterval time.Duration
 }
 
-// Run starts the tree garbage collection process. It never returns.
+// Run starts the tree garbage collection process. It runs until ctx is cancelled.
 func (gc *DeletedTreeGC) Run(ctx context.Context) {
 	for true {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		gc.RunOnce(ctx)
 
 		d := gc.MinRunInterval + time.Duration(rand.Int63n(gc.MinRunInterval.Nanoseconds()))

--- a/server/admin/tree_gc.go
+++ b/server/admin/tree_gc.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/trillian"
+	"github.com/google/trillian/storage"
+)
+
+var (
+	timeNow   = time.Now
+	timeSleep = time.Sleep
+)
+
+// DeletedTreeGC garbage collects deleted trees.
+//
+// Tree deletion goes through two separate stages:
+// * Soft deletion, which "flips a bit" (see Tree.Deleted) but otherwise leaves the tree unaltered
+// * Hard deletion, which effectively removes all tree data
+//
+// DeletedTreeGC performs the transition from soft to hard deletion. Trees that have been deleted
+// for at least DeletedThreshold are eligible for garbage collection.
+type DeletedTreeGC struct {
+	// Admin is the storage.AdminStorage interface.
+	Admin storage.AdminStorage
+
+	// DeleteThreshold defines the minimum time a tree has to remain in the soft-deleted state
+	// before its eligible for garbage collection.
+	DeleteThreshold time.Duration
+
+	// MinRunInterval defines how frequently sweeps for deleted trees are performed.
+	// Actual runs happen randomly between [minInterval,2*minInterval).
+	MinRunInterval time.Duration
+}
+
+// Run starts the tree garbage collection process. It never returns.
+func (gc *DeletedTreeGC) Run(ctx context.Context) {
+	for true {
+		gc.RunOnce(ctx)
+
+		d := gc.MinRunInterval + time.Duration(rand.Int63n(gc.MinRunInterval.Nanoseconds()))
+		timeSleep(d)
+	}
+}
+
+// RunOnce performs a single tree garbage collection sweep.
+// RunOnce never errors, instead it attempts to delete as many eligible trees as possible. Failures
+// are simply logged.
+func (gc *DeletedTreeGC) RunOnce(ctx context.Context) {
+	now := timeNow()
+
+	// List and delete trees in separate transactions. Hard-deletes may cascade to a lot of data, so
+	// each delete should be in its own transaction as well.
+	// It's OK to list and delete separately because HardDelete does its own state checking, plus
+	// deleted trees are unlikely to change, specially those deleted for a while.
+	tx, err := gc.Admin.Snapshot(ctx)
+	if err != nil {
+		glog.Errorf("DeletedTreeGC.RunOnce: error creating snapshot: %v", err)
+		return
+	}
+	defer tx.Close()
+	trees, err := tx.ListTrees(ctx, true /* includeDeleted */)
+	if err != nil {
+		glog.Errorf("DeletedTreeGC.RunOnce: error listing trees: %v", err)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		glog.Errorf("DeletedTreeGC.RunOnce: error committing snapshot: %v", err)
+		return
+	}
+
+	for _, tree := range trees {
+		if !tree.Deleted {
+			continue
+		}
+		deleteTime, err := ptypes.Timestamp(tree.DeleteTime)
+		if err != nil {
+			glog.Errorf("DeletedTreeGC.RunOnce: error parsing delete_time of tree %v: %v", tree.TreeId, err)
+			continue
+		}
+		durationSinceDelete := now.Sub(deleteTime)
+		if durationSinceDelete <= gc.DeleteThreshold {
+			continue
+		}
+
+		glog.Infof("DeletedTreeGC.RunOnce: Hard-deleting tree %v after %v", tree.TreeId, durationSinceDelete)
+		if err := gc.hardDeleteTree(ctx, tree); err != nil {
+			glog.Errorf("DeletedTreeGC.RunOnce: Error hard-deleting tree %v: %v", tree.TreeId, err)
+		}
+	}
+}
+
+func (gc *DeletedTreeGC) hardDeleteTree(ctx context.Context, tree *trillian.Tree) error {
+	tx, err := gc.Admin.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	if err := tx.HardDeleteTree(ctx, tree.TreeId); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/server/admin/tree_gc_test.go
+++ b/server/admin/tree_gc_test.go
@@ -1,0 +1,196 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/trillian"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testonly"
+)
+
+func TestDeletedTreeGC_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Test the following scenario:
+	// * 1st iteration: tree1 is listed and hard-deleted
+	// * Sleep
+	// * 2nd iteration: ListTrees returns an empty slice, nothing gets deleted
+	// * Sleep (panics)
+	//
+	// DeletedTreeGC.Run() runs forever. Since it sleeps between iterations, we
+	// make "timeSleep" panic the second time around; this aborts the loop and
+	// allows us to recover in the test.
+	stopErr := errors.New("stop run test")
+	defer func() {
+		if r := recover(); r != stopErr {
+			t.Fatal(r)
+		}
+	}()
+
+	tree1 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree1.TreeId = 1
+	tree1.Deleted = true
+	tree1.DeleteTime, _ = ptypes.TimestampProto(time.Date(2017, 9, 21, 10, 0, 0, 0, time.UTC))
+
+	listTX1 := storage.NewMockReadOnlyAdminTX(ctrl)
+	listTX2 := storage.NewMockReadOnlyAdminTX(ctrl)
+	deleteTX1 := storage.NewMockAdminTX(ctrl)
+	as := storage.NewMockAdminStorage(ctrl)
+
+	ctx := context.Background()
+
+	// Sequence Snapshot()/Begin() calls.
+	// * 1st loop: Snapshot()/ListTrees() followed by Begin()/HardDeleteTree()
+	// * 2nd loop: Snapshot()/ListTrees() only.
+	lastTXCall := as.EXPECT().Snapshot(ctx).Return(listTX1, nil)
+	lastTXCall = as.EXPECT().Begin(ctx).Return(deleteTX1, nil).After(lastTXCall)
+	as.EXPECT().Snapshot(ctx).Return(listTX2, nil).After(lastTXCall)
+
+	// 1st loop
+	listTX1.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return([]*trillian.Tree{tree1}, nil)
+	listTX1.EXPECT().Close().Return(nil)
+	listTX1.EXPECT().Commit().Return(nil)
+	deleteTX1.EXPECT().HardDeleteTree(ctx, tree1.TreeId).Return(nil)
+	deleteTX1.EXPECT().Close().Return(nil)
+	deleteTX1.EXPECT().Commit().Return(nil)
+
+	// 2nd loop
+	listTX2.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return(nil, nil)
+	listTX2.EXPECT().Close().Return(nil)
+	listTX2.EXPECT().Commit().Return(nil)
+
+	defer func(now func() time.Time, sleep func(time.Duration)) {
+		timeNow = now
+		timeSleep = sleep
+	}(timeNow, timeSleep)
+
+	const deleteThreshold = 1 * time.Hour
+	const runInterval = 3 * time.Second
+
+	// now > tree1.DeleteTime + deleteThreshold, so tree1 gets deleted on first round
+	now, _ := ptypes.Timestamp(tree1.DeleteTime)
+	now = now.Add(deleteThreshold).Add(1 * time.Second)
+	timeNow = func() time.Time { return now }
+
+	calls := 0
+	timeSleep = func(d time.Duration) {
+		calls++
+		if d < runInterval || d >= 2*runInterval {
+			t.Errorf("Called time.Sleep(%v), want %v", d, runInterval)
+		}
+		if calls >= 2 {
+			panic(stopErr)
+		}
+	}
+
+	gc := &DeletedTreeGC{
+		Admin:           as,
+		DeleteThreshold: deleteThreshold,
+		MinRunInterval:  runInterval,
+	}
+	gc.Run(ctx)
+}
+
+func TestDeletedTreeGC_RunOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tree1 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree1.TreeId = 1
+	tree2 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree2.TreeId = 2
+	tree2.Deleted = true
+	tree2.DeleteTime, _ = ptypes.TimestampProto(time.Date(2017, 9, 21, 10, 0, 0, 0, time.UTC))
+	tree3 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree3.TreeId = 3
+	tree3.Deleted = true
+	tree3.DeleteTime, _ = ptypes.TimestampProto(time.Date(2017, 9, 22, 11, 0, 0, 0, time.UTC))
+	tree4 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree4.TreeId = 4
+	tree4.Deleted = true
+	tree4.DeleteTime, _ = ptypes.TimestampProto(time.Date(2017, 9, 23, 12, 0, 0, 0, time.UTC))
+	tree5 := proto.Clone(testonly.LogTree).(*trillian.Tree)
+	tree5.TreeId = 5
+	allTrees := []*trillian.Tree{tree1, tree2, tree3, tree4, tree5}
+
+	tests := []struct {
+		desc            string
+		now             time.Time
+		deleteThreshold time.Duration
+		wantDeleted     []int64
+	}{
+		{
+			desc:            "noDeletions",
+			now:             time.Date(2017, 9, 28, 10, 0, 0, 0, time.UTC),
+			deleteThreshold: 7 * 24 * time.Hour,
+		},
+		{
+			desc:            "oneDeletion",
+			now:             time.Date(2017, 9, 28, 11, 0, 0, 0, time.UTC),
+			deleteThreshold: 7 * 24 * time.Hour,
+			wantDeleted:     []int64{tree2.TreeId},
+		},
+		{
+			desc:            "twoDeletions",
+			now:             time.Date(2017, 9, 22, 12, 1, 0, 0, time.UTC),
+			deleteThreshold: 1 * time.Hour,
+			wantDeleted:     []int64{tree2.TreeId, tree3.TreeId},
+		},
+		{
+			desc:            "threeDeletions",
+			now:             time.Date(2017, 9, 23, 13, 30, 0, 0, time.UTC),
+			deleteThreshold: 1 * time.Hour,
+			wantDeleted:     []int64{tree2.TreeId, tree3.TreeId, tree4.TreeId},
+		},
+	}
+
+	defer func(f func() time.Time) { timeNow = f }(timeNow)
+	ctx := context.Background()
+	for _, test := range tests {
+		timeNow = func() time.Time { return test.now }
+
+		as := storage.NewMockAdminStorage(ctrl)
+		listTX := storage.NewMockReadOnlyAdminTX(ctrl)
+
+		lastTXCall := as.EXPECT().Snapshot(ctx).Return(listTX, nil)
+		listTX.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return(allTrees, nil)
+		listTX.EXPECT().Close().Return(nil)
+		listTX.EXPECT().Commit().Return(nil)
+
+		for _, id := range test.wantDeleted {
+			deleteTX := storage.NewMockAdminTX(ctrl)
+			lastTXCall = as.EXPECT().Begin(ctx).After(lastTXCall).Return(deleteTX, nil)
+			deleteTX.EXPECT().HardDeleteTree(ctx, id).Return(nil)
+			deleteTX.EXPECT().Close().Return(nil)
+			deleteTX.EXPECT().Commit().Return(nil)
+		}
+
+		gc := &DeletedTreeGC{
+			Admin:           as,
+			DeleteThreshold: test.deleteThreshold,
+			MinRunInterval:  1 * time.Second, // Doesn't matter for this test
+		}
+		gc.RunOnce(ctx)
+	}
+}

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -73,6 +73,10 @@ var (
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
 		"Only effective for quota_system=mysql.")
 
+	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
+	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
+	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", server.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
+
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
 
@@ -165,6 +169,9 @@ func main() {
 			}
 			return nil
 		},
+		TreeGCEnabled:         *treeGCEnabled,
+		TreeDeleteThreshold:   *treeDeleteThreshold,
+		TreeDeleteMinInterval: *treeDeleteMinRunInterval,
 	}
 
 	if err := m.Run(ctx); err != nil {

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -69,6 +69,10 @@ var (
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
 		"Only effective for quota_system=mysql.")
 
+	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
+	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
+	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", server.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
+
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
 
@@ -148,6 +152,9 @@ func main() {
 			}
 			return nil
 		},
+		TreeGCEnabled:         *treeGCEnabled,
+		TreeDeleteThreshold:   *treeDeleteThreshold,
+		TreeDeleteMinInterval: *treeDeleteMinRunInterval,
 	}
 
 	ctx := context.Background()

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -187,7 +187,7 @@ func TestMapRootUpdate(t *testing.T) {
 				MapRevision:    8,
 				RootHash:       []byte(dummyHash),
 				Signature:      &spb.DigitallySigned{Signature: []byte("notempty")},
-				Metadata: 		testonly.MustMarshalAny(t,&ctmapperpb.MapperMetadata{HighestFullyCompletedSeq: 1}),
+				Metadata:       testonly.MustMarshalAny(t, &ctmapperpb.MapperMetadata{HighestFullyCompletedSeq: 1}),
 			}},
 	} {
 		{

--- a/testonly/marshalling.go
+++ b/testonly/marshalling.go
@@ -14,7 +14,7 @@
 
 package testonly
 
-import(
+import (
 	"log"
 	"testing"
 


### PR DESCRIPTION
Create a background task that periodically scans for and hard-deletes trees that have been soft-deleted longer than the specified period.