### PR TITLE
[storage/mysql] Tolerate gaps in GetLeavesByRange

### DIFF
--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -48,9 +48,11 @@ type ReadOnlyLogTreeTX interface {
 	// GetLeavesByIndex returns leaf metadata and data for a set of specified sequenced leaf indexes.
 	GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error)
 	// GetLeavesByRange returns leaf data for a range of indexes. Leaves are
-	// returned ordered by their LeafIndex, and the returned slice may be smaller
-	// than count if the requested range extends beyond the current log size.
-	// For PREORDERED_LOG trees, it returns leaves beyond the tree size if they
+	// returned ordered by their LeafIndex, the first one is always `start`. The
+	// returned slice may be smaller than `count` if the requested range has
+	// missing entries (e.g., it extends beyond the size of a LOG tree), or
+	// `count` is too big to handle in one go.
+	// For PREORDERED_LOG trees, must return leaves beyond the tree size if they
 	// are stored, in order to allow integrating them into the tree.
 	GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error)
 	// GetLeavesByHash looks up sequenced leaf metadata and data by their Merkle leaf hash. If the

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -567,10 +567,10 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	if count <= 0 {
-		return nil, fmt.Errorf("count=%d,want>0", count)
+		return nil, fmt.Errorf("invalid count %d, want > 0", count)
 	}
 	if start < 0 {
-		return nil, fmt.Errorf("start=%d,want>=0", start)
+		return nil, fmt.Errorf("invalid start %d, want >= 0", start)
 	}
 
 	if t.treeType == trillian.TreeType_LOG {
@@ -578,7 +578,7 @@ func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([
 		if treeSize <= 0 {
 			return nil, fmt.Errorf("empty tree")
 		} else if start >= treeSize {
-			return nil, fmt.Errorf("start=%d,want<%d", start, treeSize)
+			return nil, fmt.Errorf("invalid start %d, want < TreeSize(%d)", start, treeSize)
 		}
 		// Ensure no entries queried/returned beyond the tree.
 		if maxCount := treeSize - start; count > maxCount {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -566,7 +566,7 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 }
 
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
-	// TODO(pavelkalinnikov): Clip `count`, for example to max(count, 64k).
+	// TODO(pavelkalinnikov): Clip `count`, for example to min(count, 64k).
 	if count <= 0 {
 		return nil, fmt.Errorf("invalid count %d", count)
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -611,9 +611,7 @@ func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([
 		ret = append(ret, leaf)
 	}
 
-	if len(ret) == 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "no contiguous prefix of leaves found in [%d, %d+%d)", start, start, count)
-	}
+	// Note: Empty ret is not an error.
 	return ret, nil
 }
 

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -786,37 +786,34 @@ func TestGetLeavesByIndex(t *testing.T) {
 	})
 }
 
-func TestGetLeavesByRange(t *testing.T) {
-	var tests = []struct {
-		start, count int64
-		want         []int64
-		wantErr      bool
-	}{
-		{start: 0, count: 1, want: []int64{0}},
-		{start: 0, count: 2, want: []int64{0, 1}},
-		{start: 1, count: 3, want: []int64{1, 2, 3}},
-		{start: 10, count: 7, want: []int64{10, 11, 12, 13}},
-		{start: 3, count: 5, want: []int64{3, 4}}, // Hits non-contiguous leaves.
-		{start: 5, count: 5, want: []int64{}},     // Starts from a missing leaf.
-		{start: 1, count: 0, wantErr: true},
-		{start: -1, count: 1, wantErr: true},
-		{start: 1, count: -1, wantErr: true},
-		{start: 14, count: 1, want: []int64{}},
-	}
-	ctx := context.Background()
-	cleanTestDB(DB)
-	logID := createLogForTests(DB)
-	s := NewLogStorage(DB, nil)
-	tree := logTree(logID)
+// GetLeavesByRange tests. -----------------------------------------------------
 
-	// Create leaves [0]..[13] but drop leaf [5]
-	for i := int64(0); i < 14; i++ {
+type getLeavesByRangeTest struct {
+	start, count int64
+	want         []int64
+	wantErr      bool
+}
+
+func testGetLeavesByRangeImpl(t *testing.T, create *trillian.Tree, tests []getLeavesByRangeTest) {
+	cleanTestDB(DB)
+
+	ctx := context.Background()
+	tree, err := createTree(DB, create)
+	if err != nil {
+		t.Fatalf("Error creating log: %v", err)
+	}
+	// Note: GetLeavesByRange loads the root internally to get the tree size.
+	createFakeSignedLogRoot(DB, tree, 14)
+	s := NewLogStorage(DB, nil)
+
+	// Create leaves [0]..[19] but drop leaf [5] and set the tree size to 14.
+	for i := int64(0); i < 20; i++ {
 		if i == 5 {
 			continue
 		}
 		data := []byte{byte(i)}
 		identityHash := sha256.Sum256(data)
-		createFakeLeaf(ctx, DB, logID, identityHash[:], identityHash[:], data, someExtraData, i, t)
+		createFakeLeaf(ctx, DB, tree.TreeId, identityHash[:], identityHash[:], data, someExtraData, i, t)
 	}
 
 	for _, test := range tests {
@@ -842,6 +839,47 @@ func TestGetLeavesByRange(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLeavesByRangeFromLog(t *testing.T) {
+	var tests = []getLeavesByRangeTest{
+		{start: 0, count: 1, want: []int64{0}},
+		{start: 0, count: 2, want: []int64{0, 1}},
+		{start: 1, count: 3, want: []int64{1, 2, 3}},
+		{start: 10, count: 7, want: []int64{10, 11, 12, 13}},
+		{start: 13, count: 1, want: []int64{13}},
+		{start: 14, count: 4, wantErr: true},   // Starts right after tree size.
+		{start: 19, count: 2, wantErr: true},   // Starts further away.
+		{start: 3, count: 5, wantErr: true},    // Hits non-contiguous leaves.
+		{start: 5, count: 5, wantErr: true},    // Starts from a missing leaf.
+		{start: 1, count: 0, wantErr: true},    // Empty range.
+		{start: -1, count: 1, wantErr: true},   // Negative start.
+		{start: 1, count: -1, wantErr: true},   // Negative count.
+		{start: 100, count: 30, wantErr: true}, // Starts after all stored leaves.
+	}
+	testGetLeavesByRangeImpl(t, testonly.LogTree, tests)
+}
+
+func TestGetLeavesByRangeFromPreorderedLog(t *testing.T) {
+	var tests = []getLeavesByRangeTest{
+		{start: 0, count: 1, want: []int64{0}},
+		{start: 0, count: 2, want: []int64{0, 1}},
+		{start: 1, count: 3, want: []int64{1, 2, 3}},
+		{start: 10, count: 7, want: []int64{10, 11, 12, 13, 14, 15, 16}},
+		{start: 13, count: 1, want: []int64{13}},
+		// Starts right after tree size.
+		{start: 14, count: 4, want: []int64{14, 15, 16, 17}},
+		{start: 19, count: 2, want: []int64{19}}, // Starts further away.
+		{start: 3, count: 5, wantErr: true},      // Hits non-contiguous leaves.
+		{start: 5, count: 5, wantErr: true},      // Starts from a missing leaf.
+		{start: 1, count: 0, wantErr: true},      // Empty range.
+		{start: -1, count: 1, wantErr: true},     // Negative start.
+		{start: 1, count: -1, wantErr: true},     // Negative count.
+		{start: 100, count: 30, want: []int64{}}, // Starts after all stored leaves.
+	}
+	testGetLeavesByRangeImpl(t, testonly.PreorderedLogTree, tests)
+}
+
+// -----------------------------------------------------------------------------
 
 func TestLatestSignedRootNoneWritten(t *testing.T) {
 	ctx := context.Background()

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -797,11 +797,11 @@ func TestGetLeavesByRange(t *testing.T) {
 		{start: 1, count: 3, want: []int64{1, 2, 3}},
 		{start: 10, count: 7, want: []int64{10, 11, 12, 13}},
 		{start: 3, count: 5, want: []int64{3, 4}}, // Hits non-contiguous leaves.
-		{start: 5, count: 5, wantErr: true},       // Starts from a missing leaf.
+		{start: 5, count: 5, want: []int64{}},     // Starts from a missing leaf.
 		{start: 1, count: 0, wantErr: true},
 		{start: -1, count: 1, wantErr: true},
 		{start: 1, count: -1, wantErr: true},
-		{start: 14, count: 1, wantErr: true},
+		{start: 14, count: 1, want: []int64{}},
 	}
 	ctx := context.Background()
 	cleanTestDB(DB)

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -796,7 +796,8 @@ func TestGetLeavesByRange(t *testing.T) {
 		{start: 0, count: 2, want: []int64{0, 1}},
 		{start: 1, count: 3, want: []int64{1, 2, 3}},
 		{start: 10, count: 7, want: []int64{10, 11, 12, 13}},
-		{start: 3, count: 5, wantErr: true}, // hits non-contiguous leaves
+		{start: 3, count: 5, want: []int64{3, 4}}, // Hits non-contiguous leaves.
+		{start: 5, count: 5, wantErr: true},       // Starts from a missing leaf.
 		{start: 1, count: 0, wantErr: true},
 		{start: -1, count: 1, wantErr: true},
 		{start: 1, count: -1, wantErr: true},

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -102,7 +102,7 @@ func (m *mySQLMapStorage) begin(ctx context.Context, tree *trillian.Tree) (stora
 	}
 
 	stCache := cache.NewMapSubtreeCache(defaultMapStrata, tree.TreeId, hasher)
-	ttx, err := m.beginTreeTx(ctx, tree.TreeId, hasher.Size(), stCache)
+	ttx, err := m.beginTreeTx(ctx, tree, hasher.Size(), stCache)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`PREORDERED_LOG` uses `GetLeavesByRange` to load sequenced entries beyond the tree size. It is a normal situation when those entries are not contiguous (`AddSequencedLeaves` does not enforce the order). This PR makes `GetLeavesByRange` return a shorter range in such scenario, instead of an error.