### PR TITLE
Allow switching TreeType from PREORDERED_LOG to LOG

### DIFF
--- a/crypto/keyspb/keyspb.pb.go
+++ b/crypto/keyspb/keyspb.pb.go
@@ -76,9 +76,7 @@ func (m *Specification) String() string            { return proto.CompactTextStr
 func (*Specification) ProtoMessage()               {}
 func (*Specification) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
-type isSpecification_Params interface {
-	isSpecification_Params()
-}
+type isSpecification_Params interface{ isSpecification_Params() }
 
 type Specification_EcdsaParams struct {
 	EcdsaParams *Specification_ECDSA `protobuf:"bytes,1,opt,name=ecdsa_params,json=ecdsaParams,oneof"`

--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -209,6 +209,8 @@ func applyUpdateMask(from, to *trillian.Tree, mask *field_mask.FieldMask) error 
 		switch path {
 		case "tree_state":
 			to.TreeState = from.TreeState
+		case "tree_type":
+			to.TreeType = from.TreeType
 		case "display_name":
 			to.DisplayName = from.DisplayName
 		case "description":

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -476,9 +476,8 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 		return nil, err
 	}
 
-	// TODO(pavelkalinnikov): When switching TreeState to FROZEN for a
-	// PREORDERED_LOG, ensure there are no gaps in SequencedLeafData, in order to
-	// allow smoothly changing TreeType to LOG.
+	// TODO(pavelkalinnikov): When switching TreeType from PREORDERED_LOG to LOG,
+	// ensure all entries in SequencedLeafData are integrated.
 
 	// Use the time truncated-to-millis throughout, as that's what's stored.
 	nowMillis := toMillisSinceEpoch(time.Now())

--- a/storage/tree_validation.go
+++ b/storage/tree_validation.go
@@ -77,7 +77,13 @@ func ValidateTreeForUpdate(ctx context.Context, storedTree, newTree *trillian.Tr
 	case storedTree.TreeId != newTree.TreeId:
 		return status.Error(codes.InvalidArgument, "readonly field changed: tree_id")
 	case storedTree.TreeType != newTree.TreeType:
-		return status.Error(codes.InvalidArgument, "readonly field changed: tree_type")
+		if got, want := storedTree.TreeType, trillian.TreeType_PREORDERED_LOG; got != want {
+			return status.Errorf(codes.InvalidArgument, "can't change tree_type from %v, only %v", got, want)
+		} else if got, want := newTree.TreeType, trillian.TreeType_LOG; got != want {
+			return status.Errorf(codes.InvalidArgument, "can't change tree_type to %v, only %v", got, want)
+		} else if got, want := storedTree.TreeState, trillian.TreeState_FROZEN; got != want {
+			return status.Errorf(codes.InvalidArgument, "can't change tree_type: tree_state=%v, want %v", got, want)
+		}
 	case storedTree.HashStrategy != newTree.HashStrategy:
 		return status.Error(codes.InvalidArgument, "readonly field changed: hash_strategy")
 	case storedTree.HashAlgorithm != newTree.HashAlgorithm:

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -254,9 +254,11 @@ func TestValidateTreeForUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		desc     string
-		updatefn func(*trillian.Tree)
-		wantErr  bool
+		desc      string
+		treeType  trillian.TreeType
+		treeState trillian.TreeState
+		updatefn  func(*trillian.Tree)
+		wantErr   bool
 	}{
 		{
 			desc: "valid",
@@ -360,6 +362,23 @@ func TestValidateTreeForUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			desc:     "TreeTypeFromPreorderedLog",
+			treeType: trillian.TreeType_PREORDERED_LOG,
+			updatefn: func(tree *trillian.Tree) {
+				tree.TreeType = trillian.TreeType_LOG
+			},
+			wantErr: true,
+		},
+		{
+			desc:      "TreeTypeFromFrozenPreorderedLog",
+			treeType:  trillian.TreeType_PREORDERED_LOG,
+			treeState: trillian.TreeState_FROZEN,
+			updatefn: func(tree *trillian.Tree) {
+				tree.TreeState = trillian.TreeState_ACTIVE
+				tree.TreeType = trillian.TreeType_LOG
+			},
+		},
+		{
 			desc: "HashStrategy",
 			updatefn: func(tree *trillian.Tree) {
 				tree.HashStrategy = trillian.HashStrategy_UNKNOWN_HASH_STRATEGY
@@ -407,6 +426,13 @@ func TestValidateTreeForUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		tree := newTree()
+		if test.treeType != trillian.TreeType_UNKNOWN_TREE_TYPE {
+			tree.TreeType = test.treeType
+		}
+		if test.treeState != trillian.TreeState_UNKNOWN_TREE_STATE {
+			tree.TreeState = test.treeState
+		}
+
 		baseTree := *tree
 		test.updatefn(tree)
 
@@ -420,7 +446,7 @@ func TestValidateTreeForUpdate(t *testing.T) {
 	}
 }
 
-// newTree returns a valid tree for tests.
+// newTree returns a valid log tree for tests.
 func newTree() *trillian.Tree {
 	privateKey, err := ptypes.MarshalAny(&keyspb.PEMKeyFile{
 		Path:     privateKeyPath,

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -255,8 +255,8 @@ func TestValidateTreeForUpdate(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		treeType  trillian.TreeType
 		treeState trillian.TreeState
+		treeType  trillian.TreeType
 		updatefn  func(*trillian.Tree)
 		wantErr   bool
 	}{
@@ -362,7 +362,7 @@ func TestValidateTreeForUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:     "TreeTypeFromPreorderedLog",
+			desc:     "TreeTypeFromPreorderedLogToLog",
 			treeType: trillian.TreeType_PREORDERED_LOG,
 			updatefn: func(tree *trillian.Tree) {
 				tree.TreeType = trillian.TreeType_LOG
@@ -370,13 +370,22 @@ func TestValidateTreeForUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:      "TreeTypeFromFrozenPreorderedLog",
-			treeType:  trillian.TreeType_PREORDERED_LOG,
+			desc:      "TreeTypeFromFrozenPreorderedLogToLog",
 			treeState: trillian.TreeState_FROZEN,
+			treeType:  trillian.TreeType_PREORDERED_LOG,
+			updatefn: func(tree *trillian.Tree) {
+				tree.TreeType = trillian.TreeType_LOG
+			},
+		},
+		{
+			desc:      "TreeTypeFromFrozenPreorderedLogToActiveLog",
+			treeState: trillian.TreeState_FROZEN,
+			treeType:  trillian.TreeType_PREORDERED_LOG,
 			updatefn: func(tree *trillian.Tree) {
 				tree.TreeState = trillian.TreeState_ACTIVE
 				tree.TreeType = trillian.TreeType_LOG
 			},
+			wantErr: true,
 		},
 		{
 			desc: "HashStrategy",

--- a/trillian.pb.go
+++ b/trillian.pb.go
@@ -196,13 +196,12 @@ type Tree struct {
 	// Readonly.
 	TreeId int64 `protobuf:"varint,1,opt,name=tree_id,json=treeId" json:"tree_id,omitempty"`
 	// State of the tree.
-	// Trees are ACTIVE after creation. At any point hhe tree may transition
-	// between ACTIVE, DRAINING and (conditionally) FROZEN state. The FROZEN state
-	// requires no entries pending to be integrated.
+	// Trees are ACTIVE after creation. At any point the tree may transition
+	// between ACTIVE, DRAINING and FROZEN states.
 	TreeState TreeState `protobuf:"varint,2,opt,name=tree_state,json=treeState,enum=trillian.TreeState" json:"tree_state,omitempty"`
 	// Type of the tree.
 	// Readonly after Tree creation. Exception: Can be switched from
-	// PREORDERED_LOG to LOG if the Tree is in the FROZEN state.
+	// PREORDERED_LOG to LOG if the Tree is and remains in the FROZEN state.
 	TreeType TreeType `protobuf:"varint,3,opt,name=tree_type,json=treeType,enum=trillian.TreeType" json:"tree_type,omitempty"`
 	// Hash strategy to be used by the tree.
 	// Readonly.

--- a/trillian.pb.go
+++ b/trillian.pb.go
@@ -163,7 +163,6 @@ const (
 	TreeType_MAP TreeType = 2
 	// Tree represents a verifiable pre-ordered log, i.e., a log whose entries are
 	// placed according to sequence numbers assigned outside of Trillian.
-	// TODO(pavelkalinnikov): Support this type.
 	TreeType_PREORDERED_LOG TreeType = 3
 )
 
@@ -197,11 +196,13 @@ type Tree struct {
 	// Readonly.
 	TreeId int64 `protobuf:"varint,1,opt,name=tree_id,json=treeId" json:"tree_id,omitempty"`
 	// State of the tree.
-	// Trees are active after creation. At any point the tree may transition
-	// between ACTIVE and FROZEN.
+	// Trees are ACTIVE after creation. At any point hhe tree may transition
+	// between ACTIVE, DRAINING and (conditionally) FROZEN state. The FROZEN state
+	// requires no entries pending to be integrated.
 	TreeState TreeState `protobuf:"varint,2,opt,name=tree_state,json=treeState,enum=trillian.TreeState" json:"tree_state,omitempty"`
 	// Type of the tree.
-	// Readonly.
+	// Readonly after Tree creation. Exception: Can be switched from
+	// PREORDERED_LOG to LOG if the Tree is in the FROZEN state.
 	TreeType TreeType `protobuf:"varint,3,opt,name=tree_type,json=treeType,enum=trillian.TreeType" json:"tree_type,omitempty"`
 	// Hash strategy to be used by the tree.
 	// Readonly.

--- a/trillian.proto
+++ b/trillian.proto
@@ -127,13 +127,12 @@ message Tree {
 
   // State of the tree.
   // Trees are ACTIVE after creation. At any point the tree may transition
-  // between ACTIVE, DRAINING and (conditionally) FROZEN state. Switching to
-  // FROZEN requires no entries pending integration.
+  // between ACTIVE, DRAINING and FROZEN states.
   TreeState tree_state = 2;
 
   // Type of the tree.
   // Readonly after Tree creation. Exception: Can be switched from
-  // PREORDERED_LOG to LOG if the Tree is in the FROZEN state.
+  // PREORDERED_LOG to LOG if the Tree is and remains in the FROZEN state.
   TreeType tree_type = 3;
 
   // Hash strategy to be used by the tree.

--- a/trillian.proto
+++ b/trillian.proto
@@ -110,7 +110,6 @@ enum TreeType {
 
   // Tree represents a verifiable pre-ordered log, i.e., a log whose entries are
   // placed according to sequence numbers assigned outside of Trillian.
-  // TODO(pavelkalinnikov): Support this type.
   PREORDERED_LOG = 3;
 }
 
@@ -127,12 +126,14 @@ message Tree {
   int64 tree_id = 1;
 
   // State of the tree.
-  // Trees are active after creation. At any point the tree may transition
-  // between ACTIVE and FROZEN.
+  // Trees are ACTIVE after creation. At any point the tree may transition
+  // between ACTIVE, DRAINING and (conditionally) FROZEN state. Switching to
+  // FROZEN requires no entries pending integration.
   TreeState tree_state = 2;
 
   // Type of the tree.
-  // Readonly.
+  // Readonly after Tree creation. Exception: Can be switched from
+  // PREORDERED_LOG to LOG if the Tree is in the FROZEN state.
   TreeType tree_type = 3;
 
   // Hash strategy to be used by the tree.


### PR DESCRIPTION
This change enables switching from the `Tree` metadata perspective. Additional support in `storage.UpdateTree` is required to avoid the situation when the type is changed while there are pending `SequencedLeafData` entries.