### PR TITLE
log/sequencer: no new root is not an error

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -437,8 +437,6 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 	seqCounter.Add(float64(numLeaves), label)
 	if newLogRoot != nil {
 		glog.Infof("%v: sequenced %v leaves, size %v, tree-revision %v", tree.TreeId, numLeaves, newLogRoot.TreeSize, newLogRoot.TreeRevision)
-	} else {
-		glog.Errorf("newLogRoot = nil")
 	}
 	return numLeaves, nil
 }


### PR DESCRIPTION
Repeat of commit b053d2e8d611a564ab which got lost in a
sequence of merges.