### PR TITLE
Tracing for trees.go and admin helpers

### DIFF
--- a/server/admin/tree_gc_test.go
+++ b/server/admin/tree_gc_test.go
@@ -62,15 +62,15 @@ func TestDeletedTreeGC_Run(t *testing.T) {
 	// * 2nd loop: Snapshot()/ListTrees() only.
 
 	// 1st loop
-	listTX1.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return([]*trillian.Tree{tree1}, nil)
+	listTX1.EXPECT().ListTrees(gomock.Any(), true /* includeDeleted */).Return([]*trillian.Tree{tree1}, nil)
 	listTX1.EXPECT().Close().Return(nil)
 	listTX1.EXPECT().Commit().Return(nil)
-	deleteTX1.EXPECT().HardDeleteTree(ctx, tree1.TreeId).Return(nil)
+	deleteTX1.EXPECT().HardDeleteTree(gomock.Any(), tree1.TreeId).Return(nil)
 	deleteTX1.EXPECT().Close().Return(nil)
 	deleteTX1.EXPECT().Commit().Return(nil)
 
 	// 2nd loop
-	listTX2.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return(nil, nil)
+	listTX2.EXPECT().ListTrees(gomock.Any(), true /* includeDeleted */).Return(nil, nil)
 	listTX2.EXPECT().Close().Return(nil)
 	listTX2.EXPECT().Commit().Return(nil)
 
@@ -162,13 +162,13 @@ func TestDeletedTreeGC_RunOnce(t *testing.T) {
 		listTX := storage.NewMockReadOnlyAdminTX(ctrl)
 		as := &testonly.FakeAdminStorage{ReadOnlyTX: []storage.ReadOnlyAdminTX{listTX}}
 
-		listTX.EXPECT().ListTrees(ctx, true /* includeDeleted */).Return(allTrees, nil)
+		listTX.EXPECT().ListTrees(gomock.Any(), true /* includeDeleted */).Return(allTrees, nil)
 		listTX.EXPECT().Close().Return(nil)
 		listTX.EXPECT().Commit().Return(nil)
 
 		for _, id := range test.wantDeleted {
 			deleteTX := storage.NewMockAdminTX(ctrl)
-			deleteTX.EXPECT().HardDeleteTree(ctx, id).Return(nil)
+			deleteTX.EXPECT().HardDeleteTree(gomock.Any(), id).Return(nil)
 			deleteTX.EXPECT().Close().Return(nil)
 			deleteTX.EXPECT().Commit().Return(nil)
 			as.TX = append(as.TX, deleteTX)

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -16,14 +16,20 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/trillian"
+	"go.opencensus.io/trace"
 )
+
+const traceSpanRoot = "github.com/google/trillian/storage"
 
 // GetTree reads a tree from storage using a snapshot transaction.
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.
 // See RunInAdminSnapshot if you need to perform more than one action per transaction.
 func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "GetTree")
+	defer span.End()
 	var tree *trillian.Tree
 	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) (err error) {
 		tree, err = tx.GetTree(ctx, treeID)
@@ -36,6 +42,8 @@ func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.T
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's ListTrees.
 // See RunInAdminSnapshot if you need to perform more than one action per transaction.
 func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "ListTrees")
+	defer span.End()
 	var resp []*trillian.Tree
 	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) (err error) {
 		resp, err = tx.ListTrees(ctx, includeDeleted)
@@ -48,6 +56,8 @@ func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's CreateTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "CreateTree")
+	defer span.End()
 	var createdTree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		createdTree, err = tx.CreateTree(ctx, tree)
@@ -60,6 +70,8 @@ func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UpdateTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*trillian.Tree)) (*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "UpdateTree")
+	defer span.End()
 	var updatedTree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		updatedTree, err = tx.UpdateTree(ctx, treeID, fn)
@@ -72,6 +84,8 @@ func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's SoftDeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "SoftDeleteTree")
+	defer span.End()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		tree, err = tx.SoftDeleteTree(ctx, treeID)
@@ -84,6 +98,8 @@ func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*tri
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's HardDeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error {
+	ctx, span := spanFor(ctx, "HardDeleteTree")
+	defer span.End()
 	return admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		return tx.HardDeleteTree(ctx, treeID)
 	})
@@ -93,10 +109,16 @@ func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UndeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UndeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
+	ctx, span := spanFor(ctx, "UndeleteTree")
+	defer span.End()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) (err error) {
 		tree, err = tx.UndeleteTree(ctx, treeID)
 		return
 	})
 	return tree, err
+}
+
+func spanFor(ctx context.Context, name string) (context.Context, *trace.Span) {
+	return trace.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
 }

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -304,8 +304,8 @@ func TestGetTree(t *testing.T) {
 
 		admin := storage.NewMockAdminStorage(ctrl)
 		tx := storage.NewMockReadOnlyAdminTX(ctrl)
-		admin.EXPECT().Snapshot(ctx).MaxTimes(1).Return(tx, test.beginErr)
-		tx.EXPECT().GetTree(ctx, test.treeID).MaxTimes(1).Return(test.storageTree, test.getErr)
+		admin.EXPECT().Snapshot(gomock.Any()).MaxTimes(1).Return(tx, test.beginErr)
+		tx.EXPECT().GetTree(gomock.Any(), test.treeID).MaxTimes(1).Return(test.storageTree, test.getErr)
 		tx.EXPECT().Close().MaxTimes(1).Return(nil)
 		tx.EXPECT().Commit().MaxTimes(1).Return(test.commitErr)
 


### PR DESCRIPTION
GetTree is sometimes in the request path.