### PR TITLE
Fix MapInit

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -309,7 +309,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 
 	if currentRoot.RootHash == nil {
 		glog.Warningf("%v: Fresh log - no previous TreeHeads exist.", logID)
-		return 0, storage.ErrLogNeedsInit
+		return 0, storage.ErrTreeNeedsInit
 	}
 
 	var st sequencingTask = logSequencingTask{

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -308,7 +308,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 	{
 		ls := mysql.NewLogStorage(db, nil)
 		tx, err := ls.BeginForTree(ctx, tree.TreeId)
-		if err != nil && err != storage.ErrLogNeedsInit {
+		if err != nil && err != storage.ErrTreeNeedsInit {
 			return nil, err
 		}
 		defer tx.Close()

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -525,13 +525,13 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 	}
 
 	tx, err := t.registry.LogStorage.BeginForTree(ctx, logID)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, status.Errorf(codes.FailedPrecondition, "BeginForTree(): %v", err)
 	}
 	defer tx.Close()
 
 	latestRoot, err := tx.LatestSignedLogRoot(ctx)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, status.Errorf(codes.FailedPrecondition, "LatestSignedLogRoot(): %v", err)
 	}
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1682,7 +1682,7 @@ func TestInitLog(t *testing.T) {
 		root     []byte
 		wantCode codes.Code
 	}{
-		{desc: "init new log", txErr: storage.ErrLogNeedsInit, wantInit: true, root: nil, wantCode: codes.OK},
+		{desc: "init new log", txErr: storage.ErrTreeNeedsInit, wantInit: true, root: nil, wantCode: codes.OK},
 		{desc: "init new log, no err", txErr: nil, wantInit: true, root: nil, wantCode: codes.OK},
 		{desc: "init already initialised log", txErr: nil, wantInit: false, root: []byte{}, wantCode: codes.AlreadyExists},
 	} {

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -331,7 +331,7 @@ func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRe
 	ctx = trees.NewContext(ctx, tree)
 
 	tx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
-	if err != storage.ErrMapNeedsInit && err != nil {
+	if err != storage.ErrTreeNeedsInit && err != nil {
 		return nil, err
 	}
 	defer tx.Close()

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -326,19 +326,23 @@ func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRe
 	mapID := req.MapId
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, false /* readonly */)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.FailedPrecondition, "getTreeAndHasher(): %v", err)
 	}
 	ctx = trees.NewContext(ctx, tree)
 
 	tx, err := t.registry.MapStorage.BeginForTree(ctx, mapID)
 	if err != storage.ErrTreeNeedsInit && err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.FailedPrecondition, "BeginForTree(): %v", err)
 	}
 	defer tx.Close()
 
-	if err == nil {
-		// Init() not needed.
-		return nil, status.New(codes.AlreadyExists, "map already intialised.").Err()
+	latestRoot, err := tx.LatestSignedMapRoot(ctx)
+	if err != nil && err != storage.ErrTreeNeedsInit {
+		return nil, status.Errorf(codes.FailedPrecondition, "LatestSignedMapRoot(): %v", err)
+	}
+	// Belt and braces check.
+	if latestRoot.GetRootHash() != nil {
+		return nil, status.Errorf(codes.AlreadyExists, "map is already initialised")
 	}
 
 	glog.V(2).Infof("%v: Need to init map root revision 0", mapID)

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -128,7 +128,7 @@ func TestGetSignedMapRoot_NotInitialised(t *testing.T) {
 		MapStorage: mockStorage,
 	})
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
-	mockTX.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrMapNeedsInit)
+	mockTX.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
 
 	smrResp, err := server.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{})
@@ -225,7 +225,7 @@ func TestGetSignedMapRootByRevision_NotInitialised(t *testing.T) {
 		MapStorage: mockStorage,
 	})
 	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
-	mockTX.EXPECT().GetSignedMapRoot(gomock.Any(), gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrMapNeedsInit)
+	mockTX.EXPECT().GetSignedMapRoot(gomock.Any(), gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
 
 	smrResp, err := server.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -90,30 +90,61 @@ func TestIsHealthy(t *testing.T) {
 	}
 }
 
-func TestInitMapAlreadyInitialised(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestInitMap(t *testing.T) {
 	ctx := context.Background()
 
-	adminStorage := mockAdminStorageForMap(ctrl, 2, mapID1)
-	mockStorage := storage.NewMockMapStorage(ctrl)
-	mockTX := storage.NewMockMapTreeTX(ctrl)
-	server := NewTrillianMapServer(extension.Registry{
-		AdminStorage: adminStorage,
-		MapStorage:   mockStorage,
-	})
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
-	mockTX.EXPECT().Close()
+	for _, tc := range []struct {
+		desc     string
+		txErr    error
+		wantInit bool
+		root     []byte
+		wantCode codes.Code
+	}{
+		{desc: "init new log", txErr: storage.ErrTreeNeedsInit, wantInit: true, root: nil, wantCode: codes.OK},
+		{desc: "init new log, no err", txErr: nil, wantInit: true, root: nil, wantCode: codes.OK},
+		{desc: "init already initialised log", txErr: nil, wantInit: false, root: []byte{}, wantCode: codes.AlreadyExists},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-	initResp, err := server.InitMap(ctx, &trillian.InitMapRequest{MapId: mapID1})
-	if err == nil {
-		t.Fatalf("InitMap() on initialised map = no error, want error")
-	}
-	if got, want := status.Code(err), codes.AlreadyExists; got != want {
-		t.Errorf("InitMap() = %v, want %v", got, want)
-	}
-	if initResp != nil {
-		t.Errorf("InitMap() returned non-nil response %v with error, want nil response", initResp)
+			mockStorage := storage.NewMockMapStorage(ctrl)
+			mockTx := storage.NewMockMapTreeTX(ctrl)
+			mockStorage.EXPECT().BeginForTree(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+
+			mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
+			mockTx.EXPECT().Close().Return(nil)
+			mockTx.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(
+				trillian.SignedMapRoot{RootHash: tc.root}, nil)
+			if tc.wantInit {
+				mockTx.EXPECT().Commit().Return(nil)
+				mockTx.EXPECT().StoreSignedMapRoot(gomock.Any(), gomock.Any())
+			}
+
+			server := NewTrillianMapServer(extension.Registry{
+				AdminStorage: mockAdminStorageForMap(ctrl, 2, mapID1),
+				MapStorage:   mockStorage,
+			})
+
+			c, err := server.InitMap(ctx, &trillian.InitMapRequest{
+				MapId: mapID1,
+			})
+			if got, want := status.Code(err), tc.wantCode; got != want {
+				t.Errorf("InitMap returned %v, want %v", got, want)
+			}
+			if tc.wantInit {
+				if err != nil {
+					t.Fatalf("InitLog returned %v, want no error", err)
+				}
+				if c.Created == nil {
+					t.Error("InitLog first attempt didn't return the created STH.")
+				}
+			} else {
+				if err == nil {
+					t.Errorf("InitLog returned nil, want error")
+				}
+			}
+		})
 	}
 }
 

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -22,8 +22,8 @@ import (
 	"github.com/google/trillian/errors"
 )
 
-// ErrLogNeedsInit is returned when calling methods on an uninitialised Log.
-var ErrLogNeedsInit = errors.New(errors.FailedPrecondition, "log needs initialising")
+// ErrTreeNeedsInit is returned when calling methods on an uninitialised Log.
+var ErrTreeNeedsInit = errors.New(errors.FailedPrecondition, "tree needs initialising")
 
 // ReadOnlyLogTX provides a read-only view into log data.
 // A ReadOnlyLogTX, unlike ReadOnlyLogTreeTX, is not tied to a particular tree.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -19,11 +19,7 @@ import (
 	"time"
 
 	"github.com/google/trillian"
-	"github.com/google/trillian/errors"
 )
-
-// ErrTreeNeedsInit is returned when calling methods on an uninitialised Log.
-var ErrTreeNeedsInit = errors.New(errors.FailedPrecondition, "tree needs initialising")
 
 // ReadOnlyLogTX provides a read-only view into log data.
 // A ReadOnlyLogTX, unlike ReadOnlyLogTreeTX, is not tied to a particular tree.

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 
 	"github.com/google/trillian"
 )
@@ -69,11 +68,6 @@ type MapTreeTX interface {
 	// Set sets key to leaf
 	Set(ctx context.Context, keyHash []byte, value trillian.MapLeaf) error
 }
-
-// ErrMapNeedsInit is an error returned from SnapshotForTree / BeginForTree when used
-// on a uninitialized map storage - i.e. a new, empty map in which the Revision 0 SMH
-// hasn't yet been created.
-var ErrMapNeedsInit = errors.New("uninitialized map")
 
 // ReadOnlyMapStorage provides a narrow read-only view into a MapStorage.
 type ReadOnlyMapStorage interface {

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -159,11 +159,11 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, treeID int64, read
 	}
 
 	ltx.root, err = ltx.fetchLatestRoot(ctx)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		ttx.Rollback()
 		return nil, err
 	}
-	if err == storage.ErrLogNeedsInit {
+	if err == storage.ErrTreeNeedsInit {
 		return ltx, err
 	}
 
@@ -290,7 +290,7 @@ func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (trillian.SignedLog
 func (t *logTreeTX) fetchLatestRoot(ctx context.Context) (trillian.SignedLogRoot, error) {
 	r := t.tx.Get(sthKey(t.treeID, t.tree.currentSTH))
 	if r == nil {
-		return trillian.SignedLogRoot{}, storage.ErrLogNeedsInit
+		return trillian.SignedLogRoot{}, storage.ErrTreeNeedsInit
 	}
 	return r.(*kv).v.(trillian.SignedLogRoot), nil
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -231,7 +231,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 
 	stCache := cache.NewLogSubtreeCache(defaultLogStrata, hasher)
 	ttx, err := m.beginTreeTx(ctx, treeID, hasher.Size(), stCache)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, err
 	}
 
@@ -241,11 +241,11 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 	}
 
 	ltx.root, err = ltx.fetchLatestRoot(ctx)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		ttx.Rollback()
 		return nil, err
 	}
-	if err == storage.ErrLogNeedsInit {
+	if err == storage.ErrTreeNeedsInit {
 		return ltx, err
 	}
 
@@ -610,7 +610,7 @@ func (t *logTreeTX) fetchLatestRoot(ctx context.Context) (trillian.SignedLogRoot
 
 	// It's possible there are no roots for this tree yet
 	if err == sql.ErrNoRows {
-		return trillian.SignedLogRoot{}, storage.ErrLogNeedsInit
+		return trillian.SignedLogRoot{}, storage.ErrTreeNeedsInit
 	}
 
 	err = proto.Unmarshal(rootSignatureBytes, &rootSignature)

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -881,8 +881,8 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	s := NewLogStorage(DB, nil)
 
 	tx, err := s.BeginForTree(ctx, logID)
-	if err != storage.ErrLogNeedsInit {
-		t.Errorf("BeginForTree gave %v, want %v", err, storage.ErrLogNeedsInit)
+	if err != storage.ErrTreeNeedsInit {
+		t.Errorf("BeginForTree gave %v, want %v", err, storage.ErrTreeNeedsInit)
 	}
 	commit(tx, t)
 }

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -123,10 +123,10 @@ func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool
 	}
 
 	mtx.root, err = mtx.LatestSignedMapRoot(ctx)
-	if err != nil && err != storage.ErrMapNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, err
 	}
-	if err == storage.ErrMapNeedsInit {
+	if err == storage.ErrTreeNeedsInit {
 		return mtx, err
 	}
 
@@ -249,7 +249,7 @@ func (m *mapTreeTX) GetSignedMapRoot(ctx context.Context, revision int64) (trill
 		&timestamp, &rootHash, &mapRevision, &rootSignatureBytes, &mapperMetaBytes)
 	if err != nil {
 		if revision == 0 {
-			return trillian.SignedMapRoot{}, storage.ErrMapNeedsInit
+			return trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit
 		}
 		return trillian.SignedMapRoot{}, err
 	}
@@ -272,7 +272,7 @@ func (m *mapTreeTX) LatestSignedMapRoot(ctx context.Context) (trillian.SignedMap
 
 	// It's possible there are no roots for this tree yet
 	if err == sql.ErrNoRows {
-		return trillian.SignedMapRoot{}, storage.ErrMapNeedsInit
+		return trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit
 	} else if err != nil {
 		return trillian.SignedMapRoot{}, err
 	}

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -422,7 +422,7 @@ func TestGetSignedMapRootNotExist(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s.BeginForTree(ctx, mapID)
-	if got, want := err, storage.ErrMapNeedsInit; got != want {
+	if got, want := err, storage.ErrTreeNeedsInit; got != want {
 		t.Fatalf("GetSignedMapRoot: %v, want %v", got, want)
 	}
 }
@@ -597,7 +597,7 @@ func createInitializedMapForTests(ctx context.Context, t *testing.T, db *sql.DB)
 
 	s := NewMapStorage(db)
 	tx, err := s.BeginForTree(ctx, mapID)
-	if err != storage.ErrMapNeedsInit {
+	if err != storage.ErrTreeNeedsInit {
 		t.Fatalf("%v: Failed to BeginForTree: %v", mapID, err)
 	}
 	defer tx.Close()

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -259,7 +259,7 @@ func createLogForTests(db *sql.DB) int64 {
 	ctx := context.Background()
 	l := NewLogStorage(db, nil)
 	tx, err := l.BeginForTree(ctx, tree.TreeId)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		panic(fmt.Sprintf("Error creating tree TX: %v", err))
 	}
 

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -212,7 +212,7 @@ func createTree(as storage.AdminStorage, ls storage.LogStorage) (*trillian.Tree,
 	}
 
 	tx, err := ls.BeginForTree(ctx, createdTree.TreeId)
-	if err != nil && err != storage.ErrLogNeedsInit {
+	if err != nil && err != storage.ErrTreeNeedsInit {
 		glog.Fatalf("BeginForTree: %v", err)
 	}
 	if err := tx.StoreSignedLogRoot(ctx, sthZero); err != nil {

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -16,7 +16,12 @@ package storage
 
 import (
 	"context"
+
+	"github.com/google/trillian/errors"
 )
+
+// ErrTreeNeedsInit is returned when calling methods on an uninitialised tree.
+var ErrTreeNeedsInit = errors.New(errors.FailedPrecondition, "tree needs initialising")
 
 // ReadOnlyTreeTX represents a read-only transaction on a TreeStorage.
 // A ReadOnlyTreeTX can only modify the tree specified in its creation.


### PR DESCRIPTION
`MapInit` needs the same fix as #976 

`BeginForTree` may not return an error when the map is uninitialized on all storage implementations. 