### PR TITLE
Channel AddSequencedLeaves to storage

### DIFF
--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -34,8 +34,7 @@ func TestAddGetLeaf(t *testing.T) {
 
 // addSequencedLeaves is a temporary stand-in function for tests until the real API gets built.
 func addSequencedLeaves(ctx context.Context, env *integration.LogEnv, client *LogClient, leaves [][]byte) error {
-	// TODO(gdbelvin): Replace with batch API.
-	// TODO(gdbelvin): Replace with AddSequencedLeaves API.
+	// TODO(pavelkalinnikov): Replace with AddSequencedLeaves batch API.
 	for _, l := range leaves {
 		if err := client.QueueLeaf(ctx, l); err != nil {
 			return err

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -186,7 +186,7 @@ func (t *TrillianLogRPCServer) AddSequencedLeaves(ctx context.Context, req *tril
 		return nil, err
 	}
 	if got, want := len(leaves), len(req.Leaves); got != want {
-		return nil, status.Errorf(codes.Internal, "AddSequencedLeaves returned %d codes, want: %d", got, want)
+		return nil, status.Errorf(codes.Internal, "AddSequencedLeaves returned %d leaves, want: %d", got, want)
 	}
 
 	return &trillian.AddSequencedLeavesResponse{Results: leaves}, nil

--- a/server/validate.go
+++ b/server/validate.go
@@ -123,12 +123,13 @@ func validateAddSequencedLeavesRequest(req *trillian.AddSequencedLeavesRequest) 
 		return err
 	}
 
-	lastIndex := int64(-1)
+	// Note: Not empty, as verified by validateLogLeaves.
+	nextIndex := req.Leaves[0].LeafIndex
 	for i, leaf := range req.Leaves {
-		if leaf.LeafIndex <= lastIndex {
-			return status.Errorf(codes.OutOfRange, "%v.Leaves[%v..%v].LeafIndex not sorted", prefix, i-1, i)
+		if leaf.LeafIndex != nextIndex {
+			return status.Errorf(codes.OutOfRange, "%v.Leaves[%v].LeafIndex=%v, want %v", prefix, i, leaf.LeafIndex, nextIndex)
 		}
-		lastIndex = leaf.LeafIndex
+		nextIndex++
 	}
 	return nil
 }

--- a/server/validate.go
+++ b/server/validate.go
@@ -124,7 +124,7 @@ func validateAddSequencedLeafRequest(req *trillian.AddSequencedLeafRequest) erro
 func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
 	if err := validateLogLeaves(req.Leaves); err != nil {
 		// validateLogLeaves errors chain nicely with "QueueLeavesRequest.".
-		return status.Errorf(codes.InvalidArgument, "QueueLeavesRequest.", err)
+		return status.Errorf(codes.InvalidArgument, "QueueLeavesRequest.%v", err)
 	}
 	return nil
 }
@@ -132,7 +132,14 @@ func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
 func validateAddSequencedLeavesRequest(req *trillian.AddSequencedLeavesRequest) error {
 	if err := validateLogLeaves(req.Leaves); err != nil {
 		// validateLogLeaves errors chain nicely with "AddSequencedLeavesRequest.".
-		return status.Errorf(codes.InvalidArgument, "AddSequencedLeavesRequest.", err)
+		return status.Errorf(codes.InvalidArgument, "AddSequencedLeavesRequest.%v", err)
+	}
+	lastIndex := int64(-1)
+	for i, leaf := range req.Leaves {
+		if leaf.LeafIndex <= lastIndex {
+			return status.Errorf(codes.OutOfRange, "AddSequencedLeavesRequest.Leaves[%v..%v].LeafIndex not sorted", i-1, i)
+		}
+		lastIndex = leaf.LeafIndex
 	}
 	return nil
 }

--- a/server/validate.go
+++ b/server/validate.go
@@ -105,18 +105,6 @@ func validateGetEntryAndProofRequest(req *trillian.GetEntryAndProofRequest) erro
 	return nil
 }
 
-func validateQueueLeafRequest(req *trillian.QueueLeafRequest) error {
-	return validateLogLeaf(req.Leaf, "QueueLeafRequest.Leaf")
-}
-
-func validateAddSequencedLeafRequest(req *trillian.AddSequencedLeafRequest) error {
-	return validateLogLeaf(req.Leaf, "AddSequencedLeafRequest.Leaf")
-}
-
-func validateQueueLeavesRequest(req *trillian.QueueLeavesRequest) error {
-	return validateLogLeaves(req.Leaves, "QueueLeavesRequest")
-}
-
 func validateAddSequencedLeavesRequest(req *trillian.AddSequencedLeavesRequest) error {
 	prefix := "AddSequencedLeavesRequest"
 	if err := validateLogLeaves(req.Leaves, prefix); err != nil {
@@ -127,7 +115,7 @@ func validateAddSequencedLeavesRequest(req *trillian.AddSequencedLeavesRequest) 
 	nextIndex := req.Leaves[0].LeafIndex
 	for i, leaf := range req.Leaves {
 		if leaf.LeafIndex != nextIndex {
-			return status.Errorf(codes.OutOfRange, "%v.Leaves[%v].LeafIndex=%v, want %v", prefix, i, leaf.LeafIndex, nextIndex)
+			return status.Errorf(codes.FailedPrecondition, "%v.Leaves[%v].LeafIndex=%v, want %v", prefix, i, leaf.LeafIndex, nextIndex)
 		}
 		nextIndex++
 	}

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -127,8 +127,8 @@ type LogStorage interface {
 	QueueLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error)
 
 	// AddSequencedLeaves stores the `leaves` and associates them with the log
-	// positions according to their `LeafIndex` field. The indices must be unique
-	// and sorted in ascending order.
+	// positions according to their `LeafIndex` field. The indices must be
+	// contiguous.
 	//
 	// If error is nil, the returned slice is the same size as the input, entries
 	// correspond to the `leaves` in the same order. Each entry describes the
@@ -136,8 +136,8 @@ type LogStorage interface {
 	//
 	// Possible `QueuedLogLeaf.status` values with their semantics:
 	//  - OK: The leaf has been successfully stored.
-	//  - AlreadyExists: The storage has another leaf with the same `LeafIndex`.
-	//    That leaf is returned in `QueuedLogLeaf.leaf`.
+	//  - AlreadyExists: The storage already contains an identical leaf at the
+	//    specified `LeafIndex`. That leaf is returned in `QueuedLogLeaf.leaf`.
 	//  - FailedPrecondition: There is another leaf with the same `LeafIndex`,
 	//    but a different value. That leaf is returned in `QueuedLogLeaf.leaf`.
 	//  - OutOfRange: The leaf can not be stored at the specified `LeafIndex`.

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -186,6 +186,10 @@ func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, treeID int6
 	return tx.Commit()
 }
 
+func (m *memoryLogStorage) AddSequencedLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf) ([]*trillian.QueuedLogLeaf, error) {
+	return nil, status.Errorf(codes.Unimplemented, "AddSequencedLeaves is not implemented")
+}
+
 func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -269,6 +269,19 @@ func (m *MockLogStorage) EXPECT() *MockLogStorageMockRecorder {
 	return m.recorder
 }
 
+// AddSequencedLeaves mocks base method
+func (m *MockLogStorage) AddSequencedLeaves(arg0 context.Context, arg1 int64, arg2 []*trillian.LogLeaf) ([]*trillian.QueuedLogLeaf, error) {
+	ret := m.ctrl.Call(m, "AddSequencedLeaves", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*trillian.QueuedLogLeaf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddSequencedLeaves indicates an expected call of AddSequencedLeaves
+func (mr *MockLogStorageMockRecorder) AddSequencedLeaves(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSequencedLeaves", reflect.TypeOf((*MockLogStorage)(nil).AddSequencedLeaves), arg0, arg1, arg2)
+}
+
 // CheckDatabaseAccessible mocks base method
 func (m *MockLogStorage) CheckDatabaseAccessible(arg0 context.Context) error {
 	ret := m.ctrl.Call(m, "CheckDatabaseAccessible", arg0)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -267,6 +267,10 @@ func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, treeID int64
 	return tx.Commit()
 }
 
+func (m *mySQLLogStorage) AddSequencedLeaves(ctx context.Context, treeID int64, leaves []*trillian.LogLeaf) ([]*trillian.QueuedLogLeaf, error) {
+	return nil, status.Errorf(codes.Unimplemented, "AddSequencedLeaves is not implemented")
+}
+
 func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, treeID int64) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := m.beginInternal(ctx, treeID, true /* readonly */)
 	if err != nil && err != storage.ErrTreeNeedsInit {

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -61,10 +61,12 @@ var ErrNotImplemented = errors.New("not implemented")
 
 // FakeLogStorage is a LogStorage implementation which is used for testing.
 type FakeLogStorage struct {
-	TX             storage.LogTreeTX
-	ReadOnlyTX     storage.ReadOnlyLogTreeTX
-	TXErr          error
-	QueueLeavesErr error
+	TX         storage.LogTreeTX
+	ReadOnlyTX storage.ReadOnlyLogTreeTX
+
+	TXErr                 error
+	QueueLeavesErr        error
+	AddSequencedLeavesErr error
 }
 
 // Snapshot implements LogStorage.Snapshot
@@ -94,6 +96,14 @@ func (f *FakeLogStorage) ReadWriteTransaction(ctx context.Context, id int64, fn 
 func (f *FakeLogStorage) QueueLeaves(ctx context.Context, logID int64, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	if f.QueueLeavesErr != nil {
 		return nil, f.QueueLeavesErr
+	}
+	return make([]*trillian.QueuedLogLeaf, len(leaves)), nil
+}
+
+// AddSequencedLeaves implements LogStorage.AddSequencedLeaves.
+func (f *FakeLogStorage) AddSequencedLeaves(ctx context.Context, logID int64, leaves []*trillian.LogLeaf) ([]*trillian.QueuedLogLeaf, error) {
+	if f.AddSequencedLeavesErr != nil {
+		return nil, f.AddSequencedLeavesErr
 	}
 	return make([]*trillian.QueuedLogLeaf, len(leaves)), nil
 }

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // RunOnLogTX is a helper for mocking out the LogStorage.ReadWriteTransaction method.
@@ -105,7 +107,11 @@ func (f *FakeLogStorage) AddSequencedLeaves(ctx context.Context, logID int64, le
 	if f.AddSequencedLeavesErr != nil {
 		return nil, f.AddSequencedLeavesErr
 	}
-	return make([]*trillian.QueuedLogLeaf, len(leaves)), nil
+	res := make([]*trillian.QueuedLogLeaf, len(leaves))
+	for i := range res {
+		res[i] = &trillian.QueuedLogLeaf{Status: status.New(codes.OK, "OK").Proto()}
+	}
+	return res, nil
 }
 
 // CheckDatabaseAccessible implements LogStorage.CheckDatabaseAccessible

--- a/trillian_log_api.proto
+++ b/trillian_log_api.proto
@@ -115,7 +115,11 @@ service TrillianLog {
     // Adds a batch of leaves to the queue.
     rpc QueueLeaves (QueueLeavesRequest) returns (QueueLeavesResponse) {
     }
-    // Adds a batch of leaves with assigned sequence numbers to the tree.
+
+    // Stores leaves from the provided batch and associates them with the log
+    // positions according to the `LeafIndex` field. The indices must be unique
+    // and sorted in ascending order.
+    //
     // Warning: This RPC is under development, don't use it.
     rpc AddSequencedLeaves (AddSequencedLeavesRequest) returns (AddSequencedLeavesResponse) {
     }

--- a/trillian_log_api.proto
+++ b/trillian_log_api.proto
@@ -117,8 +117,8 @@ service TrillianLog {
     }
 
     // Stores leaves from the provided batch and associates them with the log
-    // positions according to the `LeafIndex` field. The indices must be unique
-    // and sorted in ascending order.
+    // positions according to the `LeafIndex` field. The indices must be
+    // contiguous.
     //
     // Warning: This RPC is under development, don't use it.
     rpc AddSequencedLeaves (AddSequencedLeavesRequest) returns (AddSequencedLeavesResponse) {


### PR DESCRIPTION
This change adds `AddSequencedLeaves` to the storage API and implements the corresponding public API on top of it. This also adds method stubs to concrete storage implementations.