### PR TITLE
Disallow creation of trees whose type don't match the server

### DIFF
--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -596,7 +596,7 @@ func setupAdminServer(ctx context.Context) (*testServer, error) {
 		registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */, registry.MetricFactory)
 	netInterceptor := interceptor.Combine(interceptor.ErrorWrapper, ti.UnaryInterceptor)
 	ts.server = grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))
-	trillian.RegisterTrillianAdminServer(ts.server, sa.New(registry))
+	trillian.RegisterTrillianAdminServer(ts.server, sa.New(registry, nil /* allowedTreeTypes */))
 	go ts.server.Serve(ts.lis)
 
 	ts.conn, err = grpc.Dial(ts.lis.Addr().String(), grpc.WithInsecure())

--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -226,7 +226,7 @@ func newTestServer(registry extension.Registry) (*testServer, error) {
 		registry.AdminStorage, registry.QuotaManager, false /* quotaDryRun */, registry.MetricFactory)
 	netInterceptor := interceptor.Combine(interceptor.ErrorWrapper, intercept.UnaryInterceptor)
 	s.server = grpc.NewServer(grpc.UnaryInterceptor(netInterceptor))
-	trillian.RegisterTrillianAdminServer(s.server, admin.New(registry))
+	trillian.RegisterTrillianAdminServer(s.server, admin.New(registry, nil /* allowedTreeTypes */))
 	trillian.RegisterTrillianLogServer(s.server, server.NewTrillianLogRPCServer(registry, util.SystemTimeSource{}))
 
 	var err error

--- a/server/main.go
+++ b/server/main.go
@@ -62,6 +62,10 @@ type Main struct {
 	// RegisterServerFn is called to register RPC servers.
 	RegisterServerFn func(*grpc.Server, extension.Registry) error
 
+	// AllowedTreeTypes determines which types of trees may be created through the Admin Server
+	// bound by Main. nil means unrestricted.
+	AllowedTreeTypes []trillian.TreeType
+
 	TreeGCEnabled         bool
 	TreeDeleteThreshold   time.Duration
 	TreeDeleteMinInterval time.Duration
@@ -77,7 +81,7 @@ func (m *Main) Run(ctx context.Context) error {
 	if err := m.RegisterServerFn(m.Server, m.Registry); err != nil {
 		return err
 	}
-	trillian.RegisterTrillianAdminServer(m.Server, admin.New(m.Registry))
+	trillian.RegisterTrillianAdminServer(m.Server, admin.New(m.Registry, m.AllowedTreeTypes))
 	reflection.Register(m.Server)
 
 	if endpoint := m.HTTPEndpoint; endpoint != "" {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -169,6 +169,7 @@ func main() {
 			}
 			return nil
 		},
+		AllowedTreeTypes:      []trillian.TreeType{trillian.TreeType_LOG},
 		TreeGCEnabled:         *treeGCEnabled,
 		TreeDeleteThreshold:   *treeDeleteThreshold,
 		TreeDeleteMinInterval: *treeDeleteMinRunInterval,

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -152,6 +152,7 @@ func main() {
 			}
 			return nil
 		},
+		AllowedTreeTypes:      []trillian.TreeType{trillian.TreeType_MAP},
 		TreeGCEnabled:         *treeGCEnabled,
 		TreeDeleteThreshold:   *treeDeleteThreshold,
 		TreeDeleteMinInterval: *treeDeleteMinRunInterval,

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -111,7 +111,7 @@ func NewMapEnvWithRegistry(registry extension.Registry) (*MapEnv, error) {
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(ci))
 	mapServer := server.NewTrillianMapServer(registry)
 	trillian.RegisterTrillianMapServer(grpcServer, mapServer)
-	trillian.RegisterTrillianAdminServer(grpcServer, admin.New(registry))
+	trillian.RegisterTrillianAdminServer(grpcServer, admin.New(registry, nil /* allowedTreeTypes */))
 	go grpcServer.Serve(lis)
 
 	// Connect to the server.


### PR DESCRIPTION
I.e., creating LOG-type trees in trillian_map_server and MAP-type trees
in trillian_log_server.