### PR TITLE
Specify signature hash algorithm in verifier 

### DIFF
--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/trees"
 	"github.com/google/trillian/types"
 
 	tcrypto "github.com/google/trillian/crypto"
@@ -29,17 +30,19 @@ import (
 
 // LogVerifier contains state needed to verify output from Trillian Logs.
 type LogVerifier struct {
-	Hasher hashers.LogHasher
-	PubKey crypto.PublicKey
-	v      merkle.LogVerifier
+	Hasher  hashers.LogHasher
+	PubKey  crypto.PublicKey
+	SigHash crypto.Hash
+	v       merkle.LogVerifier
 }
 
 // NewLogVerifier returns an object that can verify output from Trillian Logs.
-func NewLogVerifier(hasher hashers.LogHasher, pubKey crypto.PublicKey) *LogVerifier {
+func NewLogVerifier(hasher hashers.LogHasher, pubKey crypto.PublicKey, sigHash crypto.Hash) *LogVerifier {
 	return &LogVerifier{
-		Hasher: hasher,
-		PubKey: pubKey,
-		v:      merkle.NewLogVerifier(hasher),
+		Hasher:  hasher,
+		PubKey:  pubKey,
+		SigHash: sigHash,
+		v:       merkle.NewLogVerifier(hasher),
 	}
 }
 
@@ -56,13 +59,19 @@ func NewLogVerifierFromTree(config *trillian.Tree) (*LogVerifier, error) {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): NewLogHasher(): %v", err)
 	}
 
-	// Log Key
+	// Log Pub Key
 	logPubKey, err := der.UnmarshalPublicKey(config.GetPublicKey().GetDer())
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log public key: %v", err)
 	}
 
-	return NewLogVerifier(logHasher, logPubKey), nil
+	// Log Sig Hash
+	sigHash, err := trees.Hash(config)
+	if err != nil {
+		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log signature hash: %v", err)
+	}
+
+	return NewLogVerifier(logHasher, logPubKey, sigHash), nil
 }
 
 // VerifyRoot verifies that newRoot is a valid append-only operation from trusted.
@@ -78,7 +87,7 @@ func (c *LogVerifier) VerifyRoot(trusted *types.LogRootV1, newRoot *trillian.Sig
 	}
 
 	// Verify SignedLogRoot signature.
-	r, err := tcrypto.VerifySignedLogRoot(c.PubKey, newRoot)
+	r, err := tcrypto.VerifySignedLogRoot(c.PubKey, c.SigHash, newRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -30,8 +30,11 @@ import (
 
 // LogVerifier contains state needed to verify output from Trillian Logs.
 type LogVerifier struct {
-	Hasher  hashers.LogHasher
-	PubKey  crypto.PublicKey
+	// Hasher is the hash strategy used to compute nodes in the merkle tree.
+	Hasher hashers.LogHasher
+	// PubKey verifies the signature on the digest of LogRoot.
+	PubKey crypto.PublicKey
+	// SigHash computes the digest of LogRoot for signing.
 	SigHash crypto.Hash
 	v       merkle.LogVerifier
 }
@@ -53,19 +56,16 @@ func NewLogVerifierFromTree(config *trillian.Tree) (*LogVerifier, error) {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): TreeType: %v, want %v", got, want)
 	}
 
-	// Log Hasher.
 	logHasher, err := hashers.NewLogHasher(config.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): NewLogHasher(): %v", err)
 	}
 
-	// Log Pub Key
 	logPubKey, err := der.UnmarshalPublicKey(config.GetPublicKey().GetDer())
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log public key: %v", err)
 	}
 
-	// Log Sig Hash
 	sigHash, err := trees.Hash(config)
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log signature hash: %v", err)

--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -30,7 +30,7 @@ import (
 
 // LogVerifier contains state needed to verify output from Trillian Logs.
 type LogVerifier struct {
-	// Hasher is the hash strategy used to compute nodes in the merkle tree.
+	// Hasher is the hash strategy used to compute nodes in the Merkle tree.
 	Hasher hashers.LogHasher
 	// PubKey verifies the signature on the digest of LogRoot.
 	PubKey crypto.PublicKey

--- a/client/log_verifier_test.go
+++ b/client/log_verifier_test.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"crypto"
 	"testing"
 
 	"github.com/google/trillian"
@@ -53,7 +54,7 @@ func TestVerifyRootErrors(t *testing.T) {
 		{desc: "trustedNil", trusted: nil, newRoot: signedRoot},
 	}
 	for _, test := range tests {
-		logVerifier := NewLogVerifier(rfc6962.DefaultHasher, pk)
+		logVerifier := NewLogVerifier(rfc6962.DefaultHasher, pk, crypto.SHA256)
 
 		// This also makes sure that no nil pointer dereference errors occur (as this would cause a panic).
 		if _, err := logVerifier.VerifyRoot(test.trusted, test.newRoot, nil); err == nil {
@@ -63,7 +64,7 @@ func TestVerifyRootErrors(t *testing.T) {
 }
 
 func TestVerifyInclusionAtIndexErrors(t *testing.T) {
-	logVerifier := NewLogVerifier(nil, nil)
+	logVerifier := NewLogVerifier(nil, nil, crypto.SHA256)
 	// An error is expected because the first parameter (trusted) is nil
 	err := logVerifier.VerifyInclusionAtIndex(nil, []byte{0, 0, 0}, 1, [][]byte{{0, 0}})
 	if err == nil {
@@ -82,7 +83,7 @@ func TestVerifyInclusionByHashErrors(t *testing.T) {
 	}
 	for _, test := range tests {
 
-		logVerifier := NewLogVerifier(nil, nil)
+		logVerifier := NewLogVerifier(nil, nil, crypto.SHA256)
 		err := logVerifier.VerifyInclusionByHash(test.trusted, nil, test.proof)
 		if err == nil {
 			t.Errorf("%v: VerifyInclusionByHash() error expected, but got nil", test.desc)

--- a/client/map_verifier.go
+++ b/client/map_verifier.go
@@ -29,8 +29,11 @@ import (
 
 // MapVerifier verifies protos produced by the Trillian Map.
 type MapVerifier struct {
-	Hasher  hashers.MapHasher
-	PubKey  crypto.PublicKey
+	// Hasher is the hash strategy used to compute nodes in the merkle tree.
+	Hasher hashers.MapHasher
+	// PubKey verifies the signature on the digest of MapRoot.
+	PubKey crypto.PublicKey
+	// SigHash computes the digest of MapRoot for signing.
 	SigHash crypto.Hash
 }
 
@@ -39,19 +42,17 @@ func NewMapVerifierFromTree(config *trillian.Tree) (*MapVerifier, error) {
 	if got, want := config.TreeType, trillian.TreeType_MAP; got != want {
 		return nil, fmt.Errorf("client: NewFromTree(): TreeType: %v, want %v", got, want)
 	}
-	// Map Hasher
+
 	mapHasher, err := hashers.NewMapHasher(config.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)
 	}
 
-	// Map Key
 	mapPubKey, err := der.UnmarshalPublicKey(config.GetPublicKey().GetDer())
 	if err != nil {
 		return nil, fmt.Errorf("Failed parsing Map public key: %v", err)
 	}
 
-	// Map Sig Hash
 	sigHash, err := trees.Hash(config)
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log signature hash: %v", err)

--- a/client/map_verifier.go
+++ b/client/map_verifier.go
@@ -29,7 +29,7 @@ import (
 
 // MapVerifier verifies protos produced by the Trillian Map.
 type MapVerifier struct {
-	// Hasher is the hash strategy used to compute nodes in the merkle tree.
+	// Hasher is the hash strategy used to compute nodes in the Merkle tree.
 	Hasher hashers.MapHasher
 	// PubKey verifies the signature on the digest of MapRoot.
 	PubKey crypto.PublicKey

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"crypto"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -57,7 +58,7 @@ func TestSign(t *testing.T) {
 			t.Errorf("Sig alg incorrect, got %s expected %s", got, want)
 		}
 		// Check that the signature is correct
-		if err := Verify(key.Public(), test.message, sig); err != nil {
+		if err := Verify(key.Public(), crypto.SHA256, test.message, sig); err != nil {
 			t.Errorf("Verify(%v) failed: %v", test.message, err)
 		}
 	}
@@ -126,7 +127,7 @@ func TestSignLogRoot(t *testing.T) {
 			t.Errorf("Sig alg incorrect, got %s expected %s", got, want)
 		}
 		// Check that the signature is correct
-		if _, err := VerifySignedLogRoot(key.Public(), slr); err != nil {
+		if _, err := VerifySignedLogRoot(key.Public(), crypto.SHA256, slr); err != nil {
 			t.Errorf("Verify(%v) failed: %v", test.root, err)
 		}
 	}
@@ -169,7 +170,7 @@ func TestSignMapRoot(t *testing.T) {
 			t.Errorf("objecthash.CommonJSONHash err: %v want nil", err)
 			continue
 		}
-		if err := Verify(key.Public(), hash[:], sig); err != nil {
+		if err := Verify(key.Public(), crypto.SHA256, hash[:], sig); err != nil {
 			t.Errorf("Verify(%v) failed: %v", test.root, err)
 		}
 	}

--- a/crypto/verifier_test.go
+++ b/crypto/verifier_test.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"crypto"
 	"testing"
 
 	"github.com/google/trillian"
@@ -77,7 +78,7 @@ func TestSignVerify(t *testing.T) {
 			}
 		}
 
-		err = Verify(key.Public(), msg, signature)
+		err = Verify(key.Public(), crypto.SHA256, msg, signature)
 		if gotErr := err != nil; gotErr != test.wantVerifyErr {
 			t.Errorf("%s: Verify(,,)=%v, want err? %t", test.name, err, test.wantVerifyErr)
 		}
@@ -128,7 +129,7 @@ func TestSignVerifyObject(t *testing.T) {
 			t.Errorf("SignObject(%#v): %v", tc.obj, err)
 			continue
 		}
-		if err := VerifyObject(key.Public(), tc.obj, sig); err != nil {
+		if err := VerifyObject(key.Public(), crypto.SHA256, tc.obj, sig); err != nil {
 			t.Errorf("SignObject(%#v): %v", tc.obj, err)
 		}
 	}


### PR DESCRIPTION
Verifying clients should rely on the Tree's declared hash algorithm for signature verification rather than the hash algorithm declared in `sigpb.HashAlgorithm`.  There several reasons for this:
- `sigpb.HashAlgorithm` is under adversarial control and should not be trusted. 
- It is bad practice to use a single key for multiple hashing / signing algorithms. 
- `SignedLogRoot.Signature` will soon be `[]byte` and `sigpb.HashAlgorithm` will not be available. 