### PR TITLE
GetLeavesByRange / GetLeavesByIndex return GRPC status codes for out of range requests

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -668,23 +668,23 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 	}
 
 	if got, want := len(ret), len(leaves); got != want {
-		return nil, fmt.Errorf("len(ret): %d, want %d", got, want)
+		return nil, status.Errorf(codes.Internal, "len(ret): %d, want %d", got, want)
 	}
 	return ret, nil
 }
 
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	if count <= 0 {
-		return nil, status.Errorf(codes.OutOfRange, "invalid count %d, want > 0", count)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid count %d, want > 0", count)
 	}
 	if start < 0 {
-		return nil, status.Errorf(codes.OutOfRange, "invalid start %d, want >= 0", start)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid start %d, want >= 0", start)
 	}
 
 	if t.treeType == trillian.TreeType_LOG {
 		treeSize := int64(t.root.TreeSize)
 		if treeSize <= 0 {
-			return nil, fmt.Errorf("empty tree")
+			return nil, status.Errorf(codes.OutOfRange, "empty tree")
 		} else if start >= treeSize {
 			return nil, status.Errorf(codes.OutOfRange, "invalid start %d, want < TreeSize(%d)", start, treeSize)
 		}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -612,10 +612,6 @@ func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
 func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
 	if t.treeType == trillian.TreeType_LOG {
 		treeSize := int64(t.root.TreeSize)
-		if treeSize <= 0 {
-			return nil, status.Errorf(codes.FailedPrecondition, "empty tree")
-		}
-
 		for _, leaf := range leaves {
 			if leaf < 0 {
 				return nil, status.Errorf(codes.InvalidArgument, "index %d is < 0", leaf)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -610,6 +610,21 @@ func (t *logTreeTX) GetSequencedLeafCount(ctx context.Context) (int64, error) {
 }
 
 func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*trillian.LogLeaf, error) {
+	if t.treeType == trillian.TreeType_LOG {
+		treeSize := int64(t.root.TreeSize)
+		if treeSize <= 0 {
+			return nil, status.Errorf(codes.FailedPrecondition, "empty tree")
+		}
+
+		for _, leaf := range leaves {
+			if leaf < 0 {
+				return nil, status.Errorf(codes.InvalidArgument, "index %d is < 0", leaf)
+			}
+			if leaf >= treeSize {
+				return nil, status.Errorf(codes.OutOfRange, "invalid leaf index %d, want < TreeSize(%d)", leaf, treeSize)
+			}
+		}
+	}
 	tmpl, err := t.ls.getLeavesByIndexStmt(ctx, len(leaves))
 	if err != nil {
 		return nil, err
@@ -664,10 +679,10 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	if count <= 0 {
-		return nil, fmt.Errorf("invalid count %d, want > 0", count)
+		return nil, status.Errorf(codes.OutOfRange, "invalid count %d, want > 0", count)
 	}
 	if start < 0 {
-		return nil, fmt.Errorf("invalid start %d, want >= 0", start)
+		return nil, status.Errorf(codes.OutOfRange, "invalid start %d, want >= 0", start)
 	}
 
 	if t.treeType == trillian.TreeType_LOG {
@@ -675,7 +690,7 @@ func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([
 		if treeSize <= 0 {
 			return nil, fmt.Errorf("empty tree")
 		} else if start >= treeSize {
-			return nil, fmt.Errorf("invalid start %d, want < TreeSize(%d)", start, treeSize)
+			return nil, status.Errorf(codes.OutOfRange, "invalid start %d, want < TreeSize(%d)", start, treeSize)
 		}
 		// Ensure no entries queried/returned beyond the tree.
 		if maxCount := treeSize - start; count > maxCount {

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -886,6 +886,13 @@ func TestGetLeavesByIndex(t *testing.T) {
 			},
 		},
 		{
+			desc:    "InTreeMultipleReverse",
+			indices: []int64{sequenceNumber, sequenceNumber - 1},
+			checkFn: func(leaves []*trillian.LogLeaf, t *testing.T) {
+				checkLeafContents(leaves[0], sequenceNumber, dummyRawHash, dummyHash, data, someExtraData, t)
+				checkLeafContents(leaves[1], sequenceNumber, dummyRawHash2, dummyHash2, data2, someExtraData2, t)
+			},
+		}, {
 			desc:     "OutsideTree",
 			indices:  []int64{sequenceNumber + 1},
 			wantErr:  true,
@@ -914,14 +921,14 @@ func TestGetLeavesByIndex(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
-				leaves, err := tx.GetLeavesByIndex(ctx, test.indices)
+				got, err := tx.GetLeavesByIndex(ctx, test.indices)
 				if test.wantErr {
 					if err == nil || status.Code(err) != test.wantCode {
-						t.Errorf("got: %v, %v, want: nil, err with code %v", leaves, err, test.wantCode)
+						t.Errorf("GetLeavesByIndex(%v)=%v,%v; want: nil, err with code %v", test.indices, got, err, test.wantCode)
 					}
 				} else {
 					if err != nil {
-						t.Errorf("got: %v, %v, want: leaves, nil", leaves, err)
+						t.Errorf("GetLeavesByIndex(%v)=%v,%v; want: got, nil", test.indices, got, err)
 					}
 				}
 				return nil

--- a/storage/types.go
+++ b/storage/types.go
@@ -25,19 +25,6 @@ import (
 	"github.com/google/trillian/storage/storagepb"
 )
 
-// Error is a typed error that the storage layer can return to give callers information
-// about the error to decide how to handle it.
-type Error struct {
-	ErrType int
-	Detail  string
-	Cause   error
-}
-
-// Error formats the internal details of an Error including the original cause.
-func (s Error) Error() string {
-	return fmt.Sprintf("Storage: %d: %s: %v", s.ErrType, s.Detail, s.Cause)
-}
-
 // Node represents a single node in a Merkle tree.
 type Node struct {
 	NodeID       NodeID


### PR DESCRIPTION
For GetLeavesByRange / GetLeavesByIndex return GRPC status codes for out of range values. Makes the mysql code more consistent with CloudSpanner and CTFE will map to a 4xx status.

Remove the storage level detailed error at the same time. This was never used and we seem to have standardized on GRPC status.

Convert the GetLeavesByIndex tests to a table and add a few extra ones.

Fixes #1162.