### PR TITLE
Limit data read during operation

### DIFF
--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -578,7 +578,7 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 			break
 		}
 	}
-	if drained > 0 {
+	if drain > 0 {
 		glog.Warningf("Drained %d", drain)
 	}
 	return ret, nil

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -537,12 +537,10 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 	}
 	ret := make([]*trillian.LogLeaf, 0, limit)
 	readOpts := &spanner.ReadOptions{Limit: limit}
-	drain := 0
 	for _, rs := range rows {
 		rows := tx.stx.ReadWithOptions(ctx, unseqTable, rs, []string{colBucket, colQueueTimestampNanos, colMerkleLeafHash, colLeafIdentityHash}, readOpts)
 		if err := rows.Do(func(r *spanner.Row) error {
 			if len(ret) >= limit {
-				drain++
 				return nil
 			}
 			var l trillian.LogLeaf
@@ -577,9 +575,6 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 		if len(ret) >= limit {
 			break
 		}
-	}
-	if drain > 0 {
-		glog.Warningf("Drained %d", drain)
 	}
 	return ret, nil
 }

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -536,11 +536,14 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 		rows = genDequeueRowsOld(tx.getLogStorageConfig(), tx.treeID, now.Unix(), rand.Int31n(numByteValues))
 	}
 	ret := make([]*trillian.LogLeaf, 0, limit)
+	readOpts := &spanner.ReadOptions{Limit: limit}
+	drain := 0
 	for _, rs := range rows {
-		rows := tx.stx.Read(ctx, unseqTable, rs, []string{colBucket, colQueueTimestampNanos, colMerkleLeafHash, colLeafIdentityHash})
+		rows := tx.stx.ReadWithOptions(ctx, unseqTable, rs, []string{colBucket, colQueueTimestampNanos, colMerkleLeafHash, colLeafIdentityHash}, readOpts)
 		if err := rows.Do(func(r *spanner.Row) error {
 			if len(ret) >= limit {
-				return errFinished
+				drain++
+				return nil
 			}
 			var l trillian.LogLeaf
 			var qe QueuedEntry
@@ -562,8 +565,11 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 			ret = append(ret, &l)
 			qe.leaf = &l
 			tx.dequeued[k] = &qe
+			if readOpts.Limit > 0 {
+				readOpts.Limit--
+			}
 			return nil
-		}); err != nil && err != errFinished {
+		}); err != nil {
 			return nil, err
 		}
 
@@ -571,6 +577,9 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 		if len(ret) >= limit {
 			break
 		}
+	}
+	if drained > 0 {
+		glog.Warningf("Drained %d", drain)
 	}
 	return ret, nil
 }

--- a/storage/cloudspanner/spanner.sdl
+++ b/storage/cloudspanner/spanner.sdl
@@ -29,10 +29,7 @@ CREATE TABLE TreeHeads(
   RootSignature           BYTES(1024) NOT NULL,
   TreeRevision            INT64 NOT NULL,
   TreeMetadata            BYTES(2097152),
-) PRIMARY KEY(TreeID, TimestampNanos DESC);
-
-CREATE UNIQUE INDEX TreeRevisionIndex
-  ON TreeHeads(TreeID, TreeRevision DESC);
+) PRIMARY KEY(TreeID, TreeRevision DESC);
 
 CREATE TABLE SubtreeData(
   TreeID      INT64 NOT NULL,

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -361,9 +361,26 @@ func (t *treeTX) getSubtree(ctx context.Context, rev int64, id storage.NodeID) (
 	}
 
 	var ret *storagepb.SubtreeProto
-	prefix := spanner.Key{t.treeID, stID}.AsPrefix()
-	rows := t.stx.Read(ctx, subtreeTbl, prefix, []string{colRevision, colSubtree})
+	stmt := spanner.NewStatement(
+		"SELECT Revision, Subtree FROM SubtreeData d" +
+			"  WHERE d.TreeID = @tree_id" +
+			"  AND   d.SubtreeID = @subtree_id" +
+			"  AND   d.Revision <= @revision" +
+			"  ORDER BY d.Revision DESC" +
+			"  LIMIT 1")
+	stmt.Params["tree_id"] = t.treeID
+	stmt.Params["subtree_id"] = stID
+	stmt.Params["revision"] = rev
+
+	drain := 0
+
+	rows := t.stx.Query(ctx, stmt)
 	err = rows.Do(func(r *spanner.Row) error {
+		if ret != nil {
+			drain++
+			return nil
+		}
+
 		var rRev int64
 		var st storagepb.SubtreeProto
 		stBytes := make([]byte, 1<<20)
@@ -375,8 +392,7 @@ func (t *treeTX) getSubtree(ctx context.Context, rev int64, id storage.NodeID) (
 		}
 
 		if rRev > rev {
-			// Too new, skip this row and wait for the next.
-			return nil
+			return fmt.Errorf("got subtree with too new a revision %d, want %d", rRev, rev)
 		}
 		if got, want := stID, st.Prefix; !bytes.Equal(got, want) {
 			return fmt.Errorf("got subtree with prefix %v, wanted %v", got, want)
@@ -391,12 +407,10 @@ func (t *treeTX) getSubtree(ctx context.Context, rev int64, id storage.NodeID) (
 		if st.Prefix == nil && len(stID) == 0 {
 			st.Prefix = []byte{}
 		}
-		// We've got what we want, tell spanner to stop reading by returning
-		// not-really-an-error:
-		return errFinished
+		return nil
 	})
-	if err == errFinished {
-		err = nil
+	if drain > 0 {
+		glog.Warningf("getSubtree drained %d", drain)
 	}
 	return ret, err
 }

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -95,6 +95,7 @@ type spanRead interface {
 	Read(ctx context.Context, table string, keys spanner.KeySet, columns []string) *spanner.RowIterator
 	ReadUsingIndex(ctx context.Context, table, index string, keys spanner.KeySet, columns []string) *spanner.RowIterator
 	ReadRow(ctx context.Context, table string, key spanner.Key, columns []string) (*spanner.Row, error)
+	ReadWithOptions(ctx context.Context, table string, keys spanner.KeySet, columns []string, opts *spanner.ReadOptions) (ri *spanner.RowIterator)
 }
 
 // latestSTH reads and returns the newest STH.
@@ -102,7 +103,7 @@ func (t *treeStorage) latestSTH(ctx context.Context, stx spanRead, treeID int64)
 	query := spanner.NewStatement(
 		"SELECT t.TreeID, t.TimestampNanos, t.TreeSize, t.RootHash, t.RootSignature, t.TreeRevision, t.TreeMetadata FROM TreeHeads t" +
 			"   WHERE t.TreeID = @tree_id" +
-			"   ORDER BY t.TimestampNanos DESC " +
+			"   ORDER BY t.TreeRevision DESC " +
 			"   LIMIT 1")
 	query.Params["tree_id"] = treeID
 


### PR DESCRIPTION
Spanner seems to not take an error being returned by a RowIterator func as a reason to cancel/abandon the underlying read, and the encapsulating transaction will not commit until the read has finished and so this causes poor performance, particularly during sequencing.

This change uses `ReadOptions.Limit` to specify the number of rows to read when dequeueing leaves, and switches to SQL for fetching subtree data.

#950 