### PR TITLE
[LogVerifier] Factor out hash chaining

### DIFF
--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -21,6 +21,8 @@ import (
 // hashChainer provides convenience methods for hashing subranges of Merkle
 // Tree proofs to obtain (sub-)tree hashes. Depending on how the path to a tree
 // node relates to the query and/or tree borders, different methods are there.
+//
+// TODO(pavelkalinnikov): Add a Merkle Trees doc with visual explanations.
 type hashChainer struct {
 	hasher hashers.LogHasher
 }

--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -15,8 +15,6 @@
 package merkle
 
 import (
-	"math/bits"
-
 	"github.com/google/trillian/merkle/hashers"
 )
 
@@ -31,9 +29,6 @@ import (
 // hash of a tree sub-range rather than the full tree.
 //
 // Border* methods are for chaining proof hashes along (sub-)tree borders.
-//
-// *Open methods are for open-ended queries, i.e. when the query result should
-// not include the boundary leaf.
 //
 // Note: There is no *Left in addition to *Right queries at the moment because
 // Merkle Trees don't hash together nodes along left borders.
@@ -61,27 +56,9 @@ func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, mask int64) []
 	return seed
 }
 
-func (c hashChainer) chainInnerRightOpen(proof [][]byte, index int64) []byte {
-	shift := bits.TrailingZeros64(uint64(index))
-	if shift >= len(proof) {
-		return nil
-	}
-	return c.chainInnerRight(proof[shift], proof[shift+1:], index>>uint(shift+1))
-}
-
 func (c hashChainer) chainBorderRight(seed []byte, proof [][]byte) []byte {
 	for _, h := range proof {
 		seed = c.hasher.HashChildren(h, seed)
 	}
 	return seed
-}
-
-func (c hashChainer) chainBorderRightOpen(seed []byte, proof [][]byte) []byte {
-	if seed == nil {
-		if len(proof) == 0 {
-			return nil
-		}
-		return c.chainBorderRight(proof[0], proof[1:])
-	}
-	return c.chainBorderRight(seed, proof)
 }

--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -1,0 +1,73 @@
+package merkle
+
+import (
+	"math/bits"
+
+	"github.com/google/trillian/merkle/hashers"
+)
+
+// hashChainer provides convenience methods for hashing subranges of Merkle
+// Tree proofs to obtain (sub-)root hashes. Depending on how the path to a tree
+// node relates to the query and/or tree borders, different methods are there.
+//
+// The family of Inner* chaining methods is for when the path is strictly below
+// the right border of the tree. InnerRight* methods can be used for one-sided
+// queries when the path goes along the query right border in addition to being
+// below the right tree border, which is useful, for example, when computing
+// hash of a tree sub-range rather than the full tree.
+//
+// Border* methods are for chaining proof hashes along (sub-)tree borders.
+//
+// *Open methods are for open-ended queries, i.e. when the query result should
+// not include the boundary leaf.
+//
+// Note: There is no *Left in addition to *Right queries at the moment because
+// Merkle Trees don't hash together nodes along left borders.
+type hashChainer struct {
+	hasher hashers.LogHasher
+}
+
+func (c hashChainer) chainInner(seed []byte, proof [][]byte, mask int64) []byte {
+	for i, h := range proof {
+		if (mask>>uint(i))&1 == 0 {
+			seed = c.hasher.HashChildren(seed, h)
+		} else {
+			seed = c.hasher.HashChildren(h, seed)
+		}
+	}
+	return seed
+}
+
+func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, mask int64) []byte {
+	for i, h := range proof {
+		if (mask>>uint(i))&1 == 1 {
+			seed = c.hasher.HashChildren(h, seed)
+		}
+	}
+	return seed
+}
+
+func (c hashChainer) chainInnerRightOpen(proof [][]byte, index int64) []byte {
+	shift := bits.TrailingZeros64(uint64(index))
+	if shift >= len(proof) {
+		return nil
+	}
+	return c.chainInnerRight(proof[shift], proof[shift+1:], index>>uint(shift+1))
+}
+
+func (c hashChainer) chainBorderRight(seed []byte, proof [][]byte) []byte {
+	for _, h := range proof {
+		seed = c.hasher.HashChildren(h, seed)
+	}
+	return seed
+}
+
+func (c hashChainer) chainBorderRightOpen(seed []byte, proof [][]byte) []byte {
+	if seed == nil {
+		if len(proof) == 0 {
+			return nil
+		}
+		return c.chainBorderRight(proof[0], proof[1:])
+	}
+	return c.chainBorderRight(seed, proof)
+}

--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -19,26 +19,19 @@ import (
 )
 
 // hashChainer provides convenience methods for hashing subranges of Merkle
-// Tree proofs to obtain (sub-)root hashes. Depending on how the path to a tree
+// Tree proofs to obtain (sub-)tree hashes. Depending on how the path to a tree
 // node relates to the query and/or tree borders, different methods are there.
-//
-// The family of Inner* chaining methods is for when the path is strictly below
-// the right border of the tree. InnerRight* methods can be used for one-sided
-// queries when the path goes along the query right border in addition to being
-// below the right tree border, which is useful, for example, when computing
-// hash of a tree sub-range rather than the full tree.
-//
-// Border* methods are for chaining proof hashes along (sub-)tree borders.
-//
-// Note: There is no *Left in addition to *Right queries at the moment because
-// Merkle Trees don't hash together nodes along left borders.
 type hashChainer struct {
 	hasher hashers.LogHasher
 }
 
-func (c hashChainer) chainInner(seed []byte, proof [][]byte, mask int64) []byte {
+// chainInner computes a subtree hash for a node on or below the tree's right
+// border. Assumes |proof| hashes are ordered from lower levels to upper, and
+// |seed| is the initial subtree/leaf hash on the path located at the specified
+// |index| on its level.
+func (c hashChainer) chainInner(seed []byte, proof [][]byte, index int64) []byte {
 	for i, h := range proof {
-		if (mask>>uint(i))&1 == 0 {
+		if (index>>uint(i))&1 == 0 {
 			seed = c.hasher.HashChildren(seed, h)
 		} else {
 			seed = c.hasher.HashChildren(h, seed)
@@ -47,15 +40,20 @@ func (c hashChainer) chainInner(seed []byte, proof [][]byte, mask int64) []byte 
 	return seed
 }
 
-func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, mask int64) []byte {
+// chainInnerRight computes a subtree hash like chainInner, but only takes
+// hashes to the left from the path into consideration, which effectively means
+// the result is a hash of the corresponding earlier version of this subtree.
+func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, index int64) []byte {
 	for i, h := range proof {
-		if (mask>>uint(i))&1 == 1 {
+		if (index>>uint(i))&1 == 1 {
 			seed = c.hasher.HashChildren(h, seed)
 		}
 	}
 	return seed
 }
 
+// chainBorderRight chains proof hashes along tree borders. This differs from
+// inner chaining because |proof| contains only left-side subtree hashes.
 func (c hashChainer) chainBorderRight(seed []byte, proof [][]byte) []byte {
 	for _, h := range proof {
 		seed = c.hasher.HashChildren(h, seed)

--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package merkle
 
 import (

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -77,7 +77,7 @@ func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][
 		return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
 	}
 
-	ch := hashChainer{v.hasher}
+	ch := hashChainer(v)
 	res := ch.chainInner(leafHash, proof[:inner], leafIndex)
 	res = ch.chainBorderRight(res, proof[inner:])
 	return res, nil
@@ -131,7 +131,7 @@ func (v LogVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, r
 	// inclusion proof for entry |snapshot1-1| in a tree of size |snapshot2|.
 
 	// Verify the first root.
-	ch := hashChainer{v.hasher}
+	ch := hashChainer(v)
 	mask := (snapshot1 - 1) >> uint(shift) // Start chaining from level |shift|.
 	hash1 := ch.chainInnerRight(seed, proof[:inner], mask)
 	hash1 = ch.chainBorderRight(hash1, proof[inner:])
@@ -173,7 +173,7 @@ func (v LogVerifier) VerifiedPrefixHashFromInclusionProof(
 	}
 
 	inner := innerProofSize(subSize, size)
-	ch := hashChainer{v.hasher}
+	ch := hashChainer(v)
 	res := ch.chainInnerRightOpen(proof[:inner], subSize)
 	res = ch.chainBorderRightOpen(res, proof[inner:])
 	return res, nil

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -87,12 +87,12 @@ func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][
 // between the passed in tree snapshots. Snapshots are the respective tree
 // sizes. Accepts shapshot2 >= snapshot1 >= 0.
 func (v LogVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
-	if snapshot1 < 0 {
+	switch {
+	case snapshot1 < 0:
 		return fmt.Errorf("snapshot1 (%d) < 0 ", snapshot1)
-	} else if snapshot2 < snapshot1 {
+	case snapshot2 < snapshot1:
 		return fmt.Errorf("snapshot2 (%d) < snapshot1 (%d)", snapshot1, snapshot2)
-	}
-	if snapshot1 == snapshot2 {
+	case snapshot1 == snapshot2:
 		if !bytes.Equal(root1, root2) {
 			return RootMismatchError{
 				CalculatedRoot: root1,
@@ -102,15 +102,13 @@ func (v LogVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, r
 			return errors.New("root1 and root2 match, but proof is non-empty")
 		}
 		return nil // Proof OK.
-	}
-	if snapshot1 == 0 {
+	case snapshot1 == 0:
 		// Any snapshot greater than 0 is consistent with snapshot 0.
 		if len(proof) > 0 {
 			return fmt.Errorf("expected empty proof, but got %d components", len(proof))
 		}
 		return nil // Proof OK.
-	}
-	if len(proof) == 0 {
+	case len(proof) == 0:
 		return errors.New("empty proof")
 	}
 

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -345,6 +345,28 @@ func TestVerifyInclusionProof(t *testing.T) {
 
 }
 
+func TestVerifyInclusionProofGenerated(t *testing.T) {
+	var sizes []int64
+	for s := 1; s <= 70; s++ {
+		sizes = append(sizes, int64(s))
+	}
+	sizes = append(sizes, []int64{1024, 5050}...)
+
+	tree, v := createTree(0)
+	for _, size := range sizes {
+		growTree(tree, size)
+		root := tree.CurrentRoot().Hash()
+		for i := int64(0); i < size; i++ {
+			t.Run(fmt.Sprintf("size:%d:index:%d", size, i), func(t *testing.T) {
+				leaf, proof := getLeafAndProof(tree, i)
+				if err := verifierCheck(&v, i, size, proof, root, leaf); err != nil {
+					t.Errorf("verifierCheck(): %v", err)
+				}
+			})
+		}
+	}
+}
+
 func TestVerifyConsistencyProof(t *testing.T) {
 	v := NewLogVerifier(rfc6962.DefaultHasher)
 

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -439,25 +439,21 @@ func TestVerifyConsistencyProof(t *testing.T) {
 }
 
 func TestVerifyConsistencyProofGenerated(t *testing.T) {
-	sizes := make([]int64, 0, 18)
-	for s := 1; s < cap(sizes); s++ {
-		sizes = append(sizes, int64(s))
+	size := int64(130)
+	tree, v := createTree(size)
+	roots := make([][]byte, size+1)
+	for i := int64(0); i <= size; i++ {
+		roots[i] = tree.RootAtSnapshot(i).Hash()
 	}
-	sizes = append(sizes, 74)
 
-	for _, size := range sizes {
-		tree, v := createTree(size)
-		for i := int64(0); i <= size; i++ {
-			for j := i; j <= size; j++ {
-				t.Run(fmt.Sprintf("size:%d:consistency:%d-%d", size, i, j), func(t *testing.T) {
-					proof := rawProof(tree.SnapshotConsistency(i, j))
-					root1 := tree.RootAtSnapshot(i).Hash()
-					root2 := tree.RootAtSnapshot(j).Hash()
-					if err := verifierConsistencyCheck(&v, i, j, root1, root2, proof); err != nil {
-						t.Fatalf("verifierConsistencyCheck(): %v", err)
-					}
-				})
-			}
+	for i := int64(0); i <= size; i++ {
+		for j := i; j <= size; j++ {
+			proof := rawProof(tree.SnapshotConsistency(i, j))
+			t.Run(fmt.Sprintf("size:%d:consistency:%d-%d", size, i, j), func(t *testing.T) {
+				if err := verifierConsistencyCheck(&v, i, j, roots[i], roots[j], proof); err != nil {
+					t.Errorf("verifierConsistencyCheck(): %v", err)
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
This PR simplifies proof verification methods in `LogVerifier` by introducing `hashChainer` - the type used for combining proof hashes in various ways depending on how the corresponding (sub-)path is related to the tree or query.
This PR also adds exhaustive testing of inclusion and consistency proof verification on generated in-memory Merkle Trees.