### PR TITLE
Fix cloud spanner breakage

### DIFF
--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -384,9 +384,9 @@ func (tx *logTX) StoreSignedLogRoot(ctx context.Context, root trillian.SignedLog
 			"TreeMetadata",
 		},
 		[]interface{}{
-			tx.treeID,
-			logRoot.TimestampNanos,
-			logRoot.TreeSize,
+			int64(tx.treeID),
+			int64(logRoot.TimestampNanos),
+			int64(logRoot.TreeSize),
 			logRoot.RootHash,
 			root.LogRootSignature,
 			writeRev,


### PR DESCRIPTION
CloudSpanner doesn't have `uint64` types so need to cast to `int64` before trying to store these values into `INT64` columns.