### PR TITLE
Better tests for types package

### DIFF
--- a/types/logroot.go
+++ b/types/logroot.go
@@ -60,7 +60,10 @@ type LogRoot struct {
 // the LOG_ROOT_FORMAT_V1 tag, and populates the caller with the deserialized
 // *LogRootV1.
 func (l *LogRootV1) UnmarshalBinary(logRootBytes []byte) error {
-	if logRootBytes == nil {
+	if len(logRootBytes) < 3 {
+		return fmt.Errorf("logRootBytes too short")
+	}
+	if l == nil {
 		return fmt.Errorf("nil log root")
 	}
 	version := binary.BigEndian.Uint16(logRootBytes)

--- a/types/logroot_test.go
+++ b/types/logroot_test.go
@@ -65,6 +65,11 @@ func TestUnmarshalLogRoot(t *testing.T) {
 			logRoot: []byte{0, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
 			wantErr: true,
 		},
+		{
+			// Incorrect type.
+			logRoot: []byte{0},
+			wantErr: true,
+		},
 		{logRoot: []byte("foo"), wantErr: true},
 		{logRoot: nil, wantErr: true},
 	} {
@@ -74,6 +79,12 @@ func TestUnmarshalLogRoot(t *testing.T) {
 		if got, want := err != nil, tc.wantErr; got != want {
 			t.Errorf("UnmarshalBinary(): %v, wantErr %v", err, want)
 		}
+	}
+
+	// Unmarshaling to a nil should throw an error.
+	var got *LogRootV1
+	if err := got.UnmarshalBinary(MustMarshalLogRoot(&LogRootV1{})); err == nil {
+		t.Errorf("nil.UnmarshalBinary(): %v, want err", err)
 	}
 }
 

--- a/types/logroot_test.go
+++ b/types/logroot_test.go
@@ -82,8 +82,8 @@ func TestUnmarshalLogRoot(t *testing.T) {
 	}
 
 	// Unmarshaling to a nil should throw an error.
-	var got *LogRootV1
-	if err := got.UnmarshalBinary(MustMarshalLogRoot(&LogRootV1{})); err == nil {
+	var nilPtr *LogRootV1
+	if err := nilPtr.UnmarshalBinary(MustMarshalLogRoot(&LogRootV1{})); err == nil {
 		t.Errorf("nil.UnmarshalBinary(): %v, want err", err)
 	}
 }

--- a/types/maproot.go
+++ b/types/maproot.go
@@ -54,7 +54,10 @@ type MapRoot struct {
 // UnmarshalBinary verifies that mapRootBytes is a TLS serialized MapRoot,
 // has the MAP_ROOT_FORMAT_V1 tag, and returns the deserialized *MapRootV1.
 func (m *MapRootV1) UnmarshalBinary(mapRootBytes []byte) error {
-	if mapRootBytes == nil {
+	if len(mapRootBytes) < 3 {
+		return fmt.Errorf("mapRootBytes too short")
+	}
+	if m == nil {
 		return fmt.Errorf("nil map root")
 	}
 	version := binary.BigEndian.Uint16(mapRootBytes)

--- a/types/maproot_test.go
+++ b/types/maproot_test.go
@@ -92,8 +92,8 @@ func TestUnmarshalMapRoot(t *testing.T) {
 		}
 	}
 	// Unmarshaling to a nil should throw an error.
-	var got *MapRootV1
-	if err := got.UnmarshalBinary(MustMarshalMapRoot(&MapRootV1{})); err == nil {
+	var nilPtr *MapRootV1
+	if err := nilPtr.UnmarshalBinary(MustMarshalMapRoot(&MapRootV1{})); err == nil {
 		t.Errorf("nil.UnmarshalBinary(): %v, want err", err)
 	}
 }

--- a/types/maproot_test.go
+++ b/types/maproot_test.go
@@ -74,6 +74,11 @@ func TestUnmarshalMapRoot(t *testing.T) {
 			mapRoot: []byte{0, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
 			wantErr: true,
 		},
+		{
+			// Incorrect type
+			mapRoot: []byte{0},
+			wantErr: true,
+		},
 		{mapRoot: []byte("foo"), wantErr: true},
 		{mapRoot: nil, wantErr: true},
 	} {
@@ -85,5 +90,10 @@ func TestUnmarshalMapRoot(t *testing.T) {
 		if got, want := r, tc.want; !reflect.DeepEqual(got, want) {
 			t.Errorf("UnmarshalBinary(): \n%#v, want: \n%#v", got, want)
 		}
+	}
+	// Unmarshaling to a nil should throw an error.
+	var got *MapRootV1
+	if err := got.UnmarshalBinary(MustMarshalMapRoot(&MapRootV1{})); err == nil {
+		t.Errorf("nil.UnmarshalBinary(): %v, want err", err)
 	}
 }


### PR DESCRIPTION
Add checks for decoding to a `nil` ptr and invalid type lengths. 

Cherry picked the orthogonal changes to `types`  out of #1037. 