### PR TITLE
Enable keygen in integration tests

### DIFF
--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
@@ -35,6 +35,9 @@ import (
 	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
 
 	ktestonly "github.com/google/trillian/crypto/keys/testonly"
@@ -85,6 +88,9 @@ func NewLogEnv(ctx context.Context, numSequencers int, testID string) (*LogEnv, 
 		AdminStorage: mysql.NewAdminStorage(db),
 		LogStorage:   mysql.NewLogStorage(db, nil),
 		QuotaManager: quota.Noop(),
+		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
+			return der.NewProtoFromSpec(spec)
+		},
 	}
 
 	ret, err := NewLogEnvWithRegistry(ctx, numSequencers, testID, registry)

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -18,16 +18,19 @@ import (
 	"context"
 	"database/sql"
 
-	_ "github.com/google/trillian/crypto/keys/der/proto" // Register PrivateKey ProtoHandler
-
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keys/der"
+	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/server/admin"
 	"github.com/google/trillian/storage/mysql"
 
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+
+	_ "github.com/google/trillian/crypto/keys/der/proto" // Register PrivateKey ProtoHandler
 )
 
 // MapEnv is a map server and connected client.
@@ -70,6 +73,9 @@ func NewMapEnv(ctx context.Context, testID string) (*MapEnv, error) {
 		AdminStorage: mysql.NewAdminStorage(db),
 		MapStorage:   mysql.NewMapStorage(db),
 		QuotaManager: quota.Noop(),
+		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
+			return der.NewProtoFromSpec(spec)
+		},
 	}
 
 	ret, err := NewMapEnvWithRegistry(ctx, testID, registry)


### PR DESCRIPTION
This allows integration tests to generate keys dynamically. 
This is needed to allow Key Transparency to exercise its new multi-tenant API during integration tests.  google/keytransparency#845