### PR TITLE
Factor out sequencing from Sequencer

### DIFF
--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -85,9 +85,9 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 		glog.Warning("failed to parse tree.MaxRootDuration, using zero")
 		maxRootDuration = 0
 	}
-	leaves, err := sequencer.SequenceBatch(ctx, logID, info.BatchSize, s.guardWindow, maxRootDuration)
+	leaves, err := sequencer.IntegrateBatch(ctx, logID, info.BatchSize, s.guardWindow, maxRootDuration)
 	if err != nil {
-		return 0, fmt.Errorf("failed to sequence batch for %v: %v", logID, err)
+		return 0, fmt.Errorf("failed to integrate batch for %v: %v", logID, err)
 	}
 	return leaves, nil
 }

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -189,8 +189,8 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 		gomock.InOrder(
 			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil),
-			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
+			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),
 			mockTx.EXPECT().Commit().Return(nil),
 			mockTx.EXPECT().Close().Return(nil),

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -133,14 +133,14 @@ Ws9xezgQPrg96YGsFrF6KYG68iqyHDlQ+4FWuKfGKXHn3ooVtB/pfawb5Q==
 
 func sequence(treeID int64, seq *log.Sequencer, count, batchSize int) {
 	glog.Infof("Sequencing batch of size %d", count)
-	sequenced, err := seq.SequenceBatch(context.TODO(), treeID, batchSize, 0, 24*time.Hour)
+	sequenced, err := seq.IntegrateBatch(context.TODO(), treeID, batchSize, 0, 24*time.Hour)
 
 	if err != nil {
-		glog.Fatalf("SequenceBatch got: %v, want: no err", err)
+		glog.Fatalf("IntegrateBatch got: %v, want: no err", err)
 	}
 
 	if got, want := sequenced, count; got != want {
-		glog.Fatalf("SequenceBatch got: %d sequenced, want: %d", got, want)
+		glog.Fatalf("IntegrateBatch got: %d sequenced, want: %d", got, want)
 	}
 }
 


### PR DESCRIPTION
This is a prerequisite for the **Pre-ordered Log** mode. The `sequencingTask` interface will have another implementation which will load batches from the `Sequenced` table instead of `Unsequenced`. The rest of Sequencer's machinery will probably remain the same, only perhaps renamed.