### PR TITLE
Add log signer to docker-compose deployment

### DIFF
--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - DB_USER=root
       - DB_PASSWORD=$DB_PASSWORD
     command: ./wait-for-it.sh -t 0 mysql:3306 -- ./scripts/resetdb.sh --verbose --force -h mysql
-  trillian-server:
+  trillian-log-server:
     build:
       context: ../..
       dockerfile: examples/deployment/docker/log_server/Dockerfile
@@ -25,4 +25,15 @@ services:
     environment:
       - DB_USER=root
       - DB_PASSWORD=$DB_PASSWORD
-      - DB_HOST=mysql:3306
+  trillian-log-signer:
+    build:
+      context: ../..
+      dockerfile: examples/deployment/docker/log_signer/Dockerfile
+    restart: always # retry while mysql is starting up
+    ports:
+      - "8092:8091"
+    depends_on:
+      - mysql
+    environment:
+      - DB_USER=root
+      - DB_PASSWORD=$DB_PASSWORD


### PR DESCRIPTION
This makes it possible to run a fully functional test instance of Trillian with docker-compose.