### PR TITLE
Factor out continuous master election

### DIFF
--- a/extension/registry.go
+++ b/extension/registry.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
 // Registry defines all extension points available in Trillian.
@@ -35,7 +35,7 @@ type Registry struct {
 	// MapStorage is the storage implementation to use for persisting maps.
 	storage.MapStorage
 	// ElectionFactory provides MasterElection instances for each tree.
-	util.ElectionFactory
+	ElectionFactory election.Factory
 	// QuotaManager provides rate limiting capabilities for Trillian.
 	QuotaManager quota.Manager
 	// MetricFactory provides metrics for monitoring.

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -125,8 +125,8 @@ func fixupElectionInfo(info LogOperationInfo) LogOperationInfo {
 	if cfg.PreElectionPause < minPreElectionPause {
 		cfg.PreElectionPause = minPreElectionPause
 	}
-	if cfg.RestartInverval < minRestartInterval {
-		cfg.RestartInverval = minRestartInterval
+	if cfg.RestartInterval < minRestartInterval {
+		cfg.RestartInterval = minRestartInterval
 	}
 	if cfg.MasterCheckInterval < minMasterCheckInterval {
 		cfg.MasterCheckInterval = minMasterCheckInterval
@@ -260,7 +260,7 @@ func (l *LogOperationManager) masterFor(ctx context.Context, allIDs []int64) ([]
 					// there is a chance of another master for this log.
 					evt.Ack()
 				default:
-					glog.Error("Wrong election event type: %v", evt.Type)
+					glog.Errorf("Wrong election event type: %v", evt.Type)
 				}
 			}
 		}(logID)

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -257,7 +257,7 @@ func (l *LogOperationManager) masterFor(ctx context.Context, allIDs []int64) ([]
 					resignations.Inc(label)
 					l.resignations <- evt
 				default:
-					glog.Errorf("unknown EventType %v", evt.Type)
+					glog.Errorf("%d: unknown EventType %v", logID, evt.Type)
 					fallthrough // Safe default to not being master.
 				case election.NotMaster, election.NotMasterTimeout:
 					glog.Errorf("%d: no longer the master", logID)

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"sort"
 	"strconv"
@@ -29,11 +28,14 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
 const (
 	minPreElectionPause    = 10 * time.Millisecond
+	minRestartInterval     = 50 * time.Millisecond
 	minMasterCheckInterval = 50 * time.Millisecond
+	minMasterTTL           = 2 * time.Second
 	minMasterHoldInterval  = 10 * time.Second
 	logIDLabel             = "logid"
 )
@@ -89,122 +91,12 @@ type LogOperationInfo struct {
 	// batch takes longer than this interval to complete, the next batch
 	// will start immediately.
 	RunInterval time.Duration
-	// PreElectionPause is the maximum interval to wait before starting a
-	// mastership election for a particular log.
-	PreElectionPause time.Duration
-	// MasterCheckInterval is the interval between checks that we still
-	// hold mastership for a log.
-	MasterCheckInterval time.Duration
-	// MasterHoldInterval is the minimum interval to hold mastership for.
-	MasterHoldInterval time.Duration
-	// ResignOdds gives the chance of resigning mastership after each
-	// check interval, as the N for 1-in-N.
-	ResignOdds int
+
+	// ElectionConfig configures per-log master election process.
+	ElectionConfig election.Config
+
 	// NumWorkers is the number of worker goroutines to run in parallel.
 	NumWorkers int
-}
-
-type electionRunner struct {
-	logID    int64
-	info     *LogOperationInfo
-	tracker  *util.MasterTracker
-	cancel   context.CancelFunc
-	wg       *sync.WaitGroup
-	election util.MasterElection
-}
-
-type resignation struct {
-	er   *electionRunner
-	done chan<- bool
-}
-
-func (r *resignation) execute(ctx context.Context) {
-	glog.Infof("%d: deliberately resigning mastership", r.er.logID)
-	if err := r.er.election.ResignAndRestart(ctx); err != nil {
-		glog.Errorf("%d: failed to resign mastership: %v", r.er.logID, err)
-	}
-	r.done <- true
-}
-
-func (er *electionRunner) Run(ctx context.Context, pending chan<- resignation) {
-	defer er.wg.Done()
-	label := strconv.FormatInt(er.logID, 10)
-
-	// Pause for a random interval so that if multiple instances start at the same
-	// time there is less of a thundering herd.
-	pause := rand.Int63n(er.info.PreElectionPause.Nanoseconds())
-	time.Sleep(time.Duration(pause))
-
-	glog.V(1).Infof("%d: start election-monitoring loop ", er.logID)
-	if err := er.election.Start(ctx); err != nil {
-		glog.Errorf("%d: election.Start() failed: %v", er.logID, err)
-		return
-	}
-	defer func(ctx context.Context, er *electionRunner) {
-		glog.Infof("%d: shutdown election-monitoring loop", er.logID)
-		er.election.Close(ctx)
-	}(ctx, er)
-
-	for {
-		glog.V(1).Infof("%d: When I left you, I was but the learner", er.logID)
-		if err := er.election.WaitForMastership(ctx); err != nil {
-			glog.Errorf("%d: er.election.WaitForMastership() failed: %v", er.logID, err)
-			return
-		}
-		glog.V(1).Infof("%d: Now, I am the master", er.logID)
-		er.tracker.Set(er.logID, true)
-		isMaster.Set(1.0, label)
-		masterSince := er.info.TimeSource.Now()
-
-		// While-master loop
-		for {
-			time.Sleep(er.info.MasterCheckInterval)
-			select {
-			case <-ctx.Done():
-				glog.Infof("%d: termination requested", er.logID)
-				return
-			default:
-			}
-			master, err := er.election.IsMaster(ctx)
-			if err != nil {
-				glog.Errorf("%d: failed to check mastership status", er.logID)
-				break
-			}
-			if !master {
-				glog.Errorf("%d: no longer the master!", er.logID)
-				er.tracker.Set(er.logID, false)
-				isMaster.Set(0.0, label)
-				break
-			}
-			if er.shouldResign(masterSince) {
-				glog.Infof("%d: queue up resignation of mastership", er.logID)
-				resignations.Inc(label)
-				er.tracker.Set(er.logID, false)
-				isMaster.Set(0.0, label)
-
-				done := make(chan bool)
-				r := resignation{er: er, done: done}
-				pending <- r
-				<-done // block until acted on
-				break  // no longer master
-			}
-		}
-	}
-}
-
-func (er *electionRunner) shouldResign(masterSince time.Time) bool {
-	now := er.info.TimeSource.Now()
-	duration := now.Sub(masterSince)
-	if duration < er.info.MasterHoldInterval {
-		// Always hold onto mastership for a minimum interval to prevent churn.
-		return false
-	}
-	// Roll the bones.
-	odds := er.info.ResignOdds
-	if odds <= 0 {
-		return true
-	}
-	return rand.Intn(er.info.ResignOdds) == 0
 }
 
 // LogOperationManager controls scheduling activities for logs.
@@ -215,30 +107,38 @@ type LogOperationManager struct {
 	logOperation LogOperation
 
 	// electionRunner tracks the goroutines that run per-log mastership elections
-	electionRunner      map[int64]*electionRunner
-	pendingResignations chan resignation
-	runnerWG            sync.WaitGroup
-	tracker             *util.MasterTracker
-	heldMutex           sync.Mutex
-	lastHeld            []int64
+	electionRunner map[int64]*election.Runner
+	runnerWG       sync.WaitGroup
+	tracker        *util.MasterTracker
+	heldMutex      sync.Mutex
+	lastHeld       []int64
 	// Cache of logID => name; assumed not to change during runtime
 	logNamesMutex sync.Mutex
 	logNames      map[int64]string
+
+	resignations chan election.Event
 }
 
-// fixupElectionInfo ensures operation parameters have required minimum values.
+// fixupElectionInfo ensures election parameters have required minimum values.
 func fixupElectionInfo(info LogOperationInfo) LogOperationInfo {
-	if info.PreElectionPause < minPreElectionPause {
-		info.PreElectionPause = minPreElectionPause
+	cfg := &info.ElectionConfig
+	if cfg.PreElectionPause < minPreElectionPause {
+		cfg.PreElectionPause = minPreElectionPause
 	}
-	if info.MasterCheckInterval < minMasterCheckInterval {
-		info.MasterCheckInterval = minMasterCheckInterval
+	if cfg.RestartInverval < minRestartInterval {
+		cfg.RestartInverval = minRestartInterval
 	}
-	if info.MasterHoldInterval < minMasterHoldInterval {
-		info.MasterHoldInterval = minMasterHoldInterval
+	if cfg.MasterCheckInterval < minMasterCheckInterval {
+		cfg.MasterCheckInterval = minMasterCheckInterval
 	}
-	if info.ResignOdds < 1 {
-		info.ResignOdds = 1
+	if cfg.MasterHoldInterval < minMasterHoldInterval {
+		cfg.MasterHoldInterval = minMasterHoldInterval
+	}
+	if cfg.MasterTTL < minMasterTTL {
+		cfg.MasterTTL = minMasterTTL
+	}
+	if cfg.ResignOdds < 1 {
+		cfg.ResignOdds = 1
 	}
 	return info
 }
@@ -249,11 +149,11 @@ func NewLogOperationManager(info LogOperationInfo, logOperation LogOperation) *L
 		createMetrics(info.Registry.MetricFactory)
 	})
 	return &LogOperationManager{
-		info:                fixupElectionInfo(info),
-		logOperation:        logOperation,
-		electionRunner:      make(map[int64]*electionRunner),
-		pendingResignations: make(chan resignation, 100),
-		logNames:            make(map[int64]string),
+		info:           fixupElectionInfo(info),
+		logOperation:   logOperation,
+		electionRunner: make(map[int64]*election.Runner),
+		logNames:       make(map[int64]string),
+		resignations:   make(chan election.Event, 100),
 	}
 }
 
@@ -322,29 +222,50 @@ func (l *LogOperationManager) masterFor(ctx context.Context, allIDs []int64) ([]
 		l.tracker = util.NewMasterTracker(allIDs)
 	}
 
-	// Synchronize the set of configured log IDs with those we are tracking mastership for.
+	// Synchronize the set of configured log IDs with those we are tracking
+	// mastership for.
 	for _, logID := range allIDs {
-		knownLogs.Set(1.0, strconv.FormatInt(logID, 10))
+		label := strconv.FormatInt(logID, 10)
+		knownLogs.Set(1.0, label)
 		if l.electionRunner[logID] != nil {
 			continue
 		}
 		glog.Infof("create master election goroutine for %v", logID)
 		innerCtx, cancel := context.WithCancel(ctx)
-		election, err := l.info.Registry.ElectionFactory.NewElection(innerCtx, logID)
+		el, err := l.info.Registry.ElectionFactory.NewElection(innerCtx, logID)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to create election for %d: %v", logID, err)
 		}
-		l.electionRunner[logID] = &electionRunner{
-			logID:    logID,
-			info:     &l.info,
-			tracker:  l.tracker,
-			cancel:   cancel,
-			wg:       &l.runnerWG,
-			election: election,
-		}
+
+		runner := election.NewRunner(&l.info.ElectionConfig, el, l.info.TimeSource, fmt.Sprintf("%d: ", logID))
+		l.electionRunner[logID] = runner
+		evts := runner.Run(innerCtx)
+
 		l.runnerWG.Add(1)
-		go l.electionRunner[logID].Run(innerCtx, l.pendingResignations)
+		go func(logID int64) {
+			defer l.runnerWG.Done()
+			for evt := range evts {
+				switch evt.Type {
+				case election.BecomeMaster:
+					l.tracker.Set(logID, true)
+					isMaster.Set(1.0, label)
+				case election.NotMasterResign:
+					l.tracker.Set(logID, false)
+					isMaster.Set(0.0, label)
+					resignations.Inc(label)
+					l.resignations <- evt
+				case election.NotMaster, election.NotMasterTimeout:
+					l.tracker.Set(logID, false)
+					isMaster.Set(0.0, label)
+					// TODO(pavelkalinnikov): Forcefully cancel operation before Ack,
+					// there is a chance of another master for this log.
+					evt.Ack()
+				default:
+					glog.Error("Wrong election event type: %v", evt.Type)
+				}
+			}
+		}(logID)
 	}
 
 	held := l.tracker.Held()
@@ -366,6 +287,9 @@ func (l *LogOperationManager) updateHeldIDs(ctx context.Context, logIDs, allIDs 
 	}
 }
 
+// TODO(pavelkalinnikov): Consider operating each log individually. Currently,
+// if a more heavily updated log takes significant time to complete a pass, all
+// lightweight logs will have to wait for it.
 func (l *LogOperationManager) getLogsAndExecutePass(ctx context.Context) error {
 	allIDs, err := l.getLogIDs(ctx)
 	if err != nil {
@@ -479,13 +403,12 @@ loop:
 		}
 
 		// Process any pending resignations while there's no activity.
-		doneResigning := false
-		for !doneResigning {
+		for done := false; !done; {
 			select {
-			case r := <-l.pendingResignations:
-				r.execute(ctx)
+			case evt := <-l.resignations:
+				evt.Ack()
 			default:
-				doneResigning = true
+				done = true
 			}
 		}
 
@@ -498,7 +421,6 @@ loop:
 		} else {
 			glog.V(1).Infof("Processing started at %v for %v; start next run immediately", start, duration)
 		}
-
 	}
 
 	// Terminate all the election runners
@@ -507,7 +429,7 @@ loop:
 			continue
 		}
 		glog.V(1).Infof("cancel election runner for %d", logID)
-		runner.cancel()
+		// runner.cancel() FIXME
 	}
 	glog.Infof("wait for termination of election runners...")
 	l.runnerWG.Wait()

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -259,7 +259,7 @@ type masterForEvenFactory struct{}
 
 func (m masterForEvenFactory) NewElection(ctx context.Context, treeID int64) (election.MasterElection, error) {
 	isMaster := (treeID % 2) == 0
-	return mock.NewMasterElection(isMaster), nil
+	return mock.NewMasterElection(isMaster, nil), nil
 }
 
 type failureFactory struct{}

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/election"
-	"github.com/google/trillian/util/election/mock"
+	"github.com/google/trillian/util/election/stub"
 )
 
 func defaultLogOperationInfo(registry extension.Registry) LogOperationInfo {
@@ -259,7 +259,7 @@ type masterForEvenFactory struct{}
 
 func (m masterForEvenFactory) NewElection(ctx context.Context, treeID int64) (election.MasterElection, error) {
 	isMaster := (treeID % 2) == 0
-	return mock.NewMasterElection(isMaster, nil), nil
+	return stub.NewMasterElection(isMaster, nil), nil
 }
 
 type failureFactory struct{}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -64,9 +64,9 @@ var (
 	preElectionPause    = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	restartInterval     = flag.Duration("restart_interval", 5*time.Second, "Inverval between master election restarts in case of errors")
 	masterCheckInterval = flag.Duration("master_check_interval", 5*time.Second, "Interval between checking mastership still held")
-	masterTTL           = flag.Duration("master_ttl", 20*time.Second, "Maximal interval between successful checks necessary to retain mastership")
+	masterTTL           = flag.Duration("master_ttl", 5*time.Second, "Maximal interval between successful checks necessary to retain mastership")
 	masterHoldInterval  = flag.Duration("master_hold_interval", 60*time.Second, "Minimum interval to hold mastership for")
-	resignOdds          = flag.Int("resign_odds", 10, "Chance of resigning mastership after each check, the N in 1-in-N")
+	resignSpread        = flag.Float64("resign_spread", 1.0, "Max extra time to keep mastership, as a fraction of master_hold_interval")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
@@ -156,7 +156,7 @@ func main() {
 			MasterCheckInterval: *masterCheckInterval,
 			MasterHoldInterval:  *masterHoldInterval,
 			MasterTTL:           *masterTTL,
-			ResignOdds:          *resignOdds,
+			ResignSpread:        *resignSpread,
 		},
 		TimeSource: util.SystemTimeSource{},
 	}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -152,8 +152,10 @@ func main() {
 		RunInterval: *sequencerIntervalFlag,
 		ElectionConfig: election.Config{
 			PreElectionPause:    *preElectionPause,
+			RestartInterval:     *restartInterval,
 			MasterCheckInterval: *masterCheckInterval,
 			MasterHoldInterval:  *masterHoldInterval,
+			MasterTTL:           *masterTTL,
 			ResignOdds:          *resignOdds,
 		},
 		TimeSource: util.SystemTimeSource{},

--- a/util/election/election.go
+++ b/util/election/election.go
@@ -30,8 +30,8 @@ type MasterElection interface {
 	WaitForMastership(context.Context) error
 	// IsMaster returns whether the current instance is master.
 	IsMaster(context.Context) (bool, error)
-	// ResignAndRestart releases mastership, and re-joins the election.
-	ResignAndRestart(context.Context) error
+	// Resign releases mastership.
+	Resign(context.Context) error
 	// Close permanently stops the mastership election process.
 	Close(context.Context) error
 	// GetCurrentMaster returns the instance ID of the current elected master, if any.
@@ -70,8 +70,8 @@ func (ne *NoopElection) IsMaster(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// ResignAndRestart releases mastership, and re-joins the election.
-func (ne *NoopElection) ResignAndRestart(ctx context.Context) error {
+// ResignAndRestart releases mastership.
+func (ne *NoopElection) Resign(ctx context.Context) error {
 	return nil
 }
 

--- a/util/election/election.go
+++ b/util/election/election.go
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+// Package election provides implementation of master election and tracking, as
+// well as interfaces for plugging in a custom underlying mechanism.
+package election
 
 import "context"
 
-// MasterElection provides operations for determining if a local instance is the current
-// master for a particular election.
+// MasterElection provides operations for determining if a local instance is
+// the current master for a particular election.
 type MasterElection interface {
 	// Start kicks off the process of mastership election.
 	Start(context.Context) error
-	// WaitForMastership blocks until the current instance is master for this election.
+	// WaitForMastership blocks until the current instance is master.
 	WaitForMastership(context.Context) error
 	// IsMaster returns whether the current instance is master.
 	IsMaster(context.Context) (bool, error)
@@ -31,12 +33,12 @@ type MasterElection interface {
 	Close(context.Context) error
 }
 
-// ElectionFactory encapsulates the creation of a MasterElection instance for a treeID.
-type ElectionFactory interface {
+// Factory encapsulates the creation of a MasterElection instance for a treeID.
+type Factory interface {
 	NewElection(ctx context.Context, treeID int64) (MasterElection, error)
 }
 
-// NoopElection is a stub implementation that tells every instance that it is master.
+// NoopElection is a stub implementation that the current instance is master.
 type NoopElection struct {
 	treeID     int64
 	instanceID string
@@ -47,7 +49,7 @@ func (ne *NoopElection) Start(ctx context.Context) error {
 	return nil
 }
 
-// WaitForMastership blocks until the current instance is master for this election.
+// WaitForMastership blocks until the current instance is master.
 func (ne *NoopElection) WaitForMastership(ctx context.Context) error {
 	return nil
 }
@@ -67,12 +69,12 @@ func (ne *NoopElection) Close(ctx context.Context) error {
 	return nil
 }
 
-// NoopElectionFactory creates NoopElection instances.
-type NoopElectionFactory struct {
+// NoopFactory creates NoopElection instances.
+type NoopFactory struct {
 	InstanceID string
 }
 
 // NewElection creates a specific NoopElection instance.
-func (nf NoopElectionFactory) NewElection(ctx context.Context, treeID int64) (MasterElection, error) {
+func (nf NoopFactory) NewElection(ctx context.Context, treeID int64) (MasterElection, error) {
 	return &NoopElection{instanceID: nf.InstanceID, treeID: treeID}, nil
 }

--- a/util/election/mock/election.go
+++ b/util/election/mock/election.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mock contains a mock MasterElection implementation.
+package mock
+
+import (
+	"context"
+	"sync"
+)
+
+// MasterElection implements election.MasterElection interface for testing.
+type MasterElection struct {
+	StartErr, WaitErr, IsMasterErr, ResignErr, CloseErr error
+
+	Master bool
+
+	mu   sync.RWMutex
+	cond *sync.Cond
+}
+
+func NewMasterElection(isMaster bool) *MasterElection {
+	res := &MasterElection{Master: isMaster}
+	res.Init()
+	return res
+}
+
+func (e *MasterElection) Init() {
+	e.cond = sync.NewCond(&e.mu)
+}
+
+func (e *MasterElection) Update(isMaster bool, err error) {
+	e.UpdateWithFn(func(e *MasterElection) {
+		e.Master = isMaster
+		e.StartErr, e.WaitErr, e.IsMasterErr, e.ResignErr, e.CloseErr = err, err, err, err, err
+	})
+}
+
+func (e *MasterElection) UpdateWithFn(fn func(*MasterElection)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	fn(e)
+	e.cond.Broadcast()
+}
+
+// Ping can be used to trigger context canceling in WaitForMastership which is
+// not supported in sync.Cond unfortunately. Normally, implementations will
+// support canceling in WaitForMastership properly.
+func (e *MasterElection) Ping() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cond.Broadcast()
+}
+
+func (e *MasterElection) Start(context.Context) error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.StartErr
+}
+
+func (e *MasterElection) WaitForMastership(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for ctx.Err() == nil && !e.Master && e.WaitErr == nil {
+		e.cond.Wait()
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return e.WaitErr
+}
+
+func (e *MasterElection) IsMaster(context.Context) (bool, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.Master, e.IsMasterErr
+}
+
+func (e *MasterElection) ResignAndRestart(context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ResignErr == nil {
+		e.Master = false
+	}
+	return e.ResignErr
+}
+
+func (e *MasterElection) Close(context.Context) error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.CloseErr
+}

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/trillian/util"
 )
 
-// EventType is a type of event occurred to an election instance.
+// EventType is a type of event which can occur on an election instance.
 type EventType byte
 
 // EventType possible values.
@@ -86,8 +86,8 @@ func (e *Event) Ack() {
 	}
 }
 
-// Runner coordinates master election for a single instance. Reports mastership
-// updates via an Event channel.
+// Runner coordinates election participation for a single instance. Reports
+// mastership updates via an Event channel.
 type Runner struct {
 	cfg        *Config
 	me         MasterElection
@@ -104,7 +104,7 @@ func NewRunner(cfg *Config, me MasterElection, ts util.TimeSource, prefix string
 
 // Run launches a continuous master election process, and returns a channel to
 // which it reports updates on this instance's mastership status. Events passed
-// to the channel will alternate between becoming and stop being the master
+// to the channel will alternate between becoming and stopping being the master
 // (see comment above the unexported run method for more details).
 //
 // The underlying goroutine will stop only if the context is done, in which
@@ -126,14 +126,14 @@ func (r *Runner) Run(ctx context.Context) <-chan Event {
 	return r.evts
 }
 
-// run executes election maitaining loop continuously until the passed in
+// run executes the election maitaining loop continuously until the passed in
 // context is done. Returns the latest error.
 //
 // Whenever mastership status of the log gets updated, a new Event is sent to
 // the output channel. It is guaranteed that the first event (if any) will be
-// becoming the master, and the events will alternate between becoming and stop
-// being the master (voluntarily, i.e. after MasterHoldInterval passes, or
-// unexpectedly, e.g. due to network partitioning).
+// becoming the master, and the events will alternate between becoming and
+// stopping being the master (voluntarily, i.e. after MasterHoldInterval
+// passes, or unexpectedly, e.g. due to network partitioning).
 func (r *Runner) run(ctx context.Context) (err error) {
 	// Pause for a random interval so that if multiple instances start at the
 	// same time there is less of a thundering herd.

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -26,6 +26,7 @@ import (
 // EventType is a type of event occurred to an election instance.
 type EventType byte
 
+// EventType possible values.
 const (
 	BecomeMaster     EventType = iota // The instance believes to be the master.
 	NotMaster                         // Lost mastership along the way.

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -1,0 +1,236 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/util"
+)
+
+type EventType byte
+
+const (
+	BecomeMaster     EventType = iota
+	NotMaster                  // Lost mastership along the way.
+	NotMasterResign            // Voluntarily resigned from mastership.
+	NotMasterTimeout           // Resigned due to master status update timeout.
+)
+
+// Config is a set of parameters for a continuous master election process.
+type Config struct {
+	// PreElectionPause is the maximum interval to wait before starting election.
+	PreElectionPause time.Duration
+	// RestartInverval is the time the instance will wait before attempting to
+	// Start election after an error returned by the previous Start call.
+	RestartInverval time.Duration
+	// MasterCheckInterval is the interval between checks that the instance still
+	// holds mastership.
+	MasterCheckInterval time.Duration
+	// MasterTTL is the time after which the instance will resign if encountered
+	// no successful IsMaster calls.
+	MasterTTL time.Duration
+	// MasterHoldInterval is the minimum interval to hold mastership for during
+	// flawless operation.
+	MasterHoldInterval time.Duration
+	// ResignOdds gives the chance of resigning mastership after each check
+	// interval, as the N for 1-in-N.
+	ResignOdds int
+}
+
+// shouldResign returns whether the instance can voluntarily give up on
+// mastership according to the config.
+func (c *Config) shouldResign(elected, now time.Time) bool {
+	passed := now.Sub(elected)
+	if passed < c.MasterHoldInterval {
+		// Always hold onto mastership for a minimum interval to prevent churn.
+		return false
+	}
+	// Roll the bones.
+	return c.ResignOdds <= 0 || rand.Intn(c.ResignOdds) == 0
+}
+
+// Event describes whether the instance has become or stopped being the master.
+// Each Event *must* be Ack-ed when acted upon by the subscriber.
+type Event struct {
+	// Type denotes the type of event occured to the election instance.
+	Type EventType
+	// done notifies the Runner back when the Event has been acted upon.
+	done chan struct{}
+}
+
+// Ack notifies the Runner that it can follow up with a new election round.
+// This allows the downstream client act on the fact of resigning before the
+// instance re-enters election, e.g. they may want to gracefully/forcefully
+// finish the outstanding work.
+func (e *Event) Ack() {
+	if e.done != nil {
+		close(e.done)
+	}
+}
+
+// Runner coordinates master election for a single instance. Reports mastership
+// updates via an Event channel.
+type Runner struct {
+	cfg        *Config
+	me         MasterElection
+	timeSource util.TimeSource // Allows for mocking tests.
+	prefix     string          // Prefix for all glog messages.
+	evts       chan Event
+}
+
+// NewRunner returns a new election runner for the provided configuration and
+// MasterElection interface.
+func NewRunner(cfg *Config, me MasterElection, ts util.TimeSource, prefix string) *Runner {
+	return &Runner{cfg: cfg, me: me, timeSource: ts, prefix: prefix}
+}
+
+// Run launches a continuous master election process, and returns a channel to
+// which it reports updates on this instance's mastership status. Events passed
+// to the channel will alternate between becoming and stop being the master
+// (see comment above the unexported run method for more details).
+//
+// The underlying goroutine will stop only if the context is done, in which
+// case it will also close the output Event channel.
+//
+// If the master election process encounters any error other than canceling the
+// context, it will put it to glog and try to continue safely.
+func (r *Runner) Run(ctx context.Context) <-chan Event {
+	if r.evts != nil {
+		panic("Run must be invoked only once")
+	}
+	r.evts = make(chan Event)
+	go func() {
+		defer close(r.evts)
+		if err := r.run(ctx); err != nil {
+			glog.Warningf("%selection runner exited: %v", r.prefix, err)
+		}
+	}()
+	return r.evts
+}
+
+// run executes election maitaining loop continuously until the passed in
+// context is done. Returns the latest error.
+//
+// Whenever mastership status of the log gets updated, a new Event is sent to
+// the output channel. It is guaranteed that the first event (if any) will be
+// becoming the master, and the events will alternate between becoming and stop
+// being the master (voluntarily, i.e. after MasterHoldInterval passes, or
+// unexpectedly, e.g. due to network partitioning).
+func (r *Runner) run(ctx context.Context) (err error) {
+	// Pause for a random interval so that if multiple instances start at the
+	// same time there is less of a thundering herd.
+	pause := rand.Int63n(r.cfg.PreElectionPause.Nanoseconds())
+	if err := sleepContext(ctx, time.Duration(pause)); err != nil {
+		return err
+	}
+
+	for {
+		if err = r.me.Start(ctx); err == nil {
+			break
+		}
+		glog.Warningf("%sMasterElection.Start: %v", r.prefix, err)
+		if err = sleepContext(ctx, r.cfg.RestartInverval); err != nil {
+			return err
+		}
+	}
+	defer func(ctx context.Context) {
+		if cerr := r.me.Close(ctx); cerr != nil {
+			err = cerr
+		}
+	}(ctx)
+
+	for {
+		if err := r.beMaster(ctx); err != nil {
+			// TODO(pavelkalinnikov): If WaitForMastership returns errors constantly,
+			// this loop is very busy.
+			if ctx.Err() != nil {
+				return err
+			}
+			glog.Warningf("%sbeMaster: %v", r.prefix, err)
+		}
+	}
+	return nil
+}
+
+func (r *Runner) beMaster(ctx context.Context) (err error) {
+	if err := r.me.WaitForMastership(ctx); err != nil {
+		return err
+	}
+
+	elected := r.timeSource.Now()
+	select {
+	case r.evts <- Event{Type: BecomeMaster}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	for deadline := elected.Add(r.cfg.MasterTTL); ; {
+		if err = sleepContext(ctx, r.cfg.MasterCheckInterval); err != nil {
+			return err
+		}
+		isMaster, err := r.me.IsMaster(ctx)
+		now := r.timeSource.Now()
+		switch {
+		case ctx.Err() != nil:
+			return ctx.Err()
+		case err != nil:
+			glog.Warningf("%sIsMaster: %v", r.prefix, err)
+			if now.After(deadline) {
+				return r.resign(ctx, NotMasterTimeout)
+			}
+		case !isMaster:
+			return r.resign(ctx, NotMaster)
+		case r.cfg.shouldResign(elected, r.timeSource.Now()):
+			return r.resign(ctx, NotMasterResign)
+		default: // We are the master, so update the deadline and continue.
+			deadline = now.Add(r.cfg.MasterTTL)
+		}
+	}
+}
+
+func (r *Runner) resign(ctx context.Context, typ EventType) error {
+	evt := Event{Type: typ, done: make(chan struct{})}
+	select {
+	case r.evts <- evt:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-evt.done: // Wait until the event is Ack-ed.
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if typ != BecomeMaster && typ != NotMaster {
+		return r.me.ResignAndRestart(ctx)
+	}
+	return nil
+}
+
+// sleepContext sleeps for at least the specified duration. Returns an error
+// iff the context is done before the timer fires.
+func sleepContext(ctx context.Context, dur time.Duration) error {
+	timer := time.NewTimer(dur)
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		timer.Stop()
+		return ctx.Err()
+	}
+	return nil
+}

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -23,22 +23,23 @@ import (
 	"github.com/google/trillian/util"
 )
 
+// EventType is a type of event occurred to an election instance.
 type EventType byte
 
 const (
-	BecomeMaster     EventType = iota
-	NotMaster                  // Lost mastership along the way.
-	NotMasterResign            // Voluntarily resigned from mastership.
-	NotMasterTimeout           // Resigned due to master status update timeout.
+	BecomeMaster     EventType = iota // The instance believes to be the master.
+	NotMaster                         // Lost mastership along the way.
+	NotMasterResign                   // Voluntarily resigned from mastership.
+	NotMasterTimeout                  // Resigned due to status update timeout.
 )
 
 // Config is a set of parameters for a continuous master election process.
 type Config struct {
 	// PreElectionPause is the maximum interval to wait before starting election.
 	PreElectionPause time.Duration
-	// RestartInverval is the time the instance will wait before attempting to
+	// RestartInterval is the time the instance will wait before attempting to
 	// Start election after an error returned by the previous Start call.
-	RestartInverval time.Duration
+	RestartInterval time.Duration
 	// MasterCheckInterval is the interval between checks that the instance still
 	// holds mastership.
 	MasterCheckInterval time.Duration
@@ -53,7 +54,7 @@ type Config struct {
 	ResignOdds int
 }
 
-// shouldResign returns whether the instance can voluntarily give up on
+// ShouldResign returns whether the instance can voluntarily give up on
 // mastership according to the config.
 func (c *Config) ShouldResign(elected, now time.Time) bool {
 	passed := now.Sub(elected)
@@ -68,7 +69,7 @@ func (c *Config) ShouldResign(elected, now time.Time) bool {
 // Event describes whether the instance has become or stopped being the master.
 // Each Event *must* be Ack-ed when acted upon by the subscriber.
 type Event struct {
-	// Type denotes the type of event occured to the election instance.
+	// Type denotes the type of event occurred to the election instance.
 	Type EventType
 	// done notifies the Runner back when the Event has been acted upon.
 	done chan struct{}
@@ -145,7 +146,7 @@ func (r *Runner) run(ctx context.Context) (err error) {
 			break
 		}
 		glog.Warningf("%sMasterElection.Start: %v", r.prefix, err)
-		if err = sleepContext(ctx, r.cfg.RestartInverval); err != nil {
+		if err = sleepContext(ctx, r.cfg.RestartInterval); err != nil {
 			return err
 		}
 	}
@@ -165,7 +166,6 @@ func (r *Runner) run(ctx context.Context) (err error) {
 			glog.Warningf("%sbeMaster: %v", r.prefix, err)
 		}
 	}
-	return nil
 }
 
 func (r *Runner) beMaster(ctx context.Context) (err error) {

--- a/util/election/runner_test.go
+++ b/util/election/runner_test.go
@@ -17,8 +17,6 @@ package election_test
 import (
 	"context"
 	"errors"
-	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -30,283 +28,147 @@ import (
 var (
 	cfg = Config{
 		PreElectionPause:    time.Millisecond,
-		RestartInterval:     time.Millisecond,
 		MasterCheckInterval: time.Millisecond,
-		MasterHoldInterval:  time.Millisecond,
+		MasterTTL:           time.Millisecond,
 	}
-	noEventDur = 10 * time.Millisecond
-	stubError  = errors.New("stub.MasterElection error")
+	decentDur = 10 * time.Millisecond
+	stubErr   = errors.New("stub.MasterElection error")
 )
 
-func expectEvent(t *testing.T, evts <-chan Event, want EventType) Event {
+// expectNotClosed checks that done is not closed within some timeout.
+func expectNotClosed(t *testing.T, done <-chan struct{}, msg string) {
 	t.Helper()
-	evt, ok := <-evts
-	if !ok {
-		t.Errorf("Expected %v, but the channel was closed", want)
-		return evt
-	}
-	if got := evt.Type; got != want {
-		t.Errorf("Type=%v, want %v", got, want)
-	}
-	return evt
-}
-
-func expectNoEvent(t *testing.T, evts <-chan Event) {
-	t.Helper()
-	timer := time.NewTimer(noEventDur)
-	select {
-	case <-timer.C:
-	case evt := <-evts:
-		timer.Stop()
-		t.Errorf("Expected no event, got %+v", evt)
+	if err := util.Sleep(done, decentDur); err != nil {
+		t.Errorf(msg)
 	}
 }
 
-func expectClosed(t *testing.T, evts <-chan Event) {
-	t.Helper()
-	if evt, ok := <-evts; ok {
-		t.Errorf("Expected closed channel, got %+v", evt)
-	}
-}
-
-func waitResigned(em *stub.MasterElection) {
-	for {
-		if is, _ := em.IsMaster(context.Background()); !is {
-			return
+func becomeMaster(ctx context.Context, t *testing.T, me *stub.MasterElection, runner *Runner) (run *Run) {
+	isMaster := make(chan struct{})
+	go func() {
+		defer close(isMaster)
+		var err error
+		if run, err = runner.BeMaster(ctx); err != nil {
+			t.Fatalf("BeMaster(): %v", err)
 		}
-		time.Sleep(noEventDur)
+	}()
+	expectNotClosed(t, isMaster, "Became master unexpectedly")
+
+	me.Update(true, nil)
+	<-isMaster // Now should become the master.
+
+	if run == nil {
+		t.Fatal("Expected non-nil Run")
 	}
+	expectNotClosed(t, run.Ctx.Done(), "Closed master context unexpectedly")
+	expectNotClosed(t, run.Done, "Closed Done unexpectedly")
+	if is, _ := me.IsMaster(ctx); !is {
+		t.Errorf("Unexpected masteship resignation")
+	}
+
+	return run
 }
 
-func TestShouldResign(t *testing.T) {
-	startTime := time.Date(1970, 9, 19, 12, 00, 00, 00, time.UTC)
-	holdChecks, iterations := int64(10), 10000
-
-	var tests = []struct {
-		hold     time.Duration
-		odds     int
-		overheld time.Duration
-		wantProb float64
-	}{
-		{hold: 12 * time.Second, odds: 10, overheld: 0 * time.Second, wantProb: 0.1},
-		{hold: 12 * time.Second, odds: 10, overheld: 1 * time.Second, wantProb: 0.1},
-		{hold: 12 * time.Second, odds: 10, overheld: 10 * time.Second, wantProb: 0.1},
-		{hold: 12 * time.Second, odds: 10, overheld: -1 * time.Second, wantProb: 0.0},
-
-		{hold: 1 * time.Second, odds: 3, overheld: 0 * time.Second, wantProb: 1.0 / 3},
-		{hold: 1 * time.Second, odds: 3, overheld: 10 * time.Second, wantProb: 1.0 / 3},
-		{hold: 1 * time.Second, odds: 10, overheld: 10 * time.Second, wantProb: 0.1},
-		{hold: 10 * time.Second, odds: 0, overheld: 10 * time.Second, wantProb: 1.0},
-		{hold: 10 * time.Second, odds: 1, overheld: 10 * time.Second, wantProb: 1.0},
-		{hold: 10 * time.Second, odds: -1, overheld: 10 * time.Second, wantProb: 1.0},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("hold:%v:odds:%v", test.hold, test.odds), func(t *testing.T) {
-			cfg := Config{
-				MasterHoldInterval: test.hold,
-				ResignOdds:         test.odds,
-			}
-			holdNanos := test.hold.Nanoseconds() / holdChecks
-			for i := int64(-1); i < holdChecks; i++ {
-				gapNanos := time.Duration(i * holdNanos)
-				now := startTime.Add(gapNanos)
-				for j := 0; j < 100; j++ {
-					if cfg.ShouldResign(startTime, now) {
-						t.Fatalf("shouldResign(start+%v)=true, want false", gapNanos)
-					}
-				}
-			}
-
-			now := startTime.Add(test.hold).Add(test.overheld)
-			count := 0
-			for i := 0; i < iterations; i++ {
-				if cfg.ShouldResign(startTime, now) {
-					count++
-				}
-			}
-			got := float64(count) / float64(iterations)
-			deltaFraction := math.Abs(got-test.wantProb) / test.wantProb
-			if deltaFraction > 0.05 {
-				t.Errorf("P(shouldResign)=%f; want ~%f", got, test.wantProb)
-			}
-		})
-	}
-}
-
-func TestRunner_BecomeMaster(t *testing.T) {
+func TestRunner_BecomeMasterAndCancel(t *testing.T) {
 	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-
-	expectNoEvent(t, evts)
-	me.Update(true, nil)
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts) // Still holds mastership.
-}
-
-func TestRunner_ForcefullyResignAndRecover(t *testing.T) {
-	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-	expectEvent(t, evts, BecomeMaster)
-
-	me.Update(false, nil) // Force losing mastership.
-	evt := expectEvent(t, evts, NotMaster)
-	expectNoEvent(t, evts)
-
-	me.Update(true, nil)   // Make mastership available again.
-	expectNoEvent(t, evts) // But observe no taking over.
-	evt.Ack()              // Because need to Ack the event to continue.
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-}
-
-func TestRunner_VoluntarilyResignAndRecover(t *testing.T) {
-	ctx := context.Background()
-
-	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(ctx)
-	expectEvent(t, evts, BecomeMaster)
-
-	// Advance fake time just enough to trigger resignation.
-	ts.Set(ts.Now().Add(cfg.MasterHoldInterval))
-	evt := expectEvent(t, evts, NotMasterResign)
-	expectNoEvent(t, evts) // Should not re-enter election.
-	if is, _ := me.IsMaster(ctx); !is {
-		t.Errorf("Should not call ResignAndRestart until after Ack")
+	ctx, cancel := context.WithCancel(context.Background())
+	run := becomeMaster(ctx, t, me, runner)
+	cancel()
+	<-run.Done
+	if is, _ := me.IsMaster(ctx); is {
+		t.Error("Expected masteship resignation")
 	}
+}
 
-	me.Update(true, nil)   // Make mastership available again.
-	expectNoEvent(t, evts) // But observe no taking over.
-	evt.Ack()              // Because need to Ack the event to continue.
-	waitResigned(me)       // Which will finalize the resignation.
-	expectNoEvent(t, evts) // Still no taking over, because Ack has given it away.
-	me.Update(true, nil)   // But it should be taken over when available again.
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
+func TestRunner_BecomeMasterAndResign(t *testing.T) {
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	ctx := context.Background()
+	run := becomeMaster(ctx, t, me, runner)
+	run.Resign()
+	if run.Ctx.Err() == nil {
+		t.Error("Expected closed master context")
+	}
+	if is, _ := me.IsMaster(ctx); is {
+		t.Error("Expected masteship resignation")
+	}
+}
+
+func TestRunner_BecomeMasterAndError(t *testing.T) {
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	ctx := context.Background()
+	run := becomeMaster(ctx, t, me, runner)
+
+	me.Update(true, &stub.Errors{IsMaster: stubErr})
+	expectNotClosed(t, run.Ctx.Done(), "Closed master context unexpectedly")
+	ts.Set(ts.Now().Add(cfg.MasterTTL))
+	expectNotClosed(t, run.Ctx.Done(), "Closed master context unexpectedly")
+	ts.Set(ts.Now().Add(1)) // Just enough to trigger resignation.
+	<-run.Done
+
+	if run.Ctx.Err() == nil {
+		t.Error("Expected closed master context")
+	}
+	if is, _ := me.IsMaster(ctx); is {
+		t.Errorf("Expected masteship resignation")
+	}
 }
 
 func TestRunner_HealthyLoop(t *testing.T) {
-	ctx := context.Background()
-
 	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(ctx)
+	ctx := context.Background()
 
-	for iter := 0; iter < 10; iter++ {
-		me.Update(true, nil)
-		expectEvent(t, evts, BecomeMaster)
-		ts.Set(ts.Now().Add(cfg.MasterHoldInterval)) // Trigger resign.
-		evt := expectEvent(t, evts, NotMasterResign)
-		expectNoEvent(t, evts)
-		if is, _ := me.IsMaster(ctx); !is {
-			t.Errorf("Should not call ResignAndRestart until after Ack")
+	for i := 0; i < 10; i++ {
+		run := becomeMaster(ctx, t, me, runner)
+		// ... do some work as master ...
+		run.Resign()
+		if run.Ctx.Err() == nil {
+			t.Error("Expected closed context")
 		}
-		evt.Ack()
-		waitResigned(me)
-		expectNoEvent(t, evts)
+		if is, _ := me.IsMaster(ctx); is {
+			t.Errorf("Expected masteship resignation")
+		}
+	}
+
+	if err := runner.Close(ctx); err != nil {
+		t.Errorf("Close(): %v", err)
 	}
 }
 
-func TestRunner_ErrorStart(t *testing.T) {
-	me := stub.NewMasterElection(false, &stub.Errors{Start: stubError})
+func TestRunner_BeMasterErrors(t *testing.T) {
 	ts := &util.FakeTimeSource{}
 
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-	expectNoEvent(t, evts)
+	for _, tc := range []struct {
+		desc   string
+		errs   stub.Errors
+		cancel bool
+		want   error
+	}{
+		{desc: "Start", errs: stub.Errors{Start: stubErr}, want: stubErr},
+		{desc: "WaitForMastership", errs: stub.Errors{Wait: stubErr}, want: stubErr},
+		{desc: "IsMaster", errs: stub.Errors{IsMaster: stubErr}, want: nil},
+		{desc: "Resign", errs: stub.Errors{Resign: stubErr}, want: nil},
+		{desc: "cancel", cancel: true, want: context.Canceled},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
 
-	me.Update(true, nil) // Recover when error disappears.
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-}
-
-func TestRunner_ErrorWaitForMastership(t *testing.T) {
-	me := stub.NewMasterElection(false, &stub.Errors{Wait: stubError})
-	ts := &util.FakeTimeSource{}
-
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-	expectNoEvent(t, evts)
-
-	me.Update(true, nil) // Recover when error disappears.
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-}
-
-func TestRunner_ErrorIsMaster(t *testing.T) {
-	me := stub.NewMasterElection(true, &stub.Errors{IsMaster: stubError})
-	ts := &util.FakeTimeSource{}
-
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-	expectEvent(t, evts, BecomeMaster)
-
-	expectNoEvent(t, evts)
-	ts.Set(ts.Now().Add(cfg.MasterTTL)) // Right within the TTL.
-	expectNoEvent(t, evts)              // Should not trigger resignation.
-	ts.Set(ts.Now().Add(1 * time.Nanosecond))
-	evt := expectEvent(t, evts, NotMasterTimeout) // But +1 nanosecond should.
-	evt.Ack()
-	waitResigned(me)
-
-	me.Update(true, nil) // Recover when error disappears.
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-}
-
-func TestRunner_DisconnectAfterStart(t *testing.T) {
-	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
-	runner := NewRunner(&cfg, me, ts, "")
-	evts := runner.Run(context.Background())
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-
-	me.Update(false, stub.ErrAll(stubError))
-	ts.Set(ts.Now().Add(cfg.MasterTTL + 1))
-	evt := expectEvent(t, evts, NotMasterTimeout)
-	evt.Ack()
-	expectNoEvent(t, evts)
-
-	me.Update(true, nil)
-	expectEvent(t, evts, BecomeMaster)
-	expectNoEvent(t, evts)
-}
-
-func TestRunner_CancelBeforeStart(t *testing.T) {
-	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
-
-	// Delay election start so that we can intrude with cancel() before it.
-	cfg := cfg // Don't spoil the shared config template.
-	cfg.PreElectionPause = 100 * time.Hour
-	runner := NewRunner(&cfg, me, ts, "")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	evts := runner.Run(ctx)
-	expectNoEvent(t, evts)
-	cancel()
-	expectClosed(t, evts)
-}
-
-func TestRunner_CancelWhenMaster(t *testing.T) {
-	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
-	runner := NewRunner(&cfg, me, ts, "")
-	ctx, cancel := context.WithCancel(context.Background())
-	evts := runner.Run(ctx)
-	expectEvent(t, evts, BecomeMaster)
-	cancel()
-	expectClosed(t, evts)
-}
-
-func TestRunner_CancelWhenNotMaster(t *testing.T) {
-	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
-	runner := NewRunner(&cfg, me, ts, "")
-	ctx, cancel := context.WithCancel(context.Background())
-	evts := runner.Run(ctx)
-	expectNoEvent(t, evts) // Give it some time, may hit WaitForMastership.
-	cancel()
-	me.Ping() // Trigger context canceling in WaitForMastership if stuck there.
-	expectClosed(t, evts)
+			me := stub.NewMasterElection(true, &tc.errs)
+			runner := NewRunner(&cfg, me, ts, "")
+			run, err := runner.BeMaster(ctx)
+			if got, want := err, tc.want; got != want {
+				t.Errorf("BeMaster(): error=%v, want %v", got, want)
+			}
+			if got, want := (run != nil), (tc.want == nil); got != want {
+				t.Errorf("BeMaster() returned run %v, want %v", got, want)
+			}
+		})
+	}
 }

--- a/util/election/runner_test.go
+++ b/util/election/runner_test.go
@@ -1,0 +1,296 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election/mock"
+)
+
+var (
+	cfg = Config{
+		PreElectionPause:    time.Millisecond,
+		RestartInverval:     time.Millisecond,
+		MasterCheckInterval: time.Millisecond,
+		MasterHoldInterval:  time.Millisecond,
+	}
+	noEventDur = 10 * time.Millisecond
+	mockError  = errors.New("mock.MasterElection error")
+)
+
+func expectEvent(t *testing.T, evts <-chan Event, want EventType) Event {
+	t.Helper()
+	evt, ok := <-evts
+	if !ok {
+		t.Errorf("Expected %v, but the channel was closed", want)
+		return evt
+	}
+	if got := evt.Type; got != want {
+		t.Errorf("Type=%v, want %v", got, want)
+	}
+	return evt
+}
+
+func expectNoEvent(t *testing.T, evts <-chan Event) {
+	t.Helper()
+	timer := time.NewTimer(noEventDur)
+	select {
+	case <-timer.C:
+	case evt := <-evts:
+		timer.Stop()
+		t.Errorf("Expected no event, got %+v", evt)
+	}
+}
+
+func expectClosed(t *testing.T, evts <-chan Event) {
+	t.Helper()
+	if evt, ok := <-evts; ok {
+		t.Errorf("Expected closed channel, got %+v", evt)
+	}
+}
+
+func waitResigned(em *mock.MasterElection) {
+	for {
+		if is, _ := em.IsMaster(context.Background()); !is {
+			return
+		}
+		time.Sleep(noEventDur)
+	}
+}
+
+func TestShouldResign(t *testing.T) {
+	startTime := time.Date(1970, 9, 19, 12, 00, 00, 00, time.UTC)
+	holdChecks, iterations := int64(10), 10000
+
+	var tests = []struct {
+		hold     time.Duration
+		odds     int
+		overheld time.Duration
+		wantProb float64
+	}{
+		{hold: 12 * time.Second, odds: 10, overheld: 0 * time.Second, wantProb: 0.1},
+		{hold: 12 * time.Second, odds: 10, overheld: 1 * time.Second, wantProb: 0.1},
+		{hold: 12 * time.Second, odds: 10, overheld: 10 * time.Second, wantProb: 0.1},
+		{hold: 12 * time.Second, odds: 10, overheld: -1 * time.Second, wantProb: 0.0},
+
+		{hold: 1 * time.Second, odds: 3, overheld: 0 * time.Second, wantProb: 1.0 / 3},
+		{hold: 1 * time.Second, odds: 3, overheld: 10 * time.Second, wantProb: 1.0 / 3},
+		{hold: 1 * time.Second, odds: 10, overheld: 10 * time.Second, wantProb: 0.1},
+		{hold: 10 * time.Second, odds: 0, overheld: 10 * time.Second, wantProb: 1.0},
+		{hold: 10 * time.Second, odds: 1, overheld: 10 * time.Second, wantProb: 1.0},
+		{hold: 10 * time.Second, odds: -1, overheld: 10 * time.Second, wantProb: 1.0},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("hold:%v:odds:%v", test.hold, test.odds), func(t *testing.T) {
+			cfg := Config{
+				MasterHoldInterval: test.hold,
+				ResignOdds:         test.odds,
+			}
+			holdNanos := test.hold.Nanoseconds() / holdChecks
+			for i := int64(-1); i < holdChecks; i++ {
+				gapNanos := time.Duration(i * holdNanos)
+				now := startTime.Add(gapNanos)
+				for j := 0; j < 100; j++ {
+					if cfg.shouldResign(startTime, now) {
+						t.Fatalf("shouldResign(start+%v)=true, want false", gapNanos)
+					}
+				}
+			}
+
+			now := startTime.Add(test.hold).Add(test.overheld)
+			count := 0
+			for i := 0; i < iterations; i++ {
+				if cfg.shouldResign(startTime, now) {
+					count++
+				}
+			}
+			got := float64(count) / float64(iterations)
+			deltaFraction := math.Abs(got-test.wantProb) / test.wantProb
+			if deltaFraction > 0.05 {
+				t.Errorf("P(shouldResign)=%f; want ~%f", got, test.wantProb)
+			}
+		})
+	}
+}
+
+func TestRunner_BecomeMaster(t *testing.T) {
+	me, ts := mock.NewMasterElection(false), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(context.Background())
+
+	expectNoEvent(t, evts)
+	me.Update(true, nil)
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts) // Still holds mastership.
+}
+
+func TestRunner_ForcefullyResignAndRecover(t *testing.T) {
+	me, ts := mock.NewMasterElection(true), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(context.Background())
+	expectEvent(t, evts, BecomeMaster)
+
+	me.Update(false, nil) // Force losing mastership.
+	evt := expectEvent(t, evts, NotMaster)
+	expectNoEvent(t, evts)
+
+	me.Update(true, nil)   // Make mastership available again.
+	expectNoEvent(t, evts) // But observe no taking over.
+	evt.Ack()              // Because need to Ack the event to continue.
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts)
+}
+
+func TestRunner_VoluntarilyResignAndRecover(t *testing.T) {
+	ctx := context.Background()
+
+	me, ts := mock.NewMasterElection(true), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(ctx)
+	expectEvent(t, evts, BecomeMaster)
+
+	// Advance fake time just enough to trigger resignation.
+	ts.Set(ts.Now().Add(cfg.MasterHoldInterval))
+	evt := expectEvent(t, evts, NotMasterResign)
+	expectNoEvent(t, evts) // Should not re-enter election.
+	if is, _ := me.IsMaster(ctx); !is {
+		t.Errorf("Should not call ResignAndRestart until after Ack")
+	}
+
+	me.Update(true, nil)   // Make mastership available again.
+	expectNoEvent(t, evts) // But observe no taking over.
+	evt.Ack()              // Because need to Ack the event to continue.
+	waitResigned(me)       // Which will finalize the resignation.
+	expectNoEvent(t, evts) // Still no taking over, because Ack has given it away.
+	me.Update(true, nil)   // But it should be taken over when availabe again.
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts)
+}
+
+func TestRunner_HealthyLoop(t *testing.T) {
+	ctx := context.Background()
+
+	me, ts := mock.NewMasterElection(false), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(ctx)
+
+	for iter := 0; iter < 10; iter++ {
+		me.Update(true, nil)
+		expectEvent(t, evts, BecomeMaster)
+		ts.Set(ts.Now().Add(cfg.MasterHoldInterval)) // Trigger resign.
+		evt := expectEvent(t, evts, NotMasterResign)
+		expectNoEvent(t, evts)
+		if is, _ := me.IsMaster(ctx); !is {
+			t.Errorf("Should not call ResignAndRestart until after Ack")
+		}
+		evt.Ack()
+		waitResigned(me)
+		expectNoEvent(t, evts)
+	}
+}
+
+func TestRunner_ErrorStart(t *testing.T) {
+	ts := &util.FakeTimeSource{}
+	me := &mock.MasterElection{StartErr: mockError}
+	me.Init()
+
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(context.Background())
+	expectNoEvent(t, evts)
+
+	me.Update(true, nil) // Recover when error disappears.
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts)
+}
+
+func TestRunner_ErrorWaitForMastership(t *testing.T) {
+	ts := &util.FakeTimeSource{}
+	me := &mock.MasterElection{Master: true, WaitErr: mockError}
+	me.Init()
+
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(context.Background())
+	expectNoEvent(t, evts)
+
+	me.Update(true, nil) // Recover when error disappears.
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts)
+}
+
+func TestRunner_ErrorIsMaster(t *testing.T) {
+	ts := &util.FakeTimeSource{}
+	me := &mock.MasterElection{Master: true, IsMasterErr: mockError}
+	me.Init()
+
+	runner := NewRunner(&cfg, me, ts, "")
+	evts := runner.Run(context.Background())
+	expectEvent(t, evts, BecomeMaster)
+
+	expectNoEvent(t, evts)
+	ts.Set(ts.Now().Add(cfg.MasterTTL)) // Right within the TTL.
+	expectNoEvent(t, evts)              // Should not trigger resignation.
+	ts.Set(ts.Now().Add(1 * time.Nanosecond))
+	evt := expectEvent(t, evts, NotMasterTimeout) // But +1 nanosecond should.
+	evt.Ack()
+	waitResigned(me)
+
+	me.Update(true, nil) // Recover when error disappears.
+	expectEvent(t, evts, BecomeMaster)
+	expectNoEvent(t, evts)
+}
+
+func TestRunner_CancelBeforeStart(t *testing.T) {
+	me, ts := mock.NewMasterElection(false), &util.FakeTimeSource{}
+
+	// Delay election start so that we can intrude with cancel() before it.
+	cfg := cfg // Don't spoil the shared config template.
+	cfg.PreElectionPause = 100 * time.Hour
+	runner := NewRunner(&cfg, me, ts, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	evts := runner.Run(ctx)
+	expectNoEvent(t, evts)
+	cancel()
+	expectClosed(t, evts)
+}
+
+func TestRunner_CancelWhenMaster(t *testing.T) {
+	me, ts := mock.NewMasterElection(true), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	evts := runner.Run(ctx)
+	expectEvent(t, evts, BecomeMaster)
+	cancel()
+	expectClosed(t, evts)
+}
+
+func TestRunner_CancelWhenNotMaster(t *testing.T) {
+	me, ts := mock.NewMasterElection(false), &util.FakeTimeSource{}
+	runner := NewRunner(&cfg, me, ts, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	evts := runner.Run(ctx)
+	expectNoEvent(t, evts) // Give it some time, may hit WaitForMastership.
+	cancel()
+	me.Ping() // Trigger context canceling in WaitForMastership if stuck there.
+	expectClosed(t, evts)
+}

--- a/util/election/runner_test.go
+++ b/util/election/runner_test.go
@@ -30,7 +30,7 @@ import (
 var (
 	cfg = Config{
 		PreElectionPause:    time.Millisecond,
-		RestartInverval:     time.Millisecond,
+		RestartInterval:     time.Millisecond,
 		MasterCheckInterval: time.Millisecond,
 		MasterHoldInterval:  time.Millisecond,
 	}
@@ -183,7 +183,7 @@ func TestRunner_VoluntarilyResignAndRecover(t *testing.T) {
 	evt.Ack()              // Because need to Ack the event to continue.
 	waitResigned(me)       // Which will finalize the resignation.
 	expectNoEvent(t, evts) // Still no taking over, because Ack has given it away.
-	me.Update(true, nil)   // But it should be taken over when availabe again.
+	me.Update(true, nil)   // But it should be taken over when available again.
 	expectEvent(t, evts, BecomeMaster)
 	expectNoEvent(t, evts)
 }

--- a/util/election/runner_test.go
+++ b/util/election/runner_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/trillian/util"
 	. "github.com/google/trillian/util/election"
-	"github.com/google/trillian/util/election/mock"
+	"github.com/google/trillian/util/election/stub"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 		MasterHoldInterval:  time.Millisecond,
 	}
 	noEventDur = 10 * time.Millisecond
-	mockError  = errors.New("mock.MasterElection error")
+	stubError  = errors.New("stub.MasterElection error")
 )
 
 func expectEvent(t *testing.T, evts <-chan Event, want EventType) Event {
@@ -69,7 +69,7 @@ func expectClosed(t *testing.T, evts <-chan Event) {
 	}
 }
 
-func waitResigned(em *mock.MasterElection) {
+func waitResigned(em *stub.MasterElection) {
 	for {
 		if is, _ := em.IsMaster(context.Background()); !is {
 			return
@@ -135,7 +135,7 @@ func TestShouldResign(t *testing.T) {
 }
 
 func TestRunner_BecomeMaster(t *testing.T) {
-	me, ts := mock.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	evts := runner.Run(context.Background())
 
@@ -146,7 +146,7 @@ func TestRunner_BecomeMaster(t *testing.T) {
 }
 
 func TestRunner_ForcefullyResignAndRecover(t *testing.T) {
-	me, ts := mock.NewMasterElection(true, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	evts := runner.Run(context.Background())
 	expectEvent(t, evts, BecomeMaster)
@@ -165,7 +165,7 @@ func TestRunner_ForcefullyResignAndRecover(t *testing.T) {
 func TestRunner_VoluntarilyResignAndRecover(t *testing.T) {
 	ctx := context.Background()
 
-	me, ts := mock.NewMasterElection(true, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	evts := runner.Run(ctx)
 	expectEvent(t, evts, BecomeMaster)
@@ -191,7 +191,7 @@ func TestRunner_VoluntarilyResignAndRecover(t *testing.T) {
 func TestRunner_HealthyLoop(t *testing.T) {
 	ctx := context.Background()
 
-	me, ts := mock.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	evts := runner.Run(ctx)
 
@@ -211,7 +211,7 @@ func TestRunner_HealthyLoop(t *testing.T) {
 }
 
 func TestRunner_ErrorStart(t *testing.T) {
-	me := mock.NewMasterElection(false, &mock.Errors{Start: mockError})
+	me := stub.NewMasterElection(false, &stub.Errors{Start: stubError})
 	ts := &util.FakeTimeSource{}
 
 	runner := NewRunner(&cfg, me, ts, "")
@@ -224,7 +224,7 @@ func TestRunner_ErrorStart(t *testing.T) {
 }
 
 func TestRunner_ErrorWaitForMastership(t *testing.T) {
-	me := mock.NewMasterElection(false, &mock.Errors{Wait: mockError})
+	me := stub.NewMasterElection(false, &stub.Errors{Wait: stubError})
 	ts := &util.FakeTimeSource{}
 
 	runner := NewRunner(&cfg, me, ts, "")
@@ -237,7 +237,7 @@ func TestRunner_ErrorWaitForMastership(t *testing.T) {
 }
 
 func TestRunner_ErrorIsMaster(t *testing.T) {
-	me := mock.NewMasterElection(true, &mock.Errors{IsMaster: mockError})
+	me := stub.NewMasterElection(true, &stub.Errors{IsMaster: stubError})
 	ts := &util.FakeTimeSource{}
 
 	runner := NewRunner(&cfg, me, ts, "")
@@ -258,13 +258,13 @@ func TestRunner_ErrorIsMaster(t *testing.T) {
 }
 
 func TestRunner_DisconnectAfterStart(t *testing.T) {
-	me, ts := mock.NewMasterElection(true, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	evts := runner.Run(context.Background())
 	expectEvent(t, evts, BecomeMaster)
 	expectNoEvent(t, evts)
 
-	me.Update(false, mock.ErrAll(mockError))
+	me.Update(false, stub.ErrAll(stubError))
 	ts.Set(ts.Now().Add(cfg.MasterTTL + 1))
 	evt := expectEvent(t, evts, NotMasterTimeout)
 	evt.Ack()
@@ -276,7 +276,7 @@ func TestRunner_DisconnectAfterStart(t *testing.T) {
 }
 
 func TestRunner_CancelBeforeStart(t *testing.T) {
-	me, ts := mock.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 
 	// Delay election start so that we can intrude with cancel() before it.
 	cfg := cfg // Don't spoil the shared config template.
@@ -291,7 +291,7 @@ func TestRunner_CancelBeforeStart(t *testing.T) {
 }
 
 func TestRunner_CancelWhenMaster(t *testing.T) {
-	me, ts := mock.NewMasterElection(true, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(true, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	evts := runner.Run(ctx)
@@ -301,7 +301,7 @@ func TestRunner_CancelWhenMaster(t *testing.T) {
 }
 
 func TestRunner_CancelWhenNotMaster(t *testing.T) {
-	me, ts := mock.NewMasterElection(false, nil), &util.FakeTimeSource{}
+	me, ts := stub.NewMasterElection(false, nil), &util.FakeTimeSource{}
 	runner := NewRunner(&cfg, me, ts, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	evts := runner.Run(ctx)

--- a/util/election/stub/election.go
+++ b/util/election/stub/election.go
@@ -104,9 +104,9 @@ func (e *MasterElection) IsMaster(context.Context) (bool, error) {
 	return e.isMaster, e.errs.IsMaster
 }
 
-// ResignAndRestart returns the stored error and resets mastership status if
-// the error is nil.
-func (e *MasterElection) ResignAndRestart(context.Context) error {
+// Resign returns the stored error and resets mastership status if the error is
+// nil.
+func (e *MasterElection) Resign(context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.errs.Resign == nil {

--- a/util/election/stub/election.go
+++ b/util/election/stub/election.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package mock contains a mock MasterElection implementation.
-package mock
+// Package stub contains a MasterElection implementation for testing.
+package stub
 
 import (
 	"context"
@@ -22,15 +22,17 @@ import (
 	"github.com/google/trillian/util/election"
 )
 
+// Errors contains errors to be returned by each of MasterElection methods.
 type Errors struct {
 	Start     error
-	Wait      error
+	Wait      error // WaitForMastership error.
 	IsMaster  error
-	Resign    error
+	Resign    error // ResignAndRestart error.
 	Close     error
-	GetMaster error
+	GetMaster error // GetCurrentMaster error.
 }
 
+// ErrAll creates Errors containing the same err associated with each method.
 func ErrAll(err error) *Errors {
 	return &Errors{err, err, err, err, err, err}
 }
@@ -54,7 +56,7 @@ func NewMasterElection(isMaster bool, errs *Errors) *MasterElection {
 	return res
 }
 
-// Update changes mastership status and mocked error for all interface calls.
+// Update changes mastership status and errors returned by interface calls.
 func (e *MasterElection) Update(isMaster bool, errs *Errors) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -81,8 +83,8 @@ func (e *MasterElection) Start(context.Context) error {
 	return e.errs.Start
 }
 
-// WaitForMastership blocks until this instance is master or, and error is
-// supplied or context is done (triggered by explicitly calling Ping).
+// WaitForMastership blocks until this instance is master, or an error is
+// supplied, or context is done (triggered by explicitly calling Ping).
 func (e *MasterElection) WaitForMastership(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -102,7 +104,8 @@ func (e *MasterElection) IsMaster(context.Context) (bool, error) {
 	return e.isMaster, e.errs.IsMaster
 }
 
-// ResignAndRestart resets mastership status and returns the stored error.
+// ResignAndRestart returns the stored error and resets mastership status if
+// the error is nil.
 func (e *MasterElection) ResignAndRestart(context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -56,14 +56,14 @@ func (eme *MasterElection) IsMaster(ctx context.Context) (bool, error) {
 	return string(leader.Kvs[0].Value) == eme.instanceID, nil
 }
 
-// ResignAndRestart releases mastership, and re-joins the election.
-func (eme *MasterElection) ResignAndRestart(ctx context.Context) error {
+// Resign releases mastership.
+func (eme *MasterElection) Resign(ctx context.Context) error {
 	return eme.election.Resign(ctx)
 }
 
 // Close terminates election operation.
 func (eme *MasterElection) Close(ctx context.Context) error {
-	_ = eme.ResignAndRestart(ctx)
+	_ = eme.Resign(ctx)
 	return eme.session.Close()
 }
 

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package etcd holds an etcd-specific implementation of the
-// util.MasterElection interface.
+// election.MasterElection interface.
 package etcd
 
 import (
@@ -24,10 +24,10 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/golang/glog"
-	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
-// MasterElection is an implementation of util.MasterElection based on etcd.
+// MasterElection is an implementation of election.MasterElection based on etcd.
 type MasterElection struct {
 	instanceID string
 	treeID     int64
@@ -86,7 +86,7 @@ func NewElectionFactory(instanceID string, client *clientv3.Client, lockDir stri
 }
 
 // NewElection creates a specific etcd.MasterElection instance.
-func (ef ElectionFactory) NewElection(ctx context.Context, treeID int64) (util.MasterElection, error) {
+func (ef ElectionFactory) NewElection(ctx context.Context, treeID int64) (election.MasterElection, error) {
 	session, err := concurrency.NewSession(ef.client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd session: %v", err)

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"time"
+)
+
+// Sleep sleeps for at least the specified duration. Returns an error iff done
+// is closed before the timer fires.
+func Sleep(done <-chan struct{}, dur time.Duration) error {
+	timer := time.NewTimer(dur)
+	select {
+	case <-timer.C:
+	case <-done:
+		timer.Stop()
+		return context.Canceled
+	}
+	return nil
+}
+
+// SleepContext sleeps for at least the specified duration. Returns ctx.Err()
+// iff the context is canceled before the timer fires.
+func SleepContext(ctx context.Context, dur time.Duration) error {
+	if err := Sleep(ctx.Done(), dur); err != nil {
+		return ctx.Err()
+	}
+	return nil
+}


### PR DESCRIPTION
The ultimate goals of this PR are:
- Untangle master election code from log operation, make it more testable and maintainable.
- Enable other code to use election runner. One immediate client is CT's Migrillian tool.

Key changes in this PR:
- Move master election to a separate `util/election` package.
- Shorten in-package names, so for instance `ElectionFactory` becomes `election.Factory`.
- Introduce `election.Runner` which is responsible for maintaining and reporting mastership status via its output channel.
- Cover `Runner` with decent amount of tests, as opposed to the previous implementation.
- Introduce retries on `MasterElection.Start` call, otherwise election process for a log tree could never start if an error occurred.
- Allow `Runner` tolerate some `MasterElection.IsMaster` outage (up to `MasterTTL` long) so that a temporary `etcd` connection glitch wouldn't result in unnecessary resignation.