### PR TITLE
GetProofByHash: Don't include leaves that aren't in the requested TreeSize

### DIFF
--- a/trillian_log_api.proto
+++ b/trillian_log_api.proto
@@ -201,7 +201,6 @@ message GetInclusionProofByHashRequest {
 message GetInclusionProofByHashResponse {
     // Logs can potentially contain leaves with duplicate hashes so it's possible
     // for this to return multiple proofs.
-    // TODO(gbelvin) only return one proof.
     repeated Proof proof = 2;
     SignedLogRoot signed_log_root = 3;
 }


### PR DESCRIPTION
`GetProofByHash` should not return leaves that >= `req.TreeSize`. 
If no leaves have an index `< req.TreeSize`, `GetProofByHash` should return `codes.NotFound`. 

This was triggering an edge condition when a client:

* Got the current STHA
* Queued a leaf
* *The server then sequenced the leaf*
* Requested a ProofByHash for the leaf using the previous STHA

The resulting proof fails to verify against STHA because the leaf has an index >= STHA.TreeSize.

Fixes #1152 