### PR TITLE
Set ExtraData field

### DIFF
--- a/client/verifier.go
+++ b/client/verifier.go
@@ -110,5 +110,6 @@ func (c *logVerifier) buildLeaf(data []byte) (*trillian.LogLeaf, error) {
 	return &trillian.LogLeaf{
 		LeafValue:      data,
 		MerkleLeafHash: leafHash,
+		ExtraData:      []byte{},
 	}, nil
 }


### PR DESCRIPTION
Some schemas have ExtraData as NOT NULL.
As a result, they can't be set back to allowing NULLs.
Fix: set some extra_data even if we don't have any.