### PR TITLE
Use close-ended semantics in VerifiedPrefixHashFromInclusionProof

### DIFF
--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -235,13 +235,11 @@ func (v LogVerifier) VerifiedPrefixHashFromInclusionProof(
 	// |tail| is the number of proof hashes corresponding to tree nodes below the
 	// split point between paths to leaves |subSize-1| and |size-1|.
 	tail := bits.Len64(uint64(leaf ^ (size - 1)))
-
 	res := leafHash
 	for i, h := range proof {
-		if i < tail && (leaf>>uint(i))&1 == 0 {
-			continue
+		if i >= tail || (leaf>>uint(i))&1 == 1 {
+			res = v.hasher.HashChildren(h, res)
 		}
-		res = v.hasher.HashChildren(h, res)
 	}
 	return res, nil
 }

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -216,7 +216,7 @@ func (v LogVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, r
 
 // VerifiedPrefixHashFromInclusionProof calculates a root hash over leaves
 // [0..subSize), based on the inclusion |proof| and |leafHash| for a leaf at
-// the |subSize| index in a tree of the specified |size| with the passed in
+// index |subSize-1| in a tree of the specified |size| with the passed in
 // |root| hash.
 // Returns an error if the |proof| verification fails. The resulting smaller
 // tree's root hash is trusted iff the bigger tree's |root| hash is trusted.
@@ -224,27 +224,24 @@ func (v LogVerifier) VerifiedPrefixHashFromInclusionProof(
 	subSize, size int64,
 	proof [][]byte, root []byte, leafHash []byte,
 ) ([]byte, error) {
-	if err := v.VerifyInclusionProof(subSize, size, proof, root, leafHash); err != nil {
-		return nil, err
+	if subSize <= 0 {
+		return nil, fmt.Errorf("subtree size is %d, want > 0", subSize)
 	}
-	if subSize == 0 {
-		return v.hasher.EmptyRoot(), nil
+	leaf := subSize - 1
+	if err := v.VerifyInclusionProof(leaf, size, proof, root, leafHash); err != nil {
+		return nil, err
 	}
 
 	// |tail| is the number of proof hashes corresponding to tree nodes below the
-	// split point between paths to leaves |subSize| and |size-1|.
-	tail := bits.Len64(uint64(subSize ^ (size - 1)))
+	// split point between paths to leaves |subSize-1| and |size-1|.
+	tail := bits.Len64(uint64(leaf ^ (size - 1)))
 
-	var res []byte
+	res := leafHash
 	for i, h := range proof {
-		if i < tail && (subSize>>uint(i))&1 == 0 {
+		if i < tail && (leaf>>uint(i))&1 == 0 {
 			continue
 		}
-		if res == nil {
-			res = h
-		} else {
-			res = v.hasher.HashChildren(h, res)
-		}
+		res = v.hasher.HashChildren(h, res)
 	}
 	return res, nil
 }

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -472,7 +472,7 @@ func TestPrefixHashFromInclusionProofErrors(t *testing.T) {
 		t.Errorf("VerifiedPrefixHashFromInclusionProof(): %v, expected no error", err)
 	}
 
-	// Proofs #3 has the same length, but doesn't verify against index #2.
+	// Proof #3 has the same length, but doesn't verify against index #2.
 	// Neither does proof #301 as it has a different length.
 	for _, proof := range [][][]byte{proof3, proof301} {
 		if _, err := verif.VerifiedPrefixHashFromInclusionProof(3, size, proof, root, leaf2); err == nil {


### PR DESCRIPTION
This removes the corner case for empty tree, plus simplifies the hash calculation loop.
Will also allow for some simplifications in #1105.