### PR TITLE
`gcloud container node-pools create` requires ${CLUSTER_NAME}

### DIFF
--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -27,6 +27,7 @@ fi
 # Connect to gcloud
 gcloud config set project "${PROJECT_NAME}"
 gcloud config set compute/zone "${ZONE}"
+gcloud config set container/cluster "${CLUSTER_NAME}"
 
 # Create cluster & node pools
 gcloud container clusters create "${CLUSTER_NAME}" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "2" --enable-autorepair --enable-autoupgrade


### PR DESCRIPTION
Either

As here, set `gcloud config container/cluster`

Or:

My preference (and true for `project` and `compute/zone`) is to set the flag explicitly on each gcloud use:

`gcloud container node-pools create ${NAME} --cluster=${CLUSTER_NAME} --project=${PROJECT_NAME} --zone=${ZONE}

Personal preference.