### PR TITLE
Dockerfile: `ENTRYPOINT` --> Kubernetes: `args`

### DIFF
--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         cloud.google.com/gke-nodepool: signer-pool
       restartPolicy: Always
       containers:
-      - command: ["/go/bin/trillian_log_signer",
+      - args: [
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
         "--etcd_servers=trillian-etcd-cluster-client:2379",


### PR DESCRIPTION
I think it's more consistent|simpler to purely provide arguments to the container at this point.

The Dockerfile has an ENTRYPOINT that mandates our container will run `/trillian_log_signer` so we only need +arguments