### PR TITLE
Make the server interceptor stop if context cancelled / deadline expires

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -160,7 +160,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 			incRequestDeniedCounter(badTreeReason, info.treeID, quotaUser)
 			return ctx, err
 		}
-		if err = ctx.Err(); err != nil {
+		if err := ctx.Err(); err != nil {
 			contextErrCounter.Inc(getTreeStage)
 			return ctx, err
 		}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -38,7 +38,6 @@ const (
 	badInfoReason            = "bad_info"
 	badTreeReason            = "bad_tree"
 	insufficientTokensReason = "insufficient_tokens"
-	getTreeInfoStage         = "get_tree_info"
 	getTreeStage             = "get_tree"
 	getTokensStage           = "get_tokens"
 )
@@ -107,7 +106,7 @@ func initMetrics(mf monitoring.MetricFactory) {
 		"Number of requests by denied, labeled according to the reason for denial",
 		"reason", monitoring.TreeIDLabel, "quota_user")
 	contextErrCounter = mf.NewCounter(
-		"context_err_counter",
+		"interceptor_context_err_counter",
 		"Total number of times request context has been cancelled or deadline exceeded by stage",
 		"stage")
 }
@@ -147,10 +146,6 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 	if err != nil {
 		glog.Warningf("Failed to read tree info: %v", err)
 		incRequestDeniedCounter(badInfoReason, 0, quotaUser)
-		return ctx, err
-	}
-	if err = ctx.Err(); err != nil {
-		contextErrCounter.Inc(getTreeInfoStage)
 		return ctx, err
 	}
 	tp.info = info

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -111,7 +111,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 		},
 		{
 			desc:      "cancelled",
-			req:       &trillian.GetTreeRequest{TreeId: logTree.TreeId},
+			req:       &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			cancelled: true,
 			wantErr:   true,
 		},
@@ -131,7 +131,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 
 		resp, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run)
 		if hasErr := err != nil && err != test.handlerErr; hasErr != test.wantErr {
-			t.Errorf("%v: UnaryInterceptor() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
+			t.Errorf("%v: UnaryInterceptor() returned err = %v, wantErr = %v", test.desc, err, test.wantErr)
 			continue
 		} else if hasErr {
 			continue

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -124,7 +124,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 
 		if test.cancelled {
 			// Use a context that's already been cancelled
-			newCtx, cancel := context.WithTimeout(ctx, time.Second)
+			newCtx, cancel := context.WithCancel(ctx)
 			cancel()
 			ctx = newCtx
 		}

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -124,8 +124,8 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 
 		if test.cancelled {
 			// Use a context that's already been cancelled
-			newCtx, cf := context.WithTimeout(ctx, time.Second)
-			cf()
+			newCtx, cancel := context.WithTimeout(ctx, time.Second)
+			cancel()
 			ctx = newCtx
 		}
 


### PR DESCRIPTION
Previously it would continue e.g. if the get tree info timed out it would carry on. This is probably what was causing confusion in monitoring. I added a count metric for these so we can monitor it.