### PR TITLE
Strengthen typing of choice enums for invalid ops

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -85,7 +85,7 @@ const (
 
 var mapEntrypoints = []MapEntrypointName{GetLeavesName, SetLeavesName, GetSMRName, GetSMRRevName}
 
-// Choice is a readable represention a choice about how to perform a hammering operation.
+// Choice is a readable representation of a choice about how to perform a hammering operation.
 type Choice string
 
 // Constants for both valid and invalid operation choices.

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -85,8 +85,10 @@ const (
 
 var mapEntrypoints = []MapEntrypointName{GetLeavesName, SetLeavesName, GetSMRName, GetSMRRevName}
 
-// Constants for both valid and invalid operation choices.
+// Choice is a readable represention a choice about how to perform a hammering operation.
 type Choice string
+
+// Constants for both valid and invalid operation choices.
 const (
 	ExistingKey    = Choice("ExistingKey")
 	NonexistentKey = Choice("NonexistentKey")


### PR DESCRIPTION
This makes logging of choice values nicer (we get strings, not ints).
Also, log at V=2 where expected failures occur when using invalid ops.