### PR TITLE
Remove explicit calls to Commit when using ReadWriteTransaction

### DIFF
--- a/crypto/keyspb/keyspb.pb.go
+++ b/crypto/keyspb/keyspb.pb.go
@@ -76,9 +76,7 @@ func (m *Specification) String() string            { return proto.CompactTextStr
 func (*Specification) ProtoMessage()               {}
 func (*Specification) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
-type isSpecification_Params interface {
-	isSpecification_Params()
-}
+type isSpecification_Params interface{ isSpecification_Params() }
 
 type Specification_EcdsaParams struct {
 	EcdsaParams *Specification_ECDSA `protobuf:"bytes,1,opt,name=ecdsa_params,json=ecdsaParams,oneof"`

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -275,7 +275,7 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context) {
 		if err := tx.SetMerkleNodes(ctx, nodesToStore); err != nil {
 			return err
 		}
-		return tx.Commit()
+		return nil
 	})
 	if err != nil {
 		s.root <- rootHashOrError{nil, err}

--- a/quota/etcd/storagepb/storagepb.pb.go
+++ b/quota/etcd/storagepb/storagepb.pb.go
@@ -130,9 +130,7 @@ func (m *Config) String() string            { return proto.CompactTextString(m) 
 func (*Config) ProtoMessage()               {}
 func (*Config) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
-type isConfig_ReplenishmentStrategy interface {
-	isConfig_ReplenishmentStrategy()
-}
+type isConfig_ReplenishmentStrategy interface{ isConfig_ReplenishmentStrategy() }
 
 type Config_SequencingBased struct {
 	SequencingBased *SequencingBasedStrategy `protobuf:"bytes,4,opt,name=sequencing_based,json=sequencingBased,oneof"`

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -294,10 +294,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 		err := as.ReadWriteTransaction(ctx, func(ctx context.Context, tx storage.AdminTX) error {
 			var err error
 			tree, err = tx.CreateTree(ctx, testonly.LogTree)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		})
 		if err != nil {
 			return nil, err
@@ -307,10 +304,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 	{
 		ls := mysql.NewLogStorage(db, nil)
 		err := ls.ReadWriteTransaction(ctx, tree.TreeId, func(ctx context.Context, tx storage.LogTreeTX) error {
-			if err := tx.StoreSignedLogRoot(ctx, trillian.SignedLogRoot{LogId: tree.TreeId, RootHash: []byte{0}, Signature: &sigpb.DigitallySigned{}}); err != nil {
-				return err
-			}
-			return nil
+			return tx.StoreSignedLogRoot(ctx, trillian.SignedLogRoot{LogId: tree.TreeId, RootHash: []byte{0}, Signature: &sigpb.DigitallySigned{}})
 		})
 		if err != nil {
 			return nil, err
@@ -345,10 +339,8 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 
 	ls := mysql.NewLogStorage(db, nil)
 	return ls.ReadWriteTransaction(ctx, tree.TreeId, func(ctx context.Context, tx storage.LogTreeTX) error {
-		if _, err := tx.QueueLeaves(ctx, leaves, time.Now()); err != nil {
-			return err
-		}
-		return nil
+		_, err := tx.QueueLeaves(ctx, leaves, time.Now())
+		return err
 	})
 }
 

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -285,9 +285,6 @@ func TestServer_GetTree(t *testing.T) {
 }
 
 func TestServer_CreateTree(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	// PEM on the testonly trees is ECDSA, so let's use an ECDSA key for tests.
 	ecdsaPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -466,6 +463,9 @@ func TestServer_CreateTree(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			var privateKey crypto.Signer = ecdsaPrivateKey
 			var keygen keys.ProtoGenerator
 			// If KeySpec is set, select the correct type of key to "generate".
@@ -534,6 +534,7 @@ func TestServer_CreateTree(t *testing.T) {
 
 func TestServer_CreateTree_AllowedTreeTypes(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
 	tests := []struct {
 		desc      string

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -118,10 +118,6 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 			return err
 		}
 
-		if err := t.commitAndLog(ctx, logID, tx, "QueueLeaves"); err != nil {
-			return err
-		}
-
 		for i, existingLeaf := range existingLeaves {
 			if existingLeaf != nil {
 				// Append the existing leaf to the response.
@@ -553,9 +549,6 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 			return status.Errorf(codes.FailedPrecondition, "StoreSignedLogRoot(): %v", err)
 		}
 
-		if err := tx.Commit(); err != nil {
-			return status.Errorf(codes.FailedPrecondition, "Commit(): %v", err)
-		}
 		return nil
 	})
 	if err != nil && err != storage.ErrTreeNeedsInit {

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -221,7 +221,8 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		if err = tx.StoreSignedMapRoot(ctx, *newRoot); err != nil {
 			return err
 		}
-		return tx.Commit()
+
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -350,10 +351,6 @@ func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRe
 			return err
 		}
 
-		if err := tx.Commit(); err != nil {
-			glog.Warningf("%v: Commit failed for SetLeaves: %v", mapID, err)
-			return err
-		}
 		return nil
 	})
 	if err != nil {

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -52,7 +52,7 @@ func (s *memoryAdminStorage) ReadWriteTransaction(ctx context.Context, f storage
 	}
 	defer tx.Close()
 	if err := f(ctx, tx); err != nil {
-		tx.Close()
+		return err
 	}
 	return tx.Commit()
 }

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -182,7 +182,10 @@ func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int6
 		return err
 	}
 	defer tx.Close()
-	return f(ctx, tx)
+	if err := f(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -264,7 +264,10 @@ func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64
 		return err
 	}
 	defer tx.Close()
-	return f(ctx, tx)
+	if err := f(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -150,7 +150,10 @@ func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, treeID int64
 	if err != nil && err != storage.ErrTreeNeedsInit {
 		return err
 	}
-	return f(ctx, tx)
+	if err := f(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 type mapTreeTX struct {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -159,10 +159,6 @@ func TestMapReadWriteTransaction(t *testing.T) {
 				if err != nil {
 					t.Errorf("%v: LatestSignedMapRoot() returned err = %v", test.desc, err)
 				}
-				if err := tx.Commit(); err != nil {
-					t.Errorf("%v: Commit() returned err = %v", test.desc, err)
-				}
-
 				if got, want := tx.WriteRevision(), root.MapRevision+1; got != want {
 					t.Errorf("%v: WriteRevision() = %v, want = %v", test.desc, got, want)
 				}

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -24,7 +24,10 @@ import (
 func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f storage.LogTXFunc) error {
 	return func(ctx context.Context, _ int64, f storage.LogTXFunc) error {
 		defer tx.Close()
-		return f(ctx, tx)
+		if err := f(ctx, tx); err != nil {
+			return err
+		}
+		return tx.Commit()
 	}
 }
 
@@ -32,7 +35,10 @@ func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f 
 func RunOnMapTX(tx storage.MapTreeTX) func(ctx context.Context, treeID int64, f storage.MapTXFunc) error {
 	return func(ctx context.Context, _ int64, f storage.MapTXFunc) error {
 		defer tx.Close()
-		return f(ctx, tx)
+		if err := f(ctx, tx); err != nil {
+			return err
+		}
+		return tx.Commit()
 	}
 }
 


### PR DESCRIPTION
The `ReadWriteTransaction` method will always call `Commit()` if no error is returned by the passed-in function, so this PR removes the explicit calls to `Commit` from the passed-in function implementations.