### PR TITLE
storage: drop unneeded/unused interfaces

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -253,7 +253,7 @@ type logSequencingTask struct {
 	label      string
 	treeSize   int64
 	timeSource util.TimeSource
-	dequeuer   storage.LeafDequeuer
+	dequeuer   storage.LogTreeTX
 }
 
 func (s logSequencingTask) fetch(ctx context.Context, limit int, cutoff time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -88,6 +88,8 @@ type LogTreeTX interface {
 	// Leaves queued more recently than the cutoff time will not be returned. This allows for
 	// guard intervals to be configured.
 	DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error)
+	// UpdateSequencedLeaves associates the leaves with the sequence numbers
+	// assigned to them.
 	UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error
 }
 

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -39,8 +39,20 @@ type ReadOnlyMapTX interface {
 // A ReadOnlyMapTreeTX can only read from the tree specified in its creation.
 type ReadOnlyMapTreeTX interface {
 	ReadOnlyTreeTX
-	MapRootReader
-	Getter
+
+	// GetSignedMapRoot returns the SignedMapRoot associated with the
+	// specified revision.
+	GetSignedMapRoot(ctx context.Context, revision int64) (trillian.SignedMapRoot, error)
+	// LatestSignedMapRoot returns the most recently created SignedMapRoot.
+	LatestSignedMapRoot(ctx context.Context) (trillian.SignedMapRoot, error)
+
+	// Get retrieves the values associates with the keyHashes, if any, at the
+	// specified revision.
+	// Setting revision to -1 will fetch the latest revision.
+	// The returned array of MapLeaves will only contain entries for which values
+	// exist.  i.e. requesting a set of unknown keys would result in a
+	// zero-length array being returned.
+	Get(ctx context.Context, revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, error)
 }
 
 // MapTreeTX is the transactional interface for reading/modifying a Map.
@@ -49,11 +61,13 @@ type ReadOnlyMapTreeTX interface {
 // released any resources owned by the MapTX.
 // A MapTreeTX can only read from the tree specified in its creation.
 type MapTreeTX interface {
-	TreeTX
-	MapRootReader
-	MapRootWriter
-	Getter
-	Setter
+	ReadOnlyMapTreeTX
+	TreeWriter
+
+	// StoreSignedMapRoot stores root.
+	StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error
+	// Set sets key to leaf
+	Set(ctx context.Context, keyHash []byte, value trillian.MapLeaf) error
 }
 
 // ErrMapNeedsInit is an error returned from SnapshotForTree / BeginForTree when used
@@ -78,41 +92,10 @@ type ReadOnlyMapStorage interface {
 // MapStorage should be implemented by concrete storage mechanisms which want to support Maps
 type MapStorage interface {
 	ReadOnlyMapStorage
+
 	// BeginForTree starts a new Map transaction.
 	// Either Commit or Rollback must be called when the caller is finished with
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
 	BeginForTree(ctx context.Context, treeID int64) (MapTreeTX, error)
-}
-
-// Setter allows the setting of key->value pairs on the map.
-type Setter interface {
-	// Set sets key to leaf
-	Set(ctx context.Context, keyHash []byte, value trillian.MapLeaf) error
-}
-
-// Getter allows access to the values stored in the map.
-type Getter interface {
-	// Get retrieves the values associates with the keyHashes, if any, at the
-	// specified revision.
-	// Setting revision to -1 will fetch the latest revision.
-	// The returned array of MapLeaves will only contain entries for which values
-	// exist.  i.e. requesting a set of unknown keys would result in a
-	// zero-length array being returned.
-	Get(ctx context.Context, revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, error)
-}
-
-// MapRootReader provides access to the map roots.
-type MapRootReader interface {
-	// GetSignedMapRoot returns the SignedMapRoot associated with the
-	// specified revision.
-	GetSignedMapRoot(ctx context.Context, revision int64) (trillian.SignedMapRoot, error)
-	// LatestSignedMapRoot returns the most recently created SignedMapRoot.
-	LatestSignedMapRoot(ctx context.Context) (trillian.SignedMapRoot, error)
-}
-
-// MapRootWriter allows the storage of new SignedMapRoots
-type MapRootWriter interface {
-	// StoreSignedMapRoot stores root.
-	StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error
 }

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -198,7 +198,7 @@ func TestBeginSnapshot(t *testing.T) {
 	s := NewLogStorage(DB, nil)
 	for _, test := range tests {
 		func() {
-			var tx rootReaderLogTX
+			var tx storage.ReadOnlyLogTreeTX
 			var err error
 			if test.snapshot {
 				tx, err = s.SnapshotForTree(ctx, test.logID)
@@ -230,11 +230,6 @@ func TestBeginSnapshot(t *testing.T) {
 			}
 		}()
 	}
-}
-
-type rootReaderLogTX interface {
-	storage.ReadOnlyTreeTX
-	storage.LogRootReader
 }
 
 func TestIsOpenCommitRollbackClosed(t *testing.T) {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -113,7 +113,7 @@ func TestMapBeginSnapshot(t *testing.T) {
 	s := NewMapStorage(DB)
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			var tx rootReaderMapTX
+			var tx storage.ReadOnlyMapTreeTX
 			var err error
 			if test.snapshot {
 				tx, err = s.SnapshotForTree(ctx, test.mapID)
@@ -145,11 +145,6 @@ func TestMapBeginSnapshot(t *testing.T) {
 			}
 		})
 	}
-}
-
-type rootReaderMapTX interface {
-	storage.ReadOnlyTreeTX
-	storage.MapRootReader
 }
 
 func TestMapRootUpdate(t *testing.T) {

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -50,7 +50,13 @@ type ReadOnlyTreeTX interface {
 // A TreeTX can only modify the tree specified in its creation.
 type TreeTX interface {
 	ReadOnlyTreeTX
-	NodeWriter
+	TreeWriter
+}
+
+// TreeWriter represents additional transaction methods that modify the tree.
+type TreeWriter interface {
+	// SetMerkleNodes stores the provided nodes, at the transaction's writeRevision.
+	SetMerkleNodes(ctx context.Context, nodes []Node) error
 
 	// WriteRevision returns the tree revision that any writes through this TreeTX will be stored at.
 	WriteRevision() int64
@@ -62,14 +68,9 @@ type DatabaseChecker interface {
 	CheckDatabaseAccessible(context.Context) error
 }
 
-// NodeReader provides a read-only interface into the stored tree nodes.
+// NodeReader provides read-only access to the stored tree nodes, as an interface to allow easier
+// testing of node manipulation.
 type NodeReader interface {
 	// GetMerkleNodes looks up the set of nodes identified by ids, at treeRevision, and returns them.
 	GetMerkleNodes(ctx context.Context, treeRevision int64, ids []NodeID) ([]Node, error)
-}
-
-// NodeWriter provides a write interface into the stored tree nodes.
-type NodeWriter interface {
-	// SetMerkleNodes stores the provided nodes, at the transaction's writeRevision.
-	SetMerkleNodes(ctx context.Context, nodes []Node) error
 }


### PR DESCRIPTION
Drop Go interfaces that have a single implementation and which
are never used individually (possibly except in test code).

cf. https://github.com/golang/go/wiki/CodeReviewComments#interfaces