### PR TITLE
Install the correct (race/norace) versions of test dependencies

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -99,7 +99,7 @@ main() {
     echo 'running go test'
     # Install test deps so that individual test runs below can reuse them.
     echo 'installing test deps'
-    go test -i ./...
+    go test ${goflags} -i ./...
 
     if [[ ${coverage} -eq 1 ]]; then
       # Individual package profiles are written to "$profile.out" files under


### PR DESCRIPTION
Building go packages with -race takes some time.
If we build them correctly we get a big speed up (16 min down from 24)