### PR TITLE
Idempotent subtree@revision writes

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -149,8 +149,7 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 		pxKey := string(px)
 		// TODO(al): fix for non-uniform strata
 		id.PrefixLenBits = len(px) * depthQuantum
-		_, ok := s.subtrees[pxKey]
-		if !ok {
+		if _, ok := s.subtrees[pxKey]; !ok {
 			want[pxKey] = &id
 		}
 	}
@@ -330,13 +329,17 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 	// node, and store it accordingly.
 	sfxKey := sx.String()
 	if int32(sx.Bits) == c.Depth {
-		// Short-circuit write if we're simply overwriting an identical value.
+		// If the value being set is identical to the one we read from storage, then
+		// leave the cache state alone, and return.  This will prevent a write (and
+		// subtree revision bump) for identical data.
 		if bytes.Equal(c.Leaves[sfxKey], h) {
 			return nil
 		}
 		c.Leaves[sfxKey] = h
 	} else {
-		// Short-circuit write if we're simply overwriting an identical value.
+		// If the value being set is identical to the one we read from storage, then
+		// leave the cache state alone, and return.  This will prevent a write (and
+		// subtree revision bump) for identical data.
 		if bytes.Equal(c.InternalNodes[sfxKey], h) {
 			return nil
 		}


### PR DESCRIPTION
This PR short circuits writes to subtree data when the data being written is identical to the data already present.  It goes some way to dealing with #1109.

Due to the nature of Trillian's storage design, a write to any given node is always preceded with a read to fetch the previous revision of the subtree which contains that node.  This allows the `subtreeCache` an opportunity to ignore the write when the application is simply attempting to re-write the previous value.

This should not cause any issues, since when reading nodes, Trillian will always use the most recent revision subtree, which will contain the same data.

