### PR TITLE
Enable others to see who the current master is

### DIFF
--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -355,6 +355,10 @@ func (te *testElection) Close(ctx context.Context) error {
 	return te.closeErr
 }
 
+func (te *testElection) GetCurrentMaster(ctx context.Context) (string, error) {
+	return "It's you!", nil
+}
+
 type failureFactory struct{}
 
 func (ff failureFactory) NewElection(ctx context.Context, treeID int64) (util.MasterElection, error) {

--- a/util/election.go
+++ b/util/election.go
@@ -78,9 +78,9 @@ func (ne *NoopElection) Close(ctx context.Context) error {
 	return nil
 }
 
-// GetCurrentMaster returns the string "It's you!"
+// GetCurrentMaster returns ne.instanceID
 func (ne *NoopElection) GetCurrentMaster(ctx context.Context) (string, error) {
-	return "It's you!", nil
+	return ne.instanceID, nil
 }
 
 // NoopElectionFactory creates NoopElection instances.

--- a/util/election.go
+++ b/util/election.go
@@ -14,7 +14,10 @@
 
 package util
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // MasterElection provides operations for determining if a local instance is the current
 // master for a particular election.
@@ -30,8 +33,14 @@ type MasterElection interface {
 	// Close permanently stops the mastership election process.
 	Close(context.Context) error
 	// GetCurrentMaster returns the instance ID of the current elected master, if any.
+	// Implementations should allow election participants to specify their instance
+	// ID string, participants should ensure that it is unique to them.
+	// If there is currently no leader, ErrNoLeader will be returned.
 	GetCurrentMaster(context.Context) (string, error)
 }
+
+// ErrNoLeader indicates that there is currently no leader elected.
+var ErrNoLeader error = errors.New("no leader")
 
 // ElectionFactory encapsulates the creation of a MasterElection instance for a treeID.
 type ElectionFactory interface {

--- a/util/election.go
+++ b/util/election.go
@@ -40,7 +40,7 @@ type MasterElection interface {
 }
 
 // ErrNoLeader indicates that there is currently no leader elected.
-var ErrNoLeader error = errors.New("no leader")
+var ErrNoLeader = errors.New("no leader")
 
 // ElectionFactory encapsulates the creation of a MasterElection instance for a treeID.
 type ElectionFactory interface {

--- a/util/election.go
+++ b/util/election.go
@@ -29,6 +29,8 @@ type MasterElection interface {
 	ResignAndRestart(context.Context) error
 	// Close permanently stops the mastership election process.
 	Close(context.Context) error
+	// GetCurrentMaster returns the instance ID of the current elected master, if any.
+	GetCurrentMaster(context.Context) (string, error)
 }
 
 // ElectionFactory encapsulates the creation of a MasterElection instance for a treeID.
@@ -65,6 +67,11 @@ func (ne *NoopElection) ResignAndRestart(ctx context.Context) error {
 // Close permanently stops the mastership election process.
 func (ne *NoopElection) Close(ctx context.Context) error {
 	return nil
+}
+
+// GetCurrentMaster returns the string "It's you!"
+func (ne *NoopElection) GetCurrentMaster(ctx context.Context) (string, error) {
+	return "It's you!", nil
 }
 
 // NoopElectionFactory creates NoopElection instances.

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -70,7 +70,10 @@ func (eme *MasterElection) Close(ctx context.Context) error {
 // GetCurrentMaster returns the instanceID of the current master, if any.
 func (eme *MasterElection) GetCurrentMaster(ctx context.Context) (string, error) {
 	leader, err := eme.election.Leader(ctx)
-	if err != nil {
+	switch {
+	case err == concurrency.ErrElectionNoLeader:
+		return "", util.ErrNoLeader
+	case err != nil:
 		return "", err
 	}
 	return string(leader.Kvs[0].Value), nil

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -67,6 +67,15 @@ func (eme *MasterElection) Close(ctx context.Context) error {
 	return eme.session.Close()
 }
 
+// GetCurrentMaster returns the instanceID of the current master, if any.
+func (eme *MasterElection) GetCurrentMaster(ctx context.Context) (string, error) {
+	leader, err := eme.election.Leader(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(leader.Kvs[0].Value), nil
+}
+
 // ElectionFactory creates etcd.MasterElection instances.
 type ElectionFactory struct {
 	client     *clientv3.Client

--- a/util/etcd/election_test.go
+++ b/util/etcd/election_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/google/trillian/testonly/integration/etcd"
 	"github.com/google/trillian/util"
 )
@@ -65,7 +64,7 @@ func everyoneAgreesOnMaster(ctx context.Context, t *testing.T, want string, elec
 	for _, e := range elections {
 		for {
 			got, err := e.GetCurrentMaster(ctx)
-			if err == concurrency.ErrElectionNoLeader {
+			if err == util.ErrNoLeader {
 				t.Error("No leader...")
 				time.Sleep(time.Second)
 				continue

--- a/util/etcd/election_test.go
+++ b/util/etcd/election_test.go
@@ -16,9 +16,15 @@ package etcd
 
 import (
 	"context"
+	"log"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/google/trillian/testonly/integration/etcd"
+	"github.com/google/trillian/util"
 )
 
 func TestMasterElectionThroughCommonClient(t *testing.T) {
@@ -53,4 +59,75 @@ func TestMasterElectionThroughCommonClient(t *testing.T) {
 	if err := el2.Close(ctx); err != nil {
 		t.Fatalf("Close(20): %v", err)
 	}
+}
+
+func everyoneAgreesOnMaster(t *testing.T, ctx context.Context, want string, elections []util.MasterElection) {
+	t.Helper()
+	for _, e := range elections {
+		for {
+			log.Print("Getting master")
+			m, err := e.GetCurrentMaster(ctx)
+			if err == concurrency.ErrElectionNoLeader {
+				t.Error("No leader...")
+				time.Sleep(time.Second)
+				continue
+			} else if err != nil {
+				t.Fatalf("Failed to GetCurrentMaster: %v", err)
+			}
+			if m != want {
+				log.Printf("got %v want %v", m, want)
+				t.Errorf("Current master is %v, want %v", m, want)
+			}
+			break
+		}
+	}
+}
+
+func TestGetCurrentMaster(t *testing.T) {
+	e, client, cleanup, err := etcd.StartEtcd()
+	if err != nil {
+		t.Fatalf("StartEtcd(): %v", err)
+	}
+	defer cleanup()
+	client2, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{e.Config().LCUrls[0].String()},
+	})
+	if err != nil {
+		t.Fatalf("Error creating 2nd etcd client: %v", err)
+	}
+	defer client2.Close()
+
+	ctx := context.Background()
+	fact1 := NewElectionFactory("serv1", client, "trees/")
+	fact2 := NewElectionFactory("serv2", client2, "trees/")
+
+	el1, err := fact1.NewElection(ctx, 10)
+	if err != nil {
+		t.Fatalf("NewElection(10): %v", err)
+	}
+	el2, err := fact2.NewElection(ctx, 10)
+	if err != nil {
+		t.Fatalf("NewElection(10): %v", err)
+	}
+	elections := []util.MasterElection{el1, el2}
+
+	wg := &sync.WaitGroup{}
+	for _, e := range elections {
+		wg.Add(1)
+		go func(e util.MasterElection) {
+			if err := e.WaitForMastership(ctx); err != nil {
+				t.Fatalf("WaitForMastership(10): %v", err)
+			}
+			id := e.(*MasterElection).instanceID
+
+			log.Printf("%v is master", id)
+
+			everyoneAgreesOnMaster(t, ctx, id, elections)
+			if err := e.Close(ctx); err != nil {
+				t.Fatalf("Close(10): %v", err)
+			}
+			wg.Done()
+		}(e)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
This PR exposes the instance ID of the current master (if any) for a given election.
![master](https://doctorwhomagazine.com/wp-content/uploads/2015/03/Master-panel-820x300.jpg)
