### PR TITLE
[LogVerifier] Check hash size, add regression test

### DIFF
--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -28,7 +28,7 @@ type LogHasher interface {
 	HashLeaf(leaf []byte) ([]byte, error)
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
-	// Size is the number of bits in the underlying hash function.
+	// Size is the number of bytes in the underlying hash function.
 	// TODO(gbelvin): Replace Size() with BitLength().
 	Size() int
 }

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -71,6 +71,9 @@ func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][
 	case leafIndex >= treeSize:
 		return nil, fmt.Errorf("leafIndex is beyond treeSize: %d >= %d", leafIndex, treeSize)
 	}
+	if got, want := len(leafHash), v.hasher.Size(); got != want {
+		return nil, fmt.Errorf("leafHash has unexpected size %d, want %d", got, want)
+	}
 
 	inner, border := decompInclProof(leafIndex, treeSize)
 	if got, want := len(proof), inner+border; got != want {


### PR DESCRIPTION
Previously verification could succeed if `root` and `leafHash` were both empty (or, more generally, incorrect size).