### PR TITLE
Factor out log operation executor

### DIFF
--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -483,7 +483,7 @@ func newExecutor(op LogOperation, info *LogOperationInfo, jobs int) *logOperatio
 	if jobs < 0 {
 		jobs = 0
 	}
-	return &logOperationExecutor{op: op, info: info, jobs: make(chan in64, jobs)}
+	return &logOperationExecutor{op: op, info: info, jobs: make(chan int64, jobs)}
 }
 
 // run sets off a collection of transient worker goroutines which process the

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -480,12 +480,10 @@ type logOperationExecutor struct {
 }
 
 func newExecutor(op LogOperation, info *LogOperationInfo, jobs int) *logOperationExecutor {
-	ex := &logOperationExecutor{op: op, info: info}
-	if jobs <= 0 {
-		ex.jobs = make(chan int64)
-	} else {
-		ex.jobs = make(chan int64, jobs)
+	if jobs < 0 {
+		jobs = 0
 	}
+	ex := &logOperationExecutor{op: op, info: info, jobs: make(chan in64, jobs)}
 	return ex
 }
 

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -389,7 +389,7 @@ func (l *LogOperationManager) getLogsAndExecutePass(ctx context.Context) error {
 	for _, logID := range logIDs {
 		ex.jobs <- logID
 	}
-	close(ex.jobs) // Cause executor's run terminate when drained the jobs.
+	close(ex.jobs) // Cause executor's run to terminate when it has drained the jobs.
 	ex.run(ctx)
 	return nil
 }
@@ -483,8 +483,7 @@ func newExecutor(op LogOperation, info *LogOperationInfo, jobs int) *logOperatio
 	if jobs < 0 {
 		jobs = 0
 	}
-	ex := &logOperationExecutor{op: op, info: info, jobs: make(chan in64, jobs)}
-	return ex
+	return &logOperationExecutor{op: op, info: info, jobs: make(chan in64, jobs)}
 }
 
 // run sets off a collection of transient worker goroutines which process the

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/glog"
@@ -379,72 +380,17 @@ func (l *LogOperationManager) getLogsAndExecutePass(ctx context.Context) error {
 		return fmt.Errorf("failed to determine log IDs we're master for: %v", err)
 	}
 	l.updateHeldIDs(ctx, logIDs, allIDs)
+	glog.V(1).Infof("Beginning run for %v active log(s)", len(logIDs))
 
-	numWorkers := l.info.NumWorkers
-	if numWorkers == 0 {
-		glog.Warning("Executing a LogOperation pass with numWorkers == 0, assuming 1")
-		numWorkers = 1
-	}
-	glog.V(1).Infof("Beginning run for %v active log(s) using %d workers", len(logIDs), numWorkers)
-
-	var mu sync.Mutex
-	successCount := 0
-	itemCount := 0
-
-	// Build a channel of the logIDs that need to be processed.
-	toProcess := make(chan int64, len(logIDs))
+	// TODO(pavelkalinnikov): Run executor once instead of doing it on each pass.
+	// This will be also needed when factoring out per-log operation loop.
+	ex := newExecutor(l.logOperation, &l.info, len(logIDs))
+	// Put logIDs that need to be processed to the executor's channel.
 	for _, logID := range logIDs {
-		toProcess <- logID
+		ex.jobs <- logID
 	}
-	close(toProcess)
-
-	// Set off a collection of transient worker goroutines to process the pending logIDs.
-	startBatch := l.info.TimeSource.Now()
-	var wg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				logID, more := <-toProcess
-				if !more {
-					return
-				}
-
-				label := strconv.FormatInt(logID, 10)
-				start := l.info.TimeSource.Now()
-				count, err := l.logOperation.ExecutePass(ctx, logID, &l.info)
-				if err != nil {
-					glog.Errorf("ExecutePass(%v) failed: %v", logID, err)
-					failedSigningRuns.Inc(label)
-					continue
-				}
-
-				// This indicates signing activity is proceeding on the logID.
-				signingRuns.Inc(label)
-				if count > 0 {
-					d := util.SecondsSince(l.info.TimeSource, start)
-					glog.Infof("%v: processed %d items in %.2f seconds (%.2f qps)", logID, count, d, float64(count)/d)
-					// This allows an operator to determine that the queue is empty
-					// for a particular log if signing runs are succeeding but nothing
-					// is being processed then this counter will stop increasing.
-					entriesAdded.Add(float64(count), label)
-				} else {
-					glog.V(1).Infof("%v: no items to process", logID)
-				}
-				mu.Lock()
-				successCount++
-				itemCount += count
-				mu.Unlock()
-			}
-		}()
-	}
-
-	// Wait for the workers to consume all of the logIDs
-	wg.Wait()
-	d := util.SecondsSince(l.info.TimeSource, startBatch)
-	glog.Infof("Group run completed in %.2f seconds: %v succeeded, %v failed, %v items processed", d, successCount, len(logIDs)-successCount, itemCount)
-
+	close(ex.jobs) // Cause executor's run terminate when drained the jobs.
+	ex.run(ctx)
 	return nil
 }
 
@@ -518,4 +464,87 @@ loop:
 	glog.Infof("wait for termination of election runners...")
 	l.runnerWG.Wait()
 	glog.Infof("wait for termination of election runners...done")
+}
+
+// logOperationExecutor runs the specified LogOperation on the submitted logs
+// in a set of parallel workers.
+type logOperationExecutor struct {
+	op   LogOperation
+	info *LogOperationInfo
+
+	// jobs holds logIDs to run log operation on.
+	// TODO(pavelkalinnikov): Use mastership context for each job to make them
+	// auto-cancelable when mastership is lost.
+	// TODO(pavelkalinnikov): Report job completion status back.
+	jobs chan int64
+}
+
+func newExecutor(op LogOperation, info *LogOperationInfo, jobs int) *logOperationExecutor {
+	ex := &logOperationExecutor{op: op, info: info}
+	if jobs <= 0 {
+		ex.jobs = make(chan int64)
+	} else {
+		ex.jobs = make(chan int64, jobs)
+	}
+	return ex
+}
+
+// run sets off a collection of transient worker goroutines which process the
+// pending log operation jobs until the jobs channel is closed.
+func (e *logOperationExecutor) run(ctx context.Context) {
+	startBatch := e.info.TimeSource.Now()
+
+	numWorkers := e.info.NumWorkers
+	if numWorkers <= 0 {
+		glog.Warning("Running executor with NumWorkers <= 0, assuming 1")
+		numWorkers = 1
+	}
+	glog.V(1).Infof("Running executor with %d worker(s)", numWorkers)
+
+	var wg sync.WaitGroup
+	var successCount, failCount, itemCount int64
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				logID, ok := <-e.jobs
+				if !ok {
+					return
+				}
+
+				label := strconv.FormatInt(logID, 10)
+				start := e.info.TimeSource.Now()
+				count, err := e.op.ExecutePass(ctx, logID, e.info)
+				if err != nil {
+					glog.Errorf("ExecutePass(%v) failed: %v", logID, err)
+					failedSigningRuns.Inc(label)
+					atomic.AddInt64(&failCount, 1)
+					continue
+				}
+
+				// This indicates signing activity is proceeding on the logID.
+				signingRuns.Inc(label)
+				if count > 0 {
+					d := util.SecondsSince(e.info.TimeSource, start)
+					glog.Infof("%v: processed %d items in %.2f seconds (%.2f qps)", logID, count, d, float64(count)/d)
+					// This allows an operator to determine that the queue is empty for a
+					// particular log if signing runs are succeeding but nothing is being
+					// processed then this counter will stop increasing.
+					entriesAdded.Add(float64(count), label)
+				} else {
+					glog.V(1).Infof("%v: no items to process", logID)
+				}
+
+				atomic.AddInt64(&successCount, 1)
+				atomic.AddInt64(&itemCount, int64(count))
+			}
+		}()
+	}
+
+	// Wait for the workers to consume all of the logIDs.
+	wg.Wait()
+	d := util.SecondsSince(e.info.TimeSource, startBatch)
+	glog.Infof("Group run completed in %.2f seconds: %v succeeded, %v failed, %v items processed", d, successCount, failCount, itemCount)
 }


### PR DESCRIPTION
This PR introduces a log operation executor. Currently, it is used as a subroutine processing **all** logs in a single signing run, but later it could be modified to run continuously (as long as `LogOperationManager` is active).

The continuous approach makes sense because:
- no need to spin up worker goroutines on each run
- fits nicely in the TODOed design where we have individual log operation loops instead of the current all-logs-together loop