### PR TITLE
Lazy init Map to write rev 0 Map Head on first use

### DIFF
--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -156,7 +156,7 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 		wantRev      int64
 	}{
 		{
-			desc:         "empty map has signed map head at revision zero",
+			desc:         "empty map has SMR at rev 0 but not rev 1",
 			hashStrategy: []trillian.HashStrategy{trillian.HashStrategy_TEST_MAP_HASHER, trillian.HashStrategy_CONIKS_SHA512_256},
 			wantRev: 0,
 		},
@@ -198,6 +198,16 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 			if diff := pretty.Compare(got, want); diff != "" {
 				t.Errorf("%v: GetSignedMapRootByRevision() != GetSignedMapRoot(); diff (-got +want):\n%v", tc.desc, diff)
 			}
+			//
+			getSmrByRevResp, err = tmap.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{
+				MapId: tree.TreeId,
+				Revision: 1,
+			})
+			if err == nil {
+				t.Errorf("%v: GetSignedMapRootByRevision(rev: 1) err? false want? true", tc.desc)
+			}
+			// TODO(phad): ideally we'd inspect err's type and check it contains a NOT_FOUND Code (5), but I don't want
+			// a dependency on gRPC here.
 		}
 	}
 }

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -158,7 +158,7 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 		{
 			desc:         "empty map has SMR at rev 0 but not rev 1",
 			hashStrategy: []trillian.HashStrategy{trillian.HashStrategy_TEST_MAP_HASHER, trillian.HashStrategy_CONIKS_SHA512_256},
-			wantRev: 0,
+			wantRev:      0,
 		},
 	} {
 		for _, hashStrategy := range tc.hashStrategy {
@@ -183,7 +183,7 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 			}
 			//
 			getSmrByRevResp, err := tmap.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{
-				MapId: tree.TreeId,
+				MapId:    tree.TreeId,
 				Revision: 0,
 			})
 			if err != nil {
@@ -200,7 +200,7 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 			}
 			//
 			getSmrByRevResp, err = tmap.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{
-				MapId: tree.TreeId,
+				MapId:    tree.TreeId,
 				Revision: 1,
 			})
 			if err == nil {

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -30,6 +30,8 @@ import (
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/testonly"
 
+	"github.com/kylelemons/godebug/pretty"
+
 	tcrypto "github.com/google/trillian/crypto"
 	stestonly "github.com/google/trillian/storage/testonly"
 )
@@ -48,6 +50,7 @@ type TestTable []NamedTestFn
 // Be sure to extend this when additional tests are added.
 // This is done so that tests can be run in different environments in a portable way.
 var AllTests = TestTable{
+	{"MapRevisionZero", RunMapRevisionZero},
 	{"LeafHistory", RunLeafHistory},
 	{"Inclusion", RunInclusion},
 	{"InclusionBatch", RunInclusionBatch},
@@ -81,22 +84,29 @@ func isEmptyMap(ctx context.Context, tmap trillian.TrillianMapClient, tree *tril
 	return nil
 }
 
+func verifyGetSignedMapRootResponse(mapRoot *trillian.SignedMapRoot,
+	wantRevision int64, pubKey crypto.PublicKey, hasher hashers.MapHasher, treeID int64) error {
+	if got, want := mapRoot.GetMapRevision(), wantRevision; got != want {
+		return fmt.Errorf("got SMR with revision %d, want %d", got, want)
+	}
+	// SignedMapRoot contains its own signature. To verify, we need to create a local
+	// copy of the object and return the object to the state it was in when signed
+	// by removing the signature from the object.
+	smr := *mapRoot
+	smr.Signature = nil // Remove the signature from the object to be verified.
+	if err := tcrypto.VerifyObject(pubKey, smr, mapRoot.GetSignature()); err != nil {
+		return fmt.Errorf("VerifyObject(SMR): %v", err)
+	}
+	return nil
+}
+
 func verifyGetMapLeavesResponse(getResp *trillian.GetMapLeavesResponse, indexes [][]byte,
 	wantRevision int64, pubKey crypto.PublicKey, hasher hashers.MapHasher, treeID int64) error {
 	if got, want := len(getResp.MapLeafInclusion), len(indexes); got != want {
 		return fmt.Errorf("got %d values, want %d", got, want)
 	}
-	if got, want := getResp.GetMapRoot().GetMapRevision(), wantRevision; got != want {
-		return fmt.Errorf("got SMR with revision %d, want %d", got, want)
-	}
-
-	// SignedMapRoot contains its own signature. To verify, we need to create a local
-	// copy of the object and return the object to the state it was in when signed
-	// by removing the signature from the object.
-	smr := *getResp.GetMapRoot()
-	smr.Signature = nil // Remove the signature from the object to be verified.
-	if err := tcrypto.VerifyObject(pubKey, smr, getResp.GetMapRoot().GetSignature()); err != nil {
-		return fmt.Errorf("VerifyObject(SMR): %v", err)
+	if err := verifyGetSignedMapRootResponse(getResp.GetMapRoot(), wantRevision, pubKey, hasher, treeID); err != nil {
+		return err
 	}
 	rootHash := getResp.GetMapRoot().GetRootHash()
 	for _, incl := range getResp.MapLeafInclusion {
@@ -136,6 +146,60 @@ func newTreeWithHasher(ctx context.Context, tadmin trillian.TrillianAdminClient,
 		return nil, nil, nil
 	}
 	return tree, hasher, nil
+}
+
+// RunMapRevisionZero performs checks on Trillian Map behavior for new, empty maps.
+func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient) {
+	for _, tc := range []struct {
+		desc         string
+		hashStrategy []trillian.HashStrategy
+		wantRev      int64
+	}{
+		{
+			desc:         "empty map has signed map head at revision zero",
+			hashStrategy: []trillian.HashStrategy{trillian.HashStrategy_TEST_MAP_HASHER, trillian.HashStrategy_CONIKS_SHA512_256},
+			wantRev: 0,
+		},
+	} {
+		for _, hashStrategy := range tc.hashStrategy {
+			tree, hasher, err := newTreeWithHasher(ctx, tadmin, hashStrategy)
+			if err != nil {
+				t.Errorf("%v: newTreeWithHasher(%v): %v", tc.desc, hashStrategy, err)
+			}
+			pubKey, err := der.UnmarshalPublicKey(tree.GetPublicKey().GetDer())
+			if err != nil {
+				t.Errorf("%v: UnmarshalPublicKey(%v): %v", tc.desc, hashStrategy, err)
+			}
+			//
+			getSmrResp, err := tmap.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{
+				MapId: tree.TreeId,
+			})
+			if err != nil {
+				t.Errorf("%v: GetSignedMapRoot(): %v", tc.desc, err)
+			}
+			if err := verifyGetSignedMapRootResponse(getSmrResp.GetMapRoot(), tc.wantRev,
+				pubKey, hasher, tree.TreeId); err != nil {
+				t.Errorf("%v: verifyGetSignedMapRootResponse(rev %v): %v", tc.desc, tc.wantRev, err)
+			}
+			//
+			getSmrByRevResp, err := tmap.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{
+				MapId: tree.TreeId,
+				Revision: 0,
+			})
+			if err != nil {
+				t.Errorf("%v: GetSignedMapRootByRevision(): %v", tc.desc, err)
+			}
+			if err := verifyGetSignedMapRootResponse(getSmrByRevResp.GetMapRoot(), tc.wantRev,
+				pubKey, hasher, tree.TreeId); err != nil {
+				t.Errorf("%v: verifyGetSignedMapRootResponse(rev %v): %v", tc.desc, tc.wantRev, err)
+			}
+			//
+			got, want := getSmrByRevResp.GetMapRoot(), getSmrResp.GetMapRoot()
+			if diff := pretty.Compare(got, want); diff != "" {
+				t.Errorf("%v: GetSignedMapRootByRevision() != GetSignedMapRoot(); diff (-got +want):\n%v", tc.desc, diff)
+			}
+		}
+	}
 }
 
 // RunLeafHistory performs checks on Trillian Map leaf updates under a variety of Hash Strategies.

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -60,7 +60,7 @@ func (t *TrillianMapServer) Init(ctx context.Context, mapID int64) error {
 
 	tx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
 	if err != storage.ErrMapNeedsInit && err != nil {
-			return err
+		return err
 	}
 	defer tx.Close()
 
@@ -75,7 +75,7 @@ func (t *TrillianMapServer) Init(ctx context.Context, mapID int64) error {
 	smtWriter, err := merkle.NewSparseMerkleTreeWriter(
 		ctx,
 		mapID,
-		0 /* write revision */,
+		0, /* write revision */
 		hasher, func() (storage.TreeTX, error) {
 			ttx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
 			if err == storage.ErrMapNeedsInit {
@@ -267,7 +267,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		return nil, fmt.Errorf("CalculateRoot(): %v", err)
 	}
 
-	newRoot, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash,req.MapId, tx.WriteRevision(), req.Metadata)
+	newRoot, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, req.MapId, tx.WriteRevision(), req.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("makeSignedMapRoot(): %v", err)
 	}
@@ -286,7 +286,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 }
 
 func (t *TrillianMapServer) makeSignedMapRoot(ctx context.Context, tree *trillian.Tree, smrTs time.Time,
-		rootHash []byte, mapID, revision int64, meta *any.Any) (*trillian.SignedMapRoot, error) {
+	rootHash []byte, mapID, revision int64, meta *any.Any) (*trillian.SignedMapRoot, error) {
 	smr := &trillian.SignedMapRoot{
 		TimestampNanos: smrTs.UnixNano(),
 		RootHash:       rootHash,

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -92,12 +92,12 @@ func (t *TrillianMapServer) Init(ctx context.Context, mapID int64) error {
 		return fmt.Errorf("CalculateRoot(): %v", err)
 	}
 
-	newRoot, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, mapID, 0 /*revision*/, nil /* metadata */)
+	rev0Root, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, mapID, 0 /*revision*/, nil /* metadata */)
 	if err != nil {
 		return fmt.Errorf("makeSignedMapRoot(): %v", err)
 	}
 
-	if err = tx.StoreSignedMapRoot(ctx, *newRoot); err != nil {
+	if err = tx.StoreSignedMapRoot(ctx, *rev0Root); err != nil {
 		return err
 	}
 
@@ -287,7 +287,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 
 func (t *TrillianMapServer) makeSignedMapRoot(ctx context.Context, tree *trillian.Tree, smrTs time.Time,
 		rootHash []byte, mapID, revision int64, meta *any.Any) (*trillian.SignedMapRoot, error) {
-	newRoot := &trillian.SignedMapRoot{
+	smr := &trillian.SignedMapRoot{
 		TimestampNanos: smrTs.UnixNano(),
 		RootHash:       rootHash,
 		MapId:          mapID,
@@ -298,12 +298,12 @@ func (t *TrillianMapServer) makeSignedMapRoot(ctx context.Context, tree *trillia
 	if err != nil {
 		return nil, fmt.Errorf("trees.Signer(): %v", err)
 	}
-	sig, err := signer.SignObject(newRoot)
+	sig, err := signer.SignObject(smr)
 	if err != nil {
 		return nil, fmt.Errorf("SignObject(): %v", err)
 	}
-	newRoot.Signature = sig
-	return newRoot, nil
+	smr.Signature = sig
+	return smr, nil
 }
 
 // GetSignedMapRoot implements the GetSignedMapRoot RPC method.

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -58,7 +58,7 @@ func (t *TrillianMapServer) Init(ctx context.Context, mapID int64) error {
 	ctx = trees.NewContext(ctx, tree)
 
 	tx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
-	if err != nil && err != storage.ErrMapNeedsInit {
+	if err != storage.ErrMapNeedsInit && err != nil {
 			return err
 	}
 	defer tx.Close()

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -145,8 +145,8 @@ func TestGetSignedMapRoot(t *testing.T) {
 			lsmrErr: errors.New("sql: no rows in result set"),
 		},
 		{
-			desc:    "Snapshot returns Error",
-			req:     &trillian.GetSignedMapRootRequest{MapId: mapID1},
+			desc:      "Snapshot returns Error",
+			req:       &trillian.GetSignedMapRootRequest{MapId: mapID1},
 			snapShErr: errors.New("unknown map"),
 		},
 	}

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -34,6 +34,18 @@ const (
 )
 
 var (
+	signedMapRootID1Rev0 = trillian.SignedMapRoot{
+		TimestampNanos: 1508235889834964600,
+		RootHash:       []byte("\306h\237\020\201*\t\200\227m\2253\3308u(!f\025\225g\3545\025W\026\301A:\365=j"),
+		Signature: &sigpb.DigitallySigned{
+			HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+			SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+			Signature:          []byte("0F\002!\000\307b\255\223\353\23615&\022\263\323\341\342+\276\274$\rX?\366\014U\362\006\376\0269rcm\002!\000\241*\255\220\301\263D\033\275\374\340A\377\337\354\202\331%au\3179\000O\r9\237\302\021\r\363\263"),
+		},
+		MapId:       mapID1,
+		MapRevision: 0,
+	}
+
 	signedMapRootID1Rev1 = trillian.SignedMapRoot{
 		TimestampNanos: 1508235889834964600,
 		RootHash:       []byte("\306h\237\020\201*\t\200\227m\2253\3308u(!f\025\225g\3545\025W\026\301A:\365=j"),
@@ -64,7 +76,7 @@ func TestIsHealthy(t *testing.T) {
 		mockStorage.EXPECT().CheckDatabaseAccessible(gomock.Any()).Return(test.accessibleErr)
 
 		server := NewTrillianMapServer(extension.Registry{
-			AdminStorage: mockAdminStorageForMap(ctrl, mapID1),
+			AdminStorage: mockAdminStorageForMap(ctrl, 1, mapID1),
 			MapStorage:   mockStorage,
 		})
 
@@ -74,6 +86,36 @@ func TestIsHealthy(t *testing.T) {
 			t.Errorf("%s: IsHealthy() err? %t want? %t (err=%v)", test.desc, gotErr, wantErr, err)
 		}
 	}
+}
+
+func TestGetSignedMapRoot_InitFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	t.Run("Unknown map", func(t *testing.T) {
+		adminStorage := storage.NewMockAdminStorage(ctrl)
+		adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
+
+		// Calls from Init()
+		adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(1).Return(adminTX, nil)
+		adminTX.EXPECT().GetTree(gomock.Any(), gomock.Any()).MaxTimes(1).Return(nil, errors.New("unknown tree"))
+		adminTX.EXPECT().Close().MaxTimes(1).Return(nil)
+
+		server := NewTrillianMapServer(extension.Registry{
+			AdminStorage: adminStorage,
+			MapStorage:   storage.NewMockMapStorage(ctrl),
+		})
+
+		smrResp, err := server.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{})
+
+		if err == nil {
+			t.Errorf("GetSignedMapRoot()=_, nil want err? true")
+		}
+		if smrResp != nil {
+			t.Errorf("GetSignedMapRoot()=%v, _ want nil", smrResp)
+		}
+	})
 }
 
 func TestGetSignedMapRoot(t *testing.T) {
@@ -88,56 +130,101 @@ func TestGetSignedMapRoot(t *testing.T) {
 		snapShErr, lsmrErr error
 	}{
 		{
-			desc:      "Unknown map",
-			req:       &trillian.GetSignedMapRootRequest{},
-			snapShErr: errors.New("unknown map"),
-		},
-		{
 			desc:    "Map is empty, head at revision 0",
 			req:     &trillian.GetSignedMapRootRequest{MapId: mapID1},
-			lsmrErr: errors.New("sql: no rows in result set"),
+			mapRoot: signedMapRootID1Rev0,
 		},
 		{
 			desc:    "Map has leaves, head > revision 0",
 			req:     &trillian.GetSignedMapRootRequest{MapId: mapID1},
 			mapRoot: signedMapRootID1Rev1,
 		},
+		{
+			desc:    "LatestSignedMapRoot returns error",
+			req:     &trillian.GetSignedMapRootRequest{MapId: mapID1},
+			lsmrErr: errors.New("sql: no rows in result set"),
+		},
+		{
+			desc:    "Snapshot returns Error",
+			req:     &trillian.GetSignedMapRootRequest{MapId: mapID1},
+			snapShErr: errors.New("unknown map"),
+		},
 	}
 
 	for _, test := range tests {
-		mockStorage := storage.NewMockMapStorage(ctrl)
-		mockTx := storage.NewMockMapTreeTX(ctrl)
+		t.Run(test.desc, func(t *testing.T) {
+			adminStorage := mockAdminStorageForMap(ctrl, 2, mapID1)
+			mockStorage := storage.NewMockMapStorage(ctrl)
+			mockTx := storage.NewMockMapTreeTX(ctrl)
 
-		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
-		if test.snapShErr == nil {
-			mockTx.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(test.mapRoot, test.lsmrErr)
-			if test.lsmrErr == nil {
-				mockTx.EXPECT().Commit().Return(nil)
-			}
+			// Calls from Init()
+			mockStorage.EXPECT().BeginForTree(gomock.Any(), test.req.MapId).Return(mockTx, nil)
 			mockTx.EXPECT().Close().Return(nil)
-			mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
-		}
+
+			// Calls from GetSignedMapRoot()
+			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
+			if test.snapShErr == nil {
+				mockTx.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(test.mapRoot, test.lsmrErr)
+				if test.lsmrErr == nil {
+					mockTx.EXPECT().Commit().Return(nil)
+				}
+				mockTx.EXPECT().Close().Return(nil)
+				mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
+			}
+
+			server := NewTrillianMapServer(extension.Registry{
+				AdminStorage: adminStorage,
+				MapStorage:   mockStorage,
+			})
+
+			smrResp, err := server.GetSignedMapRoot(ctx, test.req)
+
+			wantErr := test.snapShErr != nil || test.lsmrErr != nil
+			if gotErr := err != nil; gotErr != wantErr {
+				t.Errorf("GetSignedMapRoot()=_, err? %t want? %t (err=%v)", gotErr, wantErr, err)
+			}
+			if err != nil {
+				return
+			}
+			want := &trillian.GetSignedMapRootResponse{MapRoot: &test.mapRoot}
+			if got := smrResp; !proto.Equal(got, want) {
+				diff := pretty.Compare(got, want)
+				t.Errorf("GetSignedMapRoot() got != want, diff:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestGetSignedMapRootByRevision_InitFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	t.Run("Unknown map", func(t *testing.T) {
+		adminStorage := storage.NewMockAdminStorage(ctrl)
+		adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
+
+		// Calls from Init()
+		adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(1).Return(adminTX, nil)
+		adminTX.EXPECT().GetTree(gomock.Any(), gomock.Any()).MaxTimes(1).Return(nil, errors.New("unknown tree"))
+		adminTX.EXPECT().Close().MaxTimes(1).Return(nil)
 
 		server := NewTrillianMapServer(extension.Registry{
-			AdminStorage: mockAdminStorageForMap(ctrl, mapID1),
-			MapStorage:   mockStorage,
+			AdminStorage: adminStorage,
+			MapStorage:   storage.NewMockMapStorage(ctrl),
 		})
 
-		smrResp, err := server.GetSignedMapRoot(ctx, test.req)
+		smrResp, err := server.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{
+			Revision: 1,
+		})
 
-		wantErr := test.snapShErr != nil || test.lsmrErr != nil
-		if gotErr := err != nil; gotErr != wantErr {
-			t.Errorf("%s: GetSignedMapRoot()=_, err? %t want? %t (err=%v)", test.desc, gotErr, wantErr, err)
+		if err == nil {
+			t.Errorf("GetSignedMapRootByRevision()=_, nil want err? true")
 		}
-		if err != nil {
-			continue
+		if smrResp != nil {
+			t.Errorf("GetSignedMapRootByRevision()=%v, _ want nil", smrResp)
 		}
-		want := &trillian.GetSignedMapRootResponse{MapRoot: &test.mapRoot}
-		if got := smrResp; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
-			t.Errorf("%s: GetSignedMapRoot() got != want, diff:\n%v", test.desc, diff)
-		}
-	}
+	})
 }
 
 func TestGetSignedMapRootByRevision(t *testing.T) {
@@ -151,11 +238,6 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 		mapRoot            trillian.SignedMapRoot
 		snapShErr, lsmrErr error
 	}{
-		{
-			desc:      "Unknown map",
-			req:       &trillian.GetSignedMapRootByRevisionRequest{},
-			snapShErr: errors.New("unknown map"),
-		},
 		{
 			desc:    "Request revision 0 for empty map",
 			req:     &trillian.GetSignedMapRootByRevisionRequest{MapId: mapID1},
@@ -179,52 +261,58 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mockStorage := storage.NewMockMapStorage(ctrl)
-		mockTx := storage.NewMockMapTreeTX(ctrl)
+		t.Run(test.desc, func(t *testing.T) {
+			adminStorage := mockAdminStorageForMap(ctrl, 2, mapID1)
+			mockStorage := storage.NewMockMapStorage(ctrl)
+			mockTx := storage.NewMockMapTreeTX(ctrl)
 
-		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
-		if test.snapShErr == nil {
-			mockTx.EXPECT().GetSignedMapRoot(gomock.Any(), test.req.Revision).Return(test.mapRoot, test.lsmrErr)
-			if test.lsmrErr == nil {
-				mockTx.EXPECT().Commit().Return(nil)
-			}
+			mockStorage.EXPECT().BeginForTree(gomock.Any(), test.req.MapId).Return(mockTx, nil)
 			mockTx.EXPECT().Close().Return(nil)
-			mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
-		}
 
-		server := NewTrillianMapServer(extension.Registry{
-			AdminStorage: mockAdminStorageForMap(ctrl, mapID1),
-			MapStorage:   mockStorage,
+			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
+			if test.snapShErr == nil {
+				mockTx.EXPECT().GetSignedMapRoot(gomock.Any(), test.req.Revision).Return(test.mapRoot, test.lsmrErr)
+				if test.lsmrErr == nil {
+					mockTx.EXPECT().Commit().Return(nil)
+				}
+				mockTx.EXPECT().Close().Return(nil)
+				mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
+			}
+
+			server := NewTrillianMapServer(extension.Registry{
+				AdminStorage: adminStorage,
+				MapStorage:   mockStorage,
+			})
+
+			smrResp, err := server.GetSignedMapRootByRevision(ctx, test.req)
+
+			wantErr := test.snapShErr != nil || test.lsmrErr != nil
+			if gotErr := err != nil; gotErr != wantErr {
+				t.Errorf("GetSignedMapRootByRevision()=_, err? %t want? %t (err=%v)", gotErr, wantErr, err)
+			}
+			if err != nil {
+				return
+			}
+			want := &trillian.GetSignedMapRootResponse{MapRoot: &test.mapRoot}
+			if got := smrResp; !proto.Equal(got, want) {
+				diff := pretty.Compare(got, want)
+				t.Errorf("GetSignedMapRootByRevision() got != want, diff:\n%v", diff)
+			}
 		})
-
-		smrResp, err := server.GetSignedMapRootByRevision(ctx, test.req)
-
-		wantErr := test.snapShErr != nil || test.lsmrErr != nil
-		if gotErr := err != nil; gotErr != wantErr {
-			t.Errorf("%s: GetSignedMapRootByRevision()=_, err? %t want? %t (err=%v)", test.desc, gotErr, wantErr, err)
-		}
-		if err != nil {
-			continue
-		}
-		want := &trillian.GetSignedMapRootResponse{MapRoot: &test.mapRoot}
-		if got := smrResp; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
-			t.Errorf("%s: GetSignedMapRootByRevision() got != want, diff:\n%v", test.desc, diff)
-		}
 	}
 }
 
-func mockAdminStorageForMap(ctrl *gomock.Controller, treeID int64) storage.AdminStorage {
+func mockAdminStorageForMap(ctrl *gomock.Controller, times int, treeID int64) storage.AdminStorage {
 	tree := *stestonly.MapTree
 	tree.TreeId = treeID
 
 	adminStorage := storage.NewMockAdminStorage(ctrl)
 	adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 
-	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(1).Return(adminTX, nil)
-	adminTX.EXPECT().GetTree(gomock.Any(), treeID).MaxTimes(1).Return(&tree, nil)
-	adminTX.EXPECT().Close().MaxTimes(1).Return(nil)
-	adminTX.EXPECT().Commit().MaxTimes(1).Return(nil)
+	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(times).Return(adminTX, nil)
+	adminTX.EXPECT().GetTree(gomock.Any(), treeID).MaxTimes(times).Return(&tree, nil)
+	adminTX.EXPECT().Close().MaxTimes(times).Return(nil)
+	adminTX.EXPECT().Commit().MaxTimes(times).Return(nil)
 
 	return adminStorage
 }

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/trillian"
 )
@@ -54,6 +55,11 @@ type MapTreeTX interface {
 	Getter
 	Setter
 }
+
+// ErrMapNeedsInit is an error returned from SnapshotForTree / BeginForTree when used
+// on a uninitialized map storage - i.e. a new, empty map in which the Revision 0 SMH
+// hasn't yet been created.
+var ErrMapNeedsInit = errors.New("Uninitialized map")
 
 // ReadOnlyMapStorage provides a narrow read-only view into a MapStorage.
 type ReadOnlyMapStorage interface {

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -123,7 +123,7 @@ func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool
 	}
 
 	mtx.root, err = mtx.LatestSignedMapRoot(ctx)
-	if err != nil && err != storage.ErrMapNeedsInit{
+	if err != nil && err != storage.ErrMapNeedsInit {
 		return nil, err
 	}
 	if err == storage.ErrMapNeedsInit {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/examples/ct/ctmapper/ctmapperpb"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
@@ -40,13 +41,14 @@ func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
 
 func TestMapBeginSnapshot(t *testing.T) {
 	cleanTestDB(DB)
+	ctx := context.Background()
 
-	frozenMapID := createMapForTests(DB)
+	frozenMapID := createInitializedMapForTests(t, ctx, DB)
 	updateTree(DB, frozenMapID, func(tree *trillian.Tree) {
 		tree.TreeState = trillian.TreeState_FROZEN
 	})
 
-	activeMapID := createMapForTests(DB)
+	activeMapID := createInitializedMapForTests(t, ctx, DB)
 	logID := createLogForTests(DB)
 
 	tests := []struct {
@@ -98,10 +100,9 @@ func TestMapBeginSnapshot(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	s := NewMapStorage(DB)
 	for _, test := range tests {
-		func() {
+		t.Run(test.desc, func(t *testing.T) {
 			var tx rootReaderMapTX
 			var err error
 			if test.snapshot {
@@ -132,7 +133,7 @@ func TestMapBeginSnapshot(t *testing.T) {
 					t.Errorf("%v: WriteRevision() = %v, want = %v", test.desc, got, want)
 				}
 			}
-		}()
+		})
 	}
 }
 
@@ -143,10 +144,9 @@ type rootReaderMapTX interface {
 
 func TestMapRootUpdate(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
-	s := NewMapStorage(DB)
-
 	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
+	s := NewMapStorage(DB)
 
 	populatedMetadata := testonly.MustMarshalAny(t, &ctmapperpb.MapperMetadata{HighestFullyCompletedSeq: 1})
 
@@ -238,11 +238,11 @@ var mapLeaf = trillian.MapLeaf{
 
 func TestMapSetGetRoundTrip(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
 	readRev := int64(1)
-	ctx := context.Background()
 	{
 		tx := beginMapTx(ctx, s, mapID, t)
 		defer tx.Close()
@@ -273,10 +273,9 @@ func TestMapSetGetRoundTrip(t *testing.T) {
 
 func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
-	s := NewMapStorage(DB)
-
 	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
+	s := NewMapStorage(DB)
 
 	{
 		tx := beginMapTx(ctx, s, mapID, t)
@@ -301,10 +300,10 @@ func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
 
 func TestMapGet0Results(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
-	ctx := context.Background()
 	for _, tc := range []struct {
 		index [][]byte
 	}{
@@ -328,7 +327,8 @@ func TestMapGet0Results(t *testing.T) {
 func TestMapSetGetMultipleRevisions(t *testing.T) {
 	// Write two roots for a map and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
 	tests := []struct {
@@ -341,7 +341,6 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 		{3, trillian.MapLeaf{Index: keyHash, LeafHash: []byte{3}, LeafValue: []byte{3}, ExtraData: []byte{3}}},
 	}
 
-	ctx := context.Background()
 	for _, tc := range tests {
 		func() {
 			// Write the current test case.
@@ -388,29 +387,26 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 
 func TestGetSignedMapRootNotExist(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	mapID := createMapForTests(DB) // Uninitialized: no revision 0 MapRoot exists.
 	s := NewMapStorage(DB)
 
 	ctx := context.Background()
-	tx := beginMapTx(ctx, s, mapID, t)
-	defer tx.Close()
-
-	root, err := tx.GetSignedMapRoot(ctx, 10)
-	if got, want := err, sql.ErrNoRows; got != want {
+	_, err := s.BeginForTree(ctx, mapID)
+	if got, want := err, storage.ErrMapNeedsInit; got != want {
 		t.Fatalf("GetSignedMapRoot: %v, want %v", got, want)
 	}
-	if root.MapId != 0 || len(root.RootHash) != 0 || root.Signature != nil {
-		t.Fatalf("Read a root with contents when it should be empty: %v", root)
-	}
-	commit(tx, t)
 }
 
-func TestLatestSignedMapRootNoneWritten(t *testing.T) {
+// TODO(phad): I'm considering removing this test, because for an Map that has been
+// initialized there should always be the revision 0 SMR written to the DB, and
+// without initialization the error path is identical to that tested in the func
+// TestGetSignedMapRootNotExist above.
+func disabledTestLatestSignedMapRootNoneWritten(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
-	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Close()
 
@@ -426,10 +422,10 @@ func TestLatestSignedMapRootNoneWritten(t *testing.T) {
 
 func TestGetSignedMapRoot(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
-	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Close()
 
@@ -464,10 +460,10 @@ func TestGetSignedMapRoot(t *testing.T) {
 
 func TestLatestSignedMapRoot(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
-	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Close()
 
@@ -501,10 +497,10 @@ func TestLatestSignedMapRoot(t *testing.T) {
 
 func TestDuplicateSignedMapRoot(t *testing.T) {
 	cleanTestDB(DB)
-	mapID := createMapForTests(DB)
+	ctx := context.Background()
+	mapID := createInitializedMapForTests(t, ctx, DB)
 	s := NewMapStorage(DB)
 
-	ctx := context.Background()
 	tx := beginMapTx(ctx, s, mapID, t)
 	defer tx.Close()
 
@@ -545,4 +541,31 @@ func beginMapTx(ctx context.Context, s storage.MapStorage, mapID int64, t *testi
 		t.Fatalf("Failed to begin map tx: %v", err)
 	}
 	return tx
+}
+
+func createInitializedMapForTests(t *testing.T, ctx context.Context, db *sql.DB) int64 {
+	mapID := createMapForTests(db)
+
+	s := NewMapStorage(db)
+	tx, err := s.BeginForTree(ctx, mapID)	
+	defer tx.Close()
+
+	initialRoot := trillian.SignedMapRoot{
+		RootHash:       []byte("rootHash"),
+		Signature:      &sigpb.DigitallySigned{
+			Signature:  []byte("sig"),
+		},
+		MapId:          mapID,
+		MapRevision:    0,
+	}
+
+	if err = tx.StoreSignedMapRoot(ctx, initialRoot); err != nil {
+		t.Fatalf("%v: Failed to StoreSignedMapRoot: %v", mapID, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("%v: Commit failed for map: %v", mapID, err)
+	}
+
+	return mapID
 }

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -547,16 +547,16 @@ func createInitializedMapForTests(t *testing.T, ctx context.Context, db *sql.DB)
 	mapID := createMapForTests(db)
 
 	s := NewMapStorage(db)
-	tx, err := s.BeginForTree(ctx, mapID)	
+	tx, err := s.BeginForTree(ctx, mapID)
 	defer tx.Close()
 
 	initialRoot := trillian.SignedMapRoot{
-		RootHash:       []byte("rootHash"),
-		Signature:      &sigpb.DigitallySigned{
-			Signature:  []byte("sig"),
+		RootHash: []byte("rootHash"),
+		Signature: &sigpb.DigitallySigned{
+			Signature: []byte("sig"),
 		},
-		MapId:          mapID,
-		MapRevision:    0,
+		MapId:       mapID,
+		MapRevision: 0,
 	}
 
 	if err = tx.StoreSignedMapRoot(ctx, initialRoot); err != nil {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/examples/ct/ctmapper/ctmapperpb"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/testonly"
 	"github.com/kylelemons/godebug/pretty"
 
@@ -32,6 +33,10 @@ import (
 )
 
 func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	s := NewMapStorage(DB)
 	if err := s.CheckDatabaseAccessible(context.Background()); err != nil {
@@ -40,6 +45,10 @@ func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
 }
 
 func TestMapBeginSnapshot(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 
@@ -143,6 +152,10 @@ type rootReaderMapTX interface {
 }
 
 func TestMapRootUpdate(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -237,6 +250,10 @@ var mapLeaf = trillian.MapLeaf{
 }
 
 func TestMapSetGetRoundTrip(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -272,6 +289,10 @@ func TestMapSetGetRoundTrip(t *testing.T) {
 }
 
 func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -299,6 +320,10 @@ func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
 }
 
 func TestMapGet0Results(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -325,6 +350,10 @@ func TestMapGet0Results(t *testing.T) {
 }
 
 func TestMapSetGetMultipleRevisions(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	// Write two roots for a map and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -386,6 +415,10 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 }
 
 func TestGetSignedMapRootNotExist(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	mapID := createMapForTests(DB) // Uninitialized: no revision 0 MapRoot exists.
 	s := NewMapStorage(DB)
@@ -423,6 +456,10 @@ func TestLatestSignedMapRootNoneWritten(t *testing.T) {
 }
 
 func TestGetSignedMapRoot(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -461,6 +498,10 @@ func TestGetSignedMapRoot(t *testing.T) {
 }
 
 func TestLatestSignedMapRoot(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -498,6 +539,10 @@ func TestLatestSignedMapRoot(t *testing.T) {
 }
 
 func TestDuplicateSignedMapRoot(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	ctx := context.Background()
 	mapID := createInitializedMapForTests(ctx, t, DB)
@@ -524,6 +569,10 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 }
 
 func TestReadOnlyMapTX_Rollback(t *testing.T) {
+	if provider := testdb.Default(); !provider.IsMySQL() {
+		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
+	}
+
 	cleanTestDB(DB)
 	s := NewMapStorage(DB)
 	tx, err := s.Snapshot(context.Background())

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -546,7 +546,7 @@ func (s *hammerState) getLeaves(ctx context.Context) error {
 }
 
 func (s *hammerState) getLeavesInvalid(ctx context.Context) error {
-	choices := []Choice{MalformedKey, RevTooBig, RevIsZero}
+	choices := []Choice{MalformedKey, RevTooBig}
 
 	req := trillian.GetMapLeavesRequest{MapId: s.cfg.MapID}
 	rev := latestRevision
@@ -564,9 +564,6 @@ func (s *hammerState) getLeavesInvalid(ctx context.Context) error {
 	case RevTooBig:
 		req.Index = [][]byte{s.pickKey(latestCopy)}
 		req.Revision = rev + invalidStretch
-	case RevIsZero:
-		req.Index = [][]byte{s.pickKey(latestCopy)}
-		req.Revision = 0
 	}
 	rsp, err := s.cfg.Client.GetLeaves(ctx, &req)
 	if err == nil {

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -676,7 +676,7 @@ func (s *hammerState) getSMR(ctx context.Context) error {
 func (s *hammerState) getSMRRev(ctx context.Context) error {
 	which := rand.Intn(smrCount)
 	smr := s.previousSMR(which)
-	if smr == nil || smr.MapRevision <= 0 {
+	if smr == nil || smr.MapRevision < 0 {
 		glog.V(3).Infof("%d: skipping get-smr-rev as no earlier SMR", s.cfg.MapID)
 		return errSkip{}
 	}
@@ -699,7 +699,7 @@ func (s *hammerState) getSMRRev(ctx context.Context) error {
 }
 
 func (s *hammerState) getSMRRevInvalid(ctx context.Context) error {
-	choices := []Choice{RevTooBig, RevIsZero, RevIsNegative}
+	choices := []Choice{RevTooBig, RevIsNegative}
 
 	rev := latestRevision
 	if !s.empty(latestCopy) {
@@ -711,9 +711,6 @@ func (s *hammerState) getSMRRevInvalid(ctx context.Context) error {
 	switch choice {
 	case RevTooBig:
 		rev += invalidStretch
-	case RevIsZero:
-		// TODO(drysdale): check if get-smr(@0) should work or not
-		rev = 0
 	case RevIsNegative:
 		rev = -invalidStretch
 	}

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -72,9 +72,9 @@ func NewMapEnv(ctx context.Context) (*MapEnv, error) {
 	}
 
 	registry := extension.Registry{
-		AdminStorage: mysql.NewAdminStorage(db),
-		MapStorage:   mysql.NewMapStorage(db),
-		QuotaManager: quota.Noop(),
+		AdminStorage:  mysql.NewAdminStorage(db),
+		MapStorage:    mysql.NewMapStorage(db),
+		QuotaManager:  quota.Noop(),
 		MetricFactory: monitoring.InertMetricFactory{},
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)


### PR DESCRIPTION
Addresses issue #828.

Each Map API endpoint checks if the Map is init'd.  If not, it creates the revision 0 Signed Map Head.

Clearly this introduces some overhead into each call.  For now, it's a simple place to start.
It would be easy to add a `map[int64]bool` to `TrillianMapServer` to track which mapIDs have been init'd and then make an immediate exit from the new `func (s *TrillianMapServer) Init(mapID int64) error`