### PR TITLE
Drop use of SQLite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ go:
 go_import_path: github.com/google/trillian
 
 env:
-  - GCE_CI=${ENABLE_GCE_CI}
-  - TRILLIAN_SQL_DRIVER=mysql WITH_COVERAGE=true
-  - GOFLAGS='-race' TRILLIAN_SQL_DRIVER=mysql
-  - GOFLAGS='-race --tags batched_queue' TRILLIAN_SQL_DRIVER=mysql
-  - GOFLAGS='-race' TRILLIAN_SQL_DRIVER=mysql WITH_ETCD=true
-  - GOFLAGS='-race --tags pkcs11' TRILLIAN_SQL_DRIVER=mysql WITH_PKCS11=true
+  - GCE_CI=${ENABLE_GCE_CI} WITH_COVERAGE=true
+  - GOFLAGS='-race'
+  - GOFLAGS='-race --tags batched_queue'
+  - GOFLAGS='-race' WITH_ETCD=true
+  - GOFLAGS='-race --tags pkcs11' WITH_PKCS11=true
 
 matrix:
   fast_finish: true
@@ -97,13 +96,11 @@ script:
         export ETCD_DIR="${GOPATH}/bin"
       fi
   - |
-      if [[ "${TRILLIAN_SQL_DRIVER}" == 'mysql' ]]; then
-        ./integration/integration_test.sh
-        cd "$HOME/gopath/src/github.com/google/certificate-transparency-go"
-        ./trillian/integration/integration_test.sh
-        cd $HOME/gopath/src/github.com/google/trillian
-        HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
-      fi
+      ./integration/integration_test.sh
+      cd "$HOME/gopath/src/github.com/google/certificate-transparency-go"
+      ./trillian/integration/integration_test.sh
+      cd $HOME/gopath/src/github.com/google/trillian
+      HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
   - set +e
 
 after_success:
@@ -123,4 +120,3 @@ after_success:
 
         . scripts/deploy_gce_ci.sh
       fi
-

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build and test Trillian you need:
 
  - Go 1.9 or later.
 
-To run integration tests (and production deployment) you need:
+To run many of the tests (and production deployment) you need:
 
  - [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/) to provide
    the data storage layer; see the [MySQL Setup](#mysql-setup) section.

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/google/trillian/storage/testdb"
 	stestonly "github.com/google/trillian/storage/testonly"
 )
 
@@ -48,6 +49,7 @@ func addSequencedLeaves(ctx context.Context, env *integration.LogEnv, client *Lo
 }
 
 func TestGetByIndex(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 1, "unused")
 	if err != nil {
@@ -90,6 +92,7 @@ func TestGetByIndex(t *testing.T) {
 }
 
 func TestListByIndex(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 1, "unused")
 	if err != nil {
@@ -131,6 +134,7 @@ func TestListByIndex(t *testing.T) {
 }
 
 func TestVerifyInclusion(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 1, "unused")
 	if err != nil {
@@ -166,6 +170,7 @@ func TestVerifyInclusion(t *testing.T) {
 }
 
 func TestVerifyInclusionAtIndex(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 1, "unused")
 	if err != nil {
@@ -201,6 +206,7 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 }
 
 func TestWaitForInclusion(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 0, "unused")
 	if err != nil {
@@ -253,6 +259,7 @@ func TestWaitForInclusion(t *testing.T) {
 }
 
 func TestUpdateRoot(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	env, err := integration.NewLogEnv(ctx, 1, "unused")
 	if err != nil {

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly/integration"
 	"github.com/kylelemons/godebug/pretty"
@@ -40,7 +41,7 @@ import (
 func TestAdminServer_CreateTree(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestAdminServer_CreateTree(t *testing.T) {
 func TestAdminServer_UpdateTree(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -236,7 +237,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 func TestAdminServer_GetTree(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -271,7 +272,7 @@ func TestAdminServer_GetTree(t *testing.T) {
 func TestAdminServer_ListTrees(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -340,7 +341,7 @@ func sortByTreeID(s []*trillian.Tree) {
 func TestAdminServer_DeleteTree(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -391,7 +392,7 @@ func TestAdminServer_DeleteTree(t *testing.T) {
 func TestAdminServer_DeleteTreeErrors(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -434,7 +435,7 @@ func TestAdminServer_DeleteTreeErrors(t *testing.T) {
 func TestAdminServer_UndeleteTree(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -482,7 +483,7 @@ func TestAdminServer_UndeleteTree(t *testing.T) {
 func TestAdminServer_UndeleteTreeErrors(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -521,7 +522,7 @@ func TestAdminServer_UndeleteTreeErrors(t *testing.T) {
 func TestAdminServer_TreeGC(t *testing.T) {
 	ctx := context.Background()
 
-	ts, err := setupAdminServer(ctx)
+	ts, err := setupAdminServer(ctx, t)
 	if err != nil {
 		t.Fatalf("setupAdminServer() failed: %v", err)
 	}
@@ -576,7 +577,9 @@ func (ts *testServer) closeAll() {
 
 // setupAdminServer prepares and starts an Admin Server, returning a testServer object.
 // If the returned error is nil, the callers must "defer ts.closeAll()" to avoid resource leakage.
-func setupAdminServer(ctx context.Context) (*testServer, error) {
+func setupAdminServer(ctx context.Context, t *testing.T) (*testServer, error) {
+	t.Helper()
+	testdb.SkipIfNoMySQL(t)
 	ts := &testServer{}
 
 	var err error

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage/memory"
+	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/testonly/integration"
 
 	_ "github.com/google/trillian/crypto/keys/der/proto" // Register PrivateKey ProtoHandler
@@ -91,6 +92,7 @@ func TestLiveLogIntegration(t *testing.T) {
 }
 
 func TestInProcessLogIntegration(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	const numSequencers = 2
 	env, err := integration.NewLogEnv(ctx, numSequencers, "unused")

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -31,7 +31,7 @@ echo "Created tree ${TEST_TREE_ID}"
 echo "Running test"
 pushd "${INTEGRATION_DIR}"
 set +e
-TRILLIAN_SQL_DRIVER=mysql go test ${GOFLAGS} \
+go test ${GOFLAGS} \
   -run ".*LiveLog.*" \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
   ./ \

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -10,7 +10,7 @@ TO_KILL+=(${RPC_SERVER_PIDS[@]})
 echo "Running test"
 cd "${INTEGRATION_DIR}"
 set +e
-TRILLIAN_SQL_DRIVER=mysql go test ${GOFLAGS} \
+go test ${GOFLAGS} \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
   ./maptest  --map_rpc_server="${RPC_SERVER_1}"
 RESULT=$?

--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -35,8 +35,8 @@ func TestMapIntegration(t *testing.T) {
 	var env *integration.MapEnv
 	var err error
 	if *server == "" {
-		if provider := testdb.Default(); !provider.IsMySQL() {
-			t.Skipf("Skipping map integration test, SQL driver is %v", provider.Driver)
+		if !testdb.MySQLAvailable() {
+			t.Skip("Skipping map integration test, MySQL not available")
 		}
 		env, err = integration.NewMapEnv(ctx)
 	} else {

--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -45,6 +45,7 @@ import (
 )
 
 func TestEtcdRateLimiting(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 
 	registry, err := integration.NewRegistryForTests(ctx)
@@ -93,13 +94,9 @@ func TestEtcdRateLimiting(t *testing.T) {
 }
 
 func TestMySQLRateLimiting(t *testing.T) {
-	provider := testdb.Default()
-	if !provider.IsMySQL() {
-		t.Skipf("Skipping MySQL rate limiting test, SQL driver is %q", provider.Driver)
-	}
-
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
-	db, err := provider.NewTrillianDB(ctx)
+	db, err := testdb.NewTrillianDB(ctx)
 	if err != nil {
 		t.Fatalf("GetTestDB() returned err = %v", err)
 	}

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestQuotaManager_GetTokens(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 
 	db, err := testdb.NewTrillianDB(ctx)
@@ -119,11 +120,7 @@ func TestQuotaManager_GetTokens(t *testing.T) {
 }
 
 func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
-	provider := testdb.Default()
-	if !provider.IsMySQL() {
-		t.Skipf("Skipping information_schema test, SQL driver is %q", provider.Driver)
-	}
-
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 
 	maxUnsequenced := 20
@@ -139,7 +136,7 @@ func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
 	for _, test := range tests {
 		desc := fmt.Sprintf("useSelectCount = %v", test.useSelectCount)
 		t.Run(desc, func(t *testing.T) {
-			db, err := provider.NewTrillianDB(ctx)
+			db, err := testdb.NewTrillianDB(ctx)
 			if err != nil {
 				t.Fatalf("NewTrillianDB() returned err = %v", err)
 			}
@@ -187,6 +184,7 @@ func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
 }
 
 func TestQuotaManager_PeekTokens(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 
 	db, err := testdb.NewTrillianDB(ctx)
@@ -228,6 +226,7 @@ func TestQuotaManager_PeekTokens(t *testing.T) {
 }
 
 func TestQuotaManager_Noops(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 
 	db, err := testdb.NewTrillianDB(ctx)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -39,7 +39,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	spb "github.com/google/trillian/crypto/sigpb"
-	sqlite3 "github.com/mattn/go-sqlite3"
 )
 
 const (
@@ -814,8 +813,6 @@ func isDuplicateErr(err error) bool {
 	switch err := err.(type) {
 	case *mysql.MySQLError:
 		return err.Number == errNumDuplicate
-	case sqlite3.Error:
-		return err.Code == sqlite3.ErrConstraint && err.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
 	default:
 		return false
 	}

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -35,9 +35,7 @@ import (
 )
 
 func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	s := NewMapStorage(DB)
@@ -47,9 +45,7 @@ func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
 }
 
 func TestMapSnapshot(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -111,9 +107,7 @@ func TestMapSnapshot(t *testing.T) {
 }
 
 func TestMapReadWriteTransaction(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -173,9 +167,7 @@ func TestMapReadWriteTransaction(t *testing.T) {
 }
 
 func TestMapRootUpdate(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -268,9 +260,7 @@ var mapLeaf = trillian.MapLeaf{
 }
 
 func TestMapSetGetRoundTrip(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -305,9 +295,7 @@ func TestMapSetGetRoundTrip(t *testing.T) {
 }
 
 func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -334,9 +322,7 @@ func TestMapSetSameKeyInSameRevisionFails(t *testing.T) {
 }
 
 func TestMapGet0Results(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -365,9 +351,7 @@ func TestMapGet0Results(t *testing.T) {
 }
 
 func TestMapSetGetMultipleRevisions(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	// Write two roots for a map and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
@@ -426,9 +410,7 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 }
 
 func TestGetSignedMapRootNotExist(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	tree := createTreeOrPanic(DB, storageto.MapTree) // Uninitialized: no revision 0 MapRoot exists.
@@ -472,9 +454,7 @@ func TestLatestSignedMapRootNoneWritten(t *testing.T) {
 }
 
 func TestGetSignedMapRoot(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -511,9 +491,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 }
 
 func TestLatestSignedMapRoot(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -549,9 +527,7 @@ func TestLatestSignedMapRoot(t *testing.T) {
 }
 
 func TestDuplicateSignedMapRoot(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	ctx := context.Background()
@@ -578,9 +554,7 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 }
 
 func TestReadOnlyMapTX_Rollback(t *testing.T) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		t.Skipf("Inhibited due to known issue (#896) on SQL driver: %q", provider.Driver)
-	}
+	testdb.SkipIfNoMySQL(t)
 
 	cleanTestDB(DB)
 	s := NewMapStorage(DB)

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -283,6 +283,10 @@ var DB *sql.DB
 
 func TestMain(m *testing.M) {
 	flag.Parse()
+	if !testdb.MySQLAvailable() {
+		glog.Errorf("MySQL not available, skipping all MySQL storage tests")
+		return
+	}
 	DB = openTestDBOrDie()
 	defer DB.Close()
 	cleanTestDB(DB)

--- a/storage/testdb/testdb_test.go
+++ b/storage/testdb/testdb_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdb
+
+import (
+	"testing"
+
+	_ "github.com/golang/glog"
+)
+
+func TestMySQLWarning(t *testing.T) {
+	if !MySQLAvailable() {
+		t.Error("Deliberate test failure as a reminder that all storage-related tests are being skipped due to absent MySQL")
+	}
+}

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
@@ -67,8 +67,8 @@ func NewMapEnvFromConn(addr string) (*MapEnv, error) {
 
 // NewMapEnv creates a fresh DB, map server, and client.
 func NewMapEnv(ctx context.Context) (*MapEnv, error) {
-	if provider := testdb.Default(); !provider.IsMySQL() {
-		return nil, fmt.Errorf("map integration test has concurrent writes and needs MySQL. SQL driver is %v", provider.Driver)
+	if !testdb.MySQLAvailable() {
+		return nil, errors.New("no MySQL available")
 	}
 
 	db, err := testdb.NewTrillianDB(ctx)


### PR DESCRIPTION
This partly-reverts commit 4023e5ab7de5 ("Use sqlite3 as the default
driver for unit tests (#886)"), removing SQLite as a storage option.

In practice, having a default DB that doesn't support much of the
Trillian functionality (e.g. none of the map tests, none of the
integration tests) has inconvenienced core developers.

However, to allow the core `git clone <repo> ; go test ./...`
scenario to still work without setup dependencies, all DB-using tests
explicitly check for MySQL availability and are skipped if MySQL
is not present.