### PR TITLE
Use math/bits for bit counting

### DIFF
--- a/merkle/compact_merkle_tree_test.go
+++ b/merkle/compact_merkle_tree_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math/bits"
 	"strings"
 	"testing"
 
@@ -34,7 +35,7 @@ func checkUnusedNodesInvariant(c *CompactMerkleTree) error {
 	// should be present for a tree of given size are fetched from the
 	// backing store via GetNodeFunc.
 	size := c.size
-	sizeBits := bitLen(size)
+	sizeBits := bits.Len64(uint64(size))
 	if isPerfectTree(size) {
 		for i, n := range c.nodes {
 			expectNil := i != sizeBits-1

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -17,6 +17,7 @@ package merkle
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/storage"
@@ -102,7 +103,7 @@ func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64, max
 // snapshotConsistency does the calculation of consistency proof node addresses between
 // two snapshots. Based on the C++ code used by CT but adjusted to fit our situation.
 func snapshotConsistency(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
-	proof := make([]NodeFetch, 0, bitLen(snapshot2)+1)
+	proof := make([]NodeFetch, 0, bits.Len64(uint64(snapshot2))+1)
 
 	glog.V(vLevel).Infof("snapshotConsistency: %d -> %d", snapshot1, snapshot2)
 
@@ -141,7 +142,7 @@ func snapshotConsistency(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([
 
 func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
 	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot(%d, %d, %d, %d, %d)", node, level, snapshot, treeSize, maxBitLen)
-	proof := make([]NodeFetch, 0, bitLen(snapshot)+1)
+	proof := make([]NodeFetch, 0, bits.Len64(uint64(snapshot))+1)
 
 	if snapshot == 0 {
 		return proof, nil

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -200,8 +200,6 @@ var expectedConsistencyProofFromSize2To8 = []NodeFetch{
 	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
 }
 
-var bitLenTests = []bitLenTestData{{0, 0}, {1, 1}, {2, 2}, {3, 2}, {12, 4}}
-
 // These should all successfully compute the expected path
 var pathTests = []auditPathTestData{
 	{1, 0, []NodeFetch{}},
@@ -245,14 +243,6 @@ var consistencyTestsBad = []consistencyProofTestData{
 	{-1, -1, []NodeFetch{}},
 	{0, 0, []NodeFetch{}},
 	{9, 8, []NodeFetch{}},
-}
-
-func TestBitLen(t *testing.T) {
-	for _, testCase := range bitLenTests {
-		if got, expected := bitLen(testCase.input), testCase.expected; expected != got {
-			t.Fatalf("expected %d for input %d but got %d", testCase.expected, testCase.input, got)
-		}
-	}
 }
 
 func TestCalcInclusionProofNodeAddresses(t *testing.T) {

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -21,11 +21,6 @@ import (
 	"github.com/google/trillian/storage"
 )
 
-type bitLenTestData struct {
-	input    int64
-	expected int
-}
-
 type auditPathTestData struct {
 	treeSize     int64
 	leafIndex    int64

--- a/storage/types.go
+++ b/storage/types.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"math/bits"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/storage/storagepb"
@@ -178,15 +179,6 @@ func NewNodeIDWithPrefix(prefix uint64, prefixLenBits, nodeIDLenBits, maxLenBits
 	return p
 }
 
-func bitLen(x int64) int {
-	r := 0
-	for x > 0 {
-		r++
-		x >>= 1
-	}
-	return r
-}
-
 // NewNodeIDForTreeCoords creates a new NodeID for a Tree node with a specified depth and
 // index.
 // This method is used exclusively by the Log, and, since the Log model grows upwards from the
@@ -197,7 +189,7 @@ func bitLen(x int64) int {
 // index is the horizontal index into the tree at level depth, so the returned
 // NodeID will be zero padded on the right by depth places.
 func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, error) {
-	bl := bitLen(index)
+	bl := bits.Len64(uint64(index))
 	if index < 0 || depth < 0 ||
 		bl > int(maxPathBits-int(depth)) ||
 		maxPathBits%8 != 0 {


### PR DESCRIPTION
This removes the `bitLen` ad-hoc function from couple of places.