### PR TITLE
First stab at refactor - pass GetOpts through to storage

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -65,8 +65,8 @@ var (
 	QuotaIncreaseFactor = 1.1
 
 	// TODO(Martin2112): Update to add options for sequencing / signing when they exist
-	sequencerOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG}
-	signerOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG}
+	sequencerOpts = trees.GetOpts{TreeType: trillian.TreeType_LOG}
+	signerOpts    = trees.GetOpts{TreeType: trillian.TreeType_LOG}
 )
 
 func quotaIncreaseFactor() float64 {

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -63,6 +63,10 @@ var (
 	// configuration should be changed instead.
 	// A factor <1 WILL lead to token shortages, therefore it'll be normalized to 1.
 	QuotaIncreaseFactor = 1.1
+
+	// TODO(Martin2112): Update to add options for sequencing / signing when they exist
+	sequencerOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG}
+	signerOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG}
 )
 
 func quotaIncreaseFactor() float64 {
@@ -291,8 +295,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 	start := s.timeSource.Now()
 	stageStart := start
 	label := strconv.FormatInt(logID, 10)
-	// TODO(Martin2112): Update to add options for sequencing when they exist
-	tx, err := s.logStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := s.logStorage.BeginForTree(ctx, logID, sequencerOpts)
 	if err != nil {
 		glog.Warningf("%v: Sequencer failed to start tx: %v", logID, err)
 		return 0, err
@@ -447,8 +450,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 
 // SignRoot wraps up all the operations for creating a new log signed root.
 func (s Sequencer) SignRoot(ctx context.Context, logID int64) error {
-	// TODO(Martin2112): Update to add options for signing if necessary
-	tx, err := s.logStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := s.logStorage.BeginForTree(ctx, logID, signerOpts)
 	if err != nil {
 		glog.Warningf("%v: signer failed to start tx: %v", logID, err)
 		return err

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/trees"
 	"github.com/google/trillian/util"
 )
 
@@ -290,7 +291,8 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 	start := s.timeSource.Now()
 	stageStart := start
 	label := strconv.FormatInt(logID, 10)
-	tx, err := s.logStorage.BeginForTree(ctx, logID)
+	// TODO(Martin2112): Update to add options for sequencing when they exist
+	tx, err := s.logStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != nil {
 		glog.Warningf("%v: Sequencer failed to start tx: %v", logID, err)
 		return 0, err
@@ -445,7 +447,8 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 
 // SignRoot wraps up all the operations for creating a new log signed root.
 func (s Sequencer) SignRoot(ctx context.Context, logID int64) error {
-	tx, err := s.logStorage.BeginForTree(ctx, logID)
+	// TODO(Martin2112): Update to add options for signing if necessary
+	tx, err := s.logStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != nil {
 		glog.Warningf("%v: signer failed to start tx: %v", logID, err)
 		return err

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -204,7 +204,7 @@ func newSignerWithErr(signErr error) (gocrypto.Signer, error) {
 func createTestContext(ctrl *gomock.Controller, params testParameters) (testContext, context.Context) {
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	opts := trees.GetOpts{TreeType:trillian.TreeType_LOG}
+	opts := trees.GetOpts{TreeType: trillian.TreeType_LOG}
 
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(params.writeRevision)
 	if params.beginFails {

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -307,7 +307,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 
 	{
 		ls := mysql.NewLogStorage(db, nil)
-		tx, err := ls.BeginForTree(ctx, tree.TreeId)
+		tx, err := ls.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 		if err != nil && err != storage.ErrTreeNeedsInit {
 			return nil, err
 		}
@@ -348,7 +348,7 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 	}
 
 	ls := mysql.NewLogStorage(db, nil)
-	tx, err := ls.BeginForTree(ctx, tree.TreeId)
+	tx, err := ls.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil {
 		return err
 	}

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -307,7 +307,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 
 	{
 		ls := mysql.NewLogStorage(db, nil)
-		tx, err := ls.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+		tx, err := ls.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 		if err != nil && err != storage.ErrTreeNeedsInit {
 			return nil, err
 		}

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -155,7 +155,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 
 	if info.getTree {
 		tree, err := trees.GetTree(
-			ctx, getterFor(tp.parent.admin), info.treeID, trees.GetOpts{TreeType: info.treeType, Readonly: info.readonly})
+			ctx, storage.GetterFor(tp.parent.admin), info.treeID, trees.GetOpts{TreeType: info.treeType, Readonly: info.readonly})
 		if err != nil {
 			incRequestDeniedCounter(badTreeReason, info.treeID, quotaUser)
 			return ctx, err
@@ -184,12 +184,6 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 	}
 
 	return ctx, nil
-}
-
-func getterFor(s storage.AdminStorage) trees.TreeGetter {
-	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-		return storage.GetTree(ctx, s, treeID)
-	}
 }
 
 func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, handlerErr error) {

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -155,7 +155,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 
 	if info.getTree {
 		tree, err := trees.GetTree(
-			ctx, tp.parent.admin, info.treeID, trees.GetOpts{TreeType: info.treeType, Readonly: info.readonly})
+			ctx, getterFor(tp.parent.admin), info.treeID, trees.GetOpts{TreeType: info.treeType, Readonly: info.readonly})
 		if err != nil {
 			incRequestDeniedCounter(badTreeReason, info.treeID, quotaUser)
 			return ctx, err
@@ -184,6 +184,12 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 	}
 
 	return ctx, nil
+}
+
+func getterFor(s storage.AdminStorage) trees.TreeGetter {
+	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+		return storage.GetTree(ctx, s, treeID)
+	}
 }
 
 func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, handlerErr error) {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -503,16 +503,10 @@ func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTr
 	return fetchNodesAndBuildProof(ctx, tx, hasher, tx.ReadRevision(), leafIndex, proofNodeIDs)
 }
 
-func getterFor(s storage.AdminStorage) trees.TreeGetter {
-	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-		return storage.GetTree(ctx, s, treeID)
-	}
-}
-
 func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, hashers.LogHasher, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		getterFor(t.registry.AdminStorage),
+		storage.GetterFor(t.registry.AdminStorage),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
 	if err != nil {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -42,6 +42,9 @@ type TrillianLogRPCServer struct {
 	leafCounter monitoring.Counter
 }
 
+var getOptsWrite = trees.GetOpts{TreeType:trillian.TreeType_LOG}
+var getOptsRead = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true}
+
 // NewTrillianLogRPCServer creates a new RPC server backed by a LogStorageProvider.
 func NewTrillianLogRPCServer(registry extension.Registry, timeSource util.TimeSource) *TrillianLogRPCServer {
 	mf := registry.MetricFactory
@@ -111,7 +114,7 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 		}
 	}
 
-	tx, err := t.prepareStorageTx(ctx, logID)
+	tx, err := t.prepareStorageTx(ctx, logID, getOptsWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +165,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +204,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +259,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 	}
 	ctx = trees.NewContext(ctx, tree)
 
-	tx, err := t.prepareReadOnlyStorageTx(ctx, logID)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, logID, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +293,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 // GetLatestSignedLogRoot obtains the latest published tree root for the Merkle Tree that
 // underlies the log.
 func (t *TrillianLogRPCServer) GetLatestSignedLogRoot(ctx context.Context, req *trillian.GetLatestSignedLogRootRequest) (*trillian.GetLatestSignedLogRootResponse, error) {
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +314,7 @@ func (t *TrillianLogRPCServer) GetLatestSignedLogRoot(ctx context.Context, req *
 // GetSequencedLeafCount returns the number of leaves that have been integrated into the Merkle
 // Tree. This can be zero for a log containing no entries.
 func (t *TrillianLogRPCServer) GetSequencedLeafCount(ctx context.Context, req *trillian.GetSequencedLeafCountRequest) (*trillian.GetSequencedLeafCountResponse, error) {
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +341,7 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 		return nil, err
 	}
 
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +367,7 @@ func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trilli
 		return nil, err
 	}
 
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +393,7 @@ func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillia
 		return nil, err
 	}
 
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +429,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
-	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId)
+	tx, err := t.prepareReadOnlyStorageTx(ctx, req.LogId, getOptsRead)
 	if err != nil {
 		return nil, err
 	}
@@ -463,16 +466,16 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 	}, nil
 }
 
-func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	tx, err := t.registry.LogStorage.BeginForTree(ctx, treeID)
+func (t *TrillianLogRPCServer) prepareStorageTx(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.LogTreeTX, error) {
+	tx, err := t.registry.LogStorage.BeginForTree(ctx, treeID, opts)
 	if err != nil {
 		return nil, err
 	}
 	return tx, err
 }
 
-func (t *TrillianLogRPCServer) prepareReadOnlyStorageTx(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
-	tx, err := t.registry.LogStorage.SnapshotForTree(ctx, treeID)
+func (t *TrillianLogRPCServer) prepareReadOnlyStorageTx(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.ReadOnlyLogTreeTX, error) {
+	tx, err := t.registry.LogStorage.SnapshotForTree(ctx, treeID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -500,10 +503,16 @@ func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTr
 	return fetchNodesAndBuildProof(ctx, tx, hasher, tx.ReadRevision(), leafIndex, proofNodeIDs)
 }
 
+func getterFor(s storage.AdminStorage) trees.TreeGetter {
+	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+		return storage.GetTree(ctx, s, treeID)
+	}
+}
+
 func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, hashers.LogHasher, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		t.registry.AdminStorage,
+		getterFor(t.registry.AdminStorage),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
 	if err != nil {
@@ -524,7 +533,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 		return nil, status.Errorf(codes.FailedPrecondition, "getTreeAndHasher(): %v", err)
 	}
 
-	tx, err := t.registry.LogStorage.BeginForTree(ctx, logID)
+	tx, err := t.registry.LogStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:false})
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, status.Errorf(codes.FailedPrecondition, "BeginForTree(): %v", err)
 	}
@@ -570,5 +579,8 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 	return &trillian.InitLogResponse{
 		Created: &newRoot,
 	}, nil
+}
 
+func logOpts() trees.GetOpts {
+	return trees.GetOpts{TreeType:trillian.TreeType_LOG}
 }

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -42,8 +42,8 @@ type TrillianLogRPCServer struct {
 	leafCounter monitoring.Counter
 }
 
-var getOptsWrite = trees.GetOpts{TreeType:trillian.TreeType_LOG}
-var getOptsRead = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true}
+var getOptsWrite = trees.GetOpts{TreeType: trillian.TreeType_LOG}
+var getOptsRead = trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}
 
 // NewTrillianLogRPCServer creates a new RPC server backed by a LogStorageProvider.
 func NewTrillianLogRPCServer(registry extension.Registry, timeSource util.TimeSource) *TrillianLogRPCServer {
@@ -527,7 +527,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 		return nil, status.Errorf(codes.FailedPrecondition, "getTreeAndHasher(): %v", err)
 	}
 
-	tx, err := t.registry.LogStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:false})
+	tx, err := t.registry.LogStorage.BeginForTree(ctx, logID, trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: false})
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		return nil, status.Errorf(codes.FailedPrecondition, "BeginForTree(): %v", err)
 	}
@@ -573,8 +573,4 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 	return &trillian.InitLogResponse{
 		Created: &newRoot,
 	}, nil
-}
-
-func logOpts() trees.GetOpts {
-	return trees.GetOpts{TreeType:trillian.TreeType_LOG}
 }

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -99,8 +99,8 @@ var (
 	nodeIdsConsistencySize4ToSize7 = []storage.NodeID{stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64)}
 
 	// Don't reuse the same options variables from the code being tested or it would always pass
-	getOptsRTest = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly: true}
-	getOptsWTest = trees.GetOpts{TreeType:trillian.TreeType_LOG}
+	getOptsRTest = trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}
+	getOptsWTest = trees.GetOpts{TreeType: trillian.TreeType_LOG}
 )
 
 func TestGetLeavesByIndexBeginFailsCausesError(t *testing.T) {
@@ -418,7 +418,7 @@ func TestQueueLeaves(t *testing.T) {
 
 	// Repeating the operation gives ALREADY_EXISTS.
 	server.registry.AdminStorage = mockAdminStorage(ctrl, queueRequest0.LogId)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsRTest).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsWTest).Return(mockTx, nil)
 	mockTx.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -98,8 +98,9 @@ var (
 
 	nodeIdsConsistencySize4ToSize7 = []storage.NodeID{stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64)}
 
-	getOptsRead = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly: false}
-	getOptsWrite = trees.GetOpts{TreeType:trillian.TreeType_LOG}
+	// Don't reuse the same options variables from the code being tested or it would always pass
+	getOptsRTest = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly: true}
+	getOptsWTest = trees.GetOpts{TreeType:trillian.TreeType_LOG}
 )
 
 func TestGetLeavesByIndexBeginFailsCausesError(t *testing.T) {
@@ -107,7 +108,7 @@ func TestGetLeavesByIndexBeginFailsCausesError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId, getOptsRead).Return(nil, errors.New("TX"))
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId, getOptsRTest).Return(nil, errors.New("TX"))
 	registry := extension.Registry{
 		AdminStorage: mockAdminStorage(ctrl, leaf0Request.LogId),
 		LogStorage:   mockStorage,
@@ -172,7 +173,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf0Request.LogId, getOptsRTest).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -200,7 +201,7 @@ func TestGetLeavesByIndexMultiple(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf03Request.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), leaf03Request.LogId, getOptsRTest).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0, 3}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -296,9 +297,9 @@ func TestGetLeavesByRange(t *testing.T) {
 		if !test.skipTX {
 			mockTx := storage.NewMockLogTreeTX(ctrl)
 			if test.txErr != nil {
-				mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRead).Return(nil, test.txErr)
+				mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRTest).Return(nil, test.txErr)
 			} else {
-				mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRead).Return(mockTx, nil)
+				mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRTest).Return(mockTx, nil)
 				if test.getErr != nil {
 					mockTx.EXPECT().GetLeavesByRange(gomock.Any(), test.start, test.count).Return(nil, test.getErr)
 				} else {
@@ -387,7 +388,7 @@ func TestQueueLeaves(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsWTest).Return(mockTx, nil)
 	mockTx.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{nil}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -417,7 +418,7 @@ func TestQueueLeaves(t *testing.T) {
 
 	// Repeating the operation gives ALREADY_EXISTS.
 	server.registry.AdminStorage = mockAdminStorage(ctrl, queueRequest0.LogId)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), queueRequest0.LogId, getOptsRTest).Return(mockTx, nil)
 	mockTx.EXPECT().QueueLeaves(gomock.Any(), []*trillian.LogLeaf{leaf1}, fakeTime).Return([]*trillian.LogLeaf{leaf1}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -506,7 +507,7 @@ func TestGetLatestSignedLogRoot2(t *testing.T) {
 		mockStorage := storage.NewMockLogStorage(ctrl)
 		mockTx := storage.NewMockLogTreeTX(ctrl)
 		if !test.noSnap {
-			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.LogId, getOptsRead).Return(mockTx, test.snapErr)
+			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.LogId, getOptsRTest).Return(mockTx, test.snapErr)
 		}
 		if !test.noRoot {
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(test.storageRoot, test.rootErr)
@@ -546,7 +547,7 @@ func TestGetLeavesByHashBeginFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId, getOptsRead).Return(nil, errors.New("TX"))
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId, getOptsRTest).Return(nil, errors.New("TX"))
 	registry := extension.Registry{
 		AdminStorage: mockAdminStorage(ctrl, getByHashRequest1.LogId),
 		LogStorage:   mockStorage,
@@ -611,7 +612,7 @@ func TestGetLeavesByHash(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getByHashRequest1.LogId, getOptsRTest).Return(mockTx, nil)
 	mockTx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
@@ -687,7 +688,7 @@ func TestGetProofByHashWrongNodeCountFetched(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -714,7 +715,7 @@ func TestGetProofByHashWrongNodeReturned(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -760,7 +761,7 @@ func TestGetProofByHash(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -839,7 +840,7 @@ func TestGetProofByIndexWrongNodeCountFetched(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByHashRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	// The server expects three nodes from storage but we return only two
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
@@ -865,7 +866,7 @@ func TestGetProofByIndexWrongNodeReturned(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	// We set this up so one of the returned nodes has the wrong ID
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
@@ -909,7 +910,7 @@ func TestGetProofByIndex(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getInclusionProofByIndexRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -954,7 +955,7 @@ func TestGetEntryAndProofBeginTXFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest17.LogId, getOptsRead).Return(nil, errors.New("BeginTX"))
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest17.LogId, getOptsRTest).Return(nil, errors.New("BeginTX"))
 	registry := extension.Registry{
 		AdminStorage: mockAdminStorage(ctrl, getEntryAndProofRequest17.LogId),
 		LogStorage:   mockStorage,
@@ -973,7 +974,7 @@ func TestGetEntryAndProofGetMerkleNodesFails(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -998,7 +999,7 @@ func TestGetEntryAndProofGetLeavesFails(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -1027,7 +1028,7 @@ func TestGetEntryAndProofGetLeavesReturnsMultiple(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -1057,7 +1058,7 @@ func TestGetEntryAndProofCommitFails(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -1087,7 +1088,7 @@ func TestGetEntryAndProof(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), getEntryAndProofRequest7.LogId, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 	mockTx.EXPECT().ReadRevision().Return(signedRoot1.TreeRevision)
@@ -1182,7 +1183,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 
 	mockStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockLogTreeTX(ctrl)
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID1, getOptsRead).Return(mockTx, nil)
+	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID1, getOptsRTest).Return(mockTx, nil)
 
 	mockTx.EXPECT().GetSequencedLeafCount(gomock.Any()).Return(int64(268), nil)
 	mockTx.EXPECT().Commit().Return(nil)
@@ -1311,7 +1312,7 @@ func TestGetConsistencyProof(t *testing.T) {
 		mockStorage := storage.NewMockLogStorage(ctrl)
 		mockTx := storage.NewMockLogTreeTX(ctrl)
 		if !test.noSnap {
-			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.LogId, getOptsRead).Return(mockTx, test.snapErr)
+			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.LogId, getOptsRTest).Return(mockTx, test.snapErr)
 		}
 		if !test.noRoot {
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, test.rootErr)
@@ -1696,7 +1697,7 @@ func TestInitLog(t *testing.T) {
 
 			mockStorage := storage.NewMockLogStorage(ctrl)
 			mockTx := storage.NewMockLogTreeTX(ctrl)
-			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID1, getOptsWrite).Return(mockTx, tc.txErr)
+			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID1, getOptsWTest).Return(mockTx, tc.txErr)
 			mockTx.EXPECT().IsOpen().AnyTimes().Return(false)
 			mockTx.EXPECT().Close().Return(nil)
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(trillian.SignedLogRoot{
@@ -1761,9 +1762,9 @@ func (p *parameterizedTest) executeCommitFailsTest(t *testing.T, logID int64) {
 
 	switch p.mode {
 	case readOnly:
-		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRead).Return(mockTx, nil)
+		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRTest).Return(mockTx, nil)
 	case readWrite:
-		mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWrite).Return(mockTx, nil)
+		mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWTest).Return(mockTx, nil)
 	}
 	p.prepareTx(mockTx)
 	mockTx.EXPECT().Commit().Return(errors.New("bang"))
@@ -1792,9 +1793,9 @@ func (p *parameterizedTest) executeInvalidLogIDTest(t *testing.T, snapshot bool)
 
 	mockStorage := storage.NewMockLogStorage(p.ctrl)
 	if ctx, logID := gomock.Any(), int64(2); snapshot {
-		mockStorage.EXPECT().SnapshotForTree(ctx, logID, getOptsRead).MaxTimes(1).Return(nil, badLogErr)
+		mockStorage.EXPECT().SnapshotForTree(ctx, logID, getOptsRTest).MaxTimes(1).Return(nil, badLogErr)
 	} else {
-		mockStorage.EXPECT().BeginForTree(ctx, logID, getOptsWrite).MaxTimes(1).Return(nil, badLogErr)
+		mockStorage.EXPECT().BeginForTree(ctx, logID, getOptsWTest).MaxTimes(1).Return(nil, badLogErr)
 	}
 
 	registry := extension.Registry{
@@ -1815,9 +1816,9 @@ func (p *parameterizedTest) executeStorageFailureTest(t *testing.T, logID int64)
 
 	switch p.mode {
 	case readOnly:
-		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRead).Return(mockTx, nil)
+		mockStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRTest).Return(mockTx, nil)
 	case readWrite:
-		mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWrite).Return(mockTx, nil)
+		mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWTest).Return(mockTx, nil)
 	}
 	p.prepareTx(mockTx)
 	mockTx.EXPECT().Close().Return(nil)
@@ -1839,9 +1840,9 @@ func (p *parameterizedTest) executeBeginFailsTest(t *testing.T, logID int64) {
 
 	switch p.mode {
 	case readOnly:
-		logStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRead).Return(logTX, errors.New("TX"))
+		logStorage.EXPECT().SnapshotForTree(gomock.Any(), logID, getOptsRTest).Return(logTX, errors.New("TX"))
 	case readWrite:
-		logStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWrite).Return(logTX, errors.New("TX"))
+		logStorage.EXPECT().BeginForTree(gomock.Any(), logID, getOptsWTest).Return(logTX, errors.New("TX"))
 	}
 
 	registry := extension.Registry{

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -308,7 +308,7 @@ func (t *TrillianMapServer) GetSignedMapRootByRevision(ctx context.Context, req 
 func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, hashers.MapHasher, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		getterFor(t.registry.AdminStorage),
+		storage.GetterFor(t.registry.AdminStorage),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
 	if err != nil {

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -308,7 +308,7 @@ func (t *TrillianMapServer) GetSignedMapRootByRevision(ctx context.Context, req 
 func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, readonly bool) (*trillian.Tree, hashers.MapHasher, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		t.registry.AdminStorage,
+		getterFor(t.registry.AdminStorage),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
 	if err != nil {

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/trees"
 )
 
@@ -61,7 +62,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 	// sequencing related write - when this exists.
 	tree, err := trees.GetTree(
 		ctx,
-		getterFor(s.registry.AdminStorage),
+		storage.GetterFor(s.registry.AdminStorage),
 		logID,
 		trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil {

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -57,10 +57,11 @@ func (s *SequencerManager) Name() string {
 func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *LogOperationInfo) (int, error) {
 	// TODO(Martin2112): Honor the sequencing enabled in log parameters, needs an API change
 	// so deferring it
-
+	// TODO(Martin2112): Should pass an option to indicate this is a
+	// sequencing related write - when this exists.
 	tree, err := trees.GetTree(
 		ctx,
-		s.registry.AdminStorage,
+		getterFor(s.registry.AdminStorage),
 		logID,
 		trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil {

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/trees"
 	"github.com/google/trillian/util"
 )
 
@@ -86,6 +87,8 @@ var updatedRoot = trillian.SignedLogRoot{
 
 var zeroDuration = 0 * time.Second
 
+var seqOptsTest = trees.GetOpts{TreeType: trillian.TreeType_LOG}
+
 const writeRev = int64(24)
 
 // newSignerWithFixedSig returns a fake signer that always returns the specified signature.
@@ -126,7 +129,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, seqOptsTest).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
@@ -188,7 +191,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 		)
 
 		gomock.InOrder(
-			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil),
+			mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, seqOptsTest).Return(mockTx, nil),
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),
@@ -280,7 +283,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), []*trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(gomock.Any(), updatedNodes0).Return(nil)
 	mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), updatedRoot).Return(nil)
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, seqOptsTest).Return(mockTx, nil)
 
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
@@ -321,7 +324,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID).Return(mockTx, nil)
+	mockStorage.EXPECT().BeginForTree(gomock.Any(), logID, seqOptsTest).Return(mockTx, nil)
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -18,7 +18,9 @@ import (
 	"context"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/trees"
 )
+
 
 // GetTree reads a tree from storage using a snapshot transaction.
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.
@@ -30,6 +32,14 @@ func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.T
 		return
 	})
 	return tree, err
+}
+
+// GetterFor returns a function that can be passed to trees.GetTree() using
+// a specified AdminStorage as backing storage.
+func GetterFor(admin AdminStorage) trees.TreeGetter {
+	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+		return GetTree(ctx, admin, treeID)
+	}
 }
 
 // ListTrees reads trees from storage using a snapshot transaction.

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/trillian/trees"
 )
 
-
 // GetTree reads a tree from storage using a snapshot transaction.
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.
 // See RunInAdminSnapshot if you need to perform more than one action per transaction.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/trees"
 )
 
 // ReadOnlyLogTX provides a read-only view into log data.
@@ -100,7 +101,7 @@ type ReadOnlyLogStorage interface {
 	// Commit must be called when the caller is finished with the returned object,
 	// and values read through it should only be propagated if Commit returns
 	// without error.
-	SnapshotForTree(ctx context.Context, treeID int64) (ReadOnlyLogTreeTX, error)
+	SnapshotForTree(ctx context.Context, treeID int64, opts trees.GetOpts) (ReadOnlyLogTreeTX, error)
 }
 
 // LogStorage should be implemented by concrete storage mechanisms which want to support Logs.
@@ -111,7 +112,7 @@ type LogStorage interface {
 	// Either Commit or Rollback must be called when the caller is finished with
 	// the returned object, and values read through it should only be propagated
 	// if Commit returns without error.
-	BeginForTree(ctx context.Context, treeID int64) (LogTreeTX, error)
+	BeginForTree(ctx context.Context, treeID int64, opts trees.GetOpts) (LogTreeTX, error)
 }
 
 // CountByLogID is a map of total number of items keyed by log ID.

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -131,12 +131,6 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return ret, nil
 }
 
-func getterFor(s storage.AdminStorage) trees.TreeGetter {
-	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-		return storage.GetTree(ctx, s, treeID)
-	}
-}
-
 func (m *memoryLogStorage) beginInternal(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.LogTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
@@ -144,7 +138,7 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, treeID int64, opts
 	if opts.TreeType != trillian.TreeType_LOG {
 		return nil, fmt.Errorf("beginInternal tree id %d, got: %v, want TreeType_LOG,", treeID, opts.TreeType)
 	}
-	tree, err := trees.GetTree(ctx, getterFor(m.admin), treeID, opts)
+	tree, err := trees.GetTree(ctx, storage.GetterFor(m.admin), treeID, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/storagepb"
+	"github.com/google/trillian/trees"
 )
 
 const degree = 8
@@ -126,12 +127,12 @@ func newTree(t trillian.Tree) *tree {
 	return ret
 }
 
-func (m *memoryTreeStorage) beginTreeTX(ctx context.Context, readonly bool, treeID int64, hashSizeBytes int, cache cache.SubtreeCache) (treeTX, error) {
+func (m *memoryTreeStorage) beginTreeTX(ctx context.Context, opts trees.GetOpts, treeID int64, hashSizeBytes int, cache cache.SubtreeCache) (treeTX, error) {
 	tree := m.getTree(treeID)
 	// Lock the tree for the duration of the TX.
 	// It will be unlocked by a call to Commit or Rollback.
 	var unlock func()
-	if readonly {
+	if opts.Readonly {
 		tree.RLock()
 		unlock = tree.RUnlock
 	} else {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	trillian "github.com/google/trillian"
+	trees "github.com/google/trillian/trees"
 	reflect "reflect"
 	time "time"
 )
@@ -271,16 +272,16 @@ func (m *MockLogStorage) EXPECT() *MockLogStorageMockRecorder {
 }
 
 // BeginForTree mocks base method
-func (m *MockLogStorage) BeginForTree(arg0 context.Context, arg1 int64) (LogTreeTX, error) {
-	ret := m.ctrl.Call(m, "BeginForTree", arg0, arg1)
+func (m *MockLogStorage) BeginForTree(arg0 context.Context, arg1 int64, arg2 trees.GetOpts) (LogTreeTX, error) {
+	ret := m.ctrl.Call(m, "BeginForTree", arg0, arg1, arg2)
 	ret0, _ := ret[0].(LogTreeTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BeginForTree indicates an expected call of BeginForTree
-func (mr *MockLogStorageMockRecorder) BeginForTree(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginForTree", reflect.TypeOf((*MockLogStorage)(nil).BeginForTree), arg0, arg1)
+func (mr *MockLogStorageMockRecorder) BeginForTree(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginForTree", reflect.TypeOf((*MockLogStorage)(nil).BeginForTree), arg0, arg1, arg2)
 }
 
 // CheckDatabaseAccessible mocks base method
@@ -309,16 +310,16 @@ func (mr *MockLogStorageMockRecorder) Snapshot(arg0 interface{}) *gomock.Call {
 }
 
 // SnapshotForTree mocks base method
-func (m *MockLogStorage) SnapshotForTree(arg0 context.Context, arg1 int64) (ReadOnlyLogTreeTX, error) {
-	ret := m.ctrl.Call(m, "SnapshotForTree", arg0, arg1)
+func (m *MockLogStorage) SnapshotForTree(arg0 context.Context, arg1 int64, arg2 trees.GetOpts) (ReadOnlyLogTreeTX, error) {
+	ret := m.ctrl.Call(m, "SnapshotForTree", arg0, arg1, arg2)
 	ret0, _ := ret[0].(ReadOnlyLogTreeTX)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SnapshotForTree indicates an expected call of SnapshotForTree
-func (mr *MockLogStorageMockRecorder) SnapshotForTree(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnapshotForTree", reflect.TypeOf((*MockLogStorage)(nil).SnapshotForTree), arg0, arg1)
+func (mr *MockLogStorageMockRecorder) SnapshotForTree(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnapshotForTree", reflect.TypeOf((*MockLogStorage)(nil).SnapshotForTree), arg0, arg1, arg2)
 }
 
 // MockLogTreeTX is a mock of LogTreeTX interface

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -212,15 +212,20 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return ids, rows.Err()
 }
 
-func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, readonly bool) (storage.LogTreeTX, error) {
+func getterFor(s storage.AdminStorage) trees.TreeGetter {
+	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+		return storage.GetTree(ctx, s, treeID)
+	}
+}
+
+func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.LogTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	tree, err := trees.GetTree(
-		ctx,
-		m.admin,
-		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+	if opts.TreeType != trillian.TreeType_LOG {
+		return nil, fmt.Errorf("beginInternal tree id %d, got: %v, want TreeType_LOG,", treeID, opts.TreeType)
+	}
+	tree, err := trees.GetTree(ctx, getterFor(m.admin), treeID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -254,12 +259,15 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 	return ltx, nil
 }
 
-func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64) (storage.LogTreeTX, error) {
-	return m.beginInternal(ctx, treeID, false /* readonly */)
+func (m *mySQLLogStorage) BeginForTree(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.LogTreeTX, error) {
+	return m.beginInternal(ctx, treeID, opts)
 }
 
-func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
-	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
+func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.ReadOnlyLogTreeTX, error) {
+	if !opts.Readonly {
+		return nil, errors.New("mysql SnapshotForTree(): got: readonly false, want: true")
+	}
+	tx, err := m.beginInternal(ctx, treeID, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -212,12 +212,6 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return ids, rows.Err()
 }
 
-func getterFor(s storage.AdminStorage) trees.TreeGetter {
-	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-		return storage.GetTree(ctx, s, treeID)
-	}
-}
-
 func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, opts trees.GetOpts) (storage.LogTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
@@ -225,7 +219,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, opts 
 	if opts.TreeType != trillian.TreeType_LOG {
 		return nil, fmt.Errorf("beginInternal tree id %d, got: %v, want TreeType_LOG,", treeID, opts.TreeType)
 	}
-	tree, err := trees.GetTree(ctx, getterFor(m.admin), treeID, opts)
+	tree, err := trees.GetTree(ctx, storage.GetterFor(m.admin), treeID, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/trees"
 	"github.com/kylelemons/godebug/pretty"
 
 	spb "github.com/google/trillian/crypto/sigpb"
@@ -201,9 +202,9 @@ func TestBeginSnapshot(t *testing.T) {
 			var tx storage.ReadOnlyLogTreeTX
 			var err error
 			if test.snapshot {
-				tx, err = s.SnapshotForTree(ctx, test.logID)
+				tx, err = s.SnapshotForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 			} else {
-				tx, err = s.BeginForTree(ctx, test.logID)
+				tx, err = s.BeginForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 			}
 
 			if hasErr := err != nil; hasErr != test.wantErr {
@@ -880,7 +881,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	logID := tree.TreeId
 	s := NewLogStorage(DB, nil)
 
-	tx, err := s.BeginForTree(ctx, logID)
+	tx, err := s.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != storage.ErrTreeNeedsInit {
 		t.Errorf("BeginForTree gave %v, want %v", err, storage.ErrTreeNeedsInit)
 	}
@@ -1276,7 +1277,7 @@ func createTestLeaves(n, startSeq int64) []*trillian.LogLeaf {
 // Convenience methods to avoid copying out "if err != nil { blah }" all over the place
 func beginLogTx(s storage.LogStorage, logID int64, t *testing.T) storage.LogTreeTX {
 	t.Helper()
-	tx, err := s.BeginForTree(context.Background(), logID)
+	tx, err := s.BeginForTree(context.Background(), logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != nil {
 		t.Fatalf("Failed to begin log tx: %v", err)
 	}

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -202,7 +202,7 @@ func TestBeginSnapshot(t *testing.T) {
 			var tx storage.ReadOnlyLogTreeTX
 			var err error
 			if test.snapshot {
-				tx, err = s.SnapshotForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+				tx, err = s.SnapshotForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true})
 			} else {
 				tx, err = s.BeginForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 			}

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -202,9 +202,9 @@ func TestBeginSnapshot(t *testing.T) {
 			var tx storage.ReadOnlyLogTreeTX
 			var err error
 			if test.snapshot {
-				tx, err = s.SnapshotForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true})
+				tx, err = s.SnapshotForTree(ctx, test.logID, trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true})
 			} else {
-				tx, err = s.BeginForTree(ctx, test.logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+				tx, err = s.BeginForTree(ctx, test.logID, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 			}
 
 			if hasErr := err != nil; hasErr != test.wantErr {
@@ -881,7 +881,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	logID := tree.TreeId
 	s := NewLogStorage(DB, nil)
 
-	tx, err := s.BeginForTree(ctx, logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := s.BeginForTree(ctx, logID, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != storage.ErrTreeNeedsInit {
 		t.Errorf("BeginForTree gave %v, want %v", err, storage.ErrTreeNeedsInit)
 	}
@@ -1277,7 +1277,7 @@ func createTestLeaves(n, startSeq int64) []*trillian.LogLeaf {
 // Convenience methods to avoid copying out "if err != nil { blah }" all over the place
 func beginLogTx(s storage.LogStorage, logID int64, t *testing.T) storage.LogTreeTX {
 	t.Helper()
-	tx, err := s.BeginForTree(context.Background(), logID, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := s.BeginForTree(context.Background(), logID, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil {
 		t.Fatalf("Failed to begin log tx: %v", err)
 	}

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -100,7 +100,7 @@ func (t *readOnlyMapTX) Close() error {
 func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool) (storage.MapTreeTX, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		m.admin,
+		getterFor(m.admin),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
 	if err != nil {

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -100,7 +100,7 @@ func (t *readOnlyMapTX) Close() error {
 func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool) (storage.MapTreeTX, error) {
 	tree, err := trees.GetTree(
 		ctx,
-		getterFor(m.admin),
+		storage.GetterFor(m.admin),
 		treeID,
 		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
 	if err != nil {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -259,7 +259,7 @@ func createLogForTests(db *sql.DB) int64 {
 
 	ctx := context.Background()
 	l := NewLogStorage(db, nil)
-	tx, err := l.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := l.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		panic(fmt.Sprintf("Error creating tree TX: %v", err))
 	}

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testdb"
+	"github.com/google/trillian/trees"
 
 	storageto "github.com/google/trillian/storage/testonly"
 )
@@ -258,7 +259,7 @@ func createLogForTests(db *sql.DB) int64 {
 
 	ctx := context.Background()
 	l := NewLogStorage(db, nil)
-	tx, err := l.BeginForTree(ctx, tree.TreeId)
+	tx, err := l.BeginForTree(ctx, tree.TreeId, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		panic(fmt.Sprintf("Error creating tree TX: %v", err))
 	}

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -59,7 +59,7 @@ var (
 // A 32 bit magic number that is written at the start of record io files to identify the format.
 const recordIOMagic int32 = 0x3ed7230a
 
-var getOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true}
+var getOpts = trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true}
 
 type treeAndRev struct {
 	fullKey  string

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -59,6 +59,8 @@ var (
 // A 32 bit magic number that is written at the start of record io files to identify the format.
 const recordIOMagic int32 = 0x3ed7230a
 
+var getOpts = trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true}
+
 type treeAndRev struct {
 	fullKey  string
 	subtree  *storagepb.SubtreeProto
@@ -211,7 +213,7 @@ func createTree(as storage.AdminStorage, ls storage.LogStorage) (*trillian.Tree,
 		glog.Fatalf("SignLogRoot: %v", err)
 	}
 
-	tx, err := ls.BeginForTree(ctx, createdTree.TreeId)
+	tx, err := ls.BeginForTree(ctx, createdTree.TreeId, getOpts)
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		glog.Fatalf("BeginForTree: %v", err)
 	}
@@ -256,7 +258,7 @@ func Main(args Options) string {
 	sequenceLeaves(ls, seq, tree.TreeId, args.TreeSize, args.BatchSize, args.LeafFormat)
 
 	// Read the latest STH back
-	tx, err := ls.BeginForTree(context.TODO(), tree.TreeId)
+	tx, err := ls.BeginForTree(context.TODO(), tree.TreeId, getOpts)
 	if err != nil {
 		glog.Fatalf("BeginForTree got: %v, want: no err", err)
 	}
@@ -384,7 +386,7 @@ func sequenceLeaves(ls storage.LogStorage, seq *log.Sequencer, treeID int64, tre
 		glog.V(1).Infof("Queuing leaf %d", l)
 
 		leafData := []byte(fmt.Sprintf(leafDataFormat, l))
-		tx, err := ls.BeginForTree(context.TODO(), treeID)
+		tx, err := ls.BeginForTree(context.TODO(), treeID, getOpts)
 		if err != nil {
 			glog.Fatalf("BeginForTree got: %v, want: no err", err)
 		}
@@ -420,7 +422,7 @@ func traverseTreeStorage(ls storage.LogStorage, treeID int64, ts int, rev int64)
 	out := new(bytes.Buffer)
 	nodesAtLevel := int64(ts)
 
-	tx, err := ls.SnapshotForTree(context.TODO(), treeID)
+	tx, err := ls.SnapshotForTree(context.TODO(), treeID, getOpts)
 	if err != nil {
 		glog.Fatalf("SnapshotForTree: %v", err)
 	}
@@ -476,7 +478,7 @@ func traverseTreeStorage(ls storage.LogStorage, treeID int64, ts int, rev int64)
 
 func dumpLeaves(ls storage.LogStorage, treeID int64, ts int) string {
 	out := new(bytes.Buffer)
-	tx, err := ls.SnapshotForTree(context.TODO(), treeID)
+	tx, err := ls.SnapshotForTree(context.TODO(), treeID, getOpts)
 	if err != nil {
 		glog.Fatalf("SnapshotForTree: %v", err)
 	}

--- a/storage/tools/fetch_leaves/main.go
+++ b/storage/tools/fetch_leaves/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	storage := mysql.NewLogStorage(db, nil)
 	ctx := context.Background()
-	tx, err := storage.SnapshotForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true})
+	tx, err := storage.SnapshotForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: true})
 	if err != nil {
 		panic(err)
 	}

--- a/storage/tools/fetch_leaves/main.go
+++ b/storage/tools/fetch_leaves/main.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 
 	_ "github.com/go-sql-driver/mysql" // Load MySQL driver
+	"github.com/google/trillian"
+	"github.com/google/trillian/trees"
 
 	log "github.com/golang/glog"
 	"github.com/google/trillian/storage/mysql"
@@ -57,7 +59,7 @@ func main() {
 
 	storage := mysql.NewLogStorage(db, nil)
 	ctx := context.Background()
-	tx, err := storage.SnapshotForTree(ctx, *treeIDFlag)
+	tx, err := storage.SnapshotForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType:trillian.TreeType_LOG, Readonly:true})
 	if err != nil {
 		panic(err)
 	}

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	storage := mysql.NewLogStorage(db, nil)
 	ctx := context.Background()
-	tx, err := storage.BeginForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType:trillian.TreeType_LOG})
+	tx, err := storage.BeginForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType: trillian.TreeType_LOG})
 	if err != nil {
 		panic(err)
 	}

--- a/storage/tools/queue_leaves/main.go
+++ b/storage/tools/queue_leaves/main.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage/mysql"
+	"github.com/google/trillian/trees"
 )
 
 var (
@@ -63,7 +64,7 @@ func main() {
 
 	storage := mysql.NewLogStorage(db, nil)
 	ctx := context.Background()
-	tx, err := storage.BeginForTree(ctx, *treeIDFlag)
+	tx, err := storage.BeginForTree(ctx, *treeIDFlag, trees.GetOpts{TreeType:trillian.TreeType_LOG})
 	if err != nil {
 		panic(err)
 	}

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -193,7 +193,7 @@ func TestGetTree(t *testing.T) {
 		tx.EXPECT().Close().MaxTimes(1).Return(nil)
 		tx.EXPECT().Commit().MaxTimes(1).Return(test.commitErr)
 
-		tree, err := GetTree(ctx, getterFor(admin), test.treeID, test.opts)
+		tree, err := GetTree(ctx, storage.GetterFor(admin), test.treeID, test.opts)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("%v: GetTree() = (_, %q), wantErr = %v", test.desc, err, test.wantErr)
 			continue
@@ -208,12 +208,6 @@ func TestGetTree(t *testing.T) {
 			diff := pretty.Compare(tree, test.wantTree)
 			t.Errorf("%v: post-GetTree diff:\n%v", test.desc, diff)
 		}
-	}
-}
-
-func getterFor(s storage.AdminStorage) TreeGetter {
-	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-		return storage.GetTree(ctx, s, treeID)
 	}
 }
 

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -193,7 +193,7 @@ func TestGetTree(t *testing.T) {
 		tx.EXPECT().Close().MaxTimes(1).Return(nil)
 		tx.EXPECT().Commit().MaxTimes(1).Return(test.commitErr)
 
-		tree, err := GetTree(ctx, admin, test.treeID, test.opts)
+		tree, err := GetTree(ctx, getterFor(admin), test.treeID, test.opts)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("%v: GetTree() = (_, %q), wantErr = %v", test.desc, err, test.wantErr)
 			continue
@@ -208,6 +208,12 @@ func TestGetTree(t *testing.T) {
 			diff := pretty.Compare(tree, test.wantTree)
 			t.Errorf("%v: post-GetTree diff:\n%v", test.desc, diff)
 		}
+	}
+}
+
+func getterFor(s storage.AdminStorage) TreeGetter {
+	return func(ctx context.Context, treeID int64) (*trillian.Tree, error) {
+		return storage.GetTree(ctx, s, treeID)
 	}
 }
 

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -24,18 +24,60 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
+	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
-	"github.com/google/trillian/storage/testonly"
 	"github.com/kylelemons/godebug/pretty"
 
 	tcrypto "github.com/google/trillian/crypto"
 	terrors "github.com/google/trillian/errors"
+)
+
+var (
+	// LogTree is a valid, LOG-type trillian.Tree for tests. Does not
+	// contain keys or other things not needed for tree testing.
+	LogTree = &trillian.Tree{
+		TreeState:          trillian.TreeState_ACTIVE,
+		TreeType:           trillian.TreeType_LOG,
+		HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
+		DisplayName:        "Llamas Log",
+		Description:        "Registry of publicly-owned llamas",
+		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+		SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+		PrivateKey: mustMarshalAny(&keyspb.PrivateKey{
+			Der: []byte("dummy_key"),
+		}),
+		PublicKey: &keyspb.PublicKey{
+			Der: []byte("dummy_key"),
+		},
+		MaxRootDuration: ptypes.DurationProto(0 * time.Millisecond),
+	}
+
+	// MapTree is a valid, MAP-type trillian.Tree for tests. Does not
+	// contain keys or other things not needed for tree testing.
+	MapTree = &trillian.Tree{
+		TreeState:          trillian.TreeState_ACTIVE,
+		TreeType:           trillian.TreeType_MAP,
+		HashStrategy:       trillian.HashStrategy_TEST_MAP_HASHER,
+		DisplayName:        "Llamas Map",
+		Description:        "Key Transparency map for all your digital llama needs.",
+		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+		SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+		PrivateKey: mustMarshalAny(&keyspb.PrivateKey{
+			Der: []byte("dummy_key"),
+		}),
+		PublicKey: &keyspb.PublicKey{
+			Der: []byte("dummy_key"),
+		},
+		MaxRootDuration: ptypes.DurationProto(0 * time.Millisecond),
+	}
 )
 
 func TestFromContext(t *testing.T) {
@@ -44,7 +86,7 @@ func TestFromContext(t *testing.T) {
 		tree *trillian.Tree
 	}{
 		{desc: "noTree"},
-		{desc: "hasTree", tree: testonly.LogTree},
+		{desc: "hasTree", tree: LogTree},
 	}
 	for _, test := range tests {
 		ctx := NewContext(context.Background(), test.tree)
@@ -62,17 +104,17 @@ func TestFromContext(t *testing.T) {
 }
 
 func TestGetTree(t *testing.T) {
-	logTree := *testonly.LogTree
+	logTree := *LogTree
 	logTree.TreeId = 1
 
-	mapTree := *testonly.MapTree
+	mapTree := *MapTree
 	mapTree.TreeId = 2
 
-	frozenTree := *testonly.LogTree
+	frozenTree := *LogTree
 	frozenTree.TreeId = 3
 	frozenTree.TreeState = trillian.TreeState_FROZEN
 
-	softDeletedTree := *testonly.LogTree
+	softDeletedTree := *LogTree
 	softDeletedTree.Deleted = true
 	softDeletedTree.DeleteTime = ptypes.TimestampNow()
 
@@ -81,7 +123,7 @@ func TestGetTree(t *testing.T) {
 		treeID                         int64
 		opts                           GetOpts
 		ctxTree, storageTree, wantTree *trillian.Tree
-		beginErr, getErr, commitErr    error
+		getErr                         error
 		wantErr                        bool
 		code                           terrors.Code
 	}{
@@ -154,14 +196,6 @@ func TestGetTree(t *testing.T) {
 			wantTree:    &logTree,
 		},
 		{
-			desc:     "beginErr",
-			treeID:   logTree.TreeId,
-			opts:     GetOpts{TreeType: trillian.TreeType_LOG},
-			beginErr: errors.New("begin err"),
-			wantErr:  true,
-			code:     terrors.Unknown,
-		},
-		{
 			desc:    "getErr",
 			treeID:  logTree.TreeId,
 			opts:    GetOpts{TreeType: trillian.TreeType_LOG},
@@ -169,18 +203,7 @@ func TestGetTree(t *testing.T) {
 			wantErr: true,
 			code:    terrors.Unknown,
 		},
-		{
-			desc:      "commitErr",
-			treeID:    logTree.TreeId,
-			opts:      GetOpts{TreeType: trillian.TreeType_LOG},
-			commitErr: errors.New("commit err"),
-			wantErr:   true,
-			code:      terrors.Unknown,
-		},
 	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	for _, test := range tests {
 		ctx := NewContext(context.Background(), test.ctxTree)
@@ -217,7 +240,7 @@ func TestHash(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tree := *testonly.LogTree
+		tree := *LogTree
 		tree.HashAlgorithm = test.hashAlgo
 
 		hash, err := Hash(&tree)
@@ -293,7 +316,7 @@ func TestSigner(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			tree := *testonly.LogTree
+			tree := *LogTree
 			tree.HashAlgorithm = sigpb.DigitallySigned_SHA256
 			tree.HashStrategy = trillian.HashStrategy_RFC6962_SHA256
 			tree.SignatureAlgorithm = test.sigAlgo
@@ -324,4 +347,12 @@ func TestSigner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustMarshalAny(pb proto.Message) *any.Any {
+	value, err := ptypes.MarshalAny(pb)
+	if err != nil {
+		panic(err)
+	}
+	return value
 }


### PR DESCRIPTION
Also breaks the dependency link from trees -> storage packages. Can be used with anything that can return a tree.

This should make it cleaner to implement the tree readonly / freezing feature.