### PR TITLE
Cleanup LogEnv and MapEnv

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -56,8 +56,7 @@ func TestGetByIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
-	client := New(logID, cli, rfc6962.DefaultHasher, env.PublicKey)
+	client := New(logID, env.Log, rfc6962.DefaultHasher, env.PublicKey)
 	// Add a few test leaves.
 	leafData := [][]byte{
 		[]byte("A"),
@@ -93,8 +92,7 @@ func TestListByIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
-	client := New(logID, cli, rfc6962.DefaultHasher, env.PublicKey)
+	client := New(logID, env.Log, rfc6962.DefaultHasher, env.PublicKey)
 	// Add a few test leaves.
 	leafData := [][]byte{
 		[]byte("A"),
@@ -130,8 +128,7 @@ func TestVerifyInclusion(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
-	client := New(logID, cli, rfc6962.DefaultHasher, env.PublicKey)
+	client := New(logID, env.Log, rfc6962.DefaultHasher, env.PublicKey)
 	// Add a few test leaves.
 	leafData := [][]byte{
 		[]byte("A"),
@@ -161,8 +158,7 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
-	client := New(logID, cli, rfc6962.DefaultHasher, env.PublicKey)
+	client := New(logID, env.Log, rfc6962.DefaultHasher, env.PublicKey)
 	// Add a few test leaves.
 	leafData := [][]byte{
 		[]byte("A"),
@@ -192,16 +188,15 @@ func TestWaitForInclusion(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
 	for _, test := range []struct {
 		desc    string
 		leaf    []byte
 		client  trillian.TrillianLogClient
 		wantErr bool
 	}{
-		{desc: "First leaf", leaf: []byte("A"), client: cli},
-		{desc: "Make TreeSize > 1", leaf: []byte("B"), client: cli},
-		{desc: "invalid inclusion proof", leaf: []byte("A"), client: &MockLogClient{c: cli, mGetInclusionProof: true}, wantErr: true},
+		{desc: "First leaf", leaf: []byte("A"), client: env.Log},
+		{desc: "Make TreeSize > 1", leaf: []byte("B"), client: env.Log},
+		{desc: "invalid inclusion proof", leaf: []byte("A"), client: &MockLogClient{c: env.Log, mGetInclusionProof: true}, wantErr: true},
 	} {
 		client := New(logID, test.client, rfc6962.DefaultHasher, env.PublicKey)
 		if err := client.QueueLeaf(ctx, test.leaf); err != nil {
@@ -226,8 +221,7 @@ func TestUpdateRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create log: %v", err)
 	}
-	cli := trillian.NewTrillianLogClient(env.ClientConn)
-	client := New(logID, cli, rfc6962.DefaultHasher, env.PublicKey)
+	client := New(logID, env.Log, rfc6962.DefaultHasher, env.PublicKey)
 
 	before := client.Root().TreeSize
 

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -100,9 +100,8 @@ func TestInProcessLogIntegration(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client := trillian.NewTrillianLogClient(env.ClientConn)
 	params := DefaultTestParameters(logID)
-	if err := RunLogIntegration(client, params); err != nil {
+	if err := RunLogIntegration(env.Log, params); err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
 }
@@ -129,10 +128,9 @@ func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client := trillian.NewTrillianLogClient(env.ClientConn)
 	params := DefaultTestParameters(logID)
 	params.uniqueLeaves = 10
-	if err := RunLogIntegration(client, params); err != nil {
+	if err := RunLogIntegration(env.Log, params); err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
 }

--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -50,7 +50,7 @@ func TestMapIntegration(t *testing.T) {
 
 	for _, test := range AllTests {
 		t.Run(test.Name, func(t *testing.T) {
-			test.Fn(ctx, t, env.AdminClient, env.MapClient)
+			test.Fn(ctx, t, env.Admin, env.Map)
 		})
 	}
 }

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -71,7 +71,7 @@ type LogEnv struct {
 	LogOperation    server.LogOperation
 	Sequencer       *server.LogOperationManager
 	sequencerCancel context.CancelFunc
-	clientConn      *grpc.ClientConn
+	ClientConn      *grpc.ClientConn // TODO(gbelvin): Deprecate.
 
 	Address string
 	Log     trillian.TrillianLogClient
@@ -196,7 +196,7 @@ func NewLogEnvWithRegistryAndGRPCOptions(ctx context.Context, numSequencers int,
 		adminServer:     adminServer,
 		logServer:       logServer,
 		Address:         addr,
-		clientConn:      cc,
+		ClientConn:      cc,
 		Log:             trillian.NewTrillianLogClient(cc),
 		Admin:           trillian.NewTrillianAdminClient(cc),
 		PublicKey:       publicKey,
@@ -211,7 +211,7 @@ func (env *LogEnv) Close() {
 	if env.sequencerCancel != nil {
 		env.sequencerCancel()
 	}
-	env.clientConn.Close()
+	env.ClientConn.Close()
 	env.grpcServer.GracefulStop()
 	env.pendingTasks.Wait()
 	if env.DB != nil {

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -47,8 +47,8 @@ type MapEnv struct {
 	clientConn *grpc.ClientConn
 
 	// Public fields
-	MapClient   trillian.TrillianMapClient
-	AdminClient trillian.TrillianAdminClient
+	Map   trillian.TrillianMapClient
+	Admin trillian.TrillianAdminClient
 }
 
 // NewMapEnvFromConn connects to a map server.
@@ -59,9 +59,9 @@ func NewMapEnvFromConn(addr string) (*MapEnv, error) {
 	}
 
 	return &MapEnv{
-		clientConn:  cc,
-		MapClient:   trillian.NewTrillianMapClient(cc),
-		AdminClient: trillian.NewTrillianAdminClient(cc),
+		clientConn: cc,
+		Map:        trillian.NewTrillianMapClient(cc),
+		Admin:      trillian.NewTrillianAdminClient(cc),
 	}, nil
 }
 
@@ -122,12 +122,12 @@ func NewMapEnvWithRegistry(registry extension.Registry) (*MapEnv, error) {
 	}
 
 	return &MapEnv{
-		registry:    registry,
-		mapServer:   mapServer,
-		grpcServer:  grpcServer,
-		clientConn:  cc,
-		MapClient:   trillian.NewTrillianMapClient(cc),
-		AdminClient: trillian.NewTrillianAdminClient(cc),
+		registry:   registry,
+		mapServer:  mapServer,
+		grpcServer: grpcServer,
+		clientConn: cc,
+		Map:        trillian.NewTrillianMapClient(cc),
+		Admin:      trillian.NewTrillianAdminClient(cc),
 	}, nil
 }
 


### PR DESCRIPTION
Better encapsulation and consistency between LogEnv and MapEnv

- LogEnv exports Log and Admin Clients rather than a ClientConn
- MapEnv export name cleanup. MapConn -> Map, AdminConn -> Admin.