### PR TITLE
Make integration tests log to stderr

### DIFF
--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -144,7 +144,11 @@ log_prep_test() {
     http=$(pick_unused_port ${port})
 
     echo "Starting Log RPC server on localhost:${port}, HTTP on localhost:${http}"
-    ./trillian_log_server ${ETCD_OPTS} ${pkcs11_opts} ${logserver_opts} --rpc_endpoint="localhost:${port}" --http_endpoint="localhost:${http}" &
+    ./trillian_log_server ${ETCD_OPTS} ${pkcs11_opts} ${logserver_opts} \
+      --rpc_endpoint="localhost:${port}" \
+      --http_endpoint="localhost:${http}" \
+      --alsologtostderr \
+      &
     pid=$!
     RPC_SERVER_PIDS+=(${pid})
     wait_for_server_startup ${port}
@@ -166,7 +170,13 @@ log_prep_test() {
   for ((i=0; i < log_signer_count; i++)); do
     http=$(pick_unused_port)
     echo "Starting Log signer, HTTP on localhost:${http}"
-    ./trillian_log_signer ${ETCD_OPTS} ${pkcs11_opts} ${logsigner_opts} --sequencer_interval="1s" --batch_size=500 --http_endpoint="localhost:${http}" --num_sequencers 2 &
+    ./trillian_log_signer ${ETCD_OPTS} ${pkcs11_opts} ${logsigner_opts} \
+      --sequencer_interval="1s" \
+      --batch_size=500 \
+      --http_endpoint="localhost:${http}" \
+      --num_sequencers 2 \
+      --alsologtostderr \
+      &
     pid=$!
     LOG_SIGNER_PIDS+=(${pid})
     wait_for_server_startup ${http}
@@ -267,7 +277,11 @@ map_prep_test() {
     http=$(pick_unused_port ${port})
 
     echo "Starting Map RPC server on localhost:${port}, HTTP on localhost:${http}"
-    ./trillian_map_server --rpc_endpoint="localhost:${port}" --http_endpoint="localhost:${http}" &
+    ./trillian_map_server \
+      --rpc_endpoint="localhost:${port}" \
+      --http_endpoint="localhost:${http}" \
+      --alsologtostderr \
+      &
     pid=$!
     RPC_SERVER_PIDS+=(${pid})
     wait_for_server_startup ${port}

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -34,7 +34,7 @@ set +e
 TRILLIAN_SQL_DRIVER=mysql go test ${GOFLAGS} \
   -run ".*LiveLog.*" \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
-  ./ --log_rpc_server="${RPC_SERVER_1}" --treeid ${TEST_TREE_ID}
+  ./ --log_rpc_server="${RPC_SERVER_1}" --treeid ${TEST_TREE_ID} --alsologtostderr
 RESULT=$?
 set -e
 popd

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -34,7 +34,10 @@ set +e
 TRILLIAN_SQL_DRIVER=mysql go test ${GOFLAGS} \
   -run ".*LiveLog.*" \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
-  ./ --log_rpc_server="${RPC_SERVER_1}" --treeid ${TEST_TREE_ID} --alsologtostderr
+  ./ \
+  --log_rpc_server="${RPC_SERVER_1}" \
+  --treeid ${TEST_TREE_ID} \
+  --alsologtostderr
 RESULT=$?
 set -e
 popd


### PR DESCRIPTION
This will make test output a little more verbose, but it will be very
useful for understanding what's happening when tests fail.