### PR TITLE
Export log verifier contents

### DIFF
--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -29,16 +29,16 @@ import (
 
 // LogVerifier contains state needed to verify output from Trillian Logs.
 type LogVerifier struct {
-	hasher hashers.LogHasher
-	pubKey crypto.PublicKey
+	Hasher hashers.LogHasher
+	Pubkey crypto.PublicKey
 	v      merkle.LogVerifier
 }
 
 // NewLogVerifier returns an object that can verify output from Trillian Logs.
 func NewLogVerifier(hasher hashers.LogHasher, pubKey crypto.PublicKey) *LogVerifier {
 	return &LogVerifier{
-		hasher: hasher,
-		pubKey: pubKey,
+		Hasher: hasher,
+		Pubkey: pubKey,
 		v:      merkle.NewLogVerifier(hasher),
 	}
 }
@@ -78,7 +78,7 @@ func (c *LogVerifier) VerifyRoot(trusted *types.LogRootV1, newRoot *trillian.Sig
 	}
 
 	// Verify SignedLogRoot signature.
-	r, err := tcrypto.VerifySignedLogRoot(c.pubKey, newRoot)
+	r, err := tcrypto.VerifySignedLogRoot(c.Pubkey, newRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *LogVerifier) VerifyInclusionByHash(trusted *types.LogRootV1, leafHash [
 
 // BuildLeaf runs the leaf hasher over data and builds a leaf.
 func (c *LogVerifier) BuildLeaf(data []byte) (*trillian.LogLeaf, error) {
-	leafHash, err := c.hasher.HashLeaf(data)
+	leafHash, err := c.Hasher.HashLeaf(data)
 	if err != nil {
 		return nil, err
 	}

--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -30,7 +30,7 @@ import (
 // LogVerifier contains state needed to verify output from Trillian Logs.
 type LogVerifier struct {
 	Hasher hashers.LogHasher
-	Pubkey crypto.PublicKey
+	PubKey crypto.PublicKey
 	v      merkle.LogVerifier
 }
 
@@ -38,7 +38,7 @@ type LogVerifier struct {
 func NewLogVerifier(hasher hashers.LogHasher, pubKey crypto.PublicKey) *LogVerifier {
 	return &LogVerifier{
 		Hasher: hasher,
-		Pubkey: pubKey,
+		PubKey: pubKey,
 		v:      merkle.NewLogVerifier(hasher),
 	}
 }
@@ -78,7 +78,7 @@ func (c *LogVerifier) VerifyRoot(trusted *types.LogRootV1, newRoot *trillian.Sig
 	}
 
 	// Verify SignedLogRoot signature.
-	r, err := tcrypto.VerifySignedLogRoot(c.Pubkey, newRoot)
+	r, err := tcrypto.VerifySignedLogRoot(c.PubKey, newRoot)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow clients to use the individual crypto objects inside the verifier.

In some cases, clients want to verify a SignedLogRoot even when the are not concerned about consistency. This change allows clients to verify `SignedLogRoot`s. It's not clear if duplicating `tcrypto.VerifySignedLogRoot` in the client would accomplish anything. 