### PR TITLE
Add storage and quota providers

### DIFF
--- a/server/etcd_quota_provider.go
+++ b/server/etcd_quota_provider.go
@@ -30,7 +30,8 @@ const QuotaEtcd = "etcd"
 
 var (
 	// EtcdServers is a flag containing the address(es) of etcd servers
-	EtcdServers       = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+	EtcdServers = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+	// TODO(Martin2112): suggested renaming these to etc_... to avoid clashes, but will it break existing deploys?
 	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
 		"Zero or lower means batching is disabled. Applicable for etcd quotas.")
 	quotaMaxCacheEntries = flag.Int("quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Max number of quota specs in the quota cache. "+

--- a/server/etcd_quota_provider.go
+++ b/server/etcd_quota_provider.go
@@ -32,14 +32,14 @@ var (
 	// EtcdServers is a flag containing the address(es) of etcd servers
 	EtcdServers       = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
 	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
+		"Zero or lower means batching is disabled. Applicable for etcd quotas.")
 	quotaMaxCacheEntries = flag.Int("quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Max number of quota specs in the quota cache. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
+		"Zero or lower means batching is disabled. Applicable for etcd quotas.")
 )
 
 func init() {
 	if err := RegisterQuotaManager(QuotaEtcd, newEtcdQuotaManager); err != nil {
-		panic(err)
+		glog.Fatalf("Failed to register quota manager %v: %v", QuotaEtcd, err)
 	}
 }
 

--- a/server/etcd_quota_provider.go
+++ b/server/etcd_quota_provider.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/quota"
+	"github.com/google/trillian/quota/cacheqm"
+	"github.com/google/trillian/quota/etcd/etcdqm"
+	"github.com/google/trillian/util/etcd"
+)
+
+// QuotaEtcd represents the etcd quota implementation.
+const QuotaEtcd = "etcd"
+
+var (
+	// EtcdServers is a flag containing the address(es) of etcd servers
+	EtcdServers       = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
+		"Zero or lower means disabled. Applicable for etcd quotas.")
+	quotaMaxCacheEntries = flag.Int("quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Max number of quota specs in the quota cache. "+
+		"Zero or lower means disabled. Applicable for etcd quotas.")
+)
+
+func init() {
+	if err := RegisterQuotaManager(QuotaEtcd, newEtcdQuotaManager); err != nil {
+		panic(err)
+	}
+}
+
+func newEtcdQuotaManager() (quota.Manager, error) {
+	if *EtcdServers == "" {
+		return nil, fmt.Errorf("Can't create etcd quotamanager - etcd_servers flag is unset")
+	}
+	client, err := etcd.NewClient(*EtcdServers)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to connect to etcd at %v: %v", *EtcdServers, err)
+	}
+
+	qm := etcdqm.New(client)
+	if *quotaMinBatchSize > 0 && *quotaMaxCacheEntries > 0 {
+		cachedQM, err := cacheqm.NewCachedManager(qm, *quotaMinBatchSize, *quotaMaxCacheEntries)
+		if err != nil {
+			return nil, err
+		}
+		qm = cachedQM
+	}
+	glog.Info("Using Etcd QuotaManager")
+	return qm, nil
+}

--- a/server/memory_storage_provider.go
+++ b/server/memory_storage_provider.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"github.com/golang/glog"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/memory"
@@ -22,7 +23,7 @@ import (
 
 func init() {
 	if err := RegisterStorageProvider("memory", newMemoryStorageProvider); err != nil {
-		panic(err)
+		glog.Fatalf("Failed to register storage provider memory: %v", err)
 	}
 }
 

--- a/server/memory_storage_provider.go
+++ b/server/memory_storage_provider.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/memory"
+)
+
+func init() {
+	if err := RegisterStorageProvider("memory", newMemoryStorageProvider); err != nil {
+		panic(err)
+	}
+}
+
+type memProvider struct {
+	mf monitoring.MetricFactory
+	ls storage.LogStorage
+	as storage.AdminStorage
+}
+
+func newMemoryStorageProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
+	ls := memory.NewLogStorage(mf)
+	return &memProvider{
+		mf: mf,
+		ls: ls,
+		as: memory.NewAdminStorage(ls),
+	}, nil
+}
+
+func (s *memProvider) LogStorage() storage.LogStorage {
+	return s.ls
+}
+
+func (s *memProvider) MapStorage() storage.MapStorage {
+	return nil
+}
+
+func (s *memProvider) AdminStorage() storage.AdminStorage {
+	return s.as
+}
+
+func (s *memProvider) Close() error {
+	return nil
+}

--- a/server/mysql_quota_provider.go
+++ b/server/mysql_quota_provider.go
@@ -32,7 +32,7 @@ var (
 
 func init() {
 	if err := RegisterQuotaManager(QuotaMySQL, newMySQLQuotaManager); err != nil {
-		panic(err)
+		glog.Fatalf("Failed to register quota manager %v: %v", QuotaMySQL, err)
 	}
 }
 

--- a/server/mysql_quota_provider.go
+++ b/server/mysql_quota_provider.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/quota"
+	"github.com/google/trillian/quota/mysqlqm"
+)
+
+// QuotaMySQL represents the MySQL quota implementation.
+const QuotaMySQL = "mysql"
+
+var (
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+		"Only effective for quota_system=mysql.")
+)
+
+func init() {
+	if err := RegisterQuotaManager(QuotaMySQL, newMySQLQuotaManager); err != nil {
+		panic(err)
+	}
+}
+
+func newMySQLQuotaManager() (quota.Manager, error) {
+	qm := &mysqlqm.QuotaManager{
+		DB:                 mySQLstorageInstance.db,
+		MaxUnsequencedRows: *maxUnsequencedRows,
+	}
+	glog.Info("Using MySQL QuotaManager")
+	return qm, nil
+}

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/mysql"
@@ -36,7 +37,7 @@ var (
 
 func init() {
 	if err := RegisterStorageProvider("mysql", newMySQLStorageProvider); err != nil {
-		panic(err)
+		glog.Fatalf("Failed to register storage provider mysql: %v", err)
 	}
 }
 

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"database/sql"
+	"flag"
+	"sync"
+
+	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/mysql"
+
+	// Load MySQL driver
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+
+	mysqlOnce            sync.Once
+	mySQLstorageInstance *mysqlProvider
+)
+
+func init() {
+	if err := RegisterStorageProvider("mysql", newMySQLStorageProvider); err != nil {
+		panic(err)
+	}
+}
+
+type mysqlProvider struct {
+	db *sql.DB
+	mf monitoring.MetricFactory
+}
+
+func newMySQLStorageProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
+	var err error
+
+	mysqlOnce.Do(func() {
+		var db *sql.DB
+		db, err = mysql.OpenDB(*mySQLURI)
+		if err != nil {
+			return
+		}
+		mySQLstorageInstance = &mysqlProvider{
+			db: db,
+			mf: mf,
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mySQLstorageInstance, nil
+}
+
+func (s *mysqlProvider) LogStorage() storage.LogStorage {
+	return mysql.NewLogStorage(s.db, s.mf)
+}
+
+func (s *mysqlProvider) MapStorage() storage.MapStorage {
+	return mysql.NewMapStorage(s.db)
+}
+
+func (s *mysqlProvider) AdminStorage() storage.AdminStorage {
+	return mysql.NewAdminStorage(s.db)
+}
+
+func (s *mysqlProvider) Close() error {
+	return s.db.Close()
+}

--- a/server/quota.go
+++ b/server/quota.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 
@@ -31,6 +32,9 @@ const (
 type NewQuotaManagerFunc func() (quota.Manager, error)
 
 var (
+	// QuotaSystem is a flag specifying which quota system is in use.
+	QuotaSystem = flag.String("quota_system", "mysql", fmt.Sprintf("Quota system to use. One of: %v", quotaSystems()))
+
 	qpMu     sync.RWMutex
 	qpOnce   sync.Once
 	qpByName map[string]NewQuotaManagerFunc
@@ -61,8 +65,8 @@ func RegisterQuotaManager(name string, qp NewQuotaManagerFunc) error {
 	return nil
 }
 
-// QuotaSystems returns a slice of registered quota system names.
-func QuotaSystems() []string {
+// quotaSystems returns a slice of registered quota system names.
+func quotaSystems() []string {
 	qpMu.RLock()
 	defer qpMu.RUnlock()
 
@@ -72,6 +76,11 @@ func QuotaSystems() []string {
 	}
 
 	return r
+}
+
+// NewQuotaManagerFromFlags returns a quota.Manager implementation as speficied by flag.
+func NewQuotaManagerFromFlags() (quota.Manager, error) {
+	return NewQuotaManager(*QuotaSystem)
 }
 
 // NewQuotaManager returns a quota.Manager implementation.

--- a/server/quota_test.go
+++ b/server/quota_test.go
@@ -67,7 +67,7 @@ func TestQuotaProviderRegistration(t *testing.T) {
 func TestQuotaSystems(t *testing.T) {
 	RegisterQuotaManager("a", func() (quota.Manager, error) { return nil, nil })
 	RegisterQuotaManager("b", func() (quota.Manager, error) { return nil, nil })
-	qs := QuotaSystems()
+	qs := quotaSystems()
 
 	if got, want := len(qs), 2; got < want {
 		t.Fatalf("Got %d names, want at least %d", got, want)

--- a/server/quota_test.go
+++ b/server/quota_test.go
@@ -73,20 +73,20 @@ func TestQuotaSystems(t *testing.T) {
 		t.Fatalf("Got %d names, want at least %d", got, want)
 	}
 
-	a := false
-	b := false
+	a := 0
+	b := 0
 	for _, n := range qs {
 		if n == "a" {
-			a = true
+			a++
 		}
 		if n == "b" {
-			b = true
+			b++
 		}
 	}
-	if !a {
-		t.Error("QuotaSystems() didn't include 'a'")
+	if a != 1 {
+		t.Errorf("QuotaSystems() returned %d 'a', want 1", a)
 	}
-	if !b {
-		t.Error("QuotaSystems() didn't include 'b'")
+	if b != 1 {
+		t.Errorf("QuotaSystems() returned %d 'b', want 1", b)
 	}
 }

--- a/server/quota_test.go
+++ b/server/quota_test.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/google/trillian/quota"
+)
+
+func TestQuotaProviderRegistration(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		reg     bool
+		wantErr bool
+	}{
+		{
+			desc:    "works",
+			reg:     true,
+			wantErr: false,
+		},
+		{
+			desc:    "unknown provider",
+			reg:     false,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+
+			called := false
+			name := test.desc
+
+			if test.reg {
+				RegisterQuotaManager(name, func() (quota.Manager, error) {
+					called = true
+					return nil, nil
+				})
+			}
+
+			_, err := NewQuotaManager(name)
+			if err != nil && !test.wantErr {
+				t.Fatalf("NewQuotaManager = %v, want no error", err)
+			}
+			if err == nil && test.wantErr {
+				t.Fatalf("NewQuotaManager = no error, want error")
+			}
+
+			if !called && !test.wantErr {
+				t.Fatal("Registered quota provider was not called")
+			}
+		})
+	}
+}
+
+func TestQuotaSystems(t *testing.T) {
+	RegisterQuotaManager("a", func() (quota.Manager, error) { return nil, nil })
+	RegisterQuotaManager("b", func() (quota.Manager, error) { return nil, nil })
+	qs := QuotaSystems()
+
+	if got, want := len(qs), 2; got < want {
+		t.Fatalf("Got %d names, want at least %d", got, want)
+	}
+
+	a := false
+	b := false
+	for _, n := range qs {
+		if n == "a" {
+			a = true
+		}
+		if n == "b" {
+			b = true
+		}
+	}
+	if !a {
+		t.Error("QuotaSystems() didn't include 'a'")
+	}
+	if !b {
+		t.Error("QuotaSystems() didn't include 'b'")
+	}
+}

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 
@@ -27,6 +28,8 @@ import (
 type NewStorageProviderFunc func(monitoring.MetricFactory) (StorageProvider, error)
 
 var (
+	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", storageProviders()))
+
 	spMu     sync.RWMutex
 	spOnce   sync.Once
 	spByName map[string]NewStorageProviderFunc
@@ -49,6 +52,12 @@ func RegisterStorageProvider(name string, sp NewStorageProviderFunc) error {
 	return nil
 }
 
+// NewStorageProviderFromFlags returns a new StorageProvider instance of the type
+// specified by flag.
+func NewStorageProviderFromFlags(mf monitoring.MetricFactory) (StorageProvider, error) {
+	return NewStorageProvider(*storageSystem, mf)
+}
+
 // NewStorageProvider returns a new StorageProvider instance of the type
 // specified by name.
 func NewStorageProvider(name string, mf monitoring.MetricFactory) (StorageProvider, error) {
@@ -63,8 +72,8 @@ func NewStorageProvider(name string, mf monitoring.MetricFactory) (StorageProvid
 	return sp(mf)
 }
 
-// StorageProviders returns a slice of all registered storage provider names.
-func StorageProviders() []string {
+// storageProviders returns a slice of all registered storage provider names.
+func storageProviders() []string {
 	spMu.RLock()
 	defer spMu.RUnlock()
 

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/storage"
+)
+
+// NewStorageProviderFunc is the signature of a function which can be registered
+// to provide instances of storage providers.
+type NewStorageProviderFunc func(monitoring.MetricFactory) (StorageProvider, error)
+
+var (
+	spMu     sync.RWMutex
+	spOnce   sync.Once
+	spByName map[string]NewStorageProviderFunc
+)
+
+// RegisterStorageProvider registers the provided StorageProvider.
+func RegisterStorageProvider(name string, sp NewStorageProviderFunc) error {
+	spMu.Lock()
+	defer spMu.Unlock()
+
+	spOnce.Do(func() {
+		spByName = make(map[string]NewStorageProviderFunc)
+	})
+
+	_, exists := spByName[name]
+	if exists {
+		return fmt.Errorf("storage provider %v already registered", name)
+	}
+	spByName[name] = sp
+	return nil
+}
+
+// NewStorageProvider returns a new StorageProvider instance of the type
+// specified by name.
+func NewStorageProvider(name string, mf monitoring.MetricFactory) (StorageProvider, error) {
+	spMu.RLock()
+	defer spMu.RUnlock()
+
+	sp := spByName[name]
+	if sp == nil {
+		return nil, fmt.Errorf("no such storage provider %v", name)
+	}
+
+	return sp(mf)
+}
+
+// StorageProviders returns a slice of all registered storage provider names.
+func StorageProviders() []string {
+	spMu.RLock()
+	defer spMu.RUnlock()
+
+	r := []string{}
+	for k := range spByName {
+		r = append(r, k)
+	}
+
+	return r
+}
+
+// StorageProvider is an interface which allows trillian binaries to use
+// different storage implementations.
+type StorageProvider interface {
+	// LogStorage creates and returns a LogStorage implementation.
+	LogStorage() storage.LogStorage
+	// MapStorage creates and returns a MapStorage implementation.
+	MapStorage() storage.MapStorage
+	// AdminStorage creates and returns a AdminStorage implementation.
+	AdminStorage() storage.AdminStorage
+
+	// Close closes the underlying storage.
+	Close() error
+}

--- a/server/storage_provider_test.go
+++ b/server/storage_provider_test.go
@@ -78,7 +78,7 @@ func TestStorageProviders(t *testing.T) {
 	RegisterStorageProvider("b", func(_ monitoring.MetricFactory) (StorageProvider, error) {
 		return &provider{}, nil
 	})
-	sp := StorageProviders()
+	sp := storageProviders()
 
 	if got, want := len(sp), 2; got < want {
 		t.Fatalf("Got %d names, want at least %d", got, want)

--- a/server/storage_provider_test.go
+++ b/server/storage_provider_test.go
@@ -84,20 +84,20 @@ func TestStorageProviders(t *testing.T) {
 		t.Fatalf("Got %d names, want at least %d", got, want)
 	}
 
-	a := false
-	b := false
+	a := 0
+	b := 0
 	for _, n := range sp {
 		if n == "a" {
-			a = true
+			a++
 		}
 		if n == "b" {
-			b = true
+			b++
 		}
 	}
-	if !a {
-		t.Error("StorageProviders() didn't include 'a'")
+	if a != 1 {
+		t.Errorf("StorageProviders() gave %d 'a', want 1", a)
 	}
-	if !b {
-		t.Error("StorageProviders() didn't include 'b'")
+	if b != 1 {
+		t.Errorf("StorageProviders() gave %d 'b', want 1", b)
 	}
 }

--- a/server/storage_provider_test.go
+++ b/server/storage_provider_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/storage"
+)
+
+type provider struct {
+}
+
+func (p *provider) LogStorage() storage.LogStorage     { return nil }
+func (p *provider) MapStorage() storage.MapStorage     { return nil }
+func (p *provider) AdminStorage() storage.AdminStorage { return nil }
+func (p *provider) Close() error                       { return nil }
+
+func TestStorageProviderRegistration(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		reg     bool
+		wantErr bool
+	}{
+		{
+			desc:    "works",
+			reg:     true,
+			wantErr: false,
+		},
+		{
+			desc:    "unknown provider",
+			reg:     false,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			called := false
+			name := test.desc
+
+			if test.reg {
+				RegisterStorageProvider(name, func(_ monitoring.MetricFactory) (StorageProvider, error) {
+					called = true
+					return &provider{}, nil
+				})
+			}
+
+			_, err := NewStorageProvider(name, nil)
+			if err != nil && !test.wantErr {
+				t.Fatalf("NewStorageProvider = %v, want no error", err)
+			}
+			if err == nil && test.wantErr {
+				t.Fatalf("NewStorageProvider = no error, want error")
+			}
+			if !called && !test.wantErr {
+				t.Fatal("Registered storage provider was not called")
+			}
+		})
+	}
+}
+
+func TestStorageProviders(t *testing.T) {
+	RegisterStorageProvider("a", func(_ monitoring.MetricFactory) (StorageProvider, error) {
+		return &provider{}, nil
+	})
+	RegisterStorageProvider("b", func(_ monitoring.MetricFactory) (StorageProvider, error) {
+		return &provider{}, nil
+	})
+	sp := StorageProviders()
+
+	if got, want := len(sp), 2; got < want {
+		t.Fatalf("Got %d names, want at least %d", got, want)
+	}
+
+	a := false
+	b := false
+	for _, n := range sp {
+		if n == "a" {
+			a = true
+		}
+		if n == "b" {
+			b = true
+		}
+	}
+	if !a {
+		t.Error("StorageProviders() didn't include 'a'")
+	}
+	if !b {
+		t.Error("StorageProviders() didn't include 'b'")
+	}
+}

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -28,12 +29,9 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/monitoring/prometheus"
-	"github.com/google/trillian/quota/cacheqm"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
-	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/server"
-	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -43,8 +41,6 @@ import (
 
 	// Register pprof HTTP handlers
 	_ "net/http/pprof"
-	// Load MySQL driver
-	_ "github.com/go-sql-driver/mysql"
 	// Register key ProtoHandlers
 	_ "github.com/google/trillian/crypto/keys/der/proto"
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
@@ -55,23 +51,16 @@ import (
 )
 
 var (
-	mySQLURI        = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	rpcEndpoint     = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint    = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
 	tlsCertFile     = flag.String("tls_cert_file", "", "Path to the TLS server certificate. If unset, the server will use unsecured connections.")
 	tlsKeyFile      = flag.String("tls_key_file", "", "Path to the TLS server key. If unset, the server will use unsecured connections.")
-	etcdServers     = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
 	etcdService     = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
 	etcdHTTPService = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
 
-	quotaDryRun       = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
-	quotaSystem       = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
-	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
-	quotaMaxCacheEntries = flag.Int("quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Max number of quota specs in the quota cache. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
-		"Only effective for quota_system=mysql.")
+	quotaDryRun   = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
+	quotaSystem   = flag.String("quota_system", "mysql", fmt.Sprintf("Quota system to use. One of: %v", server.QuotaSystems()))
+	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", server.StorageProviders()))
 
 	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
 	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
@@ -91,16 +80,16 @@ func main() {
 
 	ctx := context.Background()
 
-	// First make sure we can access the database, quit if not
-	db, err := mysql.OpenDB(*mySQLURI)
-	if err != nil {
-		glog.Exitf("Failed to open database: %v", err)
-	}
-	// No defer: database ownership is delegated to server.Main
+	mf := prometheus.MetricFactory{}
 
-	client, err := etcd.NewClient(*etcdServers)
+	sp, err := server.NewStorageProvider(*storageSystem, mf)
 	if err != nil {
-		glog.Exitf("Failed to connect to etcd at %v: %v", etcdServers, err)
+		glog.Exitf("Failed to get storage provider: %v", err)
+	}
+
+	client, err := etcd.NewClient(*server.EtcdServers)
+	if err != nil {
+		glog.Exitf("Failed to connect to etcd at %v: %v", server.EtcdServers, err)
 	}
 
 	// Announce our endpoints to etcd if so configured.
@@ -111,23 +100,14 @@ func main() {
 		defer unannounceHTTP()
 	}
 
-	qm, err := server.NewQuotaManager(&server.QuotaParams{
-		QuotaSystem:        *quotaSystem,
-		DB:                 db,
-		MaxUnsequencedRows: *maxUnsequencedRows,
-		Client:             client,
-		MinBatchSize:       *quotaMinBatchSize,
-		MaxCacheEntries:    *quotaMaxCacheEntries,
-	})
+	qm, err := server.NewQuotaManager(*quotaSystem)
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}
 
-	mf := prometheus.MetricFactory{}
-
 	registry := extension.Registry{
-		AdminStorage:  mysql.NewAdminStorage(db),
-		LogStorage:    mysql.NewLogStorage(db, mf),
+		AdminStorage:  sp.AdminStorage(),
+		LogStorage:    sp.LogStorage(),
 		QuotaManager:  qm,
 		MetricFactory: mf,
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
@@ -142,7 +122,7 @@ func main() {
 		TLSKeyFile:   *tlsKeyFile,
 		StatsPrefix:  "log",
 		QuotaDryRun:  *quotaDryRun,
-		DBClose:      db.Close,
+		DBClose:      sp.Close,
 		Registry:     registry,
 		RegisterHandlerFn: func(ctx netcontext.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 			if err := trillian.RegisterTrillianLogHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -54,11 +54,9 @@ var (
 	etcdHTTPService          = flag.String("etcd_http_service", "trillian-logsigner-http", "Service name to announce our HTTP endpoint under")
 	lockDir                  = flag.String("lock_file_path", "/test/multimaster", "etcd lock file directory path")
 
-	quotaSystem         = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
 	quotaIncreaseFactor = flag.Float64("quota_increase_factor", log.QuotaIncreaseFactor,
 		"Increase factor for tokens replenished by sequencing-based quotas (1 means a 1:1 relationship between sequenced leaves and replenished tokens)."+
 			"Only effective for --quota_system=etcd.")
-	storageSystem = flag.String("storage_system", "mysql", "Storage system to use. Once of 'mysql', 'memory'")
 
 	preElectionPause    = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	masterCheckInterval = flag.Duration("master_check_interval", 5*time.Second, "Interval between checking mastership still held")
@@ -82,7 +80,7 @@ func main() {
 
 	mf := prometheus.MetricFactory{}
 
-	sp, err := server.NewStorageProvider(*storageSystem, mf)
+	sp, err := server.NewStorageProviderFromFlags(mf)
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}
@@ -109,7 +107,7 @@ func main() {
 		glog.Exit("Either --force_master or --etcd_servers must be supplied")
 	}
 
-	qm, err := server.NewQuotaManager(*quotaSystem)
+	qm, err := server.NewQuotaManagerFromFlags()
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -26,12 +26,9 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/monitoring/prometheus"
-	"github.com/google/trillian/quota/cacheqm"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
-	"github.com/google/trillian/quota/mysqlqm"
 	"github.com/google/trillian/server"
-	"github.com/google/trillian/storage/mysql"
 	"github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
@@ -40,8 +37,6 @@ import (
 
 	// Register pprof HTTP handlers
 	_ "net/http/pprof"
-	// Load MySQL driver
-	_ "github.com/go-sql-driver/mysql"
 	// Register key ProtoHandlers
 	_ "github.com/google/trillian/crypto/keys/der/proto"
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
@@ -52,21 +47,14 @@ import (
 )
 
 var (
-	mySQLURI     = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	rpcEndpoint  = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
 	httpEndpoint = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
 	tlsCertFile  = flag.String("tls_cert_file", "", "Path to the TLS server certificate. If unset, the server will use unsecured connections.")
 	tlsKeyFile   = flag.String("tls_key_file", "", "Path to the TLS server key. If unset, the server will use unsecured connections.")
-	etcdServers  = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
 
-	quotaDryRun       = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
-	quotaSystem       = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
-	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
-	quotaMaxCacheEntries = flag.Int("quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Max number of quota specs in the quota cache. "+
-		"Zero or lower means disabled. Applicable for etcd quotas.")
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
-		"Only effective for quota_system=mysql.")
+	quotaDryRun   = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
+	quotaSystem   = flag.String("quota_system", "mysql", "Quota system to use. One of: \"noop\", \"mysql\" or \"etcd\"")
+	storageSystem = flag.String("storage_system", "mysql", "Storage system to use. Once of 'mysql', 'memory'")
 
 	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
 	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
@@ -84,34 +72,28 @@ func main() {
 		}
 	}
 
-	db, err := mysql.OpenDB(*mySQLURI)
-	if err != nil {
-		glog.Exitf("Failed to open database: %v", err)
-	}
-	// No defer: database ownership is delegated to server.Main
+	mf := prometheus.MetricFactory{}
 
-	client, err := etcd.NewClient(*etcdServers)
+	sp, err := server.NewStorageProvider(*storageSystem, mf)
 	if err != nil {
-		glog.Exitf("Failed to connect to etcd at %v: %v", etcdServers, err)
+		glog.Exitf("Failed to get storage provider: %v", err)
 	}
 
-	qm, err := server.NewQuotaManager(&server.QuotaParams{
-		QuotaSystem:        *quotaSystem,
-		DB:                 db,
-		MaxUnsequencedRows: *maxUnsequencedRows,
-		Client:             client,
-		MinBatchSize:       *quotaMinBatchSize,
-		MaxCacheEntries:    *quotaMaxCacheEntries,
-	})
+	client, err := etcd.NewClient(*server.EtcdServers)
+	if err != nil {
+		glog.Exitf("Failed to connect to etcd at %v: %v", server.EtcdServers, err)
+	}
+
+	qm, err := server.NewQuotaManager(*quotaSystem)
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}
 
 	registry := extension.Registry{
-		AdminStorage:  mysql.NewAdminStorage(db),
-		MapStorage:    mysql.NewMapStorage(db),
+		AdminStorage:  sp.AdminStorage(),
+		MapStorage:    sp.MapStorage(),
 		QuotaManager:  qm,
-		MetricFactory: prometheus.MetricFactory{},
+		MetricFactory: mf,
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)
 		},
@@ -124,7 +106,7 @@ func main() {
 		TLSKeyFile:   *tlsKeyFile,
 		StatsPrefix:  "map",
 		QuotaDryRun:  *quotaDryRun,
-		DBClose:      db.Close,
+		DBClose:      sp.Close,
 		Registry:     registry,
 		RegisterHandlerFn: func(ctx netcontext.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 			if err := trillian.RegisterTrillianMapHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {


### PR DESCRIPTION
This PR provides a more modular approach to adding and configuring the storage and quota implementations with a mechanism for self-registration by implementations, and a factory for uses.
It updates the server `main`s to use this mechanism, and existing quota/storage implementations to register themselves.

Alternatives considered include one-main-per-storage-and-quota-system (combinatorial explosion), build tags to build in exactly one quota and storage impl (seems a slight abuse of build tags, and could perhaps be considered dangerous in that it'd be possible to build for deployment but accidentally produce a binary/docker image with the wrong impls).

Paves the way for #950.