### PR TITLE
Tweak cluster

### DIFF
--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -33,7 +33,8 @@ spec:
         envFrom:
           - configMapRef:
               name: deploy-config
-        image: gcr.io/$(CLOUD_PROJECT)/log_server:latest
+        # Update this with the name of your project:
+        image: gcr.io/trillian-opensource-ci/log_server:latest
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     io.kompose.service: trillian-logserver
   name: trillian-logserver-deployment
 spec:
-  replicas: 1
+  replicas: 3
   strategy: {}
   template:
     metadata:

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     kompose.version: 1.3.0 (HEAD)
   creationTimestamp: null
   labels:
-    io.kompose.service: trillian-logserver
+    io.kompose.service: trillian-log
   name: trillian-logserver-deployment
 spec:
   replicas: 3

--- a/examples/deployment/kubernetes/trillian-log-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-service.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     io.kompose.service: trillian-logserver
   name: trillian-logserver
+  annotations:
+      cloud.google.com/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   ports:

--- a/examples/deployment/kubernetes/trillian-log-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: trillian-logserver
-  name: trillian-logserver
+    io.kompose.service: trillian-log
+  name: trillian-log
   annotations:
       cloud.google.com/load-balancer-type: "Internal"
 spec:
@@ -16,6 +16,6 @@ spec:
     port: 8091
     targetPort: 8091
   selector:
-    io.kompose.service: trillian-logserver
+    io.kompose.service: trillian-log
 status:
   loadBalancer: {}

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     kompose.version: 1.3.0 (HEAD)
   creationTimestamp: null
   labels:
-    io.kompose.service: trillian-logsigner
+    io.kompose.service: trillian-log-signer
   name: trillian-logsigner-deployment
 spec:
   replicas: 1
@@ -49,7 +49,7 @@ spec:
           failureThreshold: 3
           periodSeconds: 30
           timeoutSeconds: 30
-        name: trillian-logsigner
+        name: trillian-log-signer
         ports:
         - containerPort: 8091
         resources: {}

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -37,7 +37,8 @@ spec:
         envFrom:
           - configMapRef:
               name: deploy-config
-        image: gcr.io/$(CLOUD_PROJECT)/log_signer:latest
+        # Update this with the name of your project:
+        image: gcr.io/trillian-opensource-ci/log_signer:latest
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/examples/deployment/kubernetes/trillian-log-signer-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-service.yaml
@@ -7,14 +7,14 @@ metadata:
     cloud.google.com/load-balancer-type: "Internal"
   creationTimestamp: null
   labels:
-    io.kompose.service: trillian-logsigner
-  name: trillian-logsigner
+    io.kompose.service: trillian-log-signer
+  name: trillian-log-signer
 spec:
   ports:
   - name: "8092"
     port: 8092
     targetPort: 8091
   selector:
-    io.kompose.service: trillian-logsigner
+    io.kompose.service: trillian-log-signer
 status:
   loadBalancer: {}

--- a/examples/deployment/kubernetes/trillian-log-signer-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.3.0 (HEAD)
+    cloud.google.com/load-balancer-type: "Internal"
   creationTimestamp: null
   labels:
     io.kompose.service: trillian-logsigner

--- a/examples/deployment/kubernetes/trillian-opensource-ci.yaml
+++ b/examples/deployment/kubernetes/trillian-opensource-ci.yaml
@@ -4,8 +4,6 @@ metadata:
   name: deploy-config
   namespace: default
 data:
-  # Update this with the name of your project:
-  CLOUD_PROJECT: trillian-opensource-ci
   STORAGE_SYSTEM: cloud_spanner
   STORAGE_FLAG: --cloudspanner_uri=projects/trillian-opensource-ci/instances/trillian-opensource-ci/databases/trillian-opensource-ci-db
   GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json


### PR DESCRIPTION
This PR tweaks the kubernetes cluster a little:
* renames a couple of services to bring them into alignment.
* increases the number of log server replicas to 3.
* removes the `CLOUD_PROJECT` configmap variable which doesn't seem to work as intended. 