### PR TITLE
Refuse to sign out of order log roots

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -430,6 +430,12 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 			Revision:       uint64(newVersion),
 		}
 
+		if currentRoot.RootHash != nil && newLogRoot.TimestampNanos < currentRoot.TimestampNanos {
+			err := fmt.Errorf("refusing to sign root with timestamp earlier than previous root (%d < %d)", newLogRoot.TimestampNanos, currentRoot.TimestampNanos)
+			glog.Warningf("%v: %s", tree.TreeId, err)
+			return err
+		}
+
 		newSLR, err = s.signer.SignLogRoot(newLogRoot)
 		if err != nil {
 			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -68,6 +68,16 @@ var (
 			RootHash:       testRoot16.RootHash,
 		})
 
+	testRoot17 = &types.LogRootV1{
+		TreeSize: 16,
+		Revision: 5,
+		// RootHash can't be nil because that's how the sequencer currently
+		// detects that there was no stored tree head.
+		RootHash:       []byte{},
+		TimestampNanos: uint64(fakeTimeForTest.Add(10 * time.Millisecond).UnixNano()),
+	}
+	testSignedRoot17, _ = tcrypto.NewSigner(0, fixedSigner, crypto.SHA256).SignLogRoot(testRoot17)
+
 	// These will be accepted in either order because of custom sorting in the mock
 	updatedNodes = []storage.Node{
 		{
@@ -464,6 +474,20 @@ func TestIntegrateBatch(t *testing.T) {
 				signer:           fixedSigner,
 			},
 			wantCount: 1,
+		},
+		{
+			desc: "prev-root-timestamp-in-future",
+			params: testParameters{
+				logID:               154035,
+				writeRevision:       int64(testRoot16.Revision + 1),
+				dequeueLimit:        1,
+				dequeuedLeaves:      []*trillian.LogLeaf{getLeaf42()},
+				latestSignedRoot:    testSignedRoot17,
+				updatedLeaves:       &leaves16,
+				merkleNodesSet:      &updatedNodes,
+				skipStoreSignedRoot: true,
+			},
+			errStr: "refusing to sign root with timestamp earlier than previous root (1464173705000000000 < 1464173705010000000)",
 		},
 	}
 


### PR DESCRIPTION
When using multiple log_signers (and probably in other strange circumstances) it is possible that one node has a clock that has drifted significantly out of range of the other nodes. This can cause signing of log roots that have out of order timestamps which breaks trillian in interesting ways (mainly because the timestamp is used to determine which is the most recent log root).

This change refuses to sign a log root that has a timestamp that is earlier than the timestamp of the current log root and adds a test for this behavior.