### PR TITLE
[For discussion] Factor out election.Runner

### DIFF
--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -133,7 +133,6 @@ func (r *resignation) execute(ctx context.Context) {
 
 func (er *electionRunner) Run(ctx context.Context, pending chan<- resignation) {
 	defer er.wg.Done()
-	label := strconv.FormatInt(er.logID, 10)
 
 	// Pause for a random interval so that if multiple instances start at the same
 	// time there is less of a thundering herd.
@@ -180,7 +179,6 @@ func (er *electionRunner) Run(ctx context.Context, pending chan<- resignation) {
 			}
 			if er.shouldResign(masterSince) {
 				glog.Infof("%d: queue up resignation of mastership", er.logID)
-				resignations.Inc(label)
 				er.tracker.Set(er.logID, false)
 
 				done := make(chan bool)
@@ -435,6 +433,7 @@ loop:
 		for !doneResigning {
 			select {
 			case r := <-l.pendingResignations:
+				resignations.Inc(strconv.FormatInt(r.er.logID, 10))
 				r.execute(ctx)
 			default:
 				doneResigning = true

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -384,7 +384,7 @@ func TestElectionRunnerRun(t *testing.T) {
 			fakeTimeSource := util.NewFakeTimeSource(startTime)
 
 			el := test.election
-			tracker := election.NewMasterTracker([]int64{logID})
+			tracker := election.NewMasterTracker([]int64{logID}, nil)
 			er := electionRunner{
 				logID:    logID,
 				info:     &info,

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -148,15 +148,18 @@ func main() {
 	log.QuotaIncreaseFactor = *quotaIncreaseFactor
 	sequencerManager := server.NewSequencerManager(registry, *sequencerGuardWindowFlag)
 	info := server.LogOperationInfo{
-		Registry:            registry,
-		BatchSize:           *batchSizeFlag,
-		NumWorkers:          *numSeqFlag,
-		RunInterval:         *sequencerIntervalFlag,
-		TimeSource:          util.SystemTimeSource{},
-		PreElectionPause:    *preElectionPause,
-		MasterCheckInterval: *masterCheckInterval,
-		MasterHoldInterval:  *masterHoldInterval,
-		ResignOdds:          *resignOdds,
+		Registry:    registry,
+		BatchSize:   *batchSizeFlag,
+		NumWorkers:  *numSeqFlag,
+		RunInterval: *sequencerIntervalFlag,
+		TimeSource:  util.SystemTimeSource{},
+		ElectionConfig: election.RunnerConfig{
+			PreElectionPause:    *preElectionPause,
+			MasterCheckInterval: *masterCheckInterval,
+			MasterHoldInterval:  *masterHoldInterval,
+			ResignOdds:          *resignOdds,
+			TimeSource:          util.SystemTimeSource{},
+		},
 	}
 	sequencerTask := server.NewLogOperationManager(info, sequencerManager)
 	sequencerTask.OperationLoop(ctx)

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -1,0 +1,187 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/util"
+)
+
+// Minimum values for configuration intervals.
+const (
+	MinPreElectionPause    = 10 * time.Millisecond
+	MinMasterCheckInterval = 50 * time.Millisecond
+	MinMasterHoldInterval  = 10 * time.Second
+)
+
+// RunnerConfig describes the parameters for an election Runner.
+type RunnerConfig struct {
+	// PreElectionPause is the maximum interval to wait before starting a
+	// mastership election for a particular log.
+	PreElectionPause time.Duration
+	// MasterCheckInterval is the interval between checks that we still
+	// hold mastership for a log.
+	MasterCheckInterval time.Duration
+	// MasterHoldInterval is the minimum interval to hold mastership for.
+	MasterHoldInterval time.Duration
+	// ResignOdds gives the chance of resigning mastership after each
+	// check interval, as the N for 1-in-N.
+	ResignOdds int
+
+	TimeSource util.TimeSource
+}
+
+// fixupRunnerConfig ensures operation parameters have required minimum values.
+func fixupRunnerConfig(cfg *RunnerConfig) {
+	if cfg.PreElectionPause < MinPreElectionPause {
+		cfg.PreElectionPause = MinPreElectionPause
+	}
+	if cfg.MasterCheckInterval < MinMasterCheckInterval {
+		cfg.MasterCheckInterval = MinMasterCheckInterval
+	}
+	if cfg.MasterHoldInterval < MinMasterHoldInterval {
+		cfg.MasterHoldInterval = MinMasterHoldInterval
+	}
+	if cfg.ResignOdds < 1 {
+		cfg.ResignOdds = 1
+	}
+	if cfg.TimeSource == nil {
+		cfg.TimeSource = util.SystemTimeSource{}
+	}
+}
+
+// Runner controls a continuous election process.
+type Runner struct {
+	// Allow the user to store a Cancel function with the runner for convenience.
+	Cancel   context.CancelFunc
+	id       int64
+	cfg      *RunnerConfig
+	tracker  *MasterTracker
+	election MasterElection
+}
+
+// NewRunner builds a new election Runner instance with the given configuration.  On calling
+// Run(), the provided election will be continuously monitored and mastership changes will
+// be notified to the provided MasterTracker instance.
+func NewRunner(id int64, cfg *RunnerConfig, tracker *MasterTracker, cancel context.CancelFunc, el MasterElection) *Runner {
+	fixupRunnerConfig(cfg)
+	return &Runner{
+		Cancel:   cancel,
+		id:       id,
+		cfg:      cfg,
+		tracker:  tracker,
+		election: el,
+	}
+}
+
+// Run performs a continuous election process. It runs continuously until the
+// context is canceled or an internal error is encountered.
+func (er *Runner) Run(ctx context.Context, pending chan<- Resignation) {
+	// Pause for a random interval so that if multiple instances start at the same
+	// time there is less of a thundering herd.
+	pause := rand.Int63n(er.cfg.PreElectionPause.Nanoseconds())
+	if err := util.SleepContext(ctx, time.Duration(pause)); err != nil {
+		return
+	}
+
+	glog.V(1).Infof("%d: start election-monitoring loop ", er.id)
+	if err := er.election.Start(ctx); err != nil {
+		glog.Errorf("%d: election.Start() failed: %v", er.id, err)
+		return
+	}
+	defer func(ctx context.Context, er *Runner) {
+		glog.Infof("%d: shutdown election-monitoring loop", er.id)
+		er.election.Close(ctx)
+	}(ctx, er)
+
+	for {
+		glog.V(1).Infof("%d: When I left you, I was but the learner", er.id)
+		if err := er.election.WaitForMastership(ctx); err != nil {
+			glog.Errorf("%d: er.election.WaitForMastership() failed: %v", er.id, err)
+			return
+		}
+		glog.V(1).Infof("%d: Now, I am the master", er.id)
+		er.tracker.Set(er.id, true)
+		masterSince := er.cfg.TimeSource.Now()
+
+		// While-master loop
+		for {
+			if err := util.SleepContext(ctx, er.cfg.MasterCheckInterval); err != nil {
+				glog.Infof("%d: termination requested", er.id)
+				return
+			}
+			master, err := er.election.IsMaster(ctx)
+			if err != nil {
+				glog.Errorf("%d: failed to check mastership status", er.id)
+				break
+			}
+			if !master {
+				glog.Errorf("%d: no longer the master!", er.id)
+				er.tracker.Set(er.id, false)
+				break
+			}
+			if er.ShouldResign(masterSince) {
+				glog.Infof("%d: queue up resignation of mastership", er.id)
+				er.tracker.Set(er.id, false)
+
+				done := make(chan bool)
+				r := Resignation{ID: er.id, er: er, done: done}
+				pending <- r
+				<-done // block until acted on
+				break  // no longer master
+			}
+		}
+	}
+}
+
+// ShouldResign randomly decides whether this runner should resign mastership.
+func (er *Runner) ShouldResign(masterSince time.Time) bool {
+	now := er.cfg.TimeSource.Now()
+	duration := now.Sub(masterSince)
+	if duration < er.cfg.MasterHoldInterval {
+		// Always hold onto mastership for a minimum interval to prevent churn.
+		return false
+	}
+	// Roll the bones.
+	odds := er.cfg.ResignOdds
+	if odds <= 0 {
+		return true
+	}
+	return rand.Intn(er.cfg.ResignOdds) == 0
+}
+
+// Resignation indicates that a master should explicitly resign mastership, by invoking
+// the Execute() method at a point where no master-related activity is ongoing.
+type Resignation struct {
+	ID   int64
+	er   *Runner
+	done chan<- bool
+}
+
+// Execute performs the pending deliberate resignation for an election runner.
+func (r *Resignation) Execute(ctx context.Context) {
+	glog.Infof("%d: deliberately resigning mastership", r.er.id)
+	if err := r.er.election.Resign(ctx); err != nil {
+		glog.Errorf("%d: failed to resign mastership: %v", r.er.id, err)
+	}
+	if err := r.er.election.Start(ctx); err != nil {
+		glog.Errorf("%d: failed to restart election: %v", r.er.id, err)
+	}
+	r.done <- true
+}

--- a/util/election/runner_test.go
+++ b/util/election/runner_test.go
@@ -1,0 +1,173 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/trillian/util"
+	"github.com/google/trillian/util/election"
+	"github.com/google/trillian/util/election/stub"
+)
+
+func TestShouldResign(t *testing.T) {
+	startTime := time.Date(1970, 9, 19, 12, 00, 00, 00, time.UTC)
+	var tests = []struct {
+		hold     time.Duration
+		odds     int
+		wantHold time.Duration
+		wantProb float64
+	}{
+		{hold: 12 * time.Second, odds: 10, wantHold: 12 * time.Second, wantProb: 0.1},
+		{hold: time.Second, odds: 10, wantHold: 10 * time.Second, wantProb: 0.1},
+		{hold: 10 * time.Second, odds: 0, wantHold: 10 * time.Second, wantProb: 1.0},
+		{hold: 10 * time.Second, odds: 1, wantHold: 10 * time.Second, wantProb: 1.0},
+		{hold: 10 * time.Second, odds: -1, wantHold: 10 * time.Second, wantProb: 1.0},
+	}
+	for _, test := range tests {
+		fakeTimeSource := util.FakeTimeSource{}
+		cfg := election.RunnerConfig{
+			MasterHoldInterval: test.hold,
+			ResignOdds:         test.odds,
+			TimeSource:         &fakeTimeSource,
+		}
+		er := election.NewRunner(6962, &cfg, nil, nil, nil)
+
+		holdChecks := int64(10)
+		holdNanos := test.wantHold.Nanoseconds() / holdChecks
+	timeslot:
+		for i := int64(-1); i < holdChecks; i++ {
+			gapNanos := time.Duration(i * holdNanos)
+			fakeTimeSource.Set(startTime.Add(gapNanos))
+			for j := 0; j < 100; j++ {
+				if er.ShouldResign(startTime) {
+					t.Errorf("shouldResign(hold=%v,odds=%v @ start+%v)=true; want false", test.hold, test.odds, gapNanos)
+					continue timeslot
+				}
+			}
+		}
+
+		fakeTimeSource.Set(startTime.Add(test.wantHold).Add(time.Nanosecond))
+		iterations := 10000
+		count := 0
+		for i := 0; i < iterations; i++ {
+			if er.ShouldResign(startTime) {
+				count++
+			}
+		}
+		got := float64(count) / float64(iterations)
+		deltaFraction := math.Abs(got-test.wantProb) / test.wantProb
+		if deltaFraction > 0.05 {
+			t.Errorf("P(shouldResign(hold=%v,odds=%v))=%f; want ~%f", test.hold, test.odds, got, test.wantProb)
+		}
+	}
+}
+
+// TODO(pavelkalinnikov): Reduce flakiness risk in this test by making fewer
+// time assumptions.
+func TestElectionRunnerRun(t *testing.T) {
+	fakeTimeSource := util.NewFakeTimeSource(time.Date(2016, 6, 28, 13, 40, 12, 45, time.UTC))
+	cfg := election.RunnerConfig{TimeSource: fakeTimeSource}
+	var tests = []struct {
+		desc       string
+		election   *stub.MasterElection
+		lostMaster bool
+		wantMaster bool
+	}{
+		// Basic cases
+		{
+			desc:     "IsNotMaster",
+			election: stub.NewMasterElection(false, nil),
+		},
+		{
+			desc:       "IsMaster",
+			election:   stub.NewMasterElection(true, nil),
+			wantMaster: true,
+		},
+		{
+			desc:       "LostMaster",
+			election:   stub.NewMasterElection(true, nil),
+			lostMaster: true,
+			wantMaster: false,
+		},
+		// Error cases
+		{
+			desc: "ErrorOnStart",
+			election: stub.NewMasterElection(false,
+				&stub.Errors{Start: errors.New("on start")}),
+		},
+		{
+			desc: "ErrorOnWait",
+			election: stub.NewMasterElection(false,
+				&stub.Errors{Wait: errors.New("on wait")}),
+		},
+		{
+			desc: "ErrorOnIsMaster",
+			election: stub.NewMasterElection(true,
+				&stub.Errors{IsMaster: errors.New("on IsMaster")}),
+			wantMaster: true,
+		},
+		{
+			desc: "ErrorOnResign",
+			election: stub.NewMasterElection(true,
+				&stub.Errors{Resign: errors.New("resignation failure")}),
+			wantMaster: true,
+		},
+	}
+	const logID = int64(6962)
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var wg sync.WaitGroup
+			ctx, cancel := context.WithCancel(context.Background())
+
+			startTime := time.Now()
+			fakeTimeSource := util.NewFakeTimeSource(startTime)
+
+			el := test.election
+			tracker := election.NewMasterTracker([]int64{logID}, nil)
+			er := election.NewRunner(logID, &cfg, tracker, nil, el)
+			resignations := make(chan election.Resignation, 100)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				er.Run(ctx, resignations)
+			}()
+			time.Sleep((3 * election.MinPreElectionPause) / 2)
+			if test.lostMaster {
+				el.Update(false, nil)
+			}
+
+			// Advance fake time so that shouldResign() triggers too.
+			fakeTimeSource.Set(startTime.Add(24 * 60 * time.Hour))
+			time.Sleep(election.MinMasterCheckInterval)
+			for len(resignations) > 0 {
+				r := <-resignations
+				r.Execute(ctx)
+			}
+
+			cancel()
+			wg.Wait()
+			held := tracker.Held()
+			if got := (len(held) > 0 && held[0] == logID); got != test.wantMaster {
+				t.Errorf("held=%v => master=%v; want %v", held, got, test.wantMaster)
+			}
+		})
+	}
+}

--- a/util/election/tracker.go
+++ b/util/election/tracker.go
@@ -28,16 +28,17 @@ type MasterTracker struct {
 	mu          sync.RWMutex
 	masterFor   map[int64]bool
 	masterCount int
+	notify      func(id int64, isMaster bool)
 }
 
 // NewMasterTracker creates a new MasterTracker instance to track the mastership
 // status for the given set of ids.
-func NewMasterTracker(ids []int64) *MasterTracker {
+func NewMasterTracker(ids []int64, notify func(id int64, isMaster bool)) *MasterTracker {
 	mf := make(map[int64]bool)
 	for _, id := range ids {
 		mf[id] = false
 	}
-	return &MasterTracker{masterFor: mf}
+	return &MasterTracker{masterFor: mf, notify: notify}
 }
 
 // Set changes the tracked mastership status for the given id.  This method should
@@ -54,6 +55,9 @@ func (mt *MasterTracker) Set(id int64, val bool) {
 		mt.masterCount++
 	} else if !val && existing {
 		mt.masterCount--
+	}
+	if mt.notify != nil {
+		mt.notify(id, val)
 	}
 }
 

--- a/util/election/tracker_test.go
+++ b/util/election/tracker_test.go
@@ -92,7 +92,7 @@ func TestMasterTracker(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mt := NewMasterTracker(test.ids)
+		mt := NewMasterTracker(test.ids, nil)
 		for _, op := range test.ops {
 			mt.Set(op.id, op.val)
 		}


### PR DESCRIPTION
This just attempts to pull out the `electionRunner` code from `LogOperationManager`, as far as possible without making any other changes to it.

Changes that were necessary:
 - add a notification callback to `MasterTracker` for triggering metric updates
 - move resignation metric tracking to point of resignation
 - add an exposed `ID` field in the `resignation` struct.