### PR TITLE
Don't close etcd client on MasterElection.Close()

### DIFF
--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -92,6 +92,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to connect to etcd at %v: %v", server.EtcdServers, err)
 	}
+	defer client.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go util.AwaitSignal(cancel)

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -64,10 +64,7 @@ func (eme *MasterElection) ResignAndRestart(ctx context.Context) error {
 // Close terminates election operation.
 func (eme *MasterElection) Close(ctx context.Context) error {
 	_ = eme.ResignAndRestart(ctx)
-	if err := eme.session.Close(); err != nil {
-		glog.Errorf("error closing session: %v", err)
-	}
-	return nil
+	return eme.session.Close()
 }
 
 // ElectionFactory creates etcd.MasterElection instances.
@@ -77,7 +74,9 @@ type ElectionFactory struct {
 	lockDir    string
 }
 
-// NewElectionFactory builds an election factory that uses the given parameters.
+// NewElectionFactory builds an election factory that uses the given
+// parameters. The passed in etcd client should remain valid for the lifetime
+// of the ElectionFactory.
 func NewElectionFactory(instanceID string, client *clientv3.Client, lockDir string) *ElectionFactory {
 	return &ElectionFactory{
 		client:     client,

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -67,7 +67,7 @@ func (eme *MasterElection) Close(ctx context.Context) error {
 	if err := eme.session.Close(); err != nil {
 		glog.Errorf("error closing session: %v", err)
 	}
-	return eme.client.Close()
+	return nil
 }
 
 // ElectionFactory creates etcd.MasterElection instances.

--- a/util/etcd/election_test.go
+++ b/util/etcd/election_test.go
@@ -16,31 +16,18 @@ package etcd
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/google/trillian/testonly/integration/etcd"
 )
 
-var (
-	// client is an etcd client. Initialized by TestMain().
-	client *clientv3.Client
-)
-
-func TestMain(m *testing.M) {
-	_, c, cleanup, err := etcd.StartEtcd()
-	if err != nil {
-		panic(fmt.Sprintf("StartEtcd(): %v", err))
-	}
-	client = c
-	code := m.Run()
-	cleanup()
-	os.Exit(code)
-}
-
 func TestMasterElectionThroughCommonClient(t *testing.T) {
+	_, client, cleanup, err := etcd.StartEtcd()
+	if err != nil {
+		t.Fatalf("StartEtcd(): %v", err)
+	}
+	defer cleanup()
+
 	ctx := context.Background()
 	fact := NewElectionFactory("serv", client, "trees/")
 

--- a/util/etcd/election_test.go
+++ b/util/etcd/election_test.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/google/trillian/testonly/integration/etcd"
+)
+
+var (
+	// client is an etcd client. Initialized by TestMain().
+	client *clientv3.Client
+)
+
+func TestMain(m *testing.M) {
+	_, c, cleanup, err := etcd.StartEtcd()
+	if err != nil {
+		panic(fmt.Sprintf("StartEtcd(): %v", err))
+	}
+	client = c
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
+
+func TestMasterElectionThroughCommonClient(t *testing.T) {
+	ctx := context.Background()
+	fact := NewElectionFactory("serv", client, "trees/")
+
+	el1, err := fact.NewElection(ctx, 10)
+	if err != nil {
+		t.Fatalf("NewElection(10): %v", err)
+	}
+	el2, err := fact.NewElection(ctx, 20)
+	if err != nil {
+		t.Fatalf("NewElection(20): %v", err)
+	}
+
+	if err := el1.WaitForMastership(ctx); err != nil {
+		t.Fatalf("WaitForMastership(10): %v", err)
+	}
+	if err := el2.WaitForMastership(ctx); err != nil {
+		t.Fatalf("WaitForMastership(20): %v", err)
+	}
+
+	if err := el1.Close(ctx); err != nil {
+		t.Fatalf("Close(10): %v", err)
+	}
+	if err := el2.Close(ctx); err != nil {
+		t.Fatalf("Close(20): %v", err)
+	}
+}


### PR DESCRIPTION
The client is shared between multiple `MasterElection` instances and quota manager. It should be closed separately.
Plus regression test.