### PR TITLE
 Remove dependency on PEM file from admin_storage_tester.go

### DIFF
--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -33,11 +33,11 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/errors"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 
 	ktestonly "github.com/google/trillian/crypto/keys/testonly"
 	spb "github.com/google/trillian/crypto/sigpb"
-	ttestonly "github.com/google/trillian/testonly"
 
 	_ "github.com/google/trillian/crypto/keys/der/proto" // PrivateKey proto handler
 	_ "github.com/google/trillian/crypto/keys/pem/proto" // PEMKeyFile proto handler
@@ -100,10 +100,10 @@ var (
 		DisplayName:        "Llamas Map",
 		Description:        "Key Transparency map for all your digital llama needs.",
 		PrivateKey: mustMarshalAny(&keyspb.PrivateKey{
-			Der: ktestonly.MustMarshalPrivatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
+			Der: ktestonly.MustMarshalPrivatePEMToDER(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass),
 		}),
 		PublicKey: &keyspb.PublicKey{
-			Der: ktestonly.MustMarshalPublicPEMToDER(ttestonly.DemoPublicKey),
+			Der: ktestonly.MustMarshalPublicPEMToDER(testonly.DemoPublicKey),
 		},
 		MaxRootDuration: ptypes.DurationProto(0 * time.Millisecond),
 	}
@@ -278,7 +278,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 
 	privateKeyChangedAndKeyMaterialDifferentFunc := func(t *trillian.Tree) {
 		t.PrivateKey = mustMarshalAny(&keyspb.PrivateKey{
-			Der: ktestonly.MustMarshalPrivatePEMToDER(ttestonly.DemoPrivateKey, ttestonly.DemoPrivateKeyPass),
+			Der: ktestonly.MustMarshalPrivatePEMToDER(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass),
 		})
 	}
 

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -236,54 +236,54 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 	validLog.TreeState = trillian.TreeState_FROZEN
 	validLog.DisplayName = "Frozen Tree"
 	validLog.Description = "A Frozen Tree"
-	validLogFunc := func(t *trillian.Tree) {
-		t.TreeState = validLog.TreeState
-		t.DisplayName = validLog.DisplayName
-		t.Description = validLog.Description
+	validLogFunc := func(tree *trillian.Tree) {
+		tree.TreeState = validLog.TreeState
+		tree.DisplayName = validLog.DisplayName
+		tree.Description = validLog.Description
 	}
 
-	validLogWithoutOptionalsFunc := func(t *trillian.Tree) {
-		t.DisplayName = ""
-		t.Description = ""
+	validLogWithoutOptionalsFunc := func(tree *trillian.Tree) {
+		tree.DisplayName = ""
+		tree.Description = ""
 	}
 	validLogWithoutOptionals := referenceLog
 	validLogWithoutOptionalsFunc(&validLogWithoutOptionals)
 
-	invalidLogFunc := func(t *trillian.Tree) {
-		t.TreeState = trillian.TreeState_UNKNOWN_TREE_STATE
+	invalidLogFunc := func(tree *trillian.Tree) {
+		tree.TreeState = trillian.TreeState_UNKNOWN_TREE_STATE
 	}
 
-	readonlyChangedFunc := func(t *trillian.Tree) {
-		t.TreeType = trillian.TreeType_MAP
+	readonlyChangedFunc := func(tree *trillian.Tree) {
+		tree.TreeType = trillian.TreeType_MAP
 	}
 
 	referenceMap := *MapTree
 	validMap := referenceMap
 	validMap.DisplayName = "Updated Map"
-	validMapFunc := func(t *trillian.Tree) {
-		t.DisplayName = validMap.DisplayName
+	validMapFunc := func(tree *trillian.Tree) {
+		tree.DisplayName = validMap.DisplayName
 	}
 
 	newPrivateKey := &empty.Empty{}
 	privateKeyChangedButKeyMaterialSameTree := *LogTree
-	privateKeyChangedButKeyMaterialSameTree.PrivateKey = mustMarshalAny(newPrivateKey)
+	privateKeyChangedButKeyMaterialSameTree.PrivateKey = testonly.MustMarshalAny(t, newPrivateKey)
 	keys.RegisterHandler(newPrivateKey, func(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
 		return pem.UnmarshalPrivateKey(privateKeyPEM, privateKeyPass)
 	})
 	defer keys.UnregisterHandler(newPrivateKey)
 
-	privateKeyChangedButKeyMaterialSameFunc := func(t *trillian.Tree) {
-		t.PrivateKey = privateKeyChangedButKeyMaterialSameTree.PrivateKey
+	privateKeyChangedButKeyMaterialSameFunc := func(tree *trillian.Tree) {
+		tree.PrivateKey = privateKeyChangedButKeyMaterialSameTree.PrivateKey
 	}
 
-	privateKeyChangedAndKeyMaterialDifferentFunc := func(t *trillian.Tree) {
-		t.PrivateKey = mustMarshalAny(&keyspb.PrivateKey{
+	privateKeyChangedAndKeyMaterialDifferentFunc := func(tree *trillian.Tree) {
+		tree.PrivateKey = testonly.MustMarshalAny(t, &keyspb.PrivateKey{
 			Der: ktestonly.MustMarshalPrivatePEMToDER(testonly.DemoPrivateKey, testonly.DemoPrivateKeyPass),
 		})
 	}
 
 	// Test for an unknown tree outside the loop: it makes the test logic simpler
-	if _, errOnUpdate, err := updateTree(ctx, s, -1, func(t *trillian.Tree) {}); err == nil || !errOnUpdate {
+	if _, errOnUpdate, err := updateTree(ctx, s, -1, func(tree *trillian.Tree) {}); err == nil || !errOnUpdate {
 		t.Errorf("updateTree(_, -1, _) = (_, %v, %v), want = (_, true, lookup error)", errOnUpdate, err)
 	}
 


### PR DESCRIPTION
Depending on a relative file path from a shared test helper can be problematic. Instead, register a temporary key proto handler that treats an `Empty` proto as equivalent to the default `LogTree.PrivateKey` (i.e. they result in the same key being loaded).