### PR TITLE
Remove use of DoAndReturn

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -152,7 +152,7 @@ type testParameters struct {
 // Tests get their own mock context so they can be run in parallel safely
 type testContext struct {
 	mockTx      *storage.MockLogTreeTX
-	mockStorage storage.LogStorage
+	fakeStorage storage.LogStorage
 	signer      *crypto.Signer
 	sequencer   *Sequencer
 }
@@ -201,15 +201,15 @@ func newSignerWithErr(signErr error) (gocrypto.Signer, error) {
 }
 
 func createTestContext(ctrl *gomock.Controller, params testParameters) (testContext, context.Context) {
-	mockStorage := &stestonly.FakeLogStorage{}
+	fakeStorage := &stestonly.FakeLogStorage{}
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(params.writeRevision)
 	if params.beginFails {
-		mockStorage.Err = errors.New("TX")
+		fakeStorage.Err = errors.New("TX")
 	} else {
 		mockTx.EXPECT().Close()
-		mockStorage.TX = mockTx
+		fakeStorage.TX = mockTx
 	}
 
 	if params.shouldCommit {
@@ -256,8 +256,8 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	if qm == nil {
 		qm = quota.Noop()
 	}
-	sequencer := NewSequencer(rfc6962.DefaultHasher, util.NewFakeTimeSource(fakeTimeForTest), mockStorage, signer, nil, qm)
-	return testContext{mockTx: mockTx, mockStorage: mockStorage, signer: signer, sequencer: sequencer}, context.Background()
+	sequencer := NewSequencer(rfc6962.DefaultHasher, util.NewFakeTimeSource(fakeTimeForTest), fakeStorage, signer, nil, qm)
+	return testContext{mockTx: mockTx, fakeStorage: fakeStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 
 // Tests for sequencer. Currently relies on having a database set up. This might change in future

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -152,7 +152,7 @@ type testParameters struct {
 // Tests get their own mock context so they can be run in parallel safely
 type testContext struct {
 	mockTx      *storage.MockLogTreeTX
-	mockStorage *storage.MockLogStorage
+	mockStorage storage.LogStorage
 	signer      *crypto.Signer
 	sequencer   *Sequencer
 }
@@ -201,15 +201,15 @@ func newSignerWithErr(signErr error) (gocrypto.Signer, error) {
 }
 
 func createTestContext(ctrl *gomock.Controller, params testParameters) (testContext, context.Context) {
-	mockStorage := storage.NewMockLogStorage(ctrl)
+	mockStorage := &stestonly.FakeLogStorage{}
 	mockTx := storage.NewMockLogTreeTX(ctrl)
 
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(params.writeRevision)
 	if params.beginFails {
-		mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), params.logID, gomock.Any()).Return(errors.New("TX"))
+		mockStorage.Err = errors.New("TX")
 	} else {
 		mockTx.EXPECT().Close()
-		mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), params.logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
+		mockStorage.TX = mockTx
 	}
 
 	if params.shouldCommit {
@@ -510,7 +510,7 @@ func TestIntegrateBatch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		func() {
+		t.Run(test.desc, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -533,7 +533,7 @@ func TestIntegrateBatch(t *testing.T) {
 			if got != test.wantCount {
 				t.Errorf("IntegrateBatch(%+v)=%v,nil; want %v,nil", test.params, got, test.wantCount)
 			}
-		}()
+		})
 	}
 }
 
@@ -630,8 +630,7 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 			logTX.EXPECT().StoreSignedLogRoot(any, any).AnyTimes().Return(nil)
 			logTX.EXPECT().Commit().Return(nil)
 			logTX.EXPECT().Close().Return(nil)
-			logStorage := storage.NewMockLogStorage(ctrl)
-			logStorage.EXPECT().ReadWriteTransaction(any, any, any).DoAndReturn(stestonly.RunOnLogTX(logTX))
+			logStorage := &stestonly.FakeLogStorage{TX: logTX}
 
 			qm := quota.NewMockManager(ctrl)
 			if test.wantTokens > 0 {

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -45,11 +45,11 @@ func TestLogOperationManagerSnapshotFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(nil, errors.New("TX"))
+	fakeStorage := storage.NewMockLogStorage(ctrl)
+	fakeStorage.EXPECT().Snapshot(gomock.Any()).Return(nil, errors.New("TX"))
 
 	registry := extension.Registry{
-		LogStorage: mockStorage,
+		LogStorage: fakeStorage,
 	}
 
 	mockLogOp := NewMockLogOperation(ctrl)
@@ -68,11 +68,11 @@ func TestLogOperationManagerGetLogsFails(t *testing.T) {
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return(nil, errors.New("getactivelogs"))
 	mockTx.EXPECT().Close().Return(nil)
-	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
+	fakeStorage := storage.NewMockLogStorage(ctrl)
+	fakeStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
 	registry := extension.Registry{
-		LogStorage: mockStorage,
+		LogStorage: fakeStorage,
 	}
 
 	mockLogOp := NewMockLogOperation(ctrl)
@@ -92,11 +92,11 @@ func TestLogOperationManagerCommitFails(t *testing.T) {
 	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return([]int64{}, nil)
 	mockTx.EXPECT().Commit().Return(errors.New("commit"))
 	mockTx.EXPECT().Close().Return(nil)
-	mockStorage := storage.NewMockLogStorage(ctrl)
-	mockStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
+	fakeStorage := storage.NewMockLogStorage(ctrl)
+	fakeStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
 
 	registry := extension.Registry{
-		LogStorage: mockStorage,
+		LogStorage: fakeStorage,
 	}
 
 	mockLogOp := NewMockLogOperation(ctrl)
@@ -133,12 +133,12 @@ func setupLogIDs(ctrl *gomock.Controller, logNames map[int64]string) (*storage.M
 		ids = append(ids, id)
 	}
 
-	mockStorage := storage.NewMockLogStorage(ctrl)
+	fakeStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).AnyTimes().Return(ids, nil)
 	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
 	mockTx.EXPECT().Close().AnyTimes().Return(nil)
-	mockStorage.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(mockTx, nil)
+	fakeStorage.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(mockTx, nil)
 
 	mockAdmin := storage.NewMockAdminStorage(ctrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(ctrl)
@@ -151,7 +151,7 @@ func setupLogIDs(ctrl *gomock.Controller, logNames map[int64]string) (*storage.M
 	mockAdminTx.EXPECT().Close().AnyTimes().Return(nil)
 	mockAdmin.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(mockAdminTx, nil)
 
-	return mockStorage, mockAdmin
+	return fakeStorage, mockAdmin
 }
 
 func TestLogOperationManagerPassesIDs(t *testing.T) {
@@ -161,9 +161,9 @@ func TestLogOperationManagerPassesIDs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{451: "LogID1", 145: "LogID2"})
+	fakeStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{451: "LogID1", 145: "LogID2"})
 	registry := extension.Registry{
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		AdminStorage: mockAdmin,
 	}
 
@@ -182,8 +182,8 @@ func TestHeldInfo(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mockStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{1: "one", 2: "two"})
-	registry := extension.Registry{LogStorage: mockStorage, AdminStorage: mockAdmin}
+	fakeStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{1: "one", 2: "two"})
+	registry := extension.Registry{LogStorage: fakeStorage, AdminStorage: mockAdmin}
 	mockLogOp := NewMockLogOperation(ctrl)
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -74,12 +74,12 @@ func TestIsHealthy(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mockStorage := storage.NewMockMapStorage(ctrl)
-		mockStorage.EXPECT().CheckDatabaseAccessible(gomock.Any()).Return(test.accessibleErr)
+		fakeStorage := storage.NewMockMapStorage(ctrl)
+		fakeStorage.EXPECT().CheckDatabaseAccessible(gomock.Any()).Return(test.accessibleErr)
 
 		server := NewTrillianMapServer(extension.Registry{
-			AdminStorage: mockAdminStorageForMap(ctrl, 1, mapID1),
-			MapStorage:   mockStorage,
+			AdminStorage: fakeAdminStorageForMap(ctrl, 1, mapID1),
+			MapStorage:   fakeStorage,
 		})
 
 		wantErr := test.accessibleErr != nil
@@ -109,7 +109,7 @@ func TestInitMap(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockTx := storage.NewMockMapTreeTX(ctrl)
-			mockStorage := &stestonly.FakeMapStorage{TX: mockTx}
+			fakeStorage := &stestonly.FakeMapStorage{TX: mockTx}
 			if tc.getRootErr != nil {
 				mockTx.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(trillian.SignedMapRoot{}, tc.getRootErr)
 			} else {
@@ -125,8 +125,8 @@ func TestInitMap(t *testing.T) {
 			}
 
 			server := NewTrillianMapServer(extension.Registry{
-				AdminStorage: mockAdminStorageForMap(ctrl, 2, mapID1),
-				MapStorage:   mockStorage,
+				AdminStorage: fakeAdminStorageForMap(ctrl, 2, mapID1),
+				MapStorage:   fakeStorage,
 			})
 
 			c, err := server.InitMap(ctx, &trillian.InitMapRequest{
@@ -156,12 +156,12 @@ func TestGetSignedMapRoot_NotInitialised(t *testing.T) {
 	defer ctrl.Finish()
 	ctx := context.Background()
 
-	mockStorage := storage.NewMockMapStorage(ctrl)
+	fakeStorage := storage.NewMockMapStorage(ctrl)
 	mockTX := storage.NewMockMapTreeTX(ctrl)
 	server := NewTrillianMapServer(extension.Registry{
-		MapStorage: mockStorage,
+		MapStorage: fakeStorage,
 	})
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
+	fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
 	mockTX.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
 
@@ -210,12 +210,12 @@ func TestGetSignedMapRoot(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			adminStorage := mockAdminStorageForMap(ctrl, 2, mapID1)
-			mockStorage := storage.NewMockMapStorage(ctrl)
+			adminStorage := fakeAdminStorageForMap(ctrl, 2, mapID1)
+			fakeStorage := storage.NewMockMapStorage(ctrl)
 			mockTx := storage.NewMockMapTreeTX(ctrl)
 
 			// Calls from GetSignedMapRoot()
-			mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
+			fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
 			if test.snapShErr == nil {
 				mockTx.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(test.mapRoot, test.lsmrErr)
 				if test.lsmrErr == nil {
@@ -227,7 +227,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: adminStorage,
-				MapStorage:   mockStorage,
+				MapStorage:   fakeStorage,
 			})
 
 			smrResp, err := server.GetSignedMapRoot(ctx, test.req)
@@ -253,12 +253,12 @@ func TestGetSignedMapRootByRevision_NotInitialised(t *testing.T) {
 	defer ctrl.Finish()
 	ctx := context.Background()
 
-	mockStorage := storage.NewMockMapStorage(ctrl)
+	fakeStorage := storage.NewMockMapStorage(ctrl)
 	mockTX := storage.NewMockMapTreeTX(ctrl)
 	server := NewTrillianMapServer(extension.Registry{
-		MapStorage: mockStorage,
+		MapStorage: fakeStorage,
 	})
-	mockStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
+	fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
 	mockTX.EXPECT().GetSignedMapRoot(gomock.Any(), gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
 
@@ -312,12 +312,12 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			adminStorage := mockAdminStorageForMap(ctrl, 2, mapID1)
-			mockStorage := storage.NewMockMapStorage(ctrl)
+			adminStorage := fakeAdminStorageForMap(ctrl, 2, mapID1)
+			fakeStorage := storage.NewMockMapStorage(ctrl)
 			mockTx := storage.NewMockMapTreeTX(ctrl)
 
 			if !test.wantErr || !(test.lsmrErr == nil && test.snapShErr == nil) {
-				mockStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
+				fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), test.req.MapId).Return(mockTx, test.snapShErr)
 				if test.snapShErr == nil {
 					mockTx.EXPECT().GetSignedMapRoot(gomock.Any(), test.req.Revision).Return(test.mapRoot, test.lsmrErr)
 					if test.lsmrErr == nil {
@@ -330,7 +330,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: adminStorage,
-				MapStorage:   mockStorage,
+				MapStorage:   fakeStorage,
 			})
 
 			smrResp, err := server.GetSignedMapRootByRevision(ctx, test.req)
@@ -350,7 +350,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 	}
 }
 
-func mockAdminStorageForMap(ctrl *gomock.Controller, times int, treeID int64) storage.AdminStorage {
+func fakeAdminStorageForMap(ctrl *gomock.Controller, times int, treeID int64) storage.AdminStorage {
 	tree := *stestonly.MapTree
 	tree.TreeId = treeID
 

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -108,10 +108,10 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logID := stestonly.LogTree.GetTreeId()
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
-	mockStorage := storage.NewMockLogStorage(mockCtrl)
+	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
+	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -126,14 +126,12 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil)
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil)
 
-	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
 	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)
@@ -154,10 +152,10 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logID := stestonly.LogTree.GetTreeId()
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
-	mockStorage := storage.NewMockLogStorage(mockCtrl)
+	mockAdmin := &stestonly.FakeAdminStorage{}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
+	mockStorage := &stestonly.FakeLogStorage{}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -180,15 +178,15 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 	// Expect two sequencing passes.
 	for i := 0; i < 2; i++ {
+		mockAdmin.ReadOnlyTX = []storage.ReadOnlyAdminTX{mockAdminTx}
 		gomock.InOrder(
-			mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil),
 			mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil),
 			mockAdminTx.EXPECT().Commit().Return(nil),
 			mockAdminTx.EXPECT().Close().Return(nil),
 		)
 
+		mockStorage.TX = mockTx
 		gomock.InOrder(
-			mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx)),
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev),
@@ -215,9 +213,9 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logID := stestonly.LogTree.GetTreeId()
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
-	mockStorage := storage.NewMockLogStorage(mockCtrl)
+	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
+	mockStorage := &stestonly.FakeLogStorage{}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -228,7 +226,6 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	defer keys.UnregisterHandler(keyProto.Message)
 
 	gomock.InOrder(
-		mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil),
 		mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil),
 		mockAdminTx.EXPECT().Commit().Return(nil),
 		mockAdminTx.EXPECT().Close().Return(nil),
@@ -252,10 +249,10 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logID := stestonly.LogTree.GetTreeId()
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
-	mockStorage := storage.NewMockLogStorage(mockCtrl)
+	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
+	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -280,9 +277,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), []*trillian.LogLeaf{testLeaf0Updated}).Return(nil)
 	mockTx.EXPECT().SetMerkleNodes(gomock.Any(), updatedNodes0).Return(nil)
 	mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), updatedRoot).Return(nil)
-	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 
-	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
 	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)
@@ -303,10 +298,10 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logID := stestonly.LogTree.GetTreeId()
-	mockAdmin := storage.NewMockAdminStorage(mockCtrl)
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
-	mockStorage := storage.NewMockLogStorage(mockCtrl)
+	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
+	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -321,7 +316,6 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, signer, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockStorage.EXPECT().ReadWriteTransaction(gomock.Any(), logID, gomock.Any()).DoAndReturn(stestonly.RunOnLogTX(mockTx))
 	mockTx.EXPECT().Commit().Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision().AnyTimes().Return(writeRev)
@@ -329,7 +323,6 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	// Expect a 5 second guard window to be passed from manager -> sequencer -> storage
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime.Add(-time.Second*5)).Return([]*trillian.LogLeaf{}, nil)
 
-	mockAdmin.EXPECT().Snapshot(gomock.Any()).Return(mockAdminTx, nil)
 	mockAdminTx.EXPECT().GetTree(gomock.Any(), logID).Return(stestonly.LogTree, nil)
 	mockAdminTx.EXPECT().Commit().Return(nil)
 	mockAdminTx.EXPECT().Close().Return(nil)

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -111,7 +111,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
 	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
-	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
+	fakeStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -138,7 +138,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 
 	registry := extension.Registry{
 		AdminStorage: mockAdmin,
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		QuotaManager: quota.Noop(),
 	}
 
@@ -155,7 +155,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
 	mockAdmin := &stestonly.FakeAdminStorage{}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
-	mockStorage := &stestonly.FakeLogStorage{}
+	fakeStorage := &stestonly.FakeLogStorage{}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -171,7 +171,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 
 	registry := extension.Registry{
 		AdminStorage: mockAdmin,
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		QuotaManager: quota.Noop(),
 	}
 	sm := NewSequencerManager(registry, zeroDuration)
@@ -185,7 +185,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 			mockAdminTx.EXPECT().Close().Return(nil),
 		)
 
-		mockStorage.TX = mockTx
+		fakeStorage.TX = mockTx
 		gomock.InOrder(
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
@@ -215,7 +215,7 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 	logID := stestonly.LogTree.GetTreeId()
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
 	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
-	mockStorage := &stestonly.FakeLogStorage{}
+	fakeStorage := &stestonly.FakeLogStorage{}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -233,7 +233,7 @@ func TestSequencerManagerSingleLogNoSigner(t *testing.T) {
 
 	registry := extension.Registry{
 		AdminStorage: mockAdmin,
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		QuotaManager: quota.Noop(),
 	}
 
@@ -252,7 +252,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
 	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
-	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
+	fakeStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -284,7 +284,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 
 	registry := extension.Registry{
 		AdminStorage: mockAdmin,
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		QuotaManager: quota.Noop(),
 	}
 
@@ -301,7 +301,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	mockAdminTx := storage.NewMockReadOnlyAdminTX(mockCtrl)
 	mockAdmin := &stestonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{mockAdminTx}}
 	mockTx := storage.NewMockLogTreeTX(mockCtrl)
-	mockStorage := &stestonly.FakeLogStorage{TX: mockTx}
+	fakeStorage := &stestonly.FakeLogStorage{TX: mockTx}
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(stestonly.LogTree.PrivateKey, &keyProto); err != nil {
@@ -329,7 +329,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 
 	registry := extension.Registry{
 		AdminStorage: mockAdmin,
-		LogStorage:   mockStorage,
+		LogStorage:   fakeStorage,
 		QuotaManager: quota.Noop(),
 	}
 

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -16,6 +16,7 @@ package testonly
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/trillian/storage"
 )
@@ -45,4 +46,116 @@ func RunOnAdminTX(tx storage.AdminTX) func(ctx context.Context, f storage.AdminT
 		}
 		return tx.Commit()
 	}
+}
+
+// ErrNotImplemented is returned by unimplemented methods on the storage fakes.
+var ErrNotImplemented = errors.New("not implemented")
+
+// FakeLogStorage is a LogStorage implementation which is used for testing.
+type FakeLogStorage struct {
+	TX         storage.LogTreeTX
+	ReadOnlyTX storage.ReadOnlyLogTreeTX
+	Err        error
+}
+
+// Snapshot implements LogStorage.Snapshot
+func (f *FakeLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, error) {
+	return nil, ErrNotImplemented
+}
+
+// BeginForTree implements LogStorage.BeginForTree
+func (f *FakeLogStorage) BeginForTree(ctx context.Context, id int64) (storage.LogTreeTX, error) {
+	return nil, ErrNotImplemented
+}
+
+// SnapshotForTree implements LogStorage.SnapshotForTree
+func (f *FakeLogStorage) SnapshotForTree(ctx context.Context, id int64) (storage.ReadOnlyLogTreeTX, error) {
+	return f.ReadOnlyTX, f.Err
+}
+
+// ReadWriteTransaction implements LogStorage.ReadWriteTransaction
+func (f *FakeLogStorage) ReadWriteTransaction(ctx context.Context, id int64, fn storage.LogTXFunc) error {
+	if f.Err != nil {
+		return f.Err
+	}
+	return RunOnLogTX(f.TX)(ctx, id, fn)
+}
+
+// CheckDatabaseAccessible implements LogStorage.CheckDatabaseAccessible
+func (f *FakeLogStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return nil
+}
+
+// FakeMapStorage is a MapStorage implementation which is used for testing.
+type FakeMapStorage struct {
+	TX          storage.MapTreeTX
+	ReadOnlyTX  storage.ReadOnlyMapTreeTX
+	SnapshotErr error
+}
+
+// Snapshot implements MapStorage.Snapshot
+func (f *FakeMapStorage) Snapshot(ctx context.Context) (storage.ReadOnlyMapTX, error) {
+	return nil, ErrNotImplemented
+}
+
+// BeginForTree implements MapStorage.BeginForTree
+func (f *FakeMapStorage) BeginForTree(ctx context.Context, id int64) (storage.MapTreeTX, error) {
+	return nil, ErrNotImplemented
+}
+
+// SnapshotForTree implements MapStorage.SnapshotForTree
+func (f *FakeMapStorage) SnapshotForTree(ctx context.Context, id int64) (storage.ReadOnlyMapTreeTX, error) {
+	return f.ReadOnlyTX, f.SnapshotErr
+}
+
+// ReadWriteTransaction implements MapStorage.ReadWriteTransaction
+func (f *FakeMapStorage) ReadWriteTransaction(ctx context.Context, id int64, fn storage.MapTXFunc) error {
+	return RunOnMapTX(f.TX)(ctx, id, fn)
+}
+
+// CheckDatabaseAccessible implements MapStorage.CheckDatabaseAccessible
+func (f *FakeMapStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return nil
+}
+
+// FakeAdminStorage is a AdminStorage implementation which is used for testing.
+type FakeAdminStorage struct {
+	TX          []storage.AdminTX
+	ReadOnlyTX  []storage.ReadOnlyAdminTX
+	TXErr       []error
+	SnapshotErr []error
+}
+
+// Begin implements AdminStorage.Begin
+func (f *FakeAdminStorage) Begin(ctx context.Context) (storage.AdminTX, error) {
+	return nil, ErrNotImplemented
+}
+
+// Snapshot implements AdminStorage.Snapshot
+func (f *FakeAdminStorage) Snapshot(ctx context.Context) (storage.ReadOnlyAdminTX, error) {
+	if len(f.SnapshotErr) > 0 {
+		e := f.SnapshotErr[0]
+		f.SnapshotErr = f.SnapshotErr[1:]
+		return nil, e
+	}
+	r := f.ReadOnlyTX[0]
+	f.ReadOnlyTX = f.ReadOnlyTX[1:]
+	return r, nil
+}
+
+// ReadWriteTransaction implements AdminStorage.ReadWriteTransaction
+func (f *FakeAdminStorage) ReadWriteTransaction(ctx context.Context, fn storage.AdminTXFunc) error {
+	if len(f.TXErr) > 0 {
+		e := f.TXErr[0]
+		f.TXErr = f.TXErr[1:]
+		return e
+	}
+	t := f.TX[0]
+	f.TX = f.TX[1:]
+	return RunOnAdminTX(t)(ctx, fn)
+}
+
+// CheckDatabaseAccessible implements AdminStorage.CheckDatabaseAccessible
+func (f *FakeAdminStorage) CheckDatabaseAccessible(ctx context.Context) error {
+	return nil
 }


### PR DESCRIPTION
Replacing calls to DoAndReturn on Storage mocks with a bunch of Fakes, to better follow guidance around the careful use of golang mocks. 