### PR TITLE
docs/commitlog: remove mastership election

### DIFF
--- a/docs/storage/commit_log/signer/signer.go
+++ b/docs/storage/commit_log/signer/signer.go
@@ -74,6 +74,9 @@ func (s *Signer) StoreSTHInfo(info STHInfo) {
 
 // IsMaster indicates if this signer is master.
 func (s *Signer) IsMaster() bool {
+	if s.election == nil {
+		return true
+	}
 	return s.election.IsMaster(s.Name)
 }
 

--- a/docs/storage/commit_log/simkafka/kafka.go
+++ b/docs/storage/commit_log/simkafka/kafka.go
@@ -22,10 +22,19 @@ import (
 
 type commitLog []string
 
+const showCount = 10
+
 func (c commitLog) String() string {
 	result := ""
-	for i, entry := range c {
-		result += fmt.Sprintf("| %d:%s ", i, entry)
+	l := len(c)
+	start := l - showCount
+	if start < 0 {
+		start = 0
+	} else if start > 0 {
+		result += "... "
+	}
+	for i := start; i < l; i++ {
+		result += fmt.Sprintf("| %d:%s ", i, c[i])
 	}
 	result += "|"
 	return result


### PR DESCRIPTION
The commitlog simulation code didn't previously make clear -- it should work without mastership election.  The simkafka STHs topic effectively acts as the serialization point: N signers attempt to write a new STH at offset x, but only one of those updates actually gets written to offset x, and that's the one that counts.