### PR TITLE
Add preordered log type to MySQL enum

### DIFF
--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -9,7 +9,7 @@
 CREATE TABLE IF NOT EXISTS Trees(
   TreeId                BIGINT NOT NULL,
   TreeState             ENUM('ACTIVE', 'FROZEN') NOT NULL,
-  TreeType              ENUM('LOG', 'MAP') NOT NULL,
+  TreeType              ENUM('LOG', 'MAP', 'PREORDERED_LOG') NOT NULL,
   HashStrategy          ENUM('RFC6962_SHA256', 'TEST_MAP_HASHER', 'OBJECT_RFC6962_SHA256', 'CONIKS_SHA512_256') NOT NULL,
   HashAlgorithm         ENUM('SHA256') NOT NULL,
   SignatureAlgorithm    ENUM('ECDSA', 'RSA') NOT NULL,


### PR DESCRIPTION
I think this was omitted from #964?