### PR TITLE
Introduce AddSequencedLeaves benchmarks

### DIFF
--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -441,6 +441,35 @@ func TestAddSequencedLeavesWithDuplicates(t *testing.T) {
 	aslt.verifySequencedLeaves(6, 4, dupLeaves)
 }
 
+func BenchmarkAddSequencedLeaf(b *testing.B) {
+	leaves := createTestLeaves(int64(b.N), 0)
+	aslt := initAddSequencedLeavesTest(b)
+
+	b.ResetTimer()
+	for i := range leaves {
+		aslt.addSequencedLeaves(leaves[i : i+1])
+	}
+	b.StopTimer()
+	aslt.verifySequencedLeaves(0, int64(len(leaves)), leaves)
+}
+
+func BenchmarkAddSequencedLeaves(b *testing.B) {
+	const chunk = 1000
+	leaves := createTestLeaves(int64(b.N), 0)
+	aslt := initAddSequencedLeavesTest(b)
+
+	b.ResetTimer()
+	for begin, end := 0, 0; begin < len(leaves); begin = end {
+		end += chunk
+		if end > len(leaves) {
+			end = len(leaves)
+		}
+		aslt.addSequencedLeaves(leaves[begin:end])
+	}
+	b.StopTimer()
+	aslt.verifySequencedLeaves(0, int64(len(leaves)), leaves)
+}
+
 // -----------------------------------------------------------------------------
 
 func TestDequeueLeavesNoneQueued(t *testing.T) {

--- a/testonly/testing.go
+++ b/testonly/testing.go
@@ -14,7 +14,7 @@
 
 package testonly
 
-// This interface is an intersection of testing.T and testing.B methods.
+// TestOrBench is an intersection of testing.T and testing.B methods.
 type TestOrBench interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})

--- a/testonly/testing.go
+++ b/testonly/testing.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+// This interface is an intersection of testing.T and testing.B methods.
+type TestOrBench interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Name() string
+	Skip(args ...interface{})
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Skipped() bool
+}


### PR DESCRIPTION
Plus a handy interface to abstract from `testing.T` and `testing.B` types.