### PR TITLE
Allow multiple TreeTypes in trees.GetOpts

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -309,7 +309,7 @@ func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 		info.readonly = false
 
 	// Log / readonly
-	// Pre-orderd Log / readonly
+	// Pre-ordered Log / readonly
 	case *trillian.GetConsistencyProofRequest,
 		*trillian.GetEntryAndProofRequest,
 		*trillian.GetInclusionProofByHashRequest,

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -155,7 +155,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (conte
 
 	if info.getTree {
 		tree, err := trees.GetTree(
-			ctx, tp.parent.admin, info.treeID, trees.GetOpts{TreeType: info.treeType, Readonly: info.readonly})
+			ctx, tp.parent.admin, info.treeID, trees.NewGetOpts(info.readonly, info.treeTypes...))
 		if err != nil {
 			incRequestDeniedCounter(badTreeReason, info.treeID, quotaUser)
 			return ctx, err
@@ -249,9 +249,9 @@ type rpcInfo struct {
 	// auth, getTree and quota enable their corresponding interceptor logic.
 	auth, getTree, quota bool
 
-	readonly bool
-	treeID   int64
-	treeType trillian.TreeType
+	readonly  bool
+	treeID    int64
+	treeTypes []trillian.TreeType
 
 	specs  []quota.Spec
 	tokens int
@@ -260,11 +260,11 @@ type rpcInfo struct {
 func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 	// Set "safe" defaults: enable all interception and assume requests are readonly.
 	info := &rpcInfo{
-		auth:     true,
-		getTree:  true,
-		quota:    true,
-		readonly: true,
-		treeType: trillian.TreeType_UNKNOWN_TREE_TYPE,
+		auth:      true,
+		getTree:   true,
+		quota:     true,
+		readonly:  true,
+		treeTypes: nil,
 	}
 
 	switch req.(type) {
@@ -309,6 +309,7 @@ func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 		info.readonly = false
 
 	// Log / readonly
+	// Pre-orderd Log / readonly
 	case *trillian.GetConsistencyProofRequest,
 		*trillian.GetEntryAndProofRequest,
 		*trillian.GetInclusionProofByHashRequest,
@@ -318,27 +319,34 @@ func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 		*trillian.GetLeavesByIndexRequest,
 		*trillian.GetLeavesByRangeRequest,
 		*trillian.GetSequencedLeafCountRequest:
-		info.treeType = trillian.TreeType_LOG
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_LOG, trillian.TreeType_PREORDERED_LOG}
 
 	// Log / readwrite
 	case *trillian.QueueLeafRequest,
-		*trillian.QueueLeavesRequest,
-		*trillian.InitLogRequest:
+		*trillian.QueueLeavesRequest:
 		info.readonly = false
-		info.treeType = trillian.TreeType_LOG
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_LOG}
+
+	// TODO(pavelkalinnikov): Pre-ordered Log's AddSequencedLeaves.
+
+	// Log / readwrite
+	// Pre-ordered Log / readwrite
+	case *trillian.InitLogRequest:
+		info.readonly = false
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_LOG, trillian.TreeType_PREORDERED_LOG}
 
 	// Map / readonly
 	case *trillian.GetMapLeavesByRevisionRequest,
 		*trillian.GetMapLeavesRequest,
 		*trillian.GetSignedMapRootByRevisionRequest,
 		*trillian.GetSignedMapRootRequest:
-		info.treeType = trillian.TreeType_MAP
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_MAP}
 
 	// Map / readwrite
 	case *trillian.SetMapLeavesRequest,
 		*trillian.InitMapRequest:
 		info.readonly = false
-		info.treeType = trillian.TreeType_MAP
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_MAP}
 
 	default:
 		return nil, status.Errorf(codes.Internal, "newRPCInfo: unmapped request type: %T", req)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -493,7 +493,7 @@ func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int6
 		ctx,
 		t.registry.AdminStorage,
 		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+		trees.NewGetOpts(readonly, trillian.TreeType_LOG))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -306,7 +306,7 @@ func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, 
 		ctx,
 		t.registry.AdminStorage,
 		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
+		trees.NewGetOpts(readonly, trillian.TreeType_MAP))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -62,7 +62,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 		ctx,
 		s.registry.AdminStorage,
 		logID,
-		trees.GetOpts{TreeType: trillian.TreeType_LOG})
+		trees.NewGetOpts(false /* readonly */, trillian.TreeType_LOG))
 	if err != nil {
 		return 0, fmt.Errorf("error retrieving log %v: %v", logID, err)
 	}

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -138,7 +138,7 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, treeID int64, read
 		ctx,
 		m.admin,
 		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+		trees.NewGetOpts(readonly, trillian.TreeType_LOG))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -220,7 +220,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, treeID int64, reado
 		ctx,
 		m.admin,
 		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_LOG, Readonly: readonly})
+		trees.NewGetOpts(readonly, trillian.TreeType_LOG))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -102,7 +102,7 @@ func (m *mySQLMapStorage) begin(ctx context.Context, treeID int64, readonly bool
 		ctx,
 		m.admin,
 		treeID,
-		trees.GetOpts{TreeType: trillian.TreeType_MAP, Readonly: readonly})
+		trees.NewGetOpts(readonly, trillian.TreeType_MAP))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a prerequisite for `PREORDERED_LOG` mode. Some RPCs, like `GetInclusionProof` etc., work for both log types. Log Server must therefore allow both types when invoking `trees.GetTree`.