### PR TITLE
Make presubmit tests log to stderr

### DIFF
--- a/client/backoff/backoff_test.go
+++ b/client/backoff/backoff_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	_ "github.com/golang/glog"
 )
 
 func TestBackoff(t *testing.T) {

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	_ "github.com/golang/glog"
 )
 
 func TestParseFlags(t *testing.T) {

--- a/docs/storage/commit_log/simkafka/kafka_test.go
+++ b/docs/storage/commit_log/simkafka/kafka_test.go
@@ -17,6 +17,8 @@ package simkafka
 import (
 	"reflect"
 	"testing"
+
+	_ "github.com/golang/glog"
 )
 
 func TestReadEmpty(t *testing.T) {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	_ "github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 )
 

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"encoding/hex"
 	"testing"
+
+	_ "github.com/golang/glog"
 )
 
 func TestRfc6962Hasher(t *testing.T) {

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -126,7 +126,8 @@ main() {
             -short \
             -timeout=${GO_TEST_TIMEOUT:-5m} \
             ${coverflags} \
-            ${goflags} "$d"
+            ${goflags} \
+            "$d" -alsologtostderr
       done | xargs -I '{}' -P ${GO_TEST_PARALLELISM:-10} bash -c '{}'
 
       cat /tmp/trillian_profile/*.out > /tmp/coverage.txt
@@ -134,7 +135,8 @@ main() {
       go test \
         -short \
         -timeout=${GO_TEST_TIMEOUT:-5m} \
-        ${goflags} ./...
+        ${goflags} \
+        ./... -alsologtostderr
     fi
   fi
 

--- a/server/errors/errors_test.go
+++ b/server/errors/errors_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"testing"
 
+	_ "github.com/golang/glog"
 	te "github.com/google/trillian/errors"
 	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"

--- a/testonly/matchers/atleast_test.go
+++ b/testonly/matchers/atleast_test.go
@@ -14,7 +14,11 @@
 
 package matchers
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/golang/glog"
+)
 
 func TestAtLeast(t *testing.T) {
 	tests := []struct {

--- a/testonly/matchers/proto_test.go
+++ b/testonly/matchers/proto_test.go
@@ -17,6 +17,7 @@ package matchers
 import (
 	"testing"
 
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 )

--- a/util/flagsaver/flagsaver_test.go
+++ b/util/flagsaver/flagsaver_test.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 	"testing"
 	"time"
+
+	_ "github.com/golang/glog"
 )
 
 var (


### PR DESCRIPTION
This helps provide more verbose (and meaningful) output when failures
happen, since most of the logging which is useful for debugging uses the
glog library.

Because this adds the `-aslologtostderr` to all unit tests, this change
also makes sure that all unit tests import "github.com/golang/glog".
Otherwise the tests would fail with a "flag provided but not defined".