### PR TITLE
Fix bug introduced in PR#862

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -524,17 +524,19 @@ func (s *hammerState) getLeavesInvalid(ctx context.Context) error {
 	if s.empty(latestCopy) {
 		choice = MalformedKey
 	}
-	req.Index = [][]byte{s.pickKey(latestCopy)}
 	switch choice {
 	case MalformedKey:
 		key := testonly.TransparentHash("..invalid-size")
 		req.Index = [][]byte{key[2:]}
 		req.Revision = s.rev(latestCopy)
 	case RevTooBig:
+		req.Index = [][]byte{s.pickKey(latestCopy)}
 		req.Revision = s.rev(latestCopy) + invalidStretch
 	case RevIsZero:
+		req.Index = [][]byte{s.pickKey(latestCopy)}
 		req.Revision = 0
 	case RevIsNegative:
+		req.Index = [][]byte{s.pickKey(latestCopy)}
 		req.Revision = -s.rev(latestCopy)
 	}
 	rsp, err := s.cfg.Client.GetLeaves(ctx, &req)


### PR DESCRIPTION
I thought I could factor out the code

  req.Index = [][]byte{s.pickKey(latestCopy)}

(as it seemed to be used in every branch of switch)
but neglected to consider the case where the set of known keys is empty.

This bug trips if by random seed the first operation being hammered is a getLeavesInvalid().

This PR restores the original logic.