### PR TITLE
Make assertions when storing and retrieving rev's

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -41,6 +41,8 @@ const (
 	latestCopy = 0
 	// How far beyond current revision to request for invalid requests
 	invalidStretch = int64(10000)
+	// rev=-1 is used when requesting the latest revision
+	latestRevision = int64(-1)
 )
 
 var (
@@ -533,7 +535,7 @@ func (s *hammerState) getLeavesInvalid(ctx context.Context) error {
 	choices := []Choice{MalformedKey, RevTooBig, RevIsZero}
 
 	req := trillian.GetMapLeavesRequest{MapId: s.cfg.MapID}
-	rev := int64(-1)
+	rev := latestRevision
 	choice := choices[rand.Intn(len(choices))]
 	if s.empty(latestCopy) {
 		choice = MalformedKey
@@ -683,7 +685,7 @@ func (s *hammerState) getSMRRev(ctx context.Context) error {
 func (s *hammerState) getSMRRevInvalid(ctx context.Context) error {
 	choices := []Choice{RevTooBig, RevIsZero, RevIsNegative}
 
-	rev := int64(-1)
+	rev := latestRevision
 	if !s.empty(latestCopy) {
 		rev = s.rev(latestCopy)
 	}

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -449,6 +449,10 @@ func (s *hammerState) retryOneOp(ctx context.Context) (err error) {
 		case errSkip:
 			err = nil
 			done = true
+		case errInvariant:
+			// Ensure invariant failures are not ignorable.  They indicate a design assumption
+			// being broken or incorrect, so must be seen.
+			done = true
 		default:
 			errs.Inc(s.label(), string(ep))
 			if s.cfg.IgnoreErrors {
@@ -622,7 +626,6 @@ leafloop:
 
 	s.pushSMR(rsp.MapRoot)
 	if err := s.updateContents(rsp.MapRoot.MapRevision, leaves); err != nil {
-		glog.Warningf("%d: setLeaves: updating hammerState contents error: %v", s.cfg.MapID, err)
 		return err
 	}
 	glog.V(2).Infof("%d: set %d leaves, new SMR(time=%q, rev=%d)", s.cfg.MapID, len(leaves), timeFromNanos(rsp.MapRoot.TimestampNanos), rsp.MapRoot.MapRevision)


### PR DESCRIPTION
There are code paths in the hammer where the -1 'not found' value from
rev() was causing unexpected behavior, because -ve rev is valid in
get-leaves.  Change that rev() to panic instead.

Assert that we don't try to store -ve rev values in the hammer state
contents.

Assert that rev increases when we push new content after a set-leaves
call.