### PR TITLE
Fix InitLog

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -142,7 +142,7 @@ func (c *LogClient) WaitForRootUpdate(ctx context.Context, waitForTreeSize int64
 			if root.TreeSize >= waitForTreeSize {
 				return root, nil
 			}
-		case codes.Unavailable, codes.NotFound: // Retry.
+		case codes.Unavailable, codes.NotFound, codes.FailedPrecondition: // Retry.
 		default:
 			return nil, err
 		}


### PR DESCRIPTION
BeginForTree may or may not return an error when the log stil
need initializing.  Remove the implementation specific check.