### PR TITLE
Use etcd in Kubernetes cluster

### DIFF
--- a/examples/deployment/gce/deploy.sh
+++ b/examples/deployment/gce/deploy.sh
@@ -25,6 +25,7 @@ gcloud container node-pools create "signer-pool" --machine-type "n1-standard-1" 
 gcloud container node-pools create "ctfe-pool" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "2" --enable-autorepair --enable-autoupgrade
 gcloud container clusters get-credentials cluster-1
 
+
 # Push docker images
 gcloud docker -- push us.gcr.io/${PROJECT_NAME}/db:$TAG
 gcloud docker -- push us.gcr.io/${PROJECT_NAME}/log_server:$TAG
@@ -34,6 +35,9 @@ gcloud docker -- push us.gcr.io/${PROJECT_NAME}/map_server:$TAG
 # Prepare configmap:
 kubectl delete configmap deploy-config
 kubectl create -f examples/deployment/kubernetes/trillian-mysql.yaml
+
+# Work-around for etcd-operator role on GKE:
+kubectl create clusterrolebinding myname-cluster-admin-binding --clusterrole=cluster-admin
 
 # Launch with kubernetes
 kubectl apply -f examples/deployment/kubernetes/.

--- a/examples/deployment/gce/deploy.sh
+++ b/examples/deployment/gce/deploy.sh
@@ -25,7 +25,6 @@ gcloud container node-pools create "signer-pool" --machine-type "n1-standard-1" 
 gcloud container node-pools create "ctfe-pool" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "2" --enable-autorepair --enable-autoupgrade
 gcloud container clusters get-credentials cluster-1
 
-
 # Push docker images
 gcloud docker -- push us.gcr.io/${PROJECT_NAME}/db:$TAG
 gcloud docker -- push us.gcr.io/${PROJECT_NAME}/log_server:$TAG

--- a/examples/deployment/kubernetes/etcd-cluster.yaml
+++ b/examples/deployment/kubernetes/etcd-cluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "trillian-etcd-cluster"
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+spec:
+  size: 3
+  version: "3.2.13"

--- a/examples/deployment/kubernetes/etcd-deployment.yaml
+++ b/examples/deployment/kubernetes/etcd-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: trillian-etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: trillian-etcd-operator
+    spec:
+      containers:
+      - name: trillian-etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.9.1
+        command:
+        - etcd-operator
+        - -cluster-wide
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/examples/deployment/kubernetes/etcd-role-binding.yaml
+++ b/examples/deployment/kubernetes/etcd-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/examples/deployment/kubernetes/etcd-role.yaml
+++ b/examples/deployment/kubernetes/etcd-role.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+  namespace: default
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/examples/deployment/kubernetes/etcd-service.yaml
+++ b/examples/deployment/kubernetes/etcd-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trillian-etcd-service
+spec:
+  type: NodePort
+  selector:
+    etcd_cluster: trillian-etcd-cluster
+    app: etcd
+  ports:
+    - protocol: TCP
+      port: 2379
+      targetPort: 2379
+      nodePort: 32379

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     io.kompose.service: trillian-log
   name: trillian-logserver-deployment
 spec:
-  replicas: 3
+  replicas: 2
   strategy: {}
   template:
     metadata:
@@ -24,7 +24,9 @@ spec:
         command: ["/go/bin/trillian_log_server",
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
-        "--quota_system=noop",
+        "--quota_system=etcd",
+        "--etcd_servers=trillian-etcd-cluster-client:2379",
+        "--etcd_http_service=trillian-logserver-http",
         "--rpc_endpoint=0.0.0.0:8090",
         "--http_endpoint=0.0.0.0:8091",
         "--alsologtostderr"
@@ -37,9 +39,9 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            cpu: "1.5"
+            cpu: "1.0"
           requests:
-            cpu: "1"
+            cpu: "0.4"
         livenessProbe:
           exec:
             command:
@@ -69,6 +71,11 @@ spec:
           - --pod-id=$(POD_NAME)
           - --namespace-id=$(POD_NAMESPACE)
           - --metrics-resolution=5s
+        resources:
+          limits:
+            cpu: 20m
+          requests:
+            cpu: 20m
         env:
           - name: POD_NAME
             valueFrom:

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     io.kompose.service: trillian-log-signer
   name: trillian-logsigner-deployment
 spec:
-  replicas: 1
+  replicas: 2
   strategy: {}
   template:
     metadata:
@@ -24,14 +24,16 @@ spec:
       - command: ["/go/bin/trillian_log_signer",
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
-        "--quota_system=noop",
+        "--etcd_servers=trillian-etcd-cluster-client:2379",
+        "--quota_system=etcd",
+        "--etcd_http_service=trillian-logsigner-http",
         "--http_endpoint=0.0.0.0:8091",
         "--sequencer_guard_window=1s",
         "--sequencer_interval=10ms",
         "--num_sequencers=10",
         "--batch_size=1000",
         "--cloudspanner_dequeue_bucket_fraction=0.0078", # 2/256, or 2 merkle buckets
-        "--force_master=true",
+        "--resign_odds=1000",
         "--alsologtostderr"
         ]
         envFrom:


### PR DESCRIPTION
Mainly to allow master election so we can have redundant signers.
A bit of resource fiddling going on to help squeeze the extra pods in.

This is a bit of a work-in-progress in the grand scheme of things, but is reasonably self-contained.
