### PR TITLE
Update CT Mapper's documentation

### DIFF
--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -25,8 +25,8 @@ go build ./examples/ct/ctmapper/lookup
 go build ./cmd/createtree/
 tree_id=$(./createtree \
     --admin_server=localhost:8090 \
-    --hash_strategy TEST_MAP_HASHER \
-    --tree_type MAP)
+    --hash_strategy=TEST_MAP_HASHER \
+    --tree_type=MAP)
 echo "Created map with ID ${tree_id}"
 
 ./mapper \
@@ -34,7 +34,7 @@ echo "Created map with ID ${tree_id}"
     --log_batch_size=10 \
     --map_id=${tree_id} \
     --map_server=localhost:8090 \
-    --source http://ct.googleapis.com/pilot
+    --source=http://ct.googleapis.com/pilot
 ```
 
 You should then be able to look up domains in the map like so:

--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -25,20 +25,24 @@ go build ./examples/ct/ctmapper/lookup
 go build ./cmd/createtree/
 tree_id=$(./createtree \
     --admin_server=localhost:8090 \
-    --signature_algorithm=ECDSA)
+    --hash_strategy TEST_MAP_HASHER \
+    --tree_type MAP)
+echo "Created map with ID ${tree_id}"
+
 ./mapper \
-    -source http://ct.googleapis.com/pilot \
-    -map_id=${tree_id} \
-    -map_server=localhost:8091 \
-    --logtostderr
+    --logtostderr \
+    --log_batch_size=10 \
+    --map_id=${tree_id} \
+    --map_server=localhost:8090 \
+    --source http://ct.googleapis.com/pilot
 ```
 
 You should then be able to look up domains in the map like so:
 
 ```bash
 ./lookup \
-    -map_id=1 \
-    -map_server=localhost:8091 \
     --logtostderr \
+    --map_id=${tree_id} \
+    --map_server=localhost:8090 \
     mail.google.com www.langeoog.de  # etc. etc.
 ```


### PR DESCRIPTION
* Added tree type and hash strategy to createtree
* Use correct ports on commands (RPC, not HTTP)
* Use ${tree_id} consistently, print the ID in the console