### PR TITLE
Remove all references to obselete ENV vars from Dockerfiles

### DIFF
--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -12,9 +12,3 @@ LABEL maintainer="Trillian Team <email@address.com>"
 COPY --from=build /go/bin/trillian_log_server /
 
 ENTRYPOINT ["/trillian_log_server"]
-
-EXPOSE $RPC_PORT
-EXPOSE $HTTP_PORT
-
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -12,8 +12,3 @@ LABEL maintainer="Trillian Team <email@address.com>"
 COPY --from=build /go/bin/trillian_log_signer /
 
 ENTRYPOINT ["/trillian_log_signer"]
-
-EXPOSE $HTTP_PORT
-
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1


### PR DESCRIPTION
These vars no longer exist as of #1154 so pushes to CI have been failing since then.

`EXPOSE` is really just documentation, it doesn't do anything, and `HEALTHCHECK`s are done by kubernetes in the deployment config.