### PR TITLE
Use httpGet liveness probe

### DIFF
--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -43,11 +43,9 @@ spec:
           requests:
             cpu: "0.4"
         livenessProbe:
-          exec:
-            command:
-            - curl
-            - -f
-            - http://localhost:8091/healthz
+          httpGet:
+            path: /healthz
+            port: 8091
           failureThreshold: 3
           periodSeconds: 30
           timeoutSeconds: 5


### PR DESCRIPTION
Not only is this what was intended

But removing the `curl` dependency further simplifies the container image (no longer needs to include `curl`)