### PR TITLE
Explicitly glog.Flush() in all binaries

### DIFF
--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -155,6 +155,7 @@ func newRequest() (*trillian.CreateTreeRequest, error) {
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	if *configFile != "" {
 		if err := cmd.ParseFlagFile(*configFile); err != nil {

--- a/cmd/deletetree/main.go
+++ b/cmd/deletetree/main.go
@@ -35,6 +35,7 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	conn, err := grpc.Dial(*adminServerAddr, grpc.WithInsecure())
 	if err != nil {

--- a/cmd/updatetree/main.go
+++ b/cmd/updatetree/main.go
@@ -96,6 +96,7 @@ func updateTree(ctx context.Context) (*trillian.Tree, error) {
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	ctx, cancel := context.WithTimeout(context.Background(), *rpcDeadline)
 	defer cancel()

--- a/docs/storage/commit_log/main.go
+++ b/docs/storage/commit_log/main.go
@@ -88,6 +88,8 @@ func (ab *lockedBool) Set(v bool) {
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
+
 	epochMillis := time.Now().UnixNano() / int64(time.Millisecond)
 
 	// Add leaves forever

--- a/examples/vmap/trillian_map_client/main.go
+++ b/examples/vmap/trillian_map_client/main.go
@@ -29,6 +29,7 @@ var server = flag.String("server", "localhost:8091", "Server address:port")
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	conn, err := grpc.Dial(*server, grpc.WithInsecure())
 	if err != nil {

--- a/monitoring/prometheus/etcdiscover/main.go
+++ b/monitoring/prometheus/etcdiscover/main.go
@@ -190,6 +190,8 @@ func (s *serviceInstanceInfo) watchService(service string) {
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
+
 	if *etcdServers == "" {
 		glog.Exitf("No etcd servers configured with --etcd_servers")
 	}

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -73,6 +73,7 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	if *configFile != "" {
 		if err := cmd.ParseFlagFile(*configFile); err != nil {

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -71,6 +71,7 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	if *configFile != "" {
 		if err := cmd.ParseFlagFile(*configFile); err != nil {
@@ -159,7 +160,6 @@ func main() {
 
 	// Give things a few seconds to tidy up
 	glog.Infof("Stopping server, about to exit")
-	glog.Flush()
 	time.Sleep(time.Second * 5)
 }
 

--- a/storage/tools/dump_tree/main.go
+++ b/storage/tools/dump_tree/main.go
@@ -40,6 +40,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian/storage/tools/dump_tree/dumplib"
 )
 
@@ -59,6 +60,7 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	fmt.Print(dumplib.Main(dumplib.Options{
 		TreeSize:       *treeSizeFlag,

--- a/storage/tools/hasher/main.go
+++ b/storage/tools/hasher/main.go
@@ -63,6 +63,7 @@ func decodeArgs(args []string) [][]byte {
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	hasher := createHasher()
 	decoded := decodeArgs(flag.Args())

--- a/storage/tools/log_client/main.go
+++ b/storage/tools/log_client/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"google.golang.org/grpc"
 )
@@ -50,6 +51,7 @@ func buildGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *tril
 // It's just a basic skeleton at the moment.
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 
 	ctx := context.Background()
 

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -62,6 +62,8 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
+
 	if *mapIDs == "" {
 		glog.Exit("Test aborted as no map IDs provided (via --map_ids)")
 	}

--- a/testonly/hammer/mapreplay/main.go
+++ b/testonly/hammer/mapreplay/main.go
@@ -37,6 +37,7 @@ var (
 
 func main() {
 	flag.Parse()
+	defer glog.Flush()
 	ctx := context.Background()
 
 	if *replayFrom == "" {

--- a/util/process.go
+++ b/util/process.go
@@ -56,7 +56,6 @@ func AwaitSignal(doneFn func()) {
 	// Now block main and wait for a signal
 	sig := <-sigs
 	glog.Warningf("Signal received: %v", sig)
-	glog.Flush()
 
 	doneFn()
 }


### PR DESCRIPTION
From `glog` [documentation](https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L35): 
```
// Log output is buffered and written periodically using Flush. Programs
// should call Flush before exiting to guarantee all log output is written.
```