### PR TITLE
RunInAdmin* methods and common helpers

### DIFF
--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/google/trillian"
+)
+
+// GetTree reads a tree from storage using a snapshot transaction.
+// It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.
+// See RunInAdminSnapshot if you need to perform more than one action per transaction.
+func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	var tree *trillian.Tree
+	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) (err error) {
+		tree, err = tx.GetTree(ctx, treeID)
+		return
+	})
+	return tree, err
+}
+
+// ListTrees reads trees from storage using a snapshot transaction.
+// It's a convenience wrapper around RunInAdminSnapshot and AdminReader's ListTrees.
+// See RunInAdminSnapshot if you need to perform more than one action per transaction.
+func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]*trillian.Tree, error) {
+	var resp []*trillian.Tree
+	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) (err error) {
+		resp, err = tx.ListTrees(ctx, includeDeleted)
+		return
+	})
+	return resp, err
+}
+
+// CreateTree creates a tree in storage.
+// It's a convenience wrapper around RunInAdminTX and AdminWriter's CreateTree.
+// See RunInAdminTX if you need to perform more than one action per transaction.
+func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*trillian.Tree, error) {
+	var createdTree *trillian.Tree
+	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+		createdTree, err = tx.CreateTree(ctx, tree)
+		return
+	})
+	return createdTree, err
+}
+
+// UpdateTree updates a tree in storage.
+// It's a convenience wrapper around RunInAdminTX and AdminWriter's UpdateTree.
+// See RunInAdminTX if you need to perform more than one action per transaction.
+func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*trillian.Tree)) (*trillian.Tree, error) {
+	var updatedTree *trillian.Tree
+	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+		updatedTree, err = tx.UpdateTree(ctx, treeID, fn)
+		return
+	})
+	return updatedTree, err
+}
+
+// SoftDeleteTree soft-deletes a tree in storage.
+// It's a convenience wrapper around RunInAdminTX and AdminWriter's SoftDeleteTree.
+// See RunInAdminTX if you need to perform more than one action per transaction.
+func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	var tree *trillian.Tree
+	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+		tree, err = tx.SoftDeleteTree(ctx, treeID)
+		return
+	})
+	return tree, err
+}
+
+// HardDeleteTree hard-deletes a tree from storage.
+// It's a convenience wrapper around RunInAdminTX and AdminWriter's HardDeleteTree.
+// See RunInAdminTX if you need to perform more than one action per transaction.
+func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error {
+	return RunInAdminTX(ctx, admin, func(tx AdminTX) error {
+		return tx.HardDeleteTree(ctx, treeID)
+	})
+}
+
+// UndeleteTree undeletes a tree in storage.
+// It's a convenience wrapper around RunInAdminTX and AdminWriter's UndeleteTree.
+// See RunInAdminTX if you need to perform more than one action per transaction.
+func UndeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	var tree *trillian.Tree
+	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+		tree, err = tx.UndeleteTree(ctx, treeID)
+		return
+	})
+	return tree, err
+}

--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -123,3 +123,29 @@ type AdminWriter interface {
 	// is returned.
 	UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error)
 }
+
+// RunInAdminSnapshot runs fn against a ReadOnlyAdminTX and commits if no error is returned.
+func RunInAdminSnapshot(ctx context.Context, admin AdminStorage, fn func(tx ReadOnlyAdminTX) error) error {
+	tx, err := admin.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// RunInAdminTX runs fn against an AdminTX and commits if no error is returned.
+func RunInAdminTX(ctx context.Context, admin AdminStorage, fn func(tx AdminTX) error) error {
+	tx, err := admin.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -892,20 +892,19 @@ func TestGetActiveLogIDs(t *testing.T) {
 	map2 := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	deletedMap := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	for _, tree := range []*trillian.Tree{log1, log2, frozenLog, deletedLog, map1, map2, deletedMap} {
-		newTree, err := createTreeInternal(ctx, admin, tree)
+		newTree, err := storage.CreateTree(ctx, admin, tree)
 		if err != nil {
-			t.Fatalf("createTreeInternal(%+v) returned err = %v", tree, err)
+			t.Fatalf("CreateTree(%+v) returned err = %v", tree, err)
 		}
 		*tree = *newTree
 	}
 
 	// FROZEN is not a valid initial state, so we have to update it separately.
-	var err error
-	_, err = updateTreeInternal(ctx, admin, frozenLog.TreeId, func(t *trillian.Tree) {
+	_, err := storage.UpdateTree(ctx, admin, frozenLog.TreeId, func(t *trillian.Tree) {
 		t.TreeState = trillian.TreeState_FROZEN
 	})
 	if err != nil {
-		t.Fatalf("updateTreeInternal() returned err = %v", err)
+		t.Fatalf("UpdateTree() returned err = %v", err)
 	}
 
 	// Update deleted trees accordingly

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -202,7 +202,7 @@ func nodesAreEqual(lhs []storage.Node, rhs []storage.Node) error {
 }
 
 func diffNodes(got, want []storage.Node) ([]storage.Node, []storage.Node) {
-	missing := []storage.Node{}
+	var missing []storage.Node
 	gotMap := make(map[string]storage.Node)
 	for _, n := range got {
 		gotMap[n.NodeID.String()] = n
@@ -259,40 +259,16 @@ func createLogForTests(db *sql.DB) int64 {
 
 // createTree creates the specified tree using AdminStorage.
 func createTree(db *sql.DB, tree *trillian.Tree) (*trillian.Tree, error) {
-	s := NewAdminStorage(db)
 	ctx := context.Background()
-	tx, err := s.Begin(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Close()
-	newTree, err := tx.CreateTree(ctx, tree)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return newTree, nil
+	s := NewAdminStorage(db)
+	return storage.CreateTree(ctx, s, tree)
 }
 
 // updateTree updates the specified tree using AdminStorage.
 func updateTree(db *sql.DB, treeID int64, updateFn func(*trillian.Tree)) (*trillian.Tree, error) {
-	s := NewAdminStorage(db)
 	ctx := context.Background()
-	tx, err := s.Begin(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Close()
-	tree, err := tx.UpdateTree(ctx, treeID, updateFn)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return tree, nil
+	s := NewAdminStorage(db)
+	return storage.UpdateTree(ctx, s, treeID, updateFn)
 }
 
 // DB is the database used for tests. It's initialized and closed by TestMain().

--- a/trees/trees.go
+++ b/trees/trees.go
@@ -63,7 +63,7 @@ func GetTree(ctx context.Context, s storage.AdminStorage, treeID int64, opts Get
 	tree, ok := FromContext(ctx)
 	if !ok || tree.TreeId != treeID {
 		var err error
-		tree, err = getTreeFromStorage(ctx, s, treeID)
+		tree, err = storage.GetTree(ctx, s, treeID)
 		if err != nil {
 			return nil, err
 		}
@@ -78,22 +78,6 @@ func GetTree(ctx context.Context, s storage.AdminStorage, treeID int64, opts Get
 		return nil, errors.Errorf(errors.NotFound, "tree %v not found", tree.TreeId)
 	}
 
-	return tree, nil
-}
-
-func getTreeFromStorage(ctx context.Context, s storage.AdminStorage, treeID int64) (*trillian.Tree, error) {
-	tx, err := s.Snapshot(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Close()
-	tree, err := tx.GetTree(ctx, treeID)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
 	return tree, nil
 }
 


### PR DESCRIPTION
RunInAdminSnapshot and RunInAdminTX encapsulate the common
Begin()/defer Close()/Commit() pattern for Admin TX objects.

Admin helpers are given a "proper" place under the storage package and
replace the (ever increasing) population of helpers.

Both categories of helpers are added as standalone methods, instead of
AdminStorage members, so that different storage implementations may take
advantage of them without extra effort.