### PR TITLE
[LogOperation] Introduce and use cancelable Sleep

### DIFF
--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -335,11 +335,8 @@ func (te *testElection) WaitForMastership(ctx context.Context) error {
 		return nil
 	}
 	for {
-		time.Sleep(10 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			return errors.New("context canceled")
-		default:
+		if err := util.SleepContext(ctx, 10*time.Millisecond); err != nil {
+			return err
 		}
 	}
 }

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"time"
+)
+
+// Sleep sleeps for at least the specified duration. Returns false iff done is
+// closed before the timer fires.
+func Sleep(done <-chan struct{}, dur time.Duration) bool {
+	timer := time.NewTimer(dur)
+	select {
+	case <-timer.C:
+		return true
+	case <-done:
+		timer.Stop()
+		return false
+	}
+}
+
+// SleepContext sleeps for at least the specified duration. Returns ctx.Err()
+// iff the context is canceled before the timer fires.
+func SleepContext(ctx context.Context, dur time.Duration) error {
+	if !Sleep(ctx.Done(), dur) {
+		return ctx.Err()
+	}
+	return nil
+}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+var (
+	cases = []struct {
+		dur     time.Duration
+		timeout time.Duration
+		cancel  bool
+		wantErr error
+	}{
+		{dur: 0 * time.Second, timeout: time.Second},
+		{dur: 10 * time.Millisecond, timeout: 20 * time.Millisecond},
+		{dur: 20 * time.Millisecond, timeout: 10 * time.Millisecond, wantErr: context.DeadlineExceeded},
+		{dur: 1 * time.Millisecond, timeout: 0 * time.Second, wantErr: context.DeadlineExceeded},
+		{dur: 10 * time.Millisecond, timeout: 20 * time.Millisecond, cancel: true, wantErr: context.Canceled},
+	}
+)
+
+func TestSleep(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v:%v", tc.dur, tc.timeout), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			if tc.cancel {
+				cancel()
+			} else {
+				defer cancel()
+			}
+			if got, want := Sleep(ctx.Done(), tc.dur), (tc.wantErr == nil); got != want {
+				t.Errorf("Sleep() returned %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestSleepContext(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v:%v", tc.dur, tc.timeout), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			if tc.cancel {
+				cancel()
+			} else {
+				defer cancel()
+			}
+			if got, want := SleepContext(ctx, tc.dur), tc.wantErr; got != want {
+				t.Errorf("Sleep() returned %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -62,7 +62,7 @@ func TestSleepContext(t *testing.T) {
 				defer cancel()
 			}
 			if got, want := SleepContext(ctx, tc.dur), tc.wantErr; got != want {
-				t.Errorf("Sleep() returned %v, want %v", got, want)
+				t.Errorf("SleepContext() returned %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Cancelable `Sleep` reduces time needed for the server to shut down / clean up in cases when some canceled jobs are blocked on sleeping.