### PR TITLE
Fix potential Timer leakage

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -23,11 +23,11 @@ import (
 // closed before the timer fires.
 func Sleep(done <-chan struct{}, dur time.Duration) bool {
 	timer := time.NewTimer(dur)
+	defer timer.Stop()
 	select {
 	case <-timer.C:
 		return true
 	case <-done:
-		timer.Stop()
 		return false
 	}
 }


### PR DESCRIPTION
`Timer`'s documentation seems ambiguous about how to properly clear resources. Presumably calling `Stop` unconditionally should be safe.