### PR TITLE
Introduce a ReadWriteTransaction function on Log- and MapStorage

### DIFF
--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -226,7 +226,6 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 				}
 				// TODO(phad): ideally we'd inspect err's type and check it contains a NOT_FOUND Code (5), but I don't want
 				// a dependency on gRPC here.
-
 			})
 		}
 	}
@@ -544,7 +543,7 @@ func runMapBatchTest(ctx context.Context, t *testing.T, desc string, tmap trilli
 	r, err := tmap.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{
 		MapId: tree.TreeId,
 	})
-	if err != nil {
+	if err != nil || r.MapRoot == nil {
 		t.Fatalf("%s: failed to get map head: %v", desc, err)
 	}
 

--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -30,7 +30,6 @@ import (
 var server = flag.String("map_rpc_server", "", "Server address:port")
 
 func TestMapIntegration(t *testing.T) {
-	flag.Parse()
 
 	ctx := context.Background()
 	var env *integration.MapEnv

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -474,7 +474,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 	if newLogRoot != nil {
 		glog.Infof("%v: sequenced %v leaves, size %v, tree-revision %v", logID, numLeaves, newLogRoot.TreeSize, newLogRoot.TreeRevision)
 	} else {
-		glog.Info("newLogRoot = nil")
+		glog.Error("newLogRoot = nil")
 	}
 	return numLeaves, nil
 }

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -330,7 +330,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 			glog.Warningf("%v: Sequencer failed to load sequenced batch: %v", logID, err)
 			return 0, err
 		}
-		numLeaves := len(sequencedLeaves)
+		numLeaves = len(leaves)
 
 		// We need to create a signed root if entries were added or the latest root
 		// is too old.

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -409,12 +409,13 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 		stageStart = s.timeSource.Now()
 
 		// The batch is now fully sequenced and we're done
-		return tx.Commit()
+		err = tx.Commit()
+		seqCommitLatency.Observe(util.SecondsSince(s.timeSource, start), label)
+		return err
 	})
 	if err != nil {
 		return 0, err
 	}
-	seqCommitLatency.Observe(util.SecondsSince(s.timeSource, start), label)
 
 	// Let quota.Manager know about newly-sequenced entries.
 	// All possibly influenced quotas are replenished: {Tree/Global, Read/Write}.

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -39,7 +39,7 @@ type SparseMerkleTreeReader struct {
 	treeRevision int64
 }
 
-type newTXFunc func() (storage.TreeTX, error)
+type runTXFunc func(func(storage.MapTreeTX) error) error
 
 // SparseMerkleTreeWriter knows how to store/update a stored sparse Merkle tree
 // via a TreeStorage transaction.
@@ -107,7 +107,7 @@ type subtreeWriter struct {
 	// children is a map of child-subtrees by stringified prefix.
 	children map[string]Subtree
 
-	tx           storage.TreeTX
+	runTX        runTXFunc
 	treeRevision int64
 
 	hasher hashers.MapHasher
@@ -200,81 +200,82 @@ func (s *subtreeWriter) RootHash() ([]byte, error) {
 // subsequently closed when this method exits.
 func (s *subtreeWriter) buildSubtree(ctx context.Context) {
 	defer close(s.root)
-	defer s.tx.Close()
+	var root []byte
+	err := s.runTX(func(tx storage.MapTreeTX) error {
+		root = []byte{}
+		leaves := make([]HStar2LeafHash, 0, len(s.leafQueue))
+		nodesToStore := make([]storage.Node, 0, len(s.leafQueue)*2)
 
-	leaves := make([]HStar2LeafHash, 0, len(s.leafQueue))
-	nodesToStore := make([]storage.Node, 0, len(s.leafQueue)*2)
-
-	for leaf := range s.leafQueue {
-		ih, err := leaf()
-		if err != nil {
-			s.root <- rootHashOrError{hash: nil, err: err}
-			return
-		}
-		nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.Suffix{}, s.hasher.BitLen())
-
-		leaves = append(leaves, HStar2LeafHash{
-			Index:    nodeID.BigInt(),
-			LeafHash: ih.hash,
-		})
-		nodesToStore = append(nodesToStore,
-			storage.Node{
-				NodeID:       nodeID,
-				Hash:         ih.hash,
-				NodeRevision: s.treeRevision,
-			})
-	}
-
-	// calculate new root, and intermediate nodes:
-	hs2 := NewHStar2(s.treeID, s.hasher)
-	root, err := hs2.HStar2Nodes(s.prefix, s.subtreeDepth, leaves,
-		func(depth int, index *big.Int) ([]byte, error) {
-			nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
-			glog.V(4).Infof("buildSubtree.get(%x, %d) nid: %x, %v",
-				index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits)
-			nodes, err := s.tx.GetMerkleNodes(ctx, s.treeRevision, []storage.NodeID{nodeID})
+		for leaf := range s.leafQueue {
+			ih, err := leaf()
 			if err != nil {
-				return nil, err
+				return err
 			}
-			if len(nodes) == 0 {
-				return nil, nil
-			}
-			if got, want := nodes[0].NodeID, nodeID; !got.Equivalent(want) {
-				return nil, fmt.Errorf("got node %v from storage, want %v", got, want)
-			}
-			if got, want := nodes[0].NodeRevision, s.treeRevision; got > want {
-				return nil, fmt.Errorf("got node revision %d, want <= %d", got, want)
-			}
-			return nodes[0].Hash, nil
-		},
-		func(depth int, index *big.Int, h []byte) error {
-			// Don't store the root node of the subtree - that's part of the parent
-			// tree.
-			if depth == len(s.prefix)*8 && len(s.prefix) > 0 {
-				return nil
-			}
-			nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
-			glog.V(4).Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
-				index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits, h)
+			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.Suffix{}, s.hasher.BitLen())
+
+			leaves = append(leaves, HStar2LeafHash{
+				Index:    nodeID.BigInt(),
+				LeafHash: ih.hash,
+			})
 			nodesToStore = append(nodesToStore,
 				storage.Node{
 					NodeID:       nodeID,
-					Hash:         h,
+					Hash:         ih.hash,
 					NodeRevision: s.treeRevision,
 				})
-			return nil
-		})
-	if err != nil {
-		s.root <- rootHashOrError{nil, err}
-		return
-	}
+		}
 
-	// write nodes back to storage
-	if err := s.tx.SetMerkleNodes(ctx, nodesToStore); err != nil {
-		s.root <- rootHashOrError{nil, err}
-		return
-	}
-	if err := s.tx.Commit(); err != nil {
+		// calculate new root, and intermediate nodes:
+		hs2 := NewHStar2(s.treeID, s.hasher)
+		var err error
+		root, err = hs2.HStar2Nodes(s.prefix, s.subtreeDepth, leaves,
+			func(depth int, index *big.Int) ([]byte, error) {
+				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
+				glog.V(4).Infof("buildSubtree.get(%x, %d) nid: %x, %v",
+					index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits)
+				nodes, err := tx.GetMerkleNodes(ctx, s.treeRevision, []storage.NodeID{nodeID})
+				if err != nil {
+					return nil, err
+				}
+				if len(nodes) == 0 {
+					return nil, nil
+				}
+				if got, want := nodes[0].NodeID, nodeID; !got.Equivalent(want) {
+					return nil, fmt.Errorf("got node %v from storage, want %v", got, want)
+				}
+				if got, want := nodes[0].NodeRevision, s.treeRevision; got > want {
+					return nil, fmt.Errorf("got node revision %d, want <= %d", got, want)
+				}
+				return nodes[0].Hash, nil
+			},
+			func(depth int, index *big.Int, h []byte) error {
+				// Don't store the root node of the subtree - that's part of the parent
+				// tree.
+				if depth == len(s.prefix)*8 && len(s.prefix) > 0 {
+					return nil
+				}
+				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
+				glog.V(4).Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
+					index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits, h)
+				nodesToStore = append(nodesToStore,
+					storage.Node{
+						NodeID:       nodeID,
+						Hash:         h,
+						NodeRevision: s.treeRevision,
+					})
+				return nil
+			})
+		if err != nil {
+			return err
+		}
+
+		// write nodes back to storage
+		if err := tx.SetMerkleNodes(ctx, nodesToStore); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
+	if err != nil {
 		s.root <- rootHashOrError{nil, err}
 		return
 	}
@@ -310,11 +311,7 @@ func leafQueueSize(depths []int) int {
 }
 
 // newLocalSubtreeWriter creates a new local go-routine based subtree worker.
-func newLocalSubtreeWriter(ctx context.Context, treeID, rev int64, prefix []byte, depths []int, newTX newTXFunc, h hashers.MapHasher) (Subtree, error) {
-	tx, err := newTX()
-	if err != nil {
-		return nil, err
-	}
+func newLocalSubtreeWriter(ctx context.Context, treeID, rev int64, prefix []byte, depths []int, runTX runTXFunc, h hashers.MapHasher) (Subtree, error) {
 	tree := subtreeWriter{
 		treeID:       treeID,
 		treeRevision: rev,
@@ -324,11 +321,11 @@ func newLocalSubtreeWriter(ctx context.Context, treeID, rev int64, prefix []byte
 		leafQueue:    make(chan func() (*indexAndHash, error), leafQueueSize(depths)),
 		root:         make(chan rootHashOrError, 1),
 		children:     make(map[string]Subtree),
-		tx:           tx,
+		runTX:        runTX,
 		hasher:       h,
 		getSubtree: func(ctx context.Context, p []byte) (Subtree, error) {
 			myPrefix := bytes.Join([][]byte{prefix, p}, []byte{})
-			return newLocalSubtreeWriter(ctx, treeID, rev, myPrefix, depths[1:], newTX, h)
+			return newLocalSubtreeWriter(ctx, treeID, rev, myPrefix, depths[1:], runTX, h)
 		},
 	}
 
@@ -341,10 +338,10 @@ func newLocalSubtreeWriter(ctx context.Context, treeID, rev int64, prefix []byte
 // NewSparseMerkleTreeWriter returns a new SparseMerkleTreeWriter, which will
 // write data back into the tree at the specified revision, using the passed
 // in MapHasher to calculate/verify tree hashes, storing via tx.
-func NewSparseMerkleTreeWriter(ctx context.Context, treeID, rev int64, h hashers.MapHasher, newTX newTXFunc) (*SparseMerkleTreeWriter, error) {
+func NewSparseMerkleTreeWriter(ctx context.Context, treeID, rev int64, h hashers.MapHasher, runTX runTXFunc) (*SparseMerkleTreeWriter, error) {
 	// TODO(al): allow the tree layering sizes to be customisable somehow.
 	const topSubtreeSize = 8 // must be a multiple of 8 for now.
-	tree, err := newLocalSubtreeWriter(ctx, treeID, rev, []byte{}, []int{topSubtreeSize, h.Size()*8 - topSubtreeSize}, newTX, h)
+	tree, err := newLocalSubtreeWriter(ctx, treeID, rev, []byte{}, []int{topSubtreeSize, h.Size()*8 - topSubtreeSize}, runTX, h)
 	if err != nil {
 		return nil, err
 	}

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -39,7 +39,9 @@ type SparseMerkleTreeReader struct {
 	treeRevision int64
 }
 
-type runTXFunc func(func(storage.MapTreeTX) error) error
+// runTXFunc is the interface for a function which produces something which can
+// be passed as the last argument to MapStorage.ReadWriteTransaction.
+type runTXFunc func(context.Context, func(context.Context, storage.MapTreeTX) error) error
 
 // SparseMerkleTreeWriter knows how to store/update a stored sparse Merkle tree
 // via a TreeStorage transaction.
@@ -201,7 +203,7 @@ func (s *subtreeWriter) RootHash() ([]byte, error) {
 func (s *subtreeWriter) buildSubtree(ctx context.Context) {
 	defer close(s.root)
 	var root []byte
-	err := s.runTX(func(tx storage.MapTreeTX) error {
+	err := s.runTX(ctx, func(ctx context.Context, tx storage.MapTreeTX) error {
 		root = []byte{}
 		leaves := make([]HStar2LeafHash, 0, len(s.leafQueue))
 		nodesToStore := make([]storage.Node, 0, len(s.leafQueue)*2)

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -104,7 +104,7 @@ func TestServer_BeginError(t *testing.T) {
 		if test.snapshot {
 			as.EXPECT().Snapshot(ctx).Return(nil, errors.New("snapshot error"))
 		} else {
-			as.EXPECT().Begin(ctx).Return(nil, errors.New("begin error"))
+			as.EXPECT().ReadWriteTransaction(gomock.Any(), gomock.Any()).Return(errors.New("begin error"))
 		}
 
 		registry := extension.Registry{
@@ -938,7 +938,7 @@ func setupAdminServer(ctrl *gomock.Controller, keygen keys.ProtoGenerator, snaps
 		}
 	} else {
 		tx = storage.NewMockAdminTX(ctrl)
-		as.EXPECT().Begin(gomock.Any()).MaxTimes(1).Return(tx, nil)
+		as.EXPECT().ReadWriteTransaction(gomock.Any(), gomock.Any()).MaxTimes(1).DoAndReturn(testonly.RunOnAdminTX(tx))
 		tx.EXPECT().Close().MaxTimes(1).Return(nil)
 		if shouldCommit {
 			if commitErr {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -463,14 +463,6 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 	}, nil
 }
 
-func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	tx, err := t.registry.LogStorage.BeginForTree(ctx, treeID)
-	if err != nil {
-		return nil, err
-	}
-	return tx, err
-}
-
 func (t *TrillianLogRPCServer) prepareReadOnlyStorageTx(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := t.registry.LogStorage.SnapshotForTree(ctx, treeID)
 	if err != nil {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -558,7 +558,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 		}
 		return nil
 	})
-	if err != nil {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, err
 	}
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1792,8 +1792,6 @@ func (p *parameterizedTest) executeInvalidLogIDTest(t *testing.T, snapshot bool)
 	mockStorage := storage.NewMockLogStorage(p.ctrl)
 	if ctx, logID := gomock.Any(), int64(2); snapshot {
 		mockStorage.EXPECT().SnapshotForTree(ctx, logID).MaxTimes(1).Return(nil, badLogErr)
-	} else {
-		// ReadWriteTransaction will never be called
 	}
 
 	registry := extension.Registry{

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -162,75 +162,72 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 	}
 	ctx = trees.NewContext(ctx, tree)
 
-	tx, err := t.registry.MapStorage.BeginForTree(ctx, req.MapId)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Close()
-
-	glog.V(2).Infof("%v: Writing at revision %v", mapID, tx.WriteRevision())
-	smtWriter, err := merkle.NewSparseMerkleTreeWriter(
-		ctx,
-		req.MapId,
-		tx.WriteRevision(),
-		hasher, func() (storage.TreeTX, error) {
-			return t.registry.MapStorage.BeginForTree(ctx, req.MapId)
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, l := range req.Leaves {
-		if got, want := len(l.Index), hasher.Size(); got != want {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"len(%x): %v, want %v", l.Index, got, want)
-		}
-		if l.LeafValue == nil {
-			// Leaves are empty by default. Do not allow clients to store
-			// empty leaf values as this messes up the calculation of empty
-			// branches.
-			continue
-		}
-		// TODO(gbelvin) use LeafHash rather than computing here. #423
-		leafHash, err := hasher.HashLeaf(mapID, l.Index, l.LeafValue)
+	var newRoot *trillian.SignedMapRoot
+	err = t.registry.MapStorage.ReadWriteTransaction(ctx, req.MapId, func(ctx context.Context, tx storage.MapTreeTX) error {
+		glog.V(2).Infof("%v: Writing at revision %v", mapID, tx.WriteRevision())
+		smtWriter, err := merkle.NewSparseMerkleTreeWriter(
+			ctx,
+			req.MapId,
+			tx.WriteRevision(),
+			hasher, func(f func(storage.MapTreeTX) error) error {
+				return t.registry.MapStorage.ReadWriteTransaction(ctx, req.MapId, func(ctx context.Context, tx storage.MapTreeTX) error {
+					return f(tx)
+				})
+			})
 		if err != nil {
-			return nil, fmt.Errorf("HashLeaf(): %v", err)
+			return err
 		}
-		l.LeafHash = leafHash
 
-		if err = tx.Set(ctx, l.Index, *l); err != nil {
-			return nil, err
-		}
-		if err = smtWriter.SetLeaves(ctx, []merkle.HashKeyValue{
-			{
-				HashedKey:   l.Index,
-				HashedValue: l.LeafHash,
-			},
-		}); err != nil {
-			return nil, err
-		}
-	}
+		for _, l := range req.Leaves {
+			if got, want := len(l.Index), hasher.Size(); got != want {
+				return status.Errorf(codes.InvalidArgument,
+					"len(%x): %v, want %v", l.Index, got, want)
+			}
+			if l.LeafValue == nil {
+				// Leaves are empty by default. Do not allow clients to store
+				// empty leaf values as this messes up the calculation of empty
+				// branches.
+				continue
+			}
+			// TODO(gbelvin) use LeafHash rather than computing here. #423
+			leafHash, err := hasher.HashLeaf(mapID, l.Index, l.LeafValue)
+			if err != nil {
+				return fmt.Errorf("HashLeaf(): %v", err)
+			}
+			l.LeafHash = leafHash
 
-	rootHash, err := smtWriter.CalculateRoot()
+			if err = tx.Set(ctx, l.Index, *l); err != nil {
+				return err
+			}
+			if err = smtWriter.SetLeaves(ctx, []merkle.HashKeyValue{
+				{
+					HashedKey:   l.Index,
+					HashedValue: l.LeafHash,
+				},
+			}); err != nil {
+				return err
+			}
+		}
+
+		rootHash, err := smtWriter.CalculateRoot()
+		if err != nil {
+			return fmt.Errorf("CalculateRoot(): %v", err)
+		}
+
+		newRoot, err = t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, req.MapId, tx.WriteRevision(), req.Metadata)
+		if err != nil {
+			return fmt.Errorf("makeSignedMapRoot(): %v", err)
+		}
+
+		// TODO(al): need an smtWriter.Rollback() or similar I think.
+		if err = tx.StoreSignedMapRoot(ctx, *newRoot); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
 	if err != nil {
-		return nil, fmt.Errorf("CalculateRoot(): %v", err)
-	}
-
-	newRoot, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, req.MapId, tx.WriteRevision(), req.Metadata)
-	if err != nil {
-		return nil, fmt.Errorf("makeSignedMapRoot(): %v", err)
-	}
-
-	// TODO(al): need an smtWriter.Rollback() or similar I think.
-	if err = tx.StoreSignedMapRoot(ctx, *newRoot); err != nil {
 		return nil, err
 	}
-
-	if err := tx.Commit(); err != nil {
-		glog.Warningf("%v: Commit failed for SetLeaves: %v", mapID, err)
-		return nil, err
-	}
-
 	return &trillian.SetMapLeavesResponse{MapRoot: newRoot}, nil
 }
 
@@ -330,35 +327,40 @@ func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRe
 	}
 	ctx = trees.NewContext(ctx, tree)
 
-	tx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
-	if err != storage.ErrTreeNeedsInit && err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "BeginForTree(): %v", err)
-	}
-	defer tx.Close()
+	var rev0Root *trillian.SignedMapRoot
+	err = t.registry.MapStorage.ReadWriteTransaction(ctx, mapID, func(ctx context.Context, tx storage.MapTreeTX) error {
+		rev0Root = nil
+		defer tx.Close()
 
-	latestRoot, err := tx.LatestSignedMapRoot(ctx)
-	if err != nil && err != storage.ErrTreeNeedsInit {
-		return nil, status.Errorf(codes.FailedPrecondition, "LatestSignedMapRoot(): %v", err)
-	}
-	// Belt and braces check.
-	if latestRoot.GetRootHash() != nil {
-		return nil, status.Errorf(codes.AlreadyExists, "map is already initialised")
-	}
+		// Check that the map actually needs initialising
+		latestRoot, err := tx.LatestSignedMapRoot(ctx)
+		if err != nil && err != storage.ErrTreeNeedsInit {
+			return nil, status.Errorf(codes.FailedPrecondition, "LatestSignedMapRoot(): %v", err)
+		}
+		// Belt and braces check.
+		if latestRoot.GetRootHash() != nil {
+			return nil, status.Errorf(codes.AlreadyExists, "map is already initialised")
+		}
 
-	glog.V(2).Infof("%v: Need to init map root revision 0", mapID)
+		glog.V(2).Infof("%v: Need to init map root revision 0", mapID)
+		rootHash := hasher.HashEmpty(mapID, make([]byte, hasher.Size()), hasher.BitLen())
+		var err error
+		rev0Root, err = t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, mapID, 0 /*revision*/, nil /* metadata */)
+		if err != nil {
+			return fmt.Errorf("makeSignedMapRoot(): %v", err)
+		}
 
-	rootHash := hasher.HashEmpty(mapID, make([]byte, hasher.Size()), hasher.BitLen())
-	rev0Root, err := t.makeSignedMapRoot(ctx, tree, time.Now(), rootHash, mapID, 0 /*revision*/, nil /* metadata */)
+		if err = tx.StoreSignedMapRoot(ctx, *rev0Root); err != nil {
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			glog.Warningf("%v: Commit failed for SetLeaves: %v", mapID, err)
+			return err
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("makeSignedMapRoot(): %v", err)
-	}
-
-	if err = tx.StoreSignedMapRoot(ctx, *rev0Root); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
-		glog.Warningf("%v: Commit failed for SetLeaves: %v", mapID, err)
 		return nil, err
 	}
 

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -110,7 +110,7 @@ func TestInitMap(t *testing.T) {
 
 			mockStorage := storage.NewMockMapStorage(ctrl)
 			mockTx := storage.NewMockMapTreeTX(ctrl)
-			mockStorage.EXPECT().BeginForTree(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+			mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(stestonly.RunOnMapTX(mockTX))
 
 			mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 			mockTx.EXPECT().Close().Return(nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -126,7 +126,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
@@ -188,7 +188,8 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 		)
 
 		gomock.InOrder(
-			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil),
+			mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx)),
+			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),
@@ -280,7 +281,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), []*trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(gomock.Any(), updatedNodes0).Return(nil)
 	mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), updatedRoot).Return(nil)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
@@ -321,7 +322,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -189,7 +189,6 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 		gomock.InOrder(
 			mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx)),
-			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -45,11 +45,11 @@ func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]
 }
 
 // CreateTree creates a tree in storage.
-// It's a convenience wrapper around RunInAdminTX and AdminWriter's CreateTree.
-// See RunInAdminTX if you need to perform more than one action per transaction.
+// It's a convenience wrapper around ReadWriteTransaction and AdminWriter's CreateTree.
+// See ReadWriteTransaction if you need to perform more than one action per transaction.
 func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*trillian.Tree, error) {
 	var createdTree *trillian.Tree
-	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		createdTree, err = tx.CreateTree(ctx, tree)
 		return
 	})
@@ -57,11 +57,11 @@ func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*
 }
 
 // UpdateTree updates a tree in storage.
-// It's a convenience wrapper around RunInAdminTX and AdminWriter's UpdateTree.
-// See RunInAdminTX if you need to perform more than one action per transaction.
+// It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UpdateTree.
+// See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*trillian.Tree)) (*trillian.Tree, error) {
 	var updatedTree *trillian.Tree
-	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		updatedTree, err = tx.UpdateTree(ctx, treeID, fn)
 		return
 	})
@@ -69,11 +69,11 @@ func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*
 }
 
 // SoftDeleteTree soft-deletes a tree in storage.
-// It's a convenience wrapper around RunInAdminTX and AdminWriter's SoftDeleteTree.
-// See RunInAdminTX if you need to perform more than one action per transaction.
+// It's a convenience wrapper around ReadWriteTransaction and AdminWriter's SoftDeleteTree.
+// See ReadWriteTransaction if you need to perform more than one action per transaction.
 func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
 	var tree *trillian.Tree
-	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		tree, err = tx.SoftDeleteTree(ctx, treeID)
 		return
 	})
@@ -81,20 +81,20 @@ func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*tri
 }
 
 // HardDeleteTree hard-deletes a tree from storage.
-// It's a convenience wrapper around RunInAdminTX and AdminWriter's HardDeleteTree.
-// See RunInAdminTX if you need to perform more than one action per transaction.
+// It's a convenience wrapper around ReadWriteTransaction and AdminWriter's HardDeleteTree.
+// See ReadWriteTransaction if you need to perform more than one action per transaction.
 func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error {
-	return RunInAdminTX(ctx, admin, func(tx AdminTX) error {
+	return admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		return tx.HardDeleteTree(ctx, treeID)
 	})
 }
 
 // UndeleteTree undeletes a tree in storage.
-// It's a convenience wrapper around RunInAdminTX and AdminWriter's UndeleteTree.
-// See RunInAdminTX if you need to perform more than one action per transaction.
+// It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UndeleteTree.
+// See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UndeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
 	var tree *trillian.Tree
-	err := RunInAdminTX(ctx, admin, func(tx AdminTX) (err error) {
+	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		tree, err = tx.UndeleteTree(ctx, treeID)
 		return
 	})

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -103,6 +103,9 @@ type ReadOnlyLogStorage interface {
 	SnapshotForTree(ctx context.Context, treeID int64) (ReadOnlyLogTreeTX, error)
 }
 
+// LogTXFunc is the func signature for passing into ReadWriteTransaction.
+type LogTXFunc func(context.Context, LogTreeTX) error
+
 // LogStorage should be implemented by concrete storage mechanisms which want to support Logs.
 type LogStorage interface {
 	ReadOnlyLogStorage
@@ -117,7 +120,7 @@ type LogStorage interface {
 	// calls f with it.
 	// If f fails and returns an error, the storage implementation may optionally
 	// retry with a new transaction, and f MUST NOT keep state across calls.
-	ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx LogTreeTX) error) error
+	ReadWriteTransaction(ctx context.Context, treeID int64, f LogTXFunc) error
 }
 
 // CountByLogID is a map of total number of items keyed by log ID.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -112,6 +112,12 @@ type LogStorage interface {
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
 	BeginForTree(ctx context.Context, treeID int64) (LogTreeTX, error)
+
+	// ReadWriteTransaction starts a RW transaction on the underlying storage, and
+	// calls f with it.
+	// If f fails and returns an error, the storage implementation may optionally
+	// retry with a new transaction, and f MUST NOT keep state across calls.
+	ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx LogTreeTX) error) error
 }
 
 // CountByLogID is a map of total number of items keyed by log ID.

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -83,6 +83,9 @@ type ReadOnlyMapStorage interface {
 	SnapshotForTree(ctx context.Context, treeID int64) (ReadOnlyMapTreeTX, error)
 }
 
+// MapTXFunc is the func signature for passing into ReadWriteTransaction.
+type MapTXFunc func(context.Context, MapTreeTX) error
+
 // MapStorage should be implemented by concrete storage mechanisms which want to support Maps
 type MapStorage interface {
 	ReadOnlyMapStorage
@@ -97,5 +100,5 @@ type MapStorage interface {
 	// calls f with it.
 	// If f fails and returns an error, the storage implementation may optionally
 	// retry with a new transaction, and f MUST NOT keep state across calls.
-	ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx MapTreeTX) error) error
+	ReadWriteTransaction(ctx context.Context, treeID int64, f MapTXFunc) error
 }

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -92,4 +92,10 @@ type MapStorage interface {
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
 	BeginForTree(ctx context.Context, treeID int64) (MapTreeTX, error)
+
+	// ReadWriteTransaction starts a RW transaction on the underlying storage, and
+	// calls f with it.
+	// If f fails and returns an error, the storage implementation may optionally
+	// retry with a new transaction, and f MUST NOT keep state across calls.
+	ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx MapTreeTX) error) error
 }

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -45,6 +45,18 @@ func (s *memoryAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error)
 	return &adminTX{ms: s.ms}, nil
 }
 
+func (s *memoryAdminStorage) ReadWriteTransaction(ctx context.Context, f storage.AdminTXFunc) error {
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	if err := f(ctx, tx); err != nil {
+		tx.Close()
+	}
+	return tx.Commit()
+}
+
 func (s *memoryAdminStorage) CheckDatabaseAccessible(ctx context.Context) error {
 	return nil
 }

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -176,7 +176,7 @@ func (m *memoryLogStorage) BeginForTree(ctx context.Context, treeID int64) (stor
 	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
-func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.LogTreeTX) error) error {
+func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	tx, err := m.BeginForTree(ctx, treeID)
 	if err != nil {
 		return err

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -178,7 +178,7 @@ func (m *memoryLogStorage) BeginForTree(ctx context.Context, treeID int64) (stor
 
 func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	tx, err := m.BeginForTree(ctx, treeID)
-	if err != nil {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return err
 	}
 	defer tx.Close()

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -176,6 +176,15 @@ func (m *memoryLogStorage) BeginForTree(ctx context.Context, treeID int64) (stor
 	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
+func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.LogTreeTX) error) error {
+	tx, err := m.BeginForTree(ctx, treeID)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	return f(ctx, tx)
+}
+
 func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -295,6 +295,18 @@ func (mr *MockLogStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDatabaseAccessible", reflect.TypeOf((*MockLogStorage)(nil).CheckDatabaseAccessible), arg0)
 }
 
+// ReadWriteTransaction mocks base method
+func (m *MockLogStorage) ReadWriteTransaction(arg0 context.Context, arg1 int64, arg2 LogTXFunc) error {
+	ret := m.ctrl.Call(m, "ReadWriteTransaction", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReadWriteTransaction indicates an expected call of ReadWriteTransaction
+func (mr *MockLogStorageMockRecorder) ReadWriteTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWriteTransaction", reflect.TypeOf((*MockLogStorage)(nil).ReadWriteTransaction), arg0, arg1, arg2)
+}
+
 // Snapshot mocks base method
 func (m *MockLogStorage) Snapshot(arg0 context.Context) (ReadOnlyLogTX, error) {
 	ret := m.ctrl.Call(m, "Snapshot", arg0)
@@ -602,6 +614,18 @@ func (m *MockMapStorage) CheckDatabaseAccessible(arg0 context.Context) error {
 // CheckDatabaseAccessible indicates an expected call of CheckDatabaseAccessible
 func (mr *MockMapStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDatabaseAccessible", reflect.TypeOf((*MockMapStorage)(nil).CheckDatabaseAccessible), arg0)
+}
+
+// ReadWriteTransaction mocks base method
+func (m *MockMapStorage) ReadWriteTransaction(arg0 context.Context, arg1 int64, arg2 func(context.Context, MapTreeTX) error) error {
+	ret := m.ctrl.Call(m, "ReadWriteTransaction", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReadWriteTransaction indicates an expected call of ReadWriteTransaction
+func (mr *MockMapStorageMockRecorder) ReadWriteTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWriteTransaction", reflect.TypeOf((*MockMapStorage)(nil).ReadWriteTransaction), arg0, arg1, arg2)
 }
 
 // Snapshot mocks base method

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -60,6 +60,18 @@ func (mr *MockAdminStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDatabaseAccessible", reflect.TypeOf((*MockAdminStorage)(nil).CheckDatabaseAccessible), arg0)
 }
 
+// ReadWriteTransaction mocks base method
+func (m *MockAdminStorage) ReadWriteTransaction(arg0 context.Context, arg1 AdminTXFunc) error {
+	ret := m.ctrl.Call(m, "ReadWriteTransaction", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReadWriteTransaction indicates an expected call of ReadWriteTransaction
+func (mr *MockAdminStorageMockRecorder) ReadWriteTransaction(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWriteTransaction", reflect.TypeOf((*MockAdminStorage)(nil).ReadWriteTransaction), arg0, arg1)
+}
+
 // Snapshot mocks base method
 func (m *MockAdminStorage) Snapshot(arg0 context.Context) (ReadOnlyAdminTX, error) {
 	ret := m.ctrl.Call(m, "Snapshot", arg0)

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -617,7 +617,7 @@ func (mr *MockMapStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) 
 }
 
 // ReadWriteTransaction mocks base method
-func (m *MockMapStorage) ReadWriteTransaction(arg0 context.Context, arg1 int64, arg2 func(context.Context, MapTreeTX) error) error {
+func (m *MockMapStorage) ReadWriteTransaction(arg0 context.Context, arg1 int64, arg2 MapTXFunc) error {
 	ret := m.ctrl.Call(m, "ReadWriteTransaction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -84,6 +84,18 @@ func (s *mysqlAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error) 
 	return &adminTX{tx: tx}, nil
 }
 
+func (s *mysqlAdminStorage) ReadWriteTransaction(ctx context.Context, f storage.AdminTXFunc) error {
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	if err := f(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *mysqlAdminStorage) CheckDatabaseAccessible(ctx context.Context) error {
 	return checkDatabaseAccessible(ctx, s.db)
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -258,7 +258,7 @@ func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (stora
 	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
-func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.LogTreeTX) error) error {
+func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	tx, err := m.BeginForTree(ctx, treeID)
 	if err != nil {
 		return err

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -258,6 +258,15 @@ func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (stora
 	return m.beginInternal(ctx, treeID, false /* readonly */)
 }
 
+func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.LogTreeTX) error) error {
+	tx, err := m.BeginForTree(ctx, treeID)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	return f(ctx, tx)
+}
+
 func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -260,7 +260,7 @@ func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (stora
 
 func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	tx, err := m.BeginForTree(ctx, treeID)
-	if err != nil {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return err
 	}
 	defer tx.Close()

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -142,6 +142,15 @@ func (m *mySQLMapStorage) SnapshotForTree(ctx context.Context, treeID int64) (st
 	return m.begin(ctx, treeID, true /* readonly */)
 }
 
+func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.MapTreeTX) error) error {
+	tx, err := m.BeginForTree(ctx, treeID)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	return f(ctx, tx)
+}
+
 type mapTreeTX struct {
 	treeTX
 	ms   *mySQLMapStorage

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -144,10 +144,12 @@ func (m *mySQLMapStorage) SnapshotForTree(ctx context.Context, treeID int64) (st
 
 func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.MapTreeTX) error) error {
 	tx, err := m.BeginForTree(ctx, treeID)
-	if err != nil {
+	if tx != nil {
+		defer tx.Close()
+	}
+	if err != nil && err != storage.ErrMapNeedsInit {
 		return err
 	}
-	defer tx.Close()
 	return f(ctx, tx)
 }
 

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -147,7 +147,7 @@ func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64
 	if tx != nil {
 		defer tx.Close()
 	}
-	if err != nil && err != storage.ErrMapNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return err
 	}
 	return f(ctx, tx)

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -142,7 +142,7 @@ func (m *mySQLMapStorage) SnapshotForTree(ctx context.Context, treeID int64) (st
 	return m.begin(ctx, treeID, true /* readonly */)
 }
 
-func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f func(ctx context.Context, tx storage.MapTreeTX) error) error {
+func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64, f storage.MapTXFunc) error {
 	tx, err := m.BeginForTree(ctx, treeID)
 	if tx != nil {
 		defer tx.Close()

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"context"
+
+	"github.com/google/trillian/storage"
+)
+
+// RunOnLogTX is a helper for mocking out the LogStorage.ReadWriteTransaction method..
+func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
+	return func(ctx context.Context, _ int64, f storage.LogTXFunc) error {
+		defer tx.Close()
+		return f(ctx, tx)
+	}
+}
+
+// RunOnMapTX is a helper for mocking out the MapStorage.ReadWriteTransaction method..
+func RunOnMapTX(tx storage.MapTreeTX) func(ctx context.Context, treeID int64, f storage.MapTXFunc) error {
+	return func(ctx context.Context, _ int64, f storage.MapTXFunc) error {
+		defer tx.Close()
+		return f(ctx, tx)
+	}
+}

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/trillian/storage"
 )
 
-// RunOnLogTX is a helper for mocking out the LogStorage.ReadWriteTransaction method..
+// RunOnLogTX is a helper for mocking out the LogStorage.ReadWriteTransaction method.
 func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	return func(ctx context.Context, _ int64, f storage.LogTXFunc) error {
 		defer tx.Close()
@@ -28,10 +28,21 @@ func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f 
 	}
 }
 
-// RunOnMapTX is a helper for mocking out the MapStorage.ReadWriteTransaction method..
+// RunOnMapTX is a helper for mocking out the MapStorage.ReadWriteTransaction method.
 func RunOnMapTX(tx storage.MapTreeTX) func(ctx context.Context, treeID int64, f storage.MapTXFunc) error {
 	return func(ctx context.Context, _ int64, f storage.MapTXFunc) error {
 		defer tx.Close()
 		return f(ctx, tx)
+	}
+}
+
+// RunOnAdminTX is a helper for mocking out the AdminStorage.ReadWriteTransaction method.
+func RunOnAdminTX(tx storage.AdminTX) func(ctx context.Context, f storage.AdminTXFunc) error {
+	return func(ctx context.Context, f storage.AdminTXFunc) error {
+		defer tx.Close()
+		if err := f(ctx, tx); err != nil {
+			return err
+		}
+		return tx.Commit()
 	}
 }

--- a/vmap/toy/vmap_toy.go
+++ b/vmap/toy/vmap_toy.go
@@ -89,8 +89,8 @@ func main() {
 			mapID,
 			tx.WriteRevision(),
 			hasher,
-			func() (storage.TreeTX, error) {
-				return ms.BeginForTree(ctx, mapID)
+			func(ctx context.Context, f func(context.Context, storage.MapTreeTX) error) error {
+				return ms.ReadWriteTransaction(ctx, mapID, f)
 			})
 		if err != nil {
 			glog.Exitf("Failed to create new SMTWriter: %v", err)


### PR DESCRIPTION
A change like this seems to be a prerequisite for supporting Cloud Spanner, if we ever wanted to do so.

Despite the appalling job github's diff does below, not all that much has changed.
I've not done the Map yet as it's slightly more tricky due to the `SparseMerkleWriter`'s use of `newTXFunc`, but I'm sure that's fixable too.

Log integration tests pass against `memory` and `MySQL` implementations with this code BTW.