### PR TITLE
log/sequencer: no new root is not an error

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -437,8 +437,6 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, logID int64, limit int, g
 	seqCounter.Add(float64(numLeaves), label)
 	if newLogRoot != nil {
 		glog.Infof("%v: sequenced %v leaves, size %v, tree-revision %v", logID, numLeaves, newLogRoot.TreeSize, newLogRoot.TreeRevision)
-	} else {
-		glog.Errorf("newLogRoot = nil")
 	}
 	return numLeaves, nil
 }


### PR DESCRIPTION
If there is nothing to sequence then newLogRoot will stay nil.