### PR TITLE
maphammer: allow replay of journalled requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /etcdiscover
 /loglb
 /maphammer
+/mapreplay
 /protoc
 /trillian_log_server
 /trillian_log_signer

--- a/integration/mapreplay.sh
+++ b/integration/mapreplay.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
+. "${INTEGRATION_DIR}"/functions.sh
+
+MAP_JOURNAL=${1}
+if [[ ! -f "${MAP_JOURNAL}" ]]; then
+  echo "First argument should be map journal file"
+  exit 1
+fi
+
+echo "Building mapreplay"
+go build github.com/google/trillian/testonly/hammer/mapreplay
+
+declare -a OLD_MAP_ARRAY
+OLD_MAP_IDS=$(./mapreplay --logtostderr -v 2 --replay_from ${MAP_JOURNAL} 2>&1 >/dev/null | grep "map_id:" | sed 's/.*map_id:\([0-9]\+\).*/\1/' | sort | uniq)
+for mapid in "${OLD_MAP_IDS}"; do
+  OLD_MAP_ARRAY+=(${mapid})
+done
+MAP_COUNT=${#OLD_MAP_ARRAY[@]}
+echo "Observed map IDs in ${MAP_JOURNAL}: ${OLD_MAP_IDS}"
+
+map_prep_test 1
+TO_KILL+=(${RPC_SERVER_PIDS[@]})
+
+echo "Provisioning ${MAP_COUNT} map(s)"
+map_provision "${RPC_SERVER_1}" ${MAP_COUNT}
+echo "Provisioned ${MAP_COUNT} map(s): ${MAP_IDS}"
+
+declare -a MAP_ARRAY
+for mapid in $(echo ${MAP_IDS} | sed 's/,/ / '); do
+  MAP_ARRAY+=(${mapid})
+done
+
+# Map from original map IDs to the newly provisioned ones.
+MAPMAP=""
+for ((i=0; i < MAP_COUNT; i++)); do
+  if [[ $i -eq 0 ]]; then
+    MAPMAP="${OLD_MAP_ARRAY[$i]}:${MAP_ARRAY[$i]}"
+  else
+    MAPMAP="${MAPMAP},${OLD_MAP_ARRAY[$i]}:${MAP_ARRAY[$i]}"
+  fi
+done
+echo "Mapping map/tree IDs ${MAPMAP}"
+
+echo "Replaying requests from ${MAP_JOURNAL}"
+set +e
+./mapreplay --map_ids=${MAPMAP} --rpc_server=${RPC_SERVER_1} --logtostderr -v 1 --replay_from "${MAP_JOURNAL}"
+RESULT=$?
+set -e
+
+map_stop_test
+TO_KILL=()
+
+exit $RESULT

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -69,7 +69,7 @@ func main() {
 		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
 	}
 	fmt.Printf("Today's test has been brought to you by the letters M, A, and P and the number %#x\n", *seed)
-	rand.Seed(*seed)
+	randSrc := rand.NewSource(*seed)
 
 	bias := hammer.MapBias{
 		Bias: map[hammer.MapEntrypointName]int{
@@ -151,6 +151,7 @@ func main() {
 			Client:        trillian.NewTrillianMapClient(c),
 			Admin:         trillian.NewTrillianAdminClient(ac),
 			MetricFactory: mf,
+			RandSource:    randSrc,
 			EPBias:        bias,
 			Operations:    *operations,
 		}

--- a/testonly/hammer/mapreplay/main.go
+++ b/testonly/hammer/mapreplay/main.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mapreplay replays a log of Trillian Map requests.
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/google/trillian/testonly/hammer"
+	"google.golang.org/grpc"
+)
+
+var (
+	mapIDs     = flag.String("map_ids", "", "Comma-separated list of mapID:mapID pairs to convert")
+	rpcServer  = flag.String("rpc_server", "", "Server address:port; leave blank for dry-run mode")
+	replayFrom = flag.String("replay_from", "", "File to record operations in")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+
+	if *replayFrom == "" {
+		glog.Exit("Need --replay_from option")
+	}
+	f, err := os.Open(*replayFrom)
+	if err != nil {
+		glog.Exitf("Failed to open replay file: %v", err)
+	}
+
+	var cl trillian.TrillianMapClient
+	if *rpcServer != "" {
+		c, err := grpc.Dial(*rpcServer, grpc.WithInsecure())
+		if err != nil {
+			glog.Exitf("Failed to create map client conn: %v", err)
+		}
+		cl = trillian.NewTrillianMapClient(c)
+	}
+
+	pairRE := regexp.MustCompile(`(\d+):(\d+)`)
+	mapmap := make(map[int64]int64)
+	mIDs := strings.Split(*mapIDs, ",")
+	for _, pair := range mIDs {
+		if pair == "" {
+			continue
+		}
+		results := pairRE.FindStringSubmatch(pair)
+		if len(results) < 3 {
+			glog.Exitf("Malformed mapID mapping in %q", *mapIDs)
+		}
+		from, err := strconv.ParseInt(results[1], 10, 64)
+		if err != nil {
+			glog.Exitf("Malformed mapID mapping in %q", *mapIDs)
+		}
+		to, err := strconv.ParseInt(results[2], 10, 64)
+		if err != nil {
+			glog.Exitf("Malformed mapID mapping in %q", *mapIDs)
+		}
+		mapmap[from] = to
+	}
+	hammer.ReplayFile(ctx, f, cl, mapmap)
+}

--- a/testonly/hammer/replay.go
+++ b/testonly/hammer/replay.go
@@ -1,0 +1,180 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hammer
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/google/trillian"
+	"google.golang.org/grpc"
+)
+
+type recordingInterceptor struct {
+	mu     sync.Mutex
+	outLog io.Writer
+}
+
+// NewRecordingInterceptor returns a grpc.UnaryClientInterceptor that logs outgoing
+// requests to file.
+func NewRecordingInterceptor(filename string) (grpc.UnaryClientInterceptor, error) {
+	o, err := os.Create(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create log file: %v", err)
+	}
+	ri := recordingInterceptor{outLog: o}
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return ri.invoke(ctx, method, req, reply, cc, invoker, opts...)
+	}, nil
+}
+
+func (ri *recordingInterceptor) invoke(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	if msg, ok := req.(proto.Message); ok {
+		ri.dumpMessage(msg)
+	} else {
+		glog.Warningf("failed to convert request %T to proto.Message", req)
+	}
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if err == nil {
+		if msg, ok := reply.(proto.Message); ok {
+			ri.dumpMessage(msg)
+		} else {
+			glog.Warningf("failed to convert response %T to proto.Message", req)
+		}
+	}
+	return err
+}
+
+func (ri *recordingInterceptor) dumpMessage(in proto.Message) {
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+	if err := writeMessage(ri.outLog, in); err != nil {
+		glog.Error(err.Error())
+	}
+}
+
+func writeMessage(w io.Writer, in proto.Message) error {
+	a, err := ptypes.MarshalAny(in)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %T %+v to any.Any: %v", in, in, err)
+	}
+	data, err := proto.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("failed to marshal any.Any: %v", err)
+	}
+	// Encode as [4-byte big-endian length, message]
+	lenData := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenData, uint32(len(data)))
+	w.Write(lenData)
+	w.Write(data)
+	return nil
+}
+
+func readMessage(r io.Reader) (*any.Any, error) {
+	// Decode from [4-byte big-endian length, message]
+	var l uint32
+	if err := binary.Read(r, binary.BigEndian, &l); err != nil {
+		if err != io.EOF {
+			err = fmt.Errorf("corrupt data: expected 4-byte length: %v", err)
+		}
+		return nil, err
+	}
+	data := make([]byte, l)
+	n, err := r.Read(data)
+	if uint32(n) < l {
+		return nil, fmt.Errorf("corrupt data: expected %d bytes of data, only found %d bytes", n, l)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %d bytes of data: %v", l, err)
+	}
+	var a any.Any
+	if err := proto.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal into any.Any: %v", err)
+	}
+	return &a, nil
+}
+
+// ReplayFile reads recorded gRPC requests and re-issues them using the given
+// client.  If a request has a MapId field, and its value is present in mapmap,
+// then the MapId field is replaced before replay.
+func ReplayFile(ctx context.Context, r io.Reader, cl trillian.TrillianMapClient, mapmap map[int64]int64) {
+	for {
+		a, err := readMessage(r)
+		if err != nil {
+			if err != io.EOF {
+				glog.Errorf("Error reading message: %v", err)
+			}
+			return
+		}
+		glog.V(2).Infof("Replay %q", a.TypeUrl)
+		replayMessage(ctx, cl, a, mapmap)
+	}
+}
+
+// convertMessage modifies msg in-place so that the contents of a "MapId" field
+// are updated according to mapmap.
+func convertMessage(msg proto.Message, mapmap map[int64]int64) {
+	// Look for a "MapId" field that we can overwrite if needed.
+	pVal := reflect.ValueOf(msg)
+	if fieldVal := pVal.Elem().FieldByName("MapId"); fieldVal.CanSet() {
+		from := fieldVal.Int()
+		if to, ok := mapmap[from]; ok {
+			glog.V(2).Infof("Replacing msg.MapId=%d with %d in %T", from, to, msg)
+			fieldVal.SetInt(to)
+		}
+	}
+}
+
+func replayMessage(ctx context.Context, cl trillian.TrillianMapClient, a *any.Any, mapmap map[int64]int64) error {
+	var da ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(a, &da); err != nil {
+		return fmt.Errorf("failed to unmarshal from any.Any: %v", err)
+	}
+	req := da.Message
+	convertMessage(req, mapmap)
+	glog.V(2).Infof("Request req=%T %+v", req, req)
+	var err error
+	var rsp proto.Message
+	if cl != nil {
+		switch req := req.(type) {
+		case *trillian.GetMapLeavesRequest:
+			rsp, err = cl.GetLeaves(ctx, req)
+		case *trillian.GetMapLeavesByRevisionRequest:
+			rsp, err = cl.GetLeavesByRevision(ctx, req)
+		case *trillian.SetMapLeavesRequest:
+			rsp, err = cl.SetLeaves(ctx, req)
+		case *trillian.GetSignedMapRootRequest:
+			rsp, err = cl.GetSignedMapRoot(ctx, req)
+		case *trillian.GetSignedMapRootByRevisionRequest:
+			rsp, err = cl.GetSignedMapRootByRevision(ctx, req)
+		case *trillian.InitMapRequest:
+			rsp, err = cl.InitMap(ctx, req)
+		}
+		if rsp != nil {
+			glog.V(1).Infof("Request:  req=%T %+v", req, req)
+			glog.V(1).Infof("Response: rsp=%T %+v err=%v", rsp, rsp, err)
+		}
+	}
+	return err
+}

--- a/testonly/hammer/replay_test.go
+++ b/testonly/hammer/replay_test.go
@@ -1,0 +1,156 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hammer
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
+)
+
+var dehex = testonly.MustHexDecode
+
+func TestWriteReadMessage(t *testing.T) {
+	var tests = []struct {
+		desc string
+		in   proto.Message
+		want string
+	}{
+		{
+			desc: "get-smr-req",
+			in:   &trillian.GetSignedMapRootRequest{MapId: 123},
+			want: "type.googleapis.com/trillian.GetSignedMapRootRequest",
+		},
+		{
+			desc: "get-tree",
+			in:   &trillian.Tree{TreeId: 123},
+			want: "type.googleapis.com/trillian.Tree",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := bufio.NewWriter(&buf)
+			err := writeMessage(writer, test.in)
+			if err != nil {
+				t.Fatalf("writeMessage(%T)=%v; want nil", test.in, err)
+			}
+			writer.Flush()
+			data := buf.Bytes()
+			t.Logf("%+v => %x", test.in, data)
+
+			readFrom := bytes.NewBuffer(data)
+			got, err := readMessage(readFrom)
+			if err != nil {
+				t.Fatalf("readMessage(%x)=nil,%v; want _,nil", data, err)
+			}
+			if got.TypeUrl != test.want {
+				t.Errorf("readMessage(%x)=%q; want %q", data, got.TypeUrl, test.want)
+			}
+		})
+	}
+}
+
+func TestReadMessage(t *testing.T) {
+	var tests = []struct {
+		desc    string
+		in      []byte
+		want    string
+		wantErr string
+	}{
+		{
+			desc: "get-tree",
+			in:   dehex("00000027" + "0a21747970652e676f6f676c65617069732e636f6d2f7472696c6c69616e2e547265651202087b"),
+			want: "type.googleapis.com/trillian.Tree",
+		},
+		{
+			desc:    "len-too-short",
+			in:      dehex("0000"),
+			wantErr: "expected 4-byte length",
+		},
+		{
+			desc:    "data-too-short",
+			in:      dehex("00000027" + "0a21747970652e676f6f676c65617069732e636f6d2f7472696c6c69616e2e54726565120208"),
+			wantErr: "expected 38 bytes of data",
+		},
+		{
+			desc:    "empty",
+			in:      dehex(""),
+			wantErr: "EOF",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			readFrom := bytes.NewBuffer(test.in)
+			got, err := readMessage(readFrom)
+			if err != nil {
+				if test.wantErr == "" {
+					t.Fatalf("readMessage(%x)=nil,%v; want _,nil", test.in, err)
+				} else if !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("readMessage(%x)=nil,%v; want error containing %q", test.in, err, test.wantErr)
+				}
+				return
+			}
+			if test.wantErr != "" {
+				t.Fatalf("readMessage(%x)=%+v,nil; want nil,error containing %q", test.in, got, test.wantErr)
+			}
+			if got.TypeUrl != test.want {
+				t.Errorf("readMessage(%x).TypeUrl=%q; want %q", test.in, got.TypeUrl, test.want)
+			}
+		})
+	}
+}
+
+func TestConvertMsg(t *testing.T) {
+	mapmap := map[int64]int64{999: 123}
+	var tests = []struct {
+		desc string
+		in   proto.Message
+		want proto.Message
+	}{
+		{
+			desc: "get-smr-req-mapped",
+			in:   &trillian.GetSignedMapRootRequest{MapId: 999},
+			want: &trillian.GetSignedMapRootRequest{MapId: 123},
+		},
+		{
+			desc: "get-smr-req-unmapped",
+			in:   &trillian.GetSignedMapRootRequest{MapId: 456},
+			want: &trillian.GetSignedMapRootRequest{MapId: 456},
+		},
+		{
+			desc: "tree-id-instead",
+			in:   &trillian.Tree{TreeId: 999},
+			want: &trillian.Tree{TreeId: 999},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := test.in
+			convertMessage(got, mapmap)
+			if !proto.Equal(got, test.want) {
+				t.Fatalf("convertMsg(%+v)=%+v; want %+v", test.in, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add --log_to argument to give a filename to save a journal of
issued client requests in text protobuf format.

Add mapreplay which reads and parses a journal file, and re-generates
the same requests (albeit with a replaced MapId field value).

Towards #863 