### PR TITLE
Temporarily turn off signature verification in WaitForUpdate

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -144,10 +144,22 @@ func (c *LogClient) getLatestRoot(ctx context.Context, trusted *types.LogRootV1)
 	if err != nil {
 		return nil, err
 	}
-	slr, err := c.VerifyRoot(&types.LogRootV1{}, resp.GetSignedLogRoot(), nil)
-	if err != nil {
-		return nil, err
+
+	// TODO(gbelvin): Turn on root verification.
+	// Temporary hack while some implementations don't store digital signatures.
+	r := resp.GetSignedLogRoot()
+	slr := &types.LogRootV1{
+		TreeSize:       uint64(r.TreeSize),
+		RootHash:       r.RootHash,
+		TimestampNanos: uint64(r.TimestampNanos),
+		Revision:       uint64(r.TreeRevision),
 	}
+	/*
+		slr, err := c.VerifyRoot(&types.LogRootV1{}, resp.GetSignedLogRoot(), nil)
+		if err != nil {
+			return nil, err
+		}
+	*/
 
 	if trusted.TreeSize > 0 &&
 		slr.TreeSize == trusted.TreeSize &&


### PR DESCRIPTION
`WaitForUpdate` is currently used during integration test setup in an environment that isn't storing signatures.  The addition of signature verification prematurely breaks this integration which is waiting for the signature scheme to settle before saving signatures. 

This PR gets things working again and adds a TODO to turn on signature verification in the future. 

Note that the other methods in the client do, in fact, verify signatures. 