### PR TITLE
integration: don't log to stderr

### DIFF
--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -147,7 +147,7 @@ log_prep_test() {
     ./trillian_log_server ${ETCD_OPTS} ${pkcs11_opts} ${logserver_opts} \
       --rpc_endpoint="localhost:${port}" \
       --http_endpoint="localhost:${http}" \
-      --alsologtostderr \
+      ${LOGGING_OPTS} \
       &
     pid=$!
     RPC_SERVER_PIDS+=(${pid})
@@ -175,7 +175,7 @@ log_prep_test() {
       --batch_size=500 \
       --http_endpoint="localhost:${http}" \
       --num_sequencers 2 \
-      --alsologtostderr \
+      ${LOGGING_OPTS} \
       &
     pid=$!
     LOG_SIGNER_PIDS+=(${pid})


### PR DESCRIPTION
Partial revert of 6e529f19798f ("Make integration tests log to stderr")
in the vague hope that reducing output will make the tests less likely
to time out on Travis.

Can still run with output by doing (say):
  LOGGING_OPTS=--alsologtostderr ./integration/log_integration_test.sh