### PR TITLE
Override integration test timeouts using $GO_TEST_TIMEOUT

### DIFF
--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -31,7 +31,7 @@ echo "Created tree ${TEST_TREE_ID}"
 echo "Running test"
 pushd "${INTEGRATION_DIR}"
 set +e
-go test ${GOFLAGS} -run ".*LiveLog.*" --timeout=5m ./ --treeid ${TEST_TREE_ID} --log_rpc_server="${RPC_SERVER_1}"
+go test ${GOFLAGS} -run ".*LiveLog.*" --timeout=${GO_TEST_TIMEOUT:-5m} ./ --treeid ${TEST_TREE_ID} --log_rpc_server="${RPC_SERVER_1}"
 RESULT=$?
 set -e
 popd

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -10,7 +10,7 @@ TO_KILL+=(${RPC_SERVER_PIDS[@]})
 echo "Running test"
 cd "${INTEGRATION_DIR}"
 set +e
-go test ${GOFLAGS} --timeout=5m ./maptest  --map_rpc_server="${RPC_SERVER_1}"
+go test ${GOFLAGS} --timeout=${GO_TEST_TIMEOUT:-5m} ./maptest  --map_rpc_server="${RPC_SERVER_1}"
 RESULT=$?
 set -e
 


### PR DESCRIPTION
The unit test timeout is already controlled by this environment variable.