### PR TITLE
Proposed Google Container Builder file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,40 @@
+steps:
+- name: "gcr.io/cloud-builders/go"
+  args: [
+    "get",
+    "-t",
+#    "-u",
+    "-v",
+    "./..."
+  ]
+  env: ["PROJECT_ROOT=github.com/google/trillian"]
+- name: "gcr.io/cloud-builders/go"
+  args: [
+    "get",
+    "./server/trillian_log_server"
+  ]
+  env: ["PROJECT_ROOT=github.com/google/trillian"]
+- name: "gcr.io/cloud-builders/go"
+  args: [
+    "get",
+    "./server/trillian_log_signer"
+  ]
+  env: ["PROJECT_ROOT=github.com/google/trillian"]
+- name: "gcr.io/cloud-builders/docker"
+  args: [
+    "build",
+    "--file=examples/deployment/docker/log_server/Dockerfile",
+    "--tag=us.gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}",
+    "."
+  ]
+- name: "gcr.io/cloud-builders/docker"
+  args: [
+    "build",
+    "--file=examples/deployment/docker/log_signer/Dockerfile",
+    "--tag=us.gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}",
+    "."
+  ]
+images: [
+  "us.gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}",
+  "us.gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}"
+]


### PR DESCRIPTION
Using [Container Builder](https://cloud.google.com/container-builder/) would automate builds of container images (here `trillian_log_server`, `trillian_log_signer`) that could be triggered by commits to (e.g. `master`) on this repo.

Using Container Builder could extend the project's CI/CD and -- more importantly -- could facilitate adoption of Trillian with "known good" container images hosted in an authoritative Container Registry e.g. `gcr.io/trillian/log_server`