### PR TITLE
Move election code to a separate package

### DIFF
--- a/extension/registry.go
+++ b/extension/registry.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
 // Registry defines all extension points available in Trillian.
@@ -35,7 +35,7 @@ type Registry struct {
 	// MapStorage is the storage implementation to use for persisting maps.
 	storage.MapStorage
 	// ElectionFactory provides MasterElection instances for each tree.
-	util.ElectionFactory
+	ElectionFactory election.Factory
 	// QuotaManager provides rate limiting capabilities for Trillian.
 	QuotaManager quota.Manager
 	// MetricFactory provides metrics for monitoring.

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 	"github.com/google/trillian/util/etcd"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -99,11 +100,11 @@ func main() {
 
 	hostname, _ := os.Hostname()
 	instanceID := fmt.Sprintf("%s.%d", hostname, os.Getpid())
-	var electionFactory util.ElectionFactory
+	var electionFactory election.Factory
 	switch {
 	case *forceMaster:
 		glog.Warning("**** Acting as master for all logs ****")
-		electionFactory = util.NoopElectionFactory{InstanceID: instanceID}
+		electionFactory = election.NoopFactory{InstanceID: instanceID}
 	case client != nil:
 		electionFactory = etcd.NewElectionFactory(instanceID, client, *lockDir)
 	default:

--- a/util/election/election.go
+++ b/util/election/election.go
@@ -12,38 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+// Package election provides implementation of master election and tracking, as
+// well as interface for plugging in a custom underlying mechanism.
+package election
 
 import (
 	"context"
 	"errors"
 )
 
-// MasterElection provides operations for determining if a local instance is the current
-// master for a particular election.
+// MasterElection provides operations for determining if a local instance is
+// the current master for a particular election.
 type MasterElection interface {
-	// Start kicks off the process of mastership election.
+	// Start kicks off this instance's participation in master election.
 	Start(context.Context) error
-	// WaitForMastership blocks until the current instance is master for this election.
+	// WaitForMastership blocks until the current instance is the master.
 	WaitForMastership(context.Context) error
-	// IsMaster returns whether the current instance is master.
+	// IsMaster returns whether the current instance is the master.
 	IsMaster(context.Context) (bool, error)
-	// ResignAndRestart releases mastership, and re-joins the election.
-	ResignAndRestart(context.Context) error
-	// Close permanently stops the mastership election process.
+	// Resign releases mastership, and stops this instance from participating in
+	// the master election.
+	Resign(context.Context) error
+	// Close releases all the resources associated with this MasterElection.
 	Close(context.Context) error
-	// GetCurrentMaster returns the instance ID of the current elected master, if any.
-	// Implementations should allow election participants to specify their instance
-	// ID string, participants should ensure that it is unique to them.
-	// If there is currently no leader, ErrNoLeader will be returned.
+	// GetCurrentMaster returns the instance ID of the current elected master, if
+	// any. Implementations should allow election participants to specify their
+	// instance ID string, participants should ensure that it is unique to them.
+	// If there is currently no master, ErrNoMaster will be returned.
 	GetCurrentMaster(context.Context) (string, error)
 }
 
-// ErrNoLeader indicates that there is currently no leader elected.
-var ErrNoLeader = errors.New("no leader")
+// ErrNoMaster indicates that there is currently no master elected.
+var ErrNoMaster = errors.New("no master")
 
-// ElectionFactory encapsulates the creation of a MasterElection instance for a treeID.
-type ElectionFactory interface {
+// Factory encapsulates the creation of a MasterElection instance for a treeID.
+type Factory interface {
 	NewElection(ctx context.Context, treeID int64) (MasterElection, error)
 }
 
@@ -68,8 +71,8 @@ func (ne *NoopElection) IsMaster(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// ResignAndRestart releases mastership, and re-joins the election.
-func (ne *NoopElection) ResignAndRestart(ctx context.Context) error {
+// Resign releases mastership.
+func (ne *NoopElection) Resign(ctx context.Context) error {
 	return nil
 }
 
@@ -83,12 +86,12 @@ func (ne *NoopElection) GetCurrentMaster(ctx context.Context) (string, error) {
 	return ne.instanceID, nil
 }
 
-// NoopElectionFactory creates NoopElection instances.
-type NoopElectionFactory struct {
+// NoopFactory creates NoopElection instances.
+type NoopFactory struct {
 	InstanceID string
 }
 
 // NewElection creates a specific NoopElection instance.
-func (nf NoopElectionFactory) NewElection(ctx context.Context, treeID int64) (MasterElection, error) {
+func (nf NoopFactory) NewElection(ctx context.Context, treeID int64) (MasterElection, error) {
 	return &NoopElection{instanceID: nf.InstanceID, treeID: treeID}, nil
 }

--- a/util/election/tracker.go
+++ b/util/election/tracker.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package election
 
 import (
 	"fmt"

--- a/util/election/tracker_test.go
+++ b/util/election/tracker_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package election
 
 import (
 	"reflect"

--- a/util/etcd/election.go
+++ b/util/etcd/election.go
@@ -24,7 +24,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/golang/glog"
-	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
 // MasterElection is an implementation of util.MasterElection based on etcd.
@@ -56,14 +56,14 @@ func (eme *MasterElection) IsMaster(ctx context.Context) (bool, error) {
 	return string(leader.Kvs[0].Value) == eme.instanceID, nil
 }
 
-// ResignAndRestart releases mastership, and re-joins the election.
-func (eme *MasterElection) ResignAndRestart(ctx context.Context) error {
+// Resign releases mastership.
+func (eme *MasterElection) Resign(ctx context.Context) error {
 	return eme.election.Resign(ctx)
 }
 
 // Close terminates election operation.
 func (eme *MasterElection) Close(ctx context.Context) error {
-	_ = eme.ResignAndRestart(ctx)
+	_ = eme.Resign(ctx)
 	return eme.session.Close()
 }
 
@@ -72,7 +72,7 @@ func (eme *MasterElection) GetCurrentMaster(ctx context.Context) (string, error)
 	leader, err := eme.election.Leader(ctx)
 	switch {
 	case err == concurrency.ErrElectionNoLeader:
-		return "", util.ErrNoLeader
+		return "", election.ErrNoMaster
 	case err != nil:
 		return "", err
 	}
@@ -98,7 +98,7 @@ func NewElectionFactory(instanceID string, client *clientv3.Client, lockDir stri
 }
 
 // NewElection creates a specific etcd.MasterElection instance.
-func (ef ElectionFactory) NewElection(ctx context.Context, treeID int64) (util.MasterElection, error) {
+func (ef ElectionFactory) NewElection(ctx context.Context, treeID int64) (election.MasterElection, error) {
 	session, err := concurrency.NewSession(ef.client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd session: %v", err)

--- a/util/etcd/election_test.go
+++ b/util/etcd/election_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/google/trillian/testonly/integration/etcd"
-	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
 )
 
 func TestMasterElectionThroughCommonClient(t *testing.T) {
@@ -59,12 +59,12 @@ func TestMasterElectionThroughCommonClient(t *testing.T) {
 	}
 }
 
-func everyoneAgreesOnMaster(ctx context.Context, t *testing.T, want string, elections []util.MasterElection) {
+func everyoneAgreesOnMaster(ctx context.Context, t *testing.T, want string, elections []election.MasterElection) {
 	t.Helper()
 	for _, e := range elections {
 		for {
 			got, err := e.GetCurrentMaster(ctx)
-			if err == util.ErrNoLeader {
+			if err == election.ErrNoMaster {
 				t.Error("No leader...")
 				time.Sleep(time.Second)
 				continue
@@ -115,7 +115,7 @@ func TestGetCurrentMaster(t *testing.T) {
 		NewElectionFactory("ob2", ob2, pfx),
 	}
 
-	elections := make([]util.MasterElection, 0)
+	elections := make([]election.MasterElection, 0)
 	for _, f := range facts {
 		e, err := f.NewElection(ctx, 10)
 		if err != nil {
@@ -127,7 +127,7 @@ func TestGetCurrentMaster(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	for _, e := range elections[0:2] {
 		wg.Add(1)
-		go func(e util.MasterElection) {
+		go func(e election.MasterElection) {
 			if err := e.WaitForMastership(ctx); err != nil {
 				t.Errorf("WaitForMastership(10): %v", err)
 			}
@@ -162,7 +162,7 @@ func TestGetCurrentMasterReturnsNoLeader(t *testing.T) {
 		t.Errorf("Close(10): %v", err)
 	}
 	_, err = el.GetCurrentMaster(ctx)
-	if want := util.ErrNoLeader; err != want {
+	if want := election.ErrNoMaster; err != want {
 		t.Errorf("GetCurrentMaster()=%v, want %v", err, want)
 	}
 }


### PR DESCRIPTION
Additionally:
- rename `ErrNoLeader` to `ErrNoMaster` to be consistent (all the code uses "master" terminology)
- replace `ResignAndRestart` by `Resign` + `Start`

The reasons for changing `MasterElection` interface are:
- The `ResignAndRestart` method doesn't do what it says in `etcd` implementation, it only resigns.
- Having an option to just `Resign` without re-entering election is more flexible.
- The restarting bit is already covered by the `Start` method. I checked our internal implementation, we could easily pick up this change.

This PR is the first consumable bit of #1144.