### PR TITLE
Range inclusion verification based on 2 inclusion proofs

### DIFF
--- a/merkle/hash_stack.go
+++ b/merkle/hash_stack.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merkle
+
+import "github.com/google/trillian/merkle/hashers"
+
+type hashStack struct {
+	hasher hashers.LogHasher
+	hashes [][]byte
+	begin  int64
+	index  int64
+}
+
+func newHashStack(hasher hashers.LogHasher, begin int64) hashStack {
+	return hashStack{hasher: hasher, begin: begin, index: begin}
+}
+
+func (s *hashStack) pushAndChain(h []byte) {
+	pop, index, ln := 0, s.index, len(s.hashes)
+	for one := int64(1); index&one != 0; one <<= 1 {
+		index ^= one
+		if index < s.begin || pop >= ln {
+			break
+		}
+		pop++
+		h = s.hasher.HashChildren(s.hashes[ln-pop], h)
+	}
+	s.hashes = append(s.hashes[:ln-pop], h)
+	s.index++
+}


### PR DESCRIPTION
This is a proof-of-concept implementation of range inclusion verification.
Such functionality will be particularly useful in mirroring to Trillian's `PREORDERED_LOG`. With the current Trillian and CT APIs it is only possible to do one of the following:
1. Use `GetEntryAndProof` to obtain and verify individual entries.
2. Use regular `GetLeavesBy*` batch APIs for obtaining multiple unverified entries, put them in Trillian and hope the final STH will match the public one (after we reach at least its tree size which can be millions).

After this PR it is possible to verify **batches** having only 2 boundary entries' inclusion proofs. If, after such batch-level verification, Trillian's STH does not match the public one, we know w.h.p. that the problem is on Trillian's side.