### PR TITLE
Add error return value to {Log,Map}Hasher.HashLeaf

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -193,7 +193,10 @@ func (c *LogClient) UpdateRoot(ctx context.Context) error {
 // This assumes that the data has already been submitted.
 // Best practice is to call this method with a context that will timeout.
 func (c *LogClient) WaitForInclusion(ctx context.Context, data []byte) error {
-	leaf := c.logVerifier.buildLeaf(data)
+	leaf, err := c.logVerifier.buildLeaf(data)
+	if err != nil {
+		return err
+	}
 
 	// Fetch the current Root to improve our chances at a valid inclusion proof.
 	if err := c.UpdateRoot(ctx); err != nil {
@@ -233,7 +236,10 @@ func (c *LogClient) WaitForInclusion(ctx context.Context, data []byte) error {
 
 // VerifyInclusion updates the log root and ensures that the given leaf data has been included in the log.
 func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
-	leaf := c.logVerifier.buildLeaf(data)
+	leaf, err := c.logVerifier.buildLeaf(data)
+	if err != nil {
+		return err
+	}
 	if err := c.UpdateRoot(ctx); err != nil {
 		return fmt.Errorf("UpdateRoot(): %v", err)
 	}
@@ -281,7 +287,10 @@ func (c *LogClient) getInclusionProof(ctx context.Context, leafHash []byte, tree
 // QueueLeaf adds a leaf to a Trillian log without blocking.
 // AlreadyExists is considered a success case by this function.
 func (c *LogClient) QueueLeaf(ctx context.Context, data []byte) error {
-	leaf := c.logVerifier.buildLeaf(data)
+	leaf, err := c.logVerifier.buildLeaf(data)
+	if err != nil {
+		return err
+	}
 
 	if _, err := c.client.QueueLeaf(ctx, &trillian.QueueLeafRequest{
 		LogId: c.LogID,

--- a/client/verifier.go
+++ b/client/verifier.go
@@ -54,7 +54,10 @@ func (c *logVerifier) VerifyRoot(trusted, newRoot *trillian.SignedLogRoot,
 	}
 
 	// Verify SignedLogRoot signature.
-	hash := tcrypto.HashLogRoot(*newRoot)
+	hash, err := tcrypto.HashLogRoot(*newRoot)
+	if err != nil {
+		return err
+	}
 	if err := tcrypto.Verify(c.pubKey, hash, newRoot.Signature); err != nil {
 		return err
 	}

--- a/client/verifier_test.go
+++ b/client/verifier_test.go
@@ -37,7 +37,10 @@ func TestVerifyRootErrors(t *testing.T) {
 	}
 
 	signedRoot := trillian.SignedLogRoot{}
-	hash := tcrypto.HashLogRoot(signedRoot)
+	hash, err := tcrypto.HashLogRoot(signedRoot)
+	if err != nil {
+		t.Fatalf("HashLogRoot(): %v", err)
+	}
 	signature, err := signer.Sign(hash)
 	if err != nil {
 		t.Fatal("Failed to create test signature")

--- a/crypto/data_formats.go
+++ b/crypto/data_formats.go
@@ -16,6 +16,7 @@ package crypto
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strconv"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
@@ -46,6 +47,9 @@ func HashLogRoot(root trillian.SignedLogRoot) []byte {
 		mapKeyTimestampNanos: strconv.FormatInt(root.TimestampNanos, 10),
 		mapKeyTreeSize:       strconv.FormatInt(root.TreeSize, 10)}
 
-	hash := objecthash.ObjectHash(rootMap)
+	hash, err := objecthash.ObjectHash(rootMap)
+	if err != nil {
+		panic(fmt.Sprintf("ObjectHash(%#v): %v", rootMap, err))
+	}
 	return hash[:]
 }

--- a/crypto/data_formats.go
+++ b/crypto/data_formats.go
@@ -37,7 +37,7 @@ const (
 // HashLogRoot hashes SignedLogRoot objects using ObjectHash with
 // "RootHash", "TimestampNanos", and "TreeSize", used as keys in
 // a map.
-func HashLogRoot(root trillian.SignedLogRoot) []byte {
+func HashLogRoot(root trillian.SignedLogRoot) ([]byte, error) {
 	// Pull out the fields we want to hash.
 	// Caution: use string format for int64 values as they can overflow when
 	// JSON encoded otherwise (it uses floats). We want to be sure that people
@@ -49,7 +49,7 @@ func HashLogRoot(root trillian.SignedLogRoot) []byte {
 
 	hash, err := objecthash.ObjectHash(rootMap)
 	if err != nil {
-		panic(fmt.Sprintf("ObjectHash(%#v): %v", rootMap, err))
+		return nil, fmt.Errorf("ObjectHash(%#v): %v", rootMap, err)
 	}
-	return hash[:]
+	return hash[:], nil
 }

--- a/crypto/data_formats_test.go
+++ b/crypto/data_formats_test.go
@@ -15,22 +15,29 @@
 package crypto
 
 import (
-	"encoding/hex"
+	"bytes"
 	"testing"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
 )
+
+var dh = testonly.MustHexDecode
 
 // It's important that signatures don't change.
 func TestHashLogRootKnownValue(t *testing.T) {
-	expectedSigHex := "5e6baba8dc3465de9c01d669059dda590b7ce123d6ccd436bcd898f1c79ff6d9"
+	expectedSig := dh("5e6baba8dc3465de9c01d669059dda590b7ce123d6ccd436bcd898f1c79ff6d9")
 	root := trillian.SignedLogRoot{
 		TimestampNanos: 226770903,
 		RootHash:       []byte("Some bytes that won't change"),
 		TreeSize:       167329345,
 	}
-	if got, want := hex.EncodeToString(HashLogRoot(root)), expectedSigHex; got != want {
-		t.Fatalf("TestHashLogRootKnownValue: got:%v, want:%v", got, want)
+	hash, err := HashLogRoot(root)
+	if err != nil {
+		t.Fatalf("HashLogRoot(): %v", err)
+	}
+	if got, want := hash, expectedSig; !bytes.Equal(got, want) {
+		t.Fatalf("TestHashLogRootKnownValue: got:%x, want:%x", got, want)
 	}
 }
 
@@ -68,7 +75,11 @@ func TestHashLogRoot(t *testing.T) {
 			},
 		},
 	} {
-		hash := HashLogRoot(test.root)
+		hash, err := HashLogRoot(test.root)
+		if err != nil {
+			t.Fatalf("HashLogRoot(): %v", err)
+		}
+
 		var h [20]byte
 		copy(h[:], hash)
 		if _, ok := unique[h]; ok {

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/google/trillian/crypto/sigpb"
@@ -68,10 +69,14 @@ func (s *Signer) Sign(data []byte) (*sigpb.DigitallySigned, error) {
 
 // SignObject signs the requested object using ObjectHash.
 func (s *Signer) SignObject(obj interface{}) (*sigpb.DigitallySigned, error) {
+	// TODO(gbelvin): use objecthash.CommonJSONify
 	j, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}
-	hash := objecthash.CommonJSONHash(string(j))
+	hash, err := objecthash.CommonJSONHash(string(j))
+	if err != nil {
+		return nil, fmt.Errorf("CommonJSONHash(%s): %v", j, err)
+	}
 	return s.Sign(hash[:])
 }

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -102,7 +102,11 @@ func TestSignLogRootSignerFails(t *testing.T) {
 
 	s := testonly.NewSignerWithErr(key, errors.New("signfail"))
 	root := trillian.SignedLogRoot{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}
-	_, err = NewSHA256Signer(s).Sign(HashLogRoot(root))
+	hash, err := HashLogRoot(root)
+	if err != nil {
+		t.Fatalf("HashLogRoot(): %v", err)
+	}
+	_, err = NewSHA256Signer(s).Sign(hash)
 
 	testonly.EnsureErrorContains(t, err, "signfail")
 }

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -107,6 +107,5 @@ func TestSignLogRootSignerFails(t *testing.T) {
 		t.Fatalf("HashLogRoot(): %v", err)
 	}
 	_, err = NewSHA256Signer(s).Sign(hash)
-
 	testonly.EnsureErrorContains(t, err, "signfail")
 }

--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -42,8 +42,10 @@ func VerifyObject(pub crypto.PublicKey, obj interface{}, sig *sigpb.DigitallySig
 	if err != nil {
 		return err
 	}
-	hash := objecthash.CommonJSONHash(string(j))
-
+	hash, err := objecthash.CommonJSONHash(string(j))
+	if err != nil {
+		return fmt.Errorf("CommonJSONHash(%s): %v", j, err)
+	}
 	return Verify(pub, hash[:], sig)
 }
 

--- a/integration/log.go
+++ b/integration/log.go
@@ -495,7 +495,10 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 		compactTree.AddLeaf(leafMap[l].LeafValue, func(int, int64, []byte) error {
 			return nil
 		})
-		merkleTree.AddLeaf(leafMap[l].LeafValue)
+		_, _, err := merkleTree.AddLeaf(leafMap[l].LeafValue)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If the two reference results disagree there's no point in continuing the checks. This is a

--- a/integration/log.go
+++ b/integration/log.go
@@ -338,7 +338,10 @@ func readbackLogEntries(logID int64, client trillian.TrillianLogClient, params T
 			}
 			leafMap[leaf.LeafIndex] = leaf
 
-			hash := rfc6962.DefaultHasher.HashLeaf(leaf.LeafValue)
+			hash, err := rfc6962.DefaultHasher.HashLeaf(leaf.LeafValue)
+			if err != nil {
+				return nil, fmt.Errorf("HashLeaf(%v): %v", leaf.LeafValue, err)
+			}
 
 			if got, want := hex.EncodeToString(hash), hex.EncodeToString(leaf.MerkleLeafHash); got != want {
 				return nil, fmt.Errorf("leaf %d hash mismatch expected got: %s want: %s", leaf.LeafIndex, got, want)

--- a/integration/log.go
+++ b/integration/log.go
@@ -498,8 +498,7 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 		compactTree.AddLeaf(leafMap[l].LeafValue, func(int, int64, []byte) error {
 			return nil
 		})
-		_, _, err := merkleTree.AddLeaf(leafMap[l].LeafValue)
-		if err != nil {
+		if _, _, err := merkleTree.AddLeaf(leafMap[l].LeafValue); err != nil {
 			return nil, err
 		}
 	}

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -105,7 +105,11 @@ func verifyGetMapLeavesResponse(getResp *trillian.GetMapLeavesResponse, indexes 
 		leafHash := incl.GetLeaf().GetLeafHash()
 		proof := incl.GetInclusion()
 
-		if got, want := leafHash, hasher.HashLeaf(treeID, index, leaf); !bytes.Equal(got, want) {
+		wantLeafHash, err := hasher.HashLeaf(treeID, index, leaf)
+		if err != nil {
+			return err
+		}
+		if got, want := leafHash, wantLeafHash; !bytes.Equal(got, want) {
 			return fmt.Errorf("HashLeaf(%s): %x, want %x", leaf, got, want)
 		}
 		if err := merkle.VerifyMapInclusionProof(treeID, index,

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -213,7 +213,11 @@ func (s Sequencer) initMerkleTreeFromStorage(ctx context.Context, currentRoot tr
 }
 
 func (s Sequencer) createRootSignature(ctx context.Context, root trillian.SignedLogRoot) (*sigpb.DigitallySigned, error) {
-	signature, err := s.signer.Sign(crypto.HashLogRoot(root))
+	hash, err := crypto.HashLogRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := s.signer.Sign(hash)
 	if err != nil {
 		glog.Warningf("%v: signer failed to sign root: %v", root.LogId, err)
 		return nil, err

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -38,9 +38,10 @@ import (
 
 var (
 	// These can be shared between tests as they're never modified
-	testLeaf16Data = []byte("testdataforleaf")
-	testLeaf16     = &trillian.LogLeaf{
-		MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf(testLeaf16Data),
+	testLeaf16Data    = []byte("testdataforleaf")
+	testLeaf16Hash, _ = rfc6962.DefaultHasher.HashLeaf(testLeaf16Data)
+	testLeaf16        = &trillian.LogLeaf{
+		MerkleLeafHash: testLeaf16Hash,
 		LeafValue:      testLeaf16Data,
 		ExtraData:      nil,
 		LeafIndex:      16,
@@ -160,8 +161,9 @@ type testContext struct {
 
 // This gets modified so tests need their own copies
 func getLeaf42() *trillian.LogLeaf {
+	testLeaf16Hash, _ := rfc6962.DefaultHasher.HashLeaf(testLeaf16Data)
 	return &trillian.LogLeaf{
-		MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf(testLeaf16Data),
+		MerkleLeafHash: testLeaf16Hash,
 		LeafValue:      testLeaf16Data,
 		ExtraData:      nil,
 		LeafIndex:      42,

--- a/merkle/compact_merkle_tree.go
+++ b/merkle/compact_merkle_tree.go
@@ -174,7 +174,10 @@ func (c *CompactMerkleTree) recalculateRoot(f setNodeFunc) error {
 // AddLeaf calculates the leafhash of |data| and appends it to the tree.
 // |f| is a callback which will be called multiple times with the full MerkleTree coordinates of nodes whose hash should be updated.
 func (c *CompactMerkleTree) AddLeaf(data []byte, f setNodeFunc) (int64, []byte, error) {
-	h := c.hasher.HashLeaf(data)
+	h, err := c.hasher.HashLeaf(data)
+	if err != nil {
+		return 0, nil, err
+	}
 	seq, err := c.AddLeafHash(h, f)
 	if err != nil {
 		return 0, nil, err

--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -225,7 +225,10 @@ func TestCompactVsFullTree(t *testing.T) {
 
 		newLeaf := []byte(fmt.Sprintf("Leaf %d", i))
 
-		iSeq, iHash := imt.AddLeaf(newLeaf)
+		iSeq, iHash, err := imt.AddLeaf(newLeaf)
+		if err != nil {
+			t.Errorf("AddLeaf(): %v", err)
+		}
 
 		cSeq, cHash, err := cmt.AddLeaf(newLeaf,
 			func(depth int, index int64, hash []byte) error {

--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -71,7 +71,7 @@ func (m *hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 
 // HashLeaf calculate the merkle tree leaf value:
 // H(Identifier || treeID || depth || index || dataHash)
-func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
+func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error) {
 	depth := m.BitLen()
 	h := m.New()
 	h.Write(leafIdentifier)
@@ -81,7 +81,7 @@ func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
 	h.Write(leaf)
 	p := h.Sum(nil)
 	glog.V(5).Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
-	return p
+	return p, nil
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.

--- a/merkle/coniks/coniks_test.go
+++ b/merkle/coniks/coniks_test.go
@@ -38,7 +38,12 @@ func TestVectors(t *testing.T) {
 		// Test vector from Key Transparency
 		{0, h2b("1111111111111111111111111111111111111111111111111111111111111111"), []byte("leaf"), h2b("87f51e6ceb5a46947fedbd1de543482fb72f7459055d853a841566ef8e43c4a2")},
 	} {
-		if got, want := Default.HashLeaf(tc.treeID, tc.index, tc.leaf), tc.want; !bytes.Equal(got, want) {
+		leafHash, err := Default.HashLeaf(tc.treeID, tc.index, tc.leaf)
+		if err != nil {
+			t.Errorf("HashLeaf(): %v", err)
+			continue
+		}
+		if got, want := leafHash, tc.want; !bytes.Equal(got, want) {
 			t.Errorf("HashLeaf(%v, %s, %s): %x, want %x", tc.treeID, tc.index, tc.leaf, got, want)
 		}
 	}

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -25,7 +25,7 @@ type LogHasher interface {
 	// EmptyRoot supports returning a special case for the root of an empty tree.
 	EmptyRoot() []byte
 	// HashLeaf computes the hash of a leaf that exists.
-	HashLeaf(leaf []byte) []byte
+	HashLeaf(leaf []byte) ([]byte, error)
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
 	// Size is the number of bits in the underlying hash function.

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -40,7 +40,7 @@ type MapHasher interface {
 	// TODO(gbelvin) fully define index.
 	HashEmpty(treeID int64, index []byte, height int) []byte
 	// HashLeaf computes the hash of a leaf that exists.
-	HashLeaf(treeID int64, index []byte, leaf []byte) []byte
+	HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error)
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
 	// Size is the number of bytes in the underlying hash function.

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -62,9 +62,13 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []
 			index = b
 			continue
 		}
+		leafHash, err := hasher.HashLeaf(treeID, index, b)
+		if err != nil {
+			panic(err)
+		}
 		m[fmt.Sprintf("%x", index)] = HStar2LeafHash{
 			Index:    new(big.Int).SetBytes(index),
-			LeafHash: hasher.HashLeaf(treeID, index, b),
+			LeafHash: leafHash,
 		}
 	}
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -51,7 +51,7 @@ var simpleTestVector = []struct {
 
 // createHStar2Leaves returns a []HStar2LeafHash formed by the mapping of index, value ...
 // createHStar2Leaves panics if len(iv) is odd. Duplicate i/v pairs get over written.
-func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []HStar2LeafHash {
+func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) ([]HStar2LeafHash, error) {
 	if len(iv)%2 != 0 {
 		panic(fmt.Sprintf("merkle: createHstar2Leaves got odd number of iv pairs: %v", len(iv)))
 	}
@@ -64,7 +64,7 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []
 		}
 		leafHash, err := hasher.HashLeaf(treeID, index, b)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		m[fmt.Sprintf("%x", index)] = HStar2LeafHash{
 			Index:    new(big.Int).SetBytes(index),
@@ -76,7 +76,7 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []
 	for _, v := range m {
 		r = append(r, v)
 	}
-	return r
+	return r, nil
 }
 
 func TestHStar2SimpleDataSetKAT(t *testing.T) {
@@ -85,7 +85,10 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 	iv := [][]byte{}
 	for i, x := range simpleTestVector {
 		iv = append(iv, x.index, x.value)
-		values := createHStar2Leaves(treeID, maphasher.Default, iv...)
+		values, err := createHStar2Leaves(treeID, maphasher.Default, iv...)
+		if err != nil {
+			t.Fatalf("createHStar2Leaves(): %v", err)
+		}
 		root, err := s.HStar2Root(s.hasher.BitLen(), values)
 		if err != nil {
 			t.Errorf("Failed to calculate root at iteration %d: %v", i, err)
@@ -107,7 +110,10 @@ func TestHStar2GetSet(t *testing.T) {
 
 	for i, x := range simpleTestVector {
 		s := NewHStar2(treeID, hasher)
-		values := createHStar2Leaves(treeID, hasher, x.index, x.value)
+		values, err := createHStar2Leaves(treeID, hasher, x.index, x.value)
+		if err != nil {
+			t.Fatalf("createHStar2Leaves(): %v", err)
+		}
 		// ensure we're going incrementally, one leaf at a time.
 		if len(values) != 1 {
 			t.Fatalf("Should only have 1 leaf per run, got %d", len(values))
@@ -170,7 +176,10 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 		// TODO(al): improve rootsForTrimmedKeys to use a map and remove this
 		// requirement.
 		for size := 24; size < 256; size += 8 {
-			leaves := createHStar2Leaves(treeID, maphasher.Default, iv...)
+			leaves, err := createHStar2Leaves(treeID, maphasher.Default, iv...)
+			if err != nil {
+				t.Fatalf("createHStar2Leaves(): %v", err)
+			}
 			intermediates := rootsForTrimmedKeys(t, size, leaves)
 
 			root, err := s.HStar2Nodes(nil, size, intermediates, nil, nil)

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -333,10 +333,12 @@ func TestVerifyInclusionProof(t *testing.T) {
 		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
 			proof = append(proof, inclusionProofs[i].proof[j].h)
 		}
-		leafHash := rfc6962.DefaultHasher.HashLeaf(leaves[inclusionProofs[i].leaf-1].h)
-		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
-			roots[inclusionProofs[i].snapshot-1].h, leafHash)
+		leafHash, err := rfc6962.DefaultHasher.HashLeaf(leaves[inclusionProofs[i].leaf-1].h)
 		if err != nil {
+			t.Fatalf("HashLeaf(): %v", err)
+		}
+		if err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
+			roots[inclusionProofs[i].snapshot-1].h, leafHash); err != nil {
 			t.Fatalf("i=%d: %s", i, err)
 		}
 	}

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -44,7 +44,11 @@ func VerifyMapInclusionProof(treeID int64, index, leaf, expectedRoot []byte, pro
 
 	var runningHash []byte
 	if len(leaf) != 0 {
-		runningHash = h.HashLeaf(treeID, index, leaf)
+		leafHash, err := h.HashLeaf(treeID, index, leaf)
+		if err != nil {
+			return fmt.Errorf("HashLeaf(): %v", err)
+		}
+		runningHash = leafHash
 	}
 
 	nID := storage.NewNodeIDFromHash(index)

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -108,6 +108,8 @@ func (m *MapHasher) initNullHashes() {
 	r := make([][]byte, nodes, nodes)
 	h, err := m.HashLeaf(0, nil, nil)
 	if err != nil {
+		// This panic should be impossible to trigger.
+		// MapHasher.HashLeaf never returns an error.
 		panic(fmt.Sprintf("HashLeaf(): %v", err))
 	}
 	r[0] = h

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -71,13 +71,13 @@ func (m *MapHasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 
 // HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
 // The hashed structure is leafHashPrefix||leaf.
-func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
+func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error) {
 	h := m.New()
 	h.Write([]byte{leafHashPrefix})
 	h.Write(leaf)
 	r := h.Sum(nil)
 	glog.V(5).Infof("HashLeaf(%x): %x", index, r)
-	return r
+	return r, nil
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
@@ -106,7 +106,7 @@ func (m *MapHasher) initNullHashes() {
 	// There are Size()*8 edges, and Size()*8 + 1 nodes in the tree.
 	nodes := m.Size()*8 + 1
 	r := make([][]byte, nodes, nodes)
-	r[0] = m.HashLeaf(0, nil, nil)
+	r[0], _ = m.HashLeaf(0, nil, nil)
 	for i := 1; i < nodes; i++ {
 		r[i] = m.HashChildren(r[i-1], r[i-1])
 	}

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -106,7 +106,11 @@ func (m *MapHasher) initNullHashes() {
 	// There are Size()*8 edges, and Size()*8 + 1 nodes in the tree.
 	nodes := m.Size()*8 + 1
 	r := make([][]byte, nodes, nodes)
-	r[0], _ = m.HashLeaf(0, nil, nil)
+	h, err := m.HashLeaf(0, nil, nil)
+	if err != nil {
+		panic(fmt.Sprintf("HashLeaf(): %v", err))
+	}
+	r[0] = h
 	for i := 1; i < nodes; i++ {
 		r[i] = m.HashChildren(r[i-1], r[i-1])
 	}

--- a/merkle/maphasher/maphasher_test.go
+++ b/merkle/maphasher/maphasher_test.go
@@ -44,9 +44,13 @@ func TestEmptyRoot(t *testing.T) {
 // Compares the old HStar2 empty branch algorithm to the new.
 func TestHStar2Equivalence(t *testing.T) {
 	m := New(crypto.SHA256)
+	leafHash, err := m.HashLeaf(treeID, nil, []byte(""))
+	if err != nil {
+		t.Fatalf("HashLeaf(): %v", err)
+	}
 	star := hstar{
 		hasher:          m,
-		hStarEmptyCache: [][]byte{m.HashLeaf(treeID, nil, []byte(""))},
+		hStarEmptyCache: [][]byte{leafHash},
 	}
 	fullDepth := m.Size() * 8
 	for i := 0; i < fullDepth; i++ {

--- a/merkle/memory_merkle_tree.go
+++ b/merkle/memory_merkle_tree.go
@@ -228,8 +228,10 @@ func (mt *InMemoryMerkleTree) popBack(level int64) {
 //
 // Returns the position of the leaf in the tree. Indexing starts at 1,
 // so position = number of leaves in the tree after this update.
-func (mt *InMemoryMerkleTree) AddLeaf(leafData []byte) (int64, TreeEntry) {
-	return mt.addLeafHash(mt.hasher.HashLeaf(leafData))
+func (mt *InMemoryMerkleTree) AddLeaf(leafData []byte) (int64, TreeEntry, error) {
+	leafHash := mt.hasher.HashLeaf(leafData)
+	leafCount, treeEntry := mt.addLeafHash(leafHash)
+	return leafCount, treeEntry, nil
 }
 
 func (mt *InMemoryMerkleTree) addLeafHash(leafData []byte) (int64, TreeEntry) {

--- a/merkle/memory_merkle_tree.go
+++ b/merkle/memory_merkle_tree.go
@@ -229,7 +229,10 @@ func (mt *InMemoryMerkleTree) popBack(level int64) {
 // Returns the position of the leaf in the tree. Indexing starts at 1,
 // so position = number of leaves in the tree after this update.
 func (mt *InMemoryMerkleTree) AddLeaf(leafData []byte) (int64, TreeEntry, error) {
-	leafHash := mt.hasher.HashLeaf(leafData)
+	leafHash, err := mt.hasher.HashLeaf(leafData)
+	if err != nil {
+		return 0, TreeEntry{}, err
+	}
 	leafCount, treeEntry := mt.addLeafHash(leafHash)
 	return leafCount, treeEntry, nil
 }

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -376,8 +376,7 @@ func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for l := 0; l < 3; l++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
 		}
 	}
@@ -386,8 +385,7 @@ func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	validateTree(mt, 2, t)
 
 	for l := 3; l < 8; l++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
 		}
 	}
@@ -401,8 +399,7 @@ func TestBuildTreeBuildTwoChunks(t *testing.T) {
 
 	// Add to the tree, checking after each leaf
 	for l := 0; l < 8; l++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
 		}
 	}
@@ -462,8 +459,7 @@ func TestMerkleTreeRootFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			_, _, err := mt.AddLeaf(data[l])
-			if err != nil {
+			if _, _, err := mt.AddLeaf(data[l]); err != nil {
 				t.Fatalf("AddLeaf(%v): %v", data[l], err)
 			}
 		}
@@ -496,8 +492,7 @@ func TestMerkleTreePathFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			_, _, err := mt.AddLeaf(data[l])
-			if err != nil {
+			if _, _, err := mt.AddLeaf(data[l]); err != nil {
 				t.Fatalf("AddLeaf(%v): %v", data[l], err)
 			}
 		}
@@ -543,8 +538,7 @@ func TestMerkleTreeConsistencyFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			_, _, err := mt.AddLeaf(data[l])
-			if err != nil {
+			if _, _, err := mt.AddLeaf(data[l]); err != nil {
 				t.Fatalf("AddLeaf(%v): %v", data[l], err)
 			}
 		}
@@ -585,8 +579,7 @@ func TestMerkleTreePathBuildOnce(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
 		}
 	}
@@ -632,8 +625,7 @@ func TestMerkleTreePathBuildIncrementally(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
 		}
 	}
@@ -649,8 +641,7 @@ func TestMerkleTreePathBuildIncrementally(t *testing.T) {
 	}
 
 	for i := int64(0); i < 8; i++ {
-		_, _, err := mt2.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
-		if err != nil {
+		if _, _, err := mt2.AddLeaf(decodeHexStringOrPanic(leafInputs[i])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
 		}
 
@@ -684,8 +675,7 @@ func TestProofConsistencyTestVectors(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
-		if err != nil {
+		if _, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i])); err != nil {
 			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
 		}
 	}

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -274,8 +274,7 @@ func referenceSnapshotConsistency(inputs [][]byte, snapshot2 int64,
 	if snapshot1 <= split {
 		// Root of snapshot1 is in the left subtree of snapshot2.
 		// Prove that the left subtrees are consistent.
-		s, err := referenceSnapshotConsistency(inputs[:split], split, snapshot1,
-			treehasher, haveRoot1)
+		s, err := referenceSnapshotConsistency(inputs[:split], split, snapshot1, treehasher, haveRoot1)
 		if err != nil {
 			return nil, err
 		}
@@ -291,8 +290,7 @@ func referenceSnapshotConsistency(inputs [][]byte, snapshot2 int64,
 		// Snapshot1 root is at the same level as snapshot2 root.
 		// Prove that the right subtrees are consistent. The right subtree
 		// doesn't contain the root of snapshot1, so set haveRoot1 = false.
-		s, err := referenceSnapshotConsistency(inputs[split:], snapshot2-split,
-			snapshot1-split, treehasher, false)
+		s, err := referenceSnapshotConsistency(inputs[split:], snapshot2-split, snapshot1-split, treehasher, false)
 		if err != nil {
 			return nil, err
 		}
@@ -432,8 +430,7 @@ func TestReferenceMerklePathSanity(t *testing.T) {
 	}
 
 	for _, path := range testPaths {
-		referencePath, err := referenceMerklePath(data[:path.snapshot], path.leaf,
-			mt.hasher)
+		referencePath, err := referenceMerklePath(data[:path.snapshot], path.leaf, mt.hasher)
 		if err != nil {
 			t.Fatalf("referenceMerklePath(): %v", err)
 		}
@@ -552,8 +549,7 @@ func TestMerkleTreeConsistencyFuzz(t *testing.T) {
 			snapshot1 := rand.Int63n(snapshot2 + 1)
 
 			c1 := mt.SnapshotConsistency(snapshot1, snapshot2)
-			c2, err := referenceSnapshotConsistency(data[:snapshot2], snapshot2,
-				snapshot1, mt.hasher, true)
+			c2, err := referenceSnapshotConsistency(data[:snapshot2], snapshot2, snapshot1, mt.hasher, true)
 			if err != nil {
 				t.Fatalf("referenceSnapshotConsistency(): %v", err)
 			}

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -331,14 +331,20 @@ func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for l := 0; l < 3; l++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
+		}
 	}
 
 	// Check the intermediate state
 	validateTree(mt, 2, t)
 
 	for l := 3; l < 8; l++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
+		}
 	}
 
 	// Check the final state
@@ -350,7 +356,10 @@ func TestBuildTreeBuildTwoChunks(t *testing.T) {
 
 	// Add to the tree, checking after each leaf
 	for l := 0; l < 8; l++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[l]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[l], err)
+		}
 	}
 
 	validateTree(mt, 7, t)
@@ -405,7 +414,10 @@ func TestMerkleTreeRootFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			mt.AddLeaf(data[l])
+			_, _, err := mt.AddLeaf(data[l])
+			if err != nil {
+				t.Fatalf("AddLeaf(%v): %v", data[l], err)
+			}
 		}
 
 		// Since the tree is evaluated lazily, the order of queries is significant.
@@ -433,7 +445,10 @@ func TestMerkleTreePathFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			mt.AddLeaf(data[l])
+			_, _, err := mt.AddLeaf(data[l])
+			if err != nil {
+				t.Fatalf("AddLeaf(%v): %v", data[l], err)
+			}
 		}
 
 		// Since the tree is evaluated lazily, the order of queries is significant.
@@ -474,7 +489,10 @@ func TestMerkleTreeConsistencyFuzz(t *testing.T) {
 		mt := makeEmptyTree()
 
 		for l := int64(0); l < treeSize; l++ {
-			mt.AddLeaf(data[l])
+			_, _, err := mt.AddLeaf(data[l])
+			if err != nil {
+				t.Fatalf("AddLeaf(%v): %v", data[l], err)
+			}
 		}
 
 		// Since the tree is evaluated lazily, the order of queries is significant.
@@ -510,7 +528,10 @@ func TestMerkleTreePathBuildOnce(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
+		}
 	}
 
 	if mt.LeafCount() != 8 {
@@ -554,7 +575,10 @@ func TestMerkleTreePathBuildIncrementally(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
+		}
 	}
 
 	mt2 := makeEmptyTree()
@@ -568,7 +592,10 @@ func TestMerkleTreePathBuildIncrementally(t *testing.T) {
 	}
 
 	for i := int64(0); i < 8; i++ {
-		mt2.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		_, _, err := mt2.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
+		}
 
 		for j := int64(0); j <= i+1; j++ {
 			p1 := mt.PathToRootAtSnapshot(j, i+1)
@@ -600,7 +627,10 @@ func TestProofConsistencyTestVectors(t *testing.T) {
 	mt := makeEmptyTree()
 
 	for i := 0; i < 8; i++ {
-		mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		_, _, err := mt.AddLeaf(decodeHexStringOrPanic(leafInputs[i]))
+		if err != nil {
+			t.Fatalf("AddLeaf(%v): %v", leafInputs[i], err)
+		}
 	}
 
 	if mt.LeafCount() != 8 {

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -174,7 +174,8 @@ func referenceMerkleTreeHash(inputs [][]byte, treehasher hashers.LogHasher) []by
 	}
 
 	if len(inputs) == 1 {
-		return treehasher.HashLeaf(inputs[0])
+		leafHash, _ := treehasher.HashLeaf(inputs[0])
+		return leafHash
 	}
 
 	split := downToPowerOfTwo(int64(len(inputs)))

--- a/merkle/objhasher/objhasher.go
+++ b/merkle/objhasher/objhasher.go
@@ -52,14 +52,12 @@ func NewLogHasher(baseHasher hashers.LogHasher) hashers.LogHasher {
 }
 
 // HashLeaf returns the object hash of leaf, which must be a JSON object.
-func (o *objloghasher) HashLeaf(leaf []byte) []byte {
-	hash, _ := objecthash.CommonJSONHash(string(leaf))
-	/*
-		if err != nil {
-			return nil, fmt.Errorf("CommonJSONHash(%s): %v", leaf, err)
-		}
-	*/
-	return hash[:]
+func (o *objloghasher) HashLeaf(leaf []byte) ([]byte, error) {
+	hash, err := objecthash.CommonJSONHash(string(leaf))
+	if err != nil {
+		return nil, fmt.Errorf("CommonJSONHash(%s): %v", leaf, err)
+	}
+	return hash[:], err
 }
 
 // HashLeaf returns the object hash of leaf, which must be a JSON object.

--- a/merkle/objhasher/objhasher.go
+++ b/merkle/objhasher/objhasher.go
@@ -17,6 +17,7 @@ package objhasher
 
 import (
 	"crypto"
+	"fmt"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/google/trillian"
@@ -52,12 +53,20 @@ func NewLogHasher(baseHasher hashers.LogHasher) hashers.LogHasher {
 
 // HashLeaf returns the object hash of leaf, which must be a JSON object.
 func (o *objloghasher) HashLeaf(leaf []byte) []byte {
-	hash := objecthash.CommonJSONHash(string(leaf))
+	hash, _ := objecthash.CommonJSONHash(string(leaf))
+	/*
+		if err != nil {
+			return nil, fmt.Errorf("CommonJSONHash(%s): %v", leaf, err)
+		}
+	*/
 	return hash[:]
 }
 
 // HashLeaf returns the object hash of leaf, which must be a JSON object.
-func (o *objmaphasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
-	hash := objecthash.CommonJSONHash(string(leaf))
-	return hash[:]
+func (o *objmaphasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error) {
+	hash, err := objecthash.CommonJSONHash(string(leaf))
+	if err != nil {
+		return nil, fmt.Errorf("CommonJSONHash(%s): %v", leaf, err)
+	}
+	return hash[:], nil
 }

--- a/merkle/objhasher/objhasher_test.go
+++ b/merkle/objhasher/objhasher_test.go
@@ -44,7 +44,10 @@ func TestLeafHash(t *testing.T) {
 			want: "ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057",
 		},
 	} {
-		leaf := h.HashLeaf(tc.json)
+		leaf, err := h.HashLeaf(tc.json)
+		if err != nil {
+			t.Errorf("HashLeaf(%v): %v", tc.json, err)
+		}
 		if got := hex.EncodeToString(leaf); got != tc.want {
 			t.Errorf("HashLeaf(%v): \n%v, want \n%v", tc.json, got, tc.want)
 		}

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -53,11 +53,11 @@ func (t *Hasher) EmptyRoot() []byte {
 
 // HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
 // The data in leaf is prefixed by the LeafHashPrefix.
-func (t *Hasher) HashLeaf(leaf []byte) []byte {
+func (t *Hasher) HashLeaf(leaf []byte) ([]byte, error) {
 	h := t.New()
 	h.Write([]byte{RFC6962LeafHashPrefix})
 	h.Write(leaf)
-	return h.Sum(nil)
+	return h.Sum(nil), nil
 }
 
 // HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -22,17 +22,33 @@ import (
 func TestRfc6962Hasher(t *testing.T) {
 	hasher := DefaultHasher
 
+	leafHash, err := hasher.HashLeaf([]byte("L123456"))
+	if err != nil {
+		t.Fatalf("HashLeaf(): %v", err)
+	}
 	for _, tc := range []struct {
 		desc string
 		got  []byte
 		want string
 	}{
 		// echo -n | sha256sum
-		{desc: "RFC962 Empty", want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", got: hasher.EmptyRoot()},
+		{
+			desc: "RFC962 Empty",
+			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			got:  hasher.EmptyRoot(),
+		},
 		// echo -n 004C313233343536 | xxd -r -p | sha256sum
-		{desc: "RFC6962 Leaf", want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56", got: hasher.HashLeaf([]byte("L123456"))},
+		{
+			desc: "RFC6962 Leaf",
+			want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56",
+			got:  leafHash,
+		},
 		// echo -n 014E3132334E343536 | xxd -r -p | sha256sum
-		{desc: "RFC6962 Node", want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb", got: hasher.HashChildren([]byte("N123"), []byte("N456"))},
+		{
+			desc: "RFC6962 Node",
+			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
+			got:  hasher.HashChildren([]byte("N123"), []byte("N456")),
+		},
 	} {
 		wantBytes, err := hex.DecodeString(tc.want)
 		if err != nil {

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -356,9 +356,13 @@ func testSparseTreeCalculatedRootWithWriter(ctx context.Context, t *testing.T, r
 	var leaves []HashKeyValue
 	for _, kv := range vec.kv {
 		index := testonly.HashKey(kv.k)
+		leafHash, err := w.hasher.HashLeaf(treeID, index, []byte(kv.v))
+		if err != nil {
+			t.Fatalf("HashLeaf(): %v", err)
+		}
 		leaves = append(leaves, HashKeyValue{
 			HashedKey:   index,
-			HashedValue: w.hasher.HashLeaf(treeID, index, []byte(kv.v)),
+			HashedValue: leafHash,
 		})
 	}
 
@@ -598,8 +602,12 @@ func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 		h := make([]HashKeyValue, batchSize)
 		for y := 0; y < batchSize; y++ {
 			index := testonly.HashKey(fmt.Sprintf("key-%d-%d", x, y))
+			leafHash, err := w.hasher.HashLeaf(treeID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
+			if err != nil {
+				t.Fatalf("HashLeaf(): %v", err)
+			}
 			h[y].HashedKey = index
-			h[y].HashedValue = w.hasher.HashLeaf(treeID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
+			h[y].HashedValue = leafHash
 		}
 		if err := w.SetLeaves(ctx, h); err != nil {
 			t.Fatalf("Failed to batch %d: %v", x, err)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -97,7 +97,11 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 	ctx = trees.NewContext(ctx, tree)
 
 	for i := range req.Leaves {
-		req.Leaves[i].MerkleLeafHash = hasher.HashLeaf(req.Leaves[i].LeafValue)
+		leafHash, err := hasher.HashLeaf(req.Leaves[i].LeafValue)
+		if err != nil {
+			return nil, err
+		}
+		req.Leaves[i].MerkleLeafHash = leafHash
 	}
 
 	tx, err := t.prepareStorageTx(ctx, logID)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -41,8 +41,10 @@ var (
 	leaf0Log2Request   = trillian.GetLeavesByIndexRequest{LogId: logID2, LeafIndex: []int64{0}}
 	leaf1Data          = []byte("value")
 	leaf3Data          = []byte("value3")
-	leaf1              = &trillian.LogLeaf{LeafIndex: 1, MerkleLeafHash: th.HashLeaf(leaf1Data), LeafValue: leaf1Data, ExtraData: []byte("extra")}
-	leaf3              = &trillian.LogLeaf{LeafIndex: 3, MerkleLeafHash: th.HashLeaf(leaf3Data), LeafValue: leaf3Data, ExtraData: []byte("extra3")}
+	leaf1Hash, _       = th.HashLeaf(leaf1Data)
+	leaf3Hash, _       = th.HashLeaf(leaf3Data)
+	leaf1              = &trillian.LogLeaf{LeafIndex: 1, MerkleLeafHash: leaf1Hash, LeafValue: leaf1Data, ExtraData: []byte("extra")}
+	leaf3              = &trillian.LogLeaf{LeafIndex: 3, MerkleLeafHash: leaf3Hash, LeafValue: leaf3Data, ExtraData: []byte("extra3")}
 
 	queueRequest0     = trillian.QueueLeavesRequest{LogId: logID1, Leaves: []*trillian.LogLeaf{leaf1}}
 	queueRequest0Log2 = trillian.QueueLeavesRequest{LogId: logID2, Leaves: []*trillian.LogLeaf{leaf1}}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -103,10 +103,14 @@ func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapL
 			found++
 		} else {
 			// Empty leaf for proof of non-existence.
+			leafHash, err := hasher.HashLeaf(mapID, index, nil)
+			if err != nil {
+				return nil, fmt.Errorf("HashLeaf(nil): %v", err)
+			}
 			leaf = &trillian.MapLeaf{
 				Index:     index,
 				LeafValue: nil,
-				LeafHash:  hasher.HashLeaf(mapID, index, nil),
+				LeafHash:  leafHash,
 			}
 		}
 
@@ -173,7 +177,11 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 			continue
 		}
 		// TODO(gbelvin) use LeafHash rather than computing here. #423
-		l.LeafHash = hasher.HashLeaf(mapID, l.Index, l.LeafValue)
+		leafHash, err := hasher.HashLeaf(mapID, l.Index, l.LeafValue)
+		if err != nil {
+			return nil, fmt.Errorf("HashLeaf(): %v", err)
+		}
+		l.LeafHash = leafHash
 
 		if err = tx.Set(ctx, l.Index, *l); err != nil {
 			return nil, err

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -42,11 +42,11 @@ type rehashTest struct {
 const testTreeRevision int64 = 3
 
 // Raw hashes for dummy storage nodes
-var h1 = th.HashLeaf([]byte("Hash 1"))
-var h2 = th.HashLeaf([]byte("Hash 2"))
-var h3 = th.HashLeaf([]byte("Hash 3"))
-var h4 = th.HashLeaf([]byte("Hash 4"))
-var h5 = th.HashLeaf([]byte("Hash 5"))
+var h1, _ = th.HashLeaf([]byte("Hash 1"))
+var h2, _ = th.HashLeaf([]byte("Hash 2"))
+var h3, _ = th.HashLeaf([]byte("Hash 3"))
+var h4, _ = th.HashLeaf([]byte("Hash 4"))
+var h5, _ = th.HashLeaf([]byte("Hash 5"))
 
 // And the dummy nodes themselves.
 var sn1 = storage.Node{NodeID: storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -304,8 +304,7 @@ func treeAtSize(n int) *merkle.InMemoryMerkleTree {
 	leaves := expandLeaves(0, n-1)
 	mt := merkle.NewInMemoryMerkleTree(rfc6962.DefaultHasher)
 	for _, leaf := range leaves {
-		_, _, err := mt.AddLeaf([]byte(leaf))
-		if err != nil {
+		if _, _, err := mt.AddLeaf([]byte(leaf)); err != nil {
 			panic(err)
 		}
 	}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -304,7 +304,10 @@ func treeAtSize(n int) *merkle.InMemoryMerkleTree {
 	leaves := expandLeaves(0, n-1)
 	mt := merkle.NewInMemoryMerkleTree(rfc6962.DefaultHasher)
 	for _, leaf := range leaves {
-		mt.AddLeaf([]byte(leaf))
+		_, _, err := mt.AddLeaf([]byte(leaf))
+		if err != nil {
+			panic(err)
+		}
 	}
 	return mt
 }

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -45,8 +45,9 @@ var fakeTimeSource = util.NewFakeTimeSource(fakeTime)
 
 // We use a size zero tree for testing, Merkle tree state restore is tested elsewhere
 var testLogID1 = int64(1)
+var leaf0Hash, _ = rfc6962.DefaultHasher.HashLeaf([]byte{})
 var testLeaf0 = &trillian.LogLeaf{
-	MerkleLeafHash: rfc6962.DefaultHasher.HashLeaf([]byte{}),
+	MerkleLeafHash: leaf0Hash,
 	LeafValue:      nil,
 	ExtraData:      nil,
 	LeafIndex:      0,

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -265,8 +265,11 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		s.InternalNodes = make(map[string][]byte)
 
 		leaf := []byte(fmt.Sprintf("this is leaf %d", numLeaves))
-		leafHash := rfc6962.DefaultHasher.HashLeaf(leaf)
-		_, err := cmt.AddLeafHash(leafHash, func(depth int, index int64, h []byte) error {
+		leafHash, err := rfc6962.DefaultHasher.HashLeaf(leaf)
+		if err != nil {
+			t.Fatalf("HashLeaf(%v): %v", leaf, err)
+		}
+		_, err = cmt.AddLeafHash(leafHash, func(depth int, index int64, h []byte) error {
 			n, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 8)
 			if err != nil {
 				return fmt.Errorf("failed to create nodeID for cmt tree: %v", err)

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -161,9 +161,8 @@ func createLogNodesForTreeAtSize(ts, rev int64) ([]storage.Node, error) {
 	nodeMap := make(map[string]storage.Node)
 	for l := 0; l < int(ts); l++ {
 		// We're only interested in the side effects of adding leaves - the node updates
-		_, _, err := tree.AddLeaf([]byte(fmt.Sprintf("Leaf %d", l)), func(depth int, index int64, hash []byte) error {
+		if _, _, err := tree.AddLeaf([]byte(fmt.Sprintf("Leaf %d", l)), func(depth int, index int64, hash []byte) error {
 			nID, err := storage.NewNodeIDForTreeCoords(int64(depth), index, 64)
-
 			if err != nil {
 				return fmt.Errorf("failed to create a nodeID for tree - should not happen d:%d i:%d",
 					depth, index)
@@ -171,8 +170,7 @@ func createLogNodesForTreeAtSize(ts, rev int64) ([]storage.Node, error) {
 
 			nodeMap[nID.String()] = storage.Node{NodeID: nID, NodeRevision: rev, Hash: hash}
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/storage/tools/hasher/main.go
+++ b/storage/tools/hasher/main.go
@@ -73,7 +73,7 @@ func main() {
 		// Leaf hash requested
 		hashLeaf, err := hasher.HashLeaf(decoded[0])
 		if err != nil {
-			glog.Fatalf("HashLeaf(%v): %v", decoded[0], err)
+			glog.Exitf("HashLeaf(%v): %v", decoded[0], err)
 		}
 		hash = hashLeaf
 

--- a/storage/tools/hasher/main.go
+++ b/storage/tools/hasher/main.go
@@ -71,7 +71,11 @@ func main() {
 	switch len(decoded) {
 	case 1:
 		// Leaf hash requested
-		hash = hasher.HashLeaf(decoded[0])
+		hashLeaf, err := hasher.HashLeaf(decoded[0])
+		if err != nil {
+			glog.Fatalf("HashLeaf(%v): %v", decoded[0], err)
+		}
+		hash = hashLeaf
 
 	case 2:
 		// Node hash requested

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -100,8 +100,12 @@ func main() {
 		h := make([]merkle.HashKeyValue, batchSize)
 		for y := 0; y < batchSize; y++ {
 			index := testonly.HashKey(fmt.Sprintf("key-%d-%d", x, y))
+			leafHash, err := hasher.HashLeaf(mapID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
+			if err != nil {
+				glog.Exitf("HashLeaf(): %v", err)
+			}
 			h[y].HashedKey = index
-			h[y].HashedValue = hasher.HashLeaf(mapID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
+			h[y].HashedValue = leafHash
 		}
 		glog.Infof("Created %d k/v pairs...", len(h))
 


### PR DESCRIPTION
When novel hashers (`ObjectHash` being just one) are used in `HashLeaf`, they introduce the possibility that the leaf hash could fail.  The leaf data may be in the wrong format etc.  Previously these errors triggered panics.  Eg. #879  Since benlaurie/objecthash#25, these hashers now return errors rather than panicking. 

This PR returns errors from `HashLeaf` up the call stack so they can be handled properly. 

Closes #887 
Closes #879