### PR TITLE
Reduce image sizes using multi-stage builds

### DIFF
--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,34 +1,15 @@
-FROM golang:1.9
-
-ENV DB_FLAG="--mysql_uri=test:zaphod@tcp(mysql:3306)/test" \
-    DB_PROVIDER="mysql"
-
-ENV HOST=0.0.0.0 \
-    HTTP_PORT=8091
-
-ENV SEQUENCER_GUARD_WINDOW=0s \
-    FORCE_MASTER=true \
-    SEQUENCER_INTERVAL=300ms \
-    NUM_SEQ_FLAG=10 \
-    BATCH_SIZE=2000
-
+FROM golang:1.10 as build
 
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 RUN go get ./server/trillian_log_signer
 
-# Run the outyet command by default when the container starts.
-ENTRYPOINT /go/bin/trillian_log_signer \
-  ${DB_FLAG} \
-  --storage_system=${DB_PROVIDER} \
-  --http_endpoint="$HOST:$HTTP_PORT" \
-  --sequencer_guard_window="$SEQUENCER_GUARD_WINDOW" \
-  --sequencer_interval="$SEQUENCER_INTERVAL" \
-  --num_sequencers="$NUM_SEQ_FLAG" \
-  --batch_size="$BATCH_SIZE" \
-  --force_master="$FORCE_MASTER" \
-  --alsologtostderr
+FROM gcr.io/distroless/base
+
+LABEL maintainer="Trillian Team <email@address.com>"
+
+ENTRYPOINT ["/trillian_log_signer"]
 
 EXPOSE $HTTP_PORT
 


### PR DESCRIPTION
* Docker multi-stage builds helps reduce the image sizes from 1.2GB --> ~40MB
* Swapped `ENTRYPOINT` to the exec form which is preferred; it just runs the default (`/trillian_log_signer`)
* Deleted the arguments provided to `ENTRPOINT` as these appear (!) all provided during the Kubernetes deployment
* Thus deleted the ENV settings in the Dockerfile as redundant