### PR TITLE
Skip deprecation warning for grpc.naming things

### DIFF
--- a/monitoring/prometheus/etcdiscover/main.go
+++ b/monitoring/prometheus/etcdiscover/main.go
@@ -48,7 +48,7 @@ type serviceInstanceInfo struct {
 	target   string
 
 	mu        sync.RWMutex
-	watcher   map[string]naming.Watcher
+	watcher   map[string]naming.Watcher // nolint: megacheck
 	instances map[string]map[string]bool
 }
 
@@ -56,7 +56,7 @@ func newServiceInstanceInfo(etcdServers, etcdServices, target string) *serviceIn
 	s := serviceInstanceInfo{
 		servers:   strings.Split(etcdServers, ","),
 		services:  strings.Split(etcdServices, ","),
-		watcher:   make(map[string]naming.Watcher),
+		watcher:   make(map[string]naming.Watcher), // nolint: megacheck
 		target:    target,
 		instances: make(map[string]map[string]bool),
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -209,11 +209,11 @@ func AnnounceSelf(ctx context.Context, client *clientv3.Client, etcdService, end
 	}
 	client.KeepAlive(ctx, leaseRsp.ID)
 
-	update := naming.Update{Op: naming.Add, Addr: endpoint}
+	update := naming.Update{Op: naming.Add, Addr: endpoint} // nolint: megacheck
 	res.Update(ctx, etcdService, update, clientv3.WithLease(leaseRsp.ID))
 	glog.Infof("Announcing our presence in %v with %+v", etcdService, update)
 
-	bye := naming.Update{Op: naming.Delete, Addr: endpoint}
+	bye := naming.Update{Op: naming.Delete, Addr: endpoint} // nolint: megacheck
 	return func() {
 		// Use a background context because the original context may have been cancelled.
 		glog.Infof("Removing our presence in %v with %+v", etcdService, bye)


### PR DESCRIPTION
These were recently deprecated:
  https://github.com/grpc/grpc-go/commit/76b07ed73d1a
but are still used by our vendored etcd stuff.
