### PR TITLE
Dockerfile: `ENTRYPOINT` --> Kubernetes: `args`

### DIFF
--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         cloud.google.com/gke-nodepool: logserver-pool
       containers:
       - name: trillian-logserver
-        command: ["/go/bin/trillian_log_server",
+        args: [
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
         "--quota_system=etcd",


### PR DESCRIPTION
I think it's more consistent|simpler to purely provide arguments to the container at this point.

The Dockerfile has an ENTRYPOINT that mandates our container will run `/trillian_log_server` so we only need +arguments