### PR TITLE
Use LogRootV1 with SignLogRoot / VerifyLogRoot

### DIFF
--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/types"
 
 	tcrypto "github.com/google/trillian/crypto"
 )
@@ -66,37 +67,38 @@ func NewLogVerifierFromTree(config *trillian.Tree) (*LogVerifier, error) {
 
 // VerifyRoot verifies that newRoot is a valid append-only operation from trusted.
 // If trusted.TreeSize is zero, a consistency proof is not needed.
-func (c *LogVerifier) VerifyRoot(trusted, newRoot *trillian.SignedLogRoot,
-	consistency [][]byte) error {
+func (c *LogVerifier) VerifyRoot(trusted *types.LogRootV1, newRoot *trillian.SignedLogRoot,
+	consistency [][]byte) (*types.LogRootV1, error) {
 
 	if trusted == nil {
-		return fmt.Errorf("VerifyRoot() error: trusted == nil")
+		return nil, fmt.Errorf("VerifyRoot() error: trusted == nil")
 	}
 	if newRoot == nil {
-		return fmt.Errorf("VerifyRoot() error: newRoot == nil")
+		return nil, fmt.Errorf("VerifyRoot() error: newRoot == nil")
 	}
 
 	// Verify SignedLogRoot signature.
-	if _, err := tcrypto.VerifySignedLogRoot(c.pubKey, newRoot); err != nil {
-		return err
+	r, err := tcrypto.VerifySignedLogRoot(c.pubKey, newRoot)
+	if err != nil {
+		return nil, err
 	}
 
 	// Implicitly trust the first root we get.
 	if trusted.TreeSize != 0 {
 		// Verify consistency proof.
 		if err := c.v.VerifyConsistencyProof(
-			trusted.TreeSize, newRoot.TreeSize,
-			trusted.RootHash, newRoot.RootHash,
+			int64(trusted.TreeSize), int64(r.TreeSize),
+			trusted.RootHash, r.RootHash,
 			consistency); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return r, nil
 }
 
 // VerifyInclusionAtIndex verifies that the inclusion proof for data at index matches
 // the currently trusted root. The inclusion proof must be requested for Root().TreeSize.
-func (c *LogVerifier) VerifyInclusionAtIndex(trusted *trillian.SignedLogRoot, data []byte, leafIndex int64, proof [][]byte) error {
+func (c *LogVerifier) VerifyInclusionAtIndex(trusted *types.LogRootV1, data []byte, leafIndex int64, proof [][]byte) error {
 	if trusted == nil {
 		return fmt.Errorf("VerifyInclusionAtIndex() error: trusted == nil")
 	}
@@ -105,12 +107,12 @@ func (c *LogVerifier) VerifyInclusionAtIndex(trusted *trillian.SignedLogRoot, da
 	if err != nil {
 		return err
 	}
-	return c.v.VerifyInclusionProof(leafIndex, trusted.TreeSize,
+	return c.v.VerifyInclusionProof(leafIndex, int64(trusted.TreeSize),
 		proof, trusted.RootHash, leaf.MerkleLeafHash)
 }
 
 // VerifyInclusionByHash verifies the inclusion proof for data
-func (c *LogVerifier) VerifyInclusionByHash(trusted *trillian.SignedLogRoot, leafHash []byte, proof *trillian.Proof) error {
+func (c *LogVerifier) VerifyInclusionByHash(trusted *types.LogRootV1, leafHash []byte, proof *trillian.Proof) error {
 	if trusted == nil {
 		return fmt.Errorf("VerifyInclusionByHash() error: trusted == nil")
 	}
@@ -118,7 +120,7 @@ func (c *LogVerifier) VerifyInclusionByHash(trusted *trillian.SignedLogRoot, lea
 		return fmt.Errorf("VerifyInclusionByHash() error: proof == nil")
 	}
 
-	return c.v.VerifyInclusionProof(proof.LeafIndex, trusted.TreeSize, proof.Hashes,
+	return c.v.VerifyInclusionProof(proof.LeafIndex, int64(trusted.TreeSize), proof.Hashes,
 		trusted.RootHash, leafHash)
 }
 

--- a/client/log_verifier_test.go
+++ b/client/log_verifier_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 
 	"github.com/google/trillian"
-	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
+
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 func TestVerifyRootErrors(t *testing.T) {
@@ -44,17 +45,18 @@ func TestVerifyRootErrors(t *testing.T) {
 
 	// Test execution
 	tests := []struct {
-		desc             string
-		trusted, newRoot *trillian.SignedLogRoot
+		desc    string
+		trusted *types.LogRootV1
+		newRoot *trillian.SignedLogRoot
 	}{
-		{desc: "newRootNil", trusted: signedRoot, newRoot: nil},
+		{desc: "newRootNil", trusted: &types.LogRootV1{}, newRoot: nil},
 		{desc: "trustedNil", trusted: nil, newRoot: signedRoot},
 	}
 	for _, test := range tests {
 		logVerifier := NewLogVerifier(rfc6962.DefaultHasher, pk)
 
 		// This also makes sure that no nil pointer dereference errors occur (as this would cause a panic).
-		if err := logVerifier.VerifyRoot(test.trusted, test.newRoot, nil); err == nil {
+		if _, err := logVerifier.VerifyRoot(test.trusted, test.newRoot, nil); err == nil {
 			t.Errorf("%v: VerifyRoot() error expected, but got nil", test.desc)
 		}
 	}
@@ -72,11 +74,11 @@ func TestVerifyInclusionAtIndexErrors(t *testing.T) {
 func TestVerifyInclusionByHashErrors(t *testing.T) {
 	tests := []struct {
 		desc    string
-		trusted *trillian.SignedLogRoot
+		trusted *types.LogRootV1
 		proof   *trillian.Proof
 	}{
 		{desc: "trustedNil", trusted: nil, proof: &trillian.Proof{}},
-		{desc: "proofNil", trusted: &trillian.SignedLogRoot{}, proof: nil},
+		{desc: "proofNil", trusted: &types.LogRootV1{}, proof: nil},
 	}
 	for _, test := range tests {
 

--- a/client/log_verifier_test.go
+++ b/client/log_verifier_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/types"
 )
 
 func TestVerifyRootErrors(t *testing.T) {
@@ -36,7 +37,7 @@ func TestVerifyRootErrors(t *testing.T) {
 		t.Fatalf("Failed to load public key, err=%v", err)
 	}
 
-	signedRoot, err := signer.SignLogRoot(&trillian.SignedLogRoot{})
+	signedRoot, err := signer.SignLogRoot(&types.LogRootV1{})
 	if err != nil {
 		t.Fatal("Failed to create test signature")
 	}

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/types"
 )
 
 var sigpbHashLookup = map[crypto.Hash]sigpb.DigitallySigned_HashAlgorithm{
@@ -84,7 +85,13 @@ func (s *Signer) SignObject(obj interface{}) (*sigpb.DigitallySigned, error) {
 }
 
 // SignLogRoot returns a complete SignedLogRoot (including signature).
-func (s *Signer) SignLogRoot(root *trillian.SignedLogRoot) (*trillian.SignedLogRoot, error) {
+func (s *Signer) SignLogRoot(r *types.LogRootV1) (*trillian.SignedLogRoot, error) {
+	root := &trillian.SignedLogRoot{
+		TreeSize:       int64(r.TreeSize),
+		RootHash:       r.RootHash,
+		TimestampNanos: int64(r.TimestampNanos),
+		TreeRevision:   int64(r.Revision),
+	}
 	hash, err := hashLogRoot(*root)
 	if err != nil {
 		return nil, err
@@ -95,10 +102,8 @@ func (s *Signer) SignLogRoot(root *trillian.SignedLogRoot) (*trillian.SignedLogR
 		return nil, err
 	}
 
-	ret := *root // Don't modify the input variable.
-	ret.Signature = signature
-
-	return &ret, nil
+	root.Signature = signature
+	return root, nil
 }
 
 // SignMapRoot hashes and signs the supplied (to-be) SignedMapRoot and returns a

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/types"
 )
 
 const message string = "testing"
@@ -106,11 +107,11 @@ func TestSignLogRoot(t *testing.T) {
 	signer := NewSHA256Signer(key)
 
 	for _, test := range []struct {
-		root trillian.SignedLogRoot
+		root *types.LogRootV1
 	}{
-		{root: trillian.SignedLogRoot{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}},
+		{root: &types.LogRootV1{TimestampNanos: 2267709, RootHash: []byte("Islington"), TreeSize: 2}},
 	} {
-		slr, err := signer.SignLogRoot(&test.root)
+		slr, err := signer.SignLogRoot(test.root)
 		if err != nil {
 			t.Errorf("Failed to sign log root: %v", err)
 			continue

--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -27,6 +27,7 @@ import (
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/types"
 )
 
 var (
@@ -38,7 +39,7 @@ var (
 )
 
 // VerifySignedLogRoot verifies the SignedLogRoot and returns its contents.
-func VerifySignedLogRoot(pub crypto.PublicKey, r *trillian.SignedLogRoot) (*trillian.SignedLogRoot, error) {
+func VerifySignedLogRoot(pub crypto.PublicKey, r *trillian.SignedLogRoot) (*types.LogRootV1, error) {
 	// Verify SignedLogRoot signature.
 	hash, err := hashLogRoot(*r)
 	if err != nil {
@@ -47,7 +48,12 @@ func VerifySignedLogRoot(pub crypto.PublicKey, r *trillian.SignedLogRoot) (*tril
 	if err := Verify(pub, hash, r.Signature); err != nil {
 		return nil, err
 	}
-	return r, nil
+	return &types.LogRootV1{
+		TreeSize:       uint64(r.TreeSize),
+		RootHash:       r.RootHash,
+		TimestampNanos: uint64(r.TimestampNanos),
+		Revision:       uint64(r.TreeRevision),
+	}, nil
 
 }
 

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/types"
 	"github.com/google/trillian/util"
 )
 
@@ -385,12 +386,11 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 
 		// Create the log root ready for signing
 		seqTreeSize.Set(float64(merkleTree.Size()), label)
-		newLogRoot, err := s.signer.SignLogRoot(&trillian.SignedLogRoot{
+		newLogRoot, err := s.signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       merkleTree.CurrentRoot(),
 			TimestampNanos: s.timeSource.Now().UnixNano(),
 			TreeSize:       merkleTree.Size(),
-			LogId:          currentRoot.LogId,
-			TreeRevision:   newVersion,
+			Revision:       newVersion,
 		})
 		if err != nil {
 			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)
@@ -455,12 +455,11 @@ func (s Sequencer) SignRoot(ctx context.Context, tree *trillian.Tree) error {
 		if err != nil {
 			return err
 		}
-		newLogRoot, err := s.signer.SignLogRoot(&trillian.SignedLogRoot{
+		newLogRoot, err := s.signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       merkleTree.CurrentRoot(),
 			TimestampNanos: s.timeSource.Now().UnixNano(),
 			TreeSize:       merkleTree.Size(),
-			LogId:          currentRoot.LogId,
-			TreeRevision:   currentRoot.TreeRevision + 1,
+			Revision:       currentRoot.TreeRevision + 1,
 		})
 		if err != nil {
 			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -388,9 +388,9 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 		seqTreeSize.Set(float64(merkleTree.Size()), label)
 		newLogRoot, err := s.signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       merkleTree.CurrentRoot(),
-			TimestampNanos: s.timeSource.Now().UnixNano(),
-			TreeSize:       merkleTree.Size(),
-			Revision:       newVersion,
+			TimestampNanos: uint64(s.timeSource.Now().UnixNano()),
+			TreeSize:       uint64(merkleTree.Size()),
+			Revision:       uint64(newVersion),
 		})
 		if err != nil {
 			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)
@@ -457,9 +457,9 @@ func (s Sequencer) SignRoot(ctx context.Context, tree *trillian.Tree) error {
 		}
 		newLogRoot, err := s.signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       merkleTree.CurrentRoot(),
-			TimestampNanos: s.timeSource.Now().UnixNano(),
-			TreeSize:       merkleTree.Size(),
-			Revision:       currentRoot.TreeRevision + 1,
+			TimestampNanos: uint64(s.timeSource.Now().UnixNano()),
+			TreeSize:       uint64(merkleTree.Size()),
+			Revision:       uint64(currentRoot.TreeRevision + 1),
 		})
 		if err != nil {
 			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -607,9 +607,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 
 		root, err := signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       hasher.EmptyRoot(),
-			TimestampNanos: t.timeSource.Now().UnixNano(),
-			TreeSize:       0,
-			Revision:       0,
+			TimestampNanos: uint64(t.timeSource.Now().UnixNano()),
 		})
 		if err != nil {
 			return err

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/trees"
+	"github.com/google/trillian/types"
 	"github.com/google/trillian/util"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -604,12 +605,11 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 			return status.Errorf(codes.FailedPrecondition, "Signer() :%v", err)
 		}
 
-		root, err := signer.SignLogRoot(&trillian.SignedLogRoot{
+		root, err := signer.SignLogRoot(&types.LogRootV1{
 			RootHash:       hasher.EmptyRoot(),
 			TimestampNanos: t.timeSource.Now().UnixNano(),
 			TreeSize:       0,
-			LogId:          logID,
-			TreeRevision:   0,
+			Revision:       0,
 		})
 		if err != nil {
 			return err

--- a/server/sequencer_manager_test.go
+++ b/server/sequencer_manager_test.go
@@ -72,7 +72,6 @@ var testRoot0 = trillian.SignedLogRoot{
 }
 var updatedNodes0 = []storage.Node{{NodeID: storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 64}, Hash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), NodeRevision: 1}}
 var updatedRoot = trillian.SignedLogRoot{
-	LogId:          testLogID1,
 	TimestampNanos: fakeTime.UnixNano(),
 	RootHash:       []byte{110, 52, 11, 156, 255, 179, 122, 152, 156, 165, 68, 230, 187, 120, 10, 44, 120, 144, 29, 63, 179, 55, 56, 118, 133, 17, 163, 6, 23, 175, 160, 29},
 	TreeSize:       1,

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -49,6 +49,7 @@ import (
 	"github.com/google/trillian/storage/memory"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/trees"
+	"github.com/google/trillian/types"
 	"github.com/google/trillian/util"
 )
 
@@ -202,8 +203,7 @@ func createTree(as storage.AdminStorage, ls storage.LogStorage) (*trillian.Tree,
 		glog.Fatalf("Creating signer: %v", err)
 	}
 
-	sthZero, err := tSigner.SignLogRoot(&trillian.SignedLogRoot{
-		LogId:    createdTree.TreeId,
+	sthZero, err := tSigner.SignLogRoot(&types.LogRootV1{
 		RootHash: hasher.EmptyRoot(),
 	})
 	if err != nil {

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -35,10 +35,10 @@ import (
 //   opaque metadata<0..65535>;
 // } LogRootV1;
 type LogRootV1 struct {
-	TreeSize       uint64
+	TreeSize       int64
 	RootHash       []byte `tls:"minlen:0,maxlen:128"`
-	TimestampNanos uint64
-	Revision       uint64
+	TimestampNanos int64
+	Revision       int64
 	Metadata       []byte `tls:"minlen:0,maxlen:65535"`
 }
 

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -35,10 +35,10 @@ import (
 //   opaque metadata<0..65535>;
 // } LogRootV1;
 type LogRootV1 struct {
-	TreeSize       int64
+	TreeSize       uint64
 	RootHash       []byte `tls:"minlen:0,maxlen:128"`
-	TimestampNanos int64
-	Revision       int64
+	TimestampNanos uint64
+	Revision       uint64
 	Metadata       []byte `tls:"minlen:0,maxlen:65535"`
 }
 


### PR DESCRIPTION
This PR continues in the theme of #958 by using the `LogRootV1` defined in #1037 to create `*trillian.SignedLogRoot` objects via `SignLogRoot`.  Verifying a `*trillian.SignedLogRoot` will also extract and return the `LogRootV1` object. 

Local references to `trillian.SignedLogRoot` that access it's fields will slowly be replaced with `LogRootV1` objects. 

Note that `LogID` is no longer a part of `LogRootV1`.  In future PRs, `LogID` will be more related to the `signer` than the `LogRootV1` object. 


