### PR TITLE
QueueLeaves on LogStorage

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -206,7 +206,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(params.writeRevision)
 	if params.beginFails {
-		fakeStorage.Err = errors.New("TX")
+		fakeStorage.TXErr = errors.New("TX")
 	} else {
 		mockTx.EXPECT().Close()
 		fakeStorage.TX = mockTx

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -110,34 +110,28 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 			leaf.LeafIdentityHash = leaf.MerkleLeafHash
 		}
 	}
-	var queuedLeaves []*trillian.QueuedLogLeaf
-	err = t.registry.LogStorage.ReadWriteTransaction(ctx, logID, func(ctx context.Context, tx storage.LogTreeTX) error {
-		queuedLeaves = make([]*trillian.QueuedLogLeaf, 0, len(req.Leaves))
-		existingLeaves, err := tx.QueueLeaves(ctx, req.Leaves, t.timeSource.Now())
-		if err != nil {
-			return err
-		}
 
-		for i, existingLeaf := range existingLeaves {
-			if existingLeaf != nil {
-				// Append the existing leaf to the response.
-				queuedLeaf := trillian.QueuedLogLeaf{
-					Leaf:   existingLeaf,
-					Status: status.Newf(codes.AlreadyExists, "Leaf already exists: %v", existingLeaf.LeafIdentityHash).Proto(),
-				}
-				queuedLeaves = append(queuedLeaves, &queuedLeaf)
-				t.leafCounter.Inc("existing")
-			} else {
-				// Return the leaf from the request if it is new.
-				queuedLeaf := trillian.QueuedLogLeaf{Leaf: req.Leaves[i]}
-				queuedLeaves = append(queuedLeaves, &queuedLeaf)
-				t.leafCounter.Inc("new")
-			}
-		}
-		return nil
-	})
+	existingLeaves, err := t.registry.LogStorage.QueueLeaves(ctx, logID, req.Leaves, t.timeSource.Now())
 	if err != nil {
 		return nil, err
+	}
+
+	queuedLeaves := make([]*trillian.QueuedLogLeaf, 0, len(req.Leaves))
+	for i, existingLeaf := range existingLeaves {
+		if existingLeaf != nil {
+			// Append the existing leaf to the response.
+			queuedLeaf := trillian.QueuedLogLeaf{
+				Leaf:   existingLeaf,
+				Status: status.Newf(codes.AlreadyExists, "Leaf already exists: %v", existingLeaf.LeafIdentityHash).Proto(),
+			}
+			queuedLeaves = append(queuedLeaves, &queuedLeaf)
+			t.leafCounter.Inc("existing")
+		} else {
+			// Return the leaf from the request if it is new.
+			queuedLeaf := trillian.QueuedLogLeaf{Leaf: req.Leaves[i]}
+			queuedLeaves = append(queuedLeaves, &queuedLeaf)
+			t.leafCounter.Inc("new")
+		}
 	}
 	return &trillian.QueueLeavesResponse{QueuedLeaves: queuedLeaves}, nil
 }

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -121,8 +121,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 			// There was a pre-existing leaf.
 			t.leafCounter.Inc("existing")
 		} else {
-			// Return the leaf from the request if it is new.
-			ret[i] = &trillian.QueuedLogLeaf{Leaf: req.Leaves[i]}
+			ret[i] = &trillian.QueuedLogLeaf{Leaf: req.Leaves[i], Status: status.Convert(nil).Proto()}
 			t.leafCounter.Inc("new")
 		}
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -367,8 +367,8 @@ func TestQueueLeaves(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	c1 := mockStorage.EXPECT().QueueLeaves(gomock.Any(), queueRequest0.LogId, []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
-	mockStorage.EXPECT().QueueLeaves(gomock.Any(), queueRequest0.LogId, []*trillian.LogLeaf{leaf1}, fakeTime).After(c1).Return([]*trillian.LogLeaf{leaf1}, nil)
+	c1 := mockStorage.EXPECT().QueueLeaves(gomock.Any(), queueRequest0.LogId, []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.QueuedLogLeaf{nil}, nil)
+	mockStorage.EXPECT().QueueLeaves(gomock.Any(), queueRequest0.LogId, []*trillian.LogLeaf{leaf1}, fakeTime).After(c1).Return([]*trillian.QueuedLogLeaf{{Leaf: leaf1, Status: status.Newf(codes.AlreadyExists, "already exists").Proto()}}, nil)
 
 	registry := extension.Registry{
 		AdminStorage: fakeAdminStorage(ctrl, queueRequest0.LogId, 2),

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -384,7 +384,7 @@ func TestQueueLeaves(t *testing.T) {
 		t.Errorf("QueueLeaves() returns %d leaves; want 1", len(rsp.QueuedLeaves))
 	}
 	queuedLeaf := rsp.QueuedLeaves[0]
-	if queuedLeaf.Status != nil && queuedLeaf.Status.Code != int32(code.Code_OK) {
+	if queuedLeaf.Status.Code != int32(code.Code_OK) {
 		t.Errorf("QueueLeaves().Status=%d,nil; want %d,nil", queuedLeaf.Status.Code, code.Code_OK)
 	}
 	if !proto.Equal(queueRequest0.Leaves[0], queuedLeaf.Leaf) {

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -115,6 +115,15 @@ type LogStorage interface {
 	// If f fails and returns an error, the storage implementation may optionally
 	// retry with a new transaction, and f MUST NOT keep state across calls.
 	ReadWriteTransaction(ctx context.Context, treeID int64, f LogTXFunc) error
+
+	// QueueLeaves enqueues leaves for later integration into the tree.
+	// If error is nil, the returned slice of leaves will be the same size as the
+	// input, and each entry will hold:
+	//  - the existing leaf entry if a duplicate has been submitted
+	//  - nil otherwise.
+	// Duplicates are only reported if the underlying tree does not permit duplicates, and are
+	// considered duplicate if their leaf.LeafIdentityHash matches.
+	QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error)
 }
 
 // CountByLogID is a map of total number of items keyed by log ID.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -123,7 +123,7 @@ type LogStorage interface {
 	//  - nil otherwise.
 	// Duplicates are only reported if the underlying tree does not permit duplicates, and are
 	// considered duplicate if their leaf.LeafIdentityHash matches.
-	QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error)
+	QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error)
 }
 
 // CountByLogID is a map of total number of items keyed by log ID.

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -192,6 +192,22 @@ func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (s
 	return tx.(storage.ReadOnlyLogTreeTX), err
 }
 
+func (m *memoryLogStorage) QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+	tx, err := m.beginInternal(ctx, treeID, false /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := tx.QueueLeaves(ctx, leaves, queueTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 type logTreeTX struct {
 	treeTX
 	ls   *memoryLogStorage

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -282,9 +282,9 @@ func (mr *MockLogStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) 
 }
 
 // QueueLeaves mocks base method
-func (m *MockLogStorage) QueueLeaves(arg0 context.Context, arg1 int64, arg2 []*trillian.LogLeaf, arg3 time.Time) ([]*trillian.LogLeaf, error) {
+func (m *MockLogStorage) QueueLeaves(arg0 context.Context, arg1 int64, arg2 []*trillian.LogLeaf, arg3 time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	ret := m.ctrl.Call(m, "QueueLeaves", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]*trillian.LogLeaf)
+	ret0, _ := ret[0].([]*trillian.QueuedLogLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -281,6 +281,19 @@ func (mr *MockLogStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDatabaseAccessible", reflect.TypeOf((*MockLogStorage)(nil).CheckDatabaseAccessible), arg0)
 }
 
+// QueueLeaves mocks base method
+func (m *MockLogStorage) QueueLeaves(arg0 context.Context, arg1 int64, arg2 []*trillian.LogLeaf, arg3 time.Time) ([]*trillian.LogLeaf, error) {
+	ret := m.ctrl.Call(m, "QueueLeaves", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*trillian.LogLeaf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueueLeaves indicates an expected call of QueueLeaves
+func (mr *MockLogStorageMockRecorder) QueueLeaves(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueLeaves", reflect.TypeOf((*MockLogStorage)(nil).QueueLeaves), arg0, arg1, arg2, arg3)
+}
+
 // ReadWriteTransaction mocks base method
 func (m *MockLogStorage) ReadWriteTransaction(arg0 context.Context, arg1 int64, arg2 LogTXFunc) error {
 	ret := m.ctrl.Call(m, "ReadWriteTransaction", arg0, arg1, arg2)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -274,6 +274,22 @@ func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (st
 	return tx.(storage.ReadOnlyLogTreeTX), err
 }
 
+func (m *mySQLLogStorage) QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+	tx, err := m.beginInternal(ctx, treeID, false /* readonly */)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := tx.QueueLeaves(ctx, leaves, queueTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 type logTreeTX struct {
 	treeTX
 	ls   *mySQLLogStorage

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -91,11 +91,11 @@ func (f *FakeLogStorage) ReadWriteTransaction(ctx context.Context, id int64, fn 
 }
 
 // QueueLeaves implements LogStorage.QueueLeaves.
-func (f *FakeLogStorage) QueueLeaves(ctx context.Context, logID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+func (f *FakeLogStorage) QueueLeaves(ctx context.Context, logID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	if f.QueueLeavesErr != nil {
 		return nil, f.QueueLeavesErr
 	}
-	return make([]*trillian.LogLeaf, len(leaves)), nil
+	return make([]*trillian.QueuedLogLeaf, len(leaves)), nil
 }
 
 // CheckDatabaseAccessible implements LogStorage.CheckDatabaseAccessible

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -17,7 +17,9 @@ package testonly
 import (
 	"context"
 	"errors"
+	"time"
 
+	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
 )
 
@@ -59,9 +61,10 @@ var ErrNotImplemented = errors.New("not implemented")
 
 // FakeLogStorage is a LogStorage implementation which is used for testing.
 type FakeLogStorage struct {
-	TX         storage.LogTreeTX
-	ReadOnlyTX storage.ReadOnlyLogTreeTX
-	Err        error
+	TX             storage.LogTreeTX
+	ReadOnlyTX     storage.ReadOnlyLogTreeTX
+	TXErr          error
+	QueueLeavesErr error
 }
 
 // Snapshot implements LogStorage.Snapshot
@@ -76,15 +79,23 @@ func (f *FakeLogStorage) BeginForTree(ctx context.Context, id int64) (storage.Lo
 
 // SnapshotForTree implements LogStorage.SnapshotForTree
 func (f *FakeLogStorage) SnapshotForTree(ctx context.Context, id int64) (storage.ReadOnlyLogTreeTX, error) {
-	return f.ReadOnlyTX, f.Err
+	return f.ReadOnlyTX, f.TXErr
 }
 
 // ReadWriteTransaction implements LogStorage.ReadWriteTransaction
 func (f *FakeLogStorage) ReadWriteTransaction(ctx context.Context, id int64, fn storage.LogTXFunc) error {
-	if f.Err != nil {
-		return f.Err
+	if f.TXErr != nil {
+		return f.TXErr
 	}
 	return RunOnLogTX(f.TX)(ctx, id, fn)
+}
+
+// QueueLeaves implements LogStorage.QueueLeaves.
+func (f *FakeLogStorage) QueueLeaves(ctx context.Context, logID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+	if f.QueueLeavesErr != nil {
+		return nil, f.QueueLeavesErr
+	}
+	return make([]*trillian.LogLeaf, len(leaves)), nil
 }
 
 // CheckDatabaseAccessible implements LogStorage.CheckDatabaseAccessible


### PR DESCRIPTION
Queuing leaves is currently part of the `LogTreeTX` API, but that implies that a batch of leaves should be entirely rejected if there's a duplicate entry within the batch. In reality, current storage implementations quietly ignore this and work to submit the non-duplicate entries.

This PR adds a `LogStorage.QueueLeaves` func which delegates to the original TX-based implementation, and switches `LogRPCServer` over to use it.

We should consider whether there may be a use case for `LogTreeTX.QueueLeaves` to remain, enforcing the strict no-dupes-or-the-whole-batch-fails semantics one would expect; `QueueLeavesRequest` could be extended indicate the requested behaviour and the RPC server could select the appropriate method.