### PR TITLE
Fix/ Add NotFound test to WaitForInclusion

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -151,7 +151,7 @@ func (c *LogClient) WaitForRootUpdate(ctx context.Context, waitForTreeSize int64
 		case <-ctx.Done():
 			return nil, status.Errorf(codes.DeadlineExceeded,
 				"%v. TreeSize: %v, want >= %v. Tried %v times: %v",
-				err, c.root.TreeSize, waitForTreeSize, i+1, ctx.Err())
+				err, root.TreeSize, waitForTreeSize, i+1, ctx.Err())
 		case <-time.After(b.Duration()):
 		}
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -198,15 +198,23 @@ func TestWaitForInclusion(t *testing.T) {
 		{desc: "Make TreeSize > 1", leaf: []byte("B"), client: env.Log},
 		{desc: "invalid inclusion proof", leaf: []byte("A"), client: &MockLogClient{c: env.Log, mGetInclusionProof: true}, wantErr: true},
 	} {
-		client := New(logID, test.client, rfc6962.DefaultHasher, env.PublicKey)
-		if err := client.QueueLeaf(ctx, test.leaf); err != nil {
-			t.Fatalf("QueueLeaf(%v): %v", test.desc, err)
-		}
-		env.Sequencer.OperationSingle(ctx)
-		err := client.WaitForInclusion(ctx, test.leaf)
-		if got := err != nil; got != test.wantErr {
-			t.Errorf("WaitForInclusion(%v): %v, want error: %v", test.desc, err, test.wantErr)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			client := New(logID, test.client, rfc6962.DefaultHasher, env.PublicKey)
+			if err := client.QueueLeaf(ctx, test.leaf); err != nil {
+				t.Fatalf("QueueLeaf(): %v", err)
+			}
+			err := client.WaitForInclusion(ctx, test.leaf)
+			if got := err != nil; got != test.wantErr {
+				t.Errorf("WaitForInclusion(): %v, want error: %v", err, test.wantErr)
+			}
+
+			env.Sequencer.OperationSingle(ctx)
+
+			err = client.WaitForInclusion(ctx, test.leaf)
+			if got := err != nil; got != test.wantErr {
+				t.Errorf("WaitForInclusion(): %v, want error: %v", err, test.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
`client.WaitForInclusion` was erroring when `TreeSize == 0` and several other edge cases. 

- Added test
- Simplified logic
