### PR TITLE
quota: drop inert GetUser() interface method 

### DIFF
--- a/quota/cacheqm/cache.go
+++ b/quota/cacheqm/cache.go
@@ -77,10 +77,6 @@ func NewCachedManager(qm quota.Manager, minBatchSize, maxEntries int) (quota.Man
 	}, nil
 }
 
-func (m *manager) GetUser(ctx context.Context, req interface{}) string {
-	return m.qm.GetUser(ctx, req)
-}
-
 func (m *manager) PeekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
 	return m.qm.PeekTokens(ctx, specs)
 }

--- a/quota/cacheqm/cache_test.go
+++ b/quota/cacheqm/cache_test.go
@@ -55,25 +55,6 @@ func TestNewCachedManagerErrors(t *testing.T) {
 	}
 }
 
-func TestCachedManager_GetUser(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := context.Background()
-	want := "llama"
-	mock := quota.NewMockManager(ctrl)
-	mock.EXPECT().GetUser(ctx, nil).Return(want)
-
-	qm, err := NewCachedManager(mock, minBatchSize, maxEntries)
-	if err != nil {
-		t.Fatalf("NewCachedManager() returned err = %v", err)
-	}
-
-	if got := qm.GetUser(ctx, nil /* req */); got != want {
-		t.Errorf("GetUser() = %v, want = %v", got, want)
-	}
-}
-
 func TestCachedManager_PeekTokens(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/quota/etcd/etcdqm/etcdqm.go
+++ b/quota/etcd/etcdqm/etcdqm.go
@@ -33,10 +33,6 @@ func New(client *clientv3.Client) quota.Manager {
 	return &manager{qs: &storage.QuotaStorage{Client: client}}
 }
 
-func (m *manager) GetUser(ctx context.Context, req interface{}) string {
-	return "" // Unused
-}
-
 func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
 	return m.qs.Get(ctx, configNames(specs), int64(numTokens))
 }

--- a/quota/etcd/etcdqm/etcdqm.go
+++ b/quota/etcd/etcdqm/etcdqm.go
@@ -34,7 +34,7 @@ func New(client *clientv3.Client) quota.Manager {
 }
 
 func (m *manager) GetUser(ctx context.Context, req interface{}) string {
-	return "default" // Unused
+	return "" // Unused
 }
 
 func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {

--- a/quota/mock_quota.go
+++ b/quota/mock_quota.go
@@ -45,18 +45,6 @@ func (mr *MockManagerMockRecorder) GetTokens(arg0, arg1, arg2 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokens", reflect.TypeOf((*MockManager)(nil).GetTokens), arg0, arg1, arg2)
 }
 
-// GetUser mocks base method
-func (m *MockManager) GetUser(arg0 context.Context, arg1 interface{}) string {
-	ret := m.ctrl.Call(m, "GetUser", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetUser indicates an expected call of GetUser
-func (mr *MockManagerMockRecorder) GetUser(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockManager)(nil).GetUser), arg0, arg1)
-}
-
 // PeekTokens mocks base method
 func (m *MockManager) PeekTokens(arg0 context.Context, arg1 []Spec) (map[Spec]int, error) {
 	ret := m.ctrl.Call(m, "PeekTokens", arg0, arg1)

--- a/quota/mysqlqm/mysql_quota.go
+++ b/quota/mysqlqm/mysql_quota.go
@@ -59,12 +59,6 @@ type QuotaManager struct {
 	UseSelectCount     bool
 }
 
-// GetUser implements quota.Manager.GetUser.
-// User quotas are not implemented by QuotaManager.
-func (m *QuotaManager) GetUser(ctx context.Context, req interface{}) string {
-	return "" // Not used
-}
-
 // GetTokens implements quota.Manager.GetTokens.
 // It doesn't actually reserve or retrieve tokens, instead it allows access based on the number of
 // rows in the Unsequenced table.

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -51,7 +51,6 @@ func TestQuotaManager_GetTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTree() returned err = %v", err)
 	}
-	user := (&mysqlqm.QuotaManager{}).GetUser(ctx, nil /* req */)
 
 	tests := []struct {
 		desc                                           string
@@ -93,10 +92,10 @@ func TestQuotaManager_GetTokens(t *testing.T) {
 			desc:      "unlimitedQuotas",
 			numTokens: 10,
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
+				{Group: quota.User, Kind: quota.Read, User: "dylan"},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: tree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
-				{Group: quota.User, Kind: quota.Write, User: user},
+				{Group: quota.User, Kind: quota.Write, User: "dylan"},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: tree.TreeId},
 			},
 		},
@@ -243,13 +242,6 @@ func TestQuotaManager_Noops(t *testing.T) {
 		fn   func() error
 	}{
 		{
-			desc: "GetUser",
-			fn: func() error {
-				_ = qm.GetUser(ctx, nil /* req */)
-				return nil
-			},
-		},
-		{
 			desc: "PutTokens",
 			fn: func() error {
 				return qm.PutTokens(ctx, 10 /* numTokens */, specs)
@@ -270,12 +262,11 @@ func TestQuotaManager_Noops(t *testing.T) {
 }
 
 func allSpecs(ctx context.Context, qm quota.Manager, treeID int64) []quota.Spec {
-	user := qm.GetUser(ctx, nil /* req */)
 	return []quota.Spec{
-		{Group: quota.User, Kind: quota.Read, User: user},
+		{Group: quota.User, Kind: quota.Read, User: "florence"},
 		{Group: quota.Tree, Kind: quota.Read, TreeID: treeID},
 		{Group: quota.Global, Kind: quota.Read},
-		{Group: quota.User, Kind: quota.Write, User: user},
+		{Group: quota.User, Kind: quota.Write, User: "florence"},
 		{Group: quota.Tree, Kind: quota.Write, TreeID: treeID},
 		{Group: quota.Global, Kind: quota.Write},
 	}

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -21,17 +21,9 @@ import (
 
 type noopManager struct{}
 
-const (
-	noopUser = "noopQuotaUser" // arbitrary string
-)
-
 // Noop returns a noop implementation of Manager. It allows all requests without restriction.
 func Noop() Manager {
 	return &noopManager{}
-}
-
-func (n noopManager) GetUser(ctx context.Context, req interface{}) string {
-	return noopUser
 }
 
 func (n noopManager) GetTokens(ctx context.Context, numTokens int, specs []Spec) error {
@@ -77,8 +69,6 @@ func validateNumTokens(numTokens int) error {
 func validateSpecs(specs []Spec) error {
 	for _, spec := range specs {
 		switch {
-		case spec.Group == User && spec.User != noopUser:
-			return fmt.Errorf("invalid quota user: %v (expected %v)", spec.User, noopUser)
 		case spec.Group == Tree && spec.TreeID <= 0:
 			return fmt.Errorf("invalid tree ID: %v (expected >=0)", spec.TreeID)
 		}

--- a/quota/noop_test.go
+++ b/quota/noop_test.go
@@ -57,7 +57,7 @@ func TestNoop_ValidatesSpecs(t *testing.T) {
 	}{
 		{
 			desc:  "validUser",
-			specs: []Spec{{Group: User, Kind: Read, User: qm.GetUser(ctx, nil /* req */)}},
+			specs: []Spec{{Group: User, Kind: Read, User: "dougal"}},
 		},
 		{
 			desc:  "validTree",
@@ -70,20 +70,10 @@ func TestNoop_ValidatesSpecs(t *testing.T) {
 		{
 			desc: "validMixed",
 			specs: []Spec{
-				{Group: User, Kind: Read, User: qm.GetUser(ctx, nil /* req */)},
+				{Group: User, Kind: Read, User: "brian"},
 				{Group: Tree, Kind: Read, TreeID: 12345},
 				{Group: Global, Kind: Read},
 			},
-		},
-		{
-			desc:    "noUser",
-			specs:   []Spec{{Group: User, Kind: Read}},
-			wantErr: true,
-		},
-		{
-			desc:    "invalidUser",
-			specs:   []Spec{{Group: User, Kind: Read, User: "llama"}},
-			wantErr: true,
 		},
 		{
 			desc:    "noTreeID",
@@ -124,7 +114,7 @@ func TestNoopManager_PeekTokens(t *testing.T) {
 	qm := Noop()
 
 	specs := []Spec{
-		{Group: User, Kind: Read, User: qm.GetUser(ctx, nil /* req */)},
+		{Group: User, Kind: Read, User: "ermintrude"},
 		{Group: Tree, Kind: Read, TreeID: 12345},
 		{Group: Global, Kind: Read},
 	}

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -99,8 +99,9 @@ func (s Spec) String() string {
 
 // Manager is the component responsible for the management of tokens.
 type Manager interface {
-	// GetUser returns the quota user, as defined by the manager implementation.
-	// req is the RPC request message.
+	// GetUser returns the quota user, as defined by the manager implementation,
+	// for the given RPC request message.  If no user is appropriate, an empty
+	// string is returned.
 	GetUser(ctx context.Context, req interface{}) string
 
 	// GetTokens acquires numTokens from all specs. Tokens are taken in the order specified by

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -99,11 +99,6 @@ func (s Spec) String() string {
 
 // Manager is the component responsible for the management of tokens.
 type Manager interface {
-	// GetUser returns the quota user, as defined by the manager implementation,
-	// for the given RPC request message.  If no user is appropriate, an empty
-	// string is returned.
-	GetUser(ctx context.Context, req interface{}) string
-
 	// GetTokens acquires numTokens from all specs. Tokens are taken in the order specified by
 	// specs.
 	// Returns error if numTokens could not be acquired for all specs.

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -448,8 +448,10 @@ func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 			}
 			info.quotaUsers += user
 		}
+		if len(quotaUser) > 0 {
+			info.specs = append(info.specs, quota.Spec{Group: quota.User, Kind: kind, User: quotaUser})
+		}
 		info.specs = append(info.specs, []quota.Spec{
-			{Group: quota.User, Kind: kind, User: quotaUser},
 			{Group: quota.Tree, Kind: kind, TreeID: info.treeID},
 			{Group: quota.Global, Kind: kind},
 		}...)

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -145,11 +145,10 @@ type trillianProcessor struct {
 func (tp *trillianProcessor) Before(ctx context.Context, req interface{}) (context.Context, error) {
 	ctx, span := spanFor(ctx, "Before")
 	defer span.End()
-	quotaUser := tp.parent.qm.GetUser(ctx, req)
-	info, err := newRPCInfo(req, quotaUser)
+	info, err := newRPCInfo(req)
 	if err != nil {
 		glog.Warningf("Failed to read tree info: %v", err)
-		incRequestDeniedCounter(badInfoReason, 0, quotaUser)
+		incRequestDeniedCounter(badInfoReason, 0, "")
 		return ctx, err
 	}
 	tp.info = info
@@ -413,7 +412,7 @@ func newRPCInfoForRequest(req interface{}) (*rpcInfo, error) {
 	return info, nil
 }
 
-func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
+func newRPCInfo(req interface{}) (*rpcInfo, error) {
 	info, err := newRPCInfoForRequest(req)
 	if err != nil {
 		return nil, err
@@ -440,16 +439,12 @@ func newRPCInfo(req interface{}, quotaUser string) (*rpcInfo, error) {
 			kind = quota.Read
 		}
 
-		info.quotaUsers = quotaUser
 		for _, user := range chargedUsers(req) {
 			info.specs = append(info.specs, quota.Spec{Group: quota.User, Kind: kind, User: user})
 			if len(info.quotaUsers) > 0 {
 				info.quotaUsers += "+"
 			}
 			info.quotaUsers += user
-		}
-		if len(quotaUser) > 0 {
-			info.specs = append(info.specs, quota.Spec{Group: quota.User, Kind: kind, User: quotaUser})
 		}
 		info.specs = append(info.specs, []quota.Spec{
 			{Group: quota.Tree, Kind: kind, TreeID: info.treeID},

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -169,7 +169,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 	preorderedTree := *testonly.PreorderedLogTree
 	preorderedTree.TreeId = 12
 
-	user := "llama"
 	charge1 := "alpaca"
 	charge2 := "cama"
 	charges := &trillian.ChargeTo{User: []string{charge1, charge2}}
@@ -186,7 +185,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logRead",
 			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -196,7 +194,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logReadIndices",
 			req:  &trillian.GetLeavesByIndexRequest{LogId: logTree.TreeId, LeafIndex: []int64{1, 2, 3}},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -206,7 +203,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logReadRange",
 			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 123},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -216,7 +212,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logReadNegativeRange",
 			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: -123},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -226,7 +221,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logReadZeroRange",
 			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 0},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -238,7 +232,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Read, User: charge1},
 				{Group: quota.User, Kind: quota.Read, User: charge2},
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -248,7 +241,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "logWrite",
 			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -260,7 +252,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Write, User: charge1},
 				{Group: quota.User, Kind: quota.Write, User: charge2},
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -270,7 +261,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "mapRead",
 			req:  &trillian.GetMapLeavesRequest{MapId: mapTree.TreeId, Index: [][]byte{{0x01}, {0x02}}},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: mapTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -290,7 +280,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -303,7 +292,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: preorderedTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -319,7 +307,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Write, User: charge1},
 				{Group: quota.User, Kind: quota.Write, User: charge2},
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -332,7 +319,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				Leaves: []*trillian.MapLeaf{{}, {}, {}, {}, {}},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: mapTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -342,7 +328,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			desc: "quotaError",
 			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -355,7 +340,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			dryRun: true,
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -379,7 +363,6 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			adminTX.EXPECT().Commit().AnyTimes().Return(nil)
 
 			qm := quota.NewMockManager(ctrl)
-			qm.EXPECT().GetUser(gomock.Any(), test.req).MaxTimes(1).Return(user)
 			if test.wantTokens > 0 {
 				qm.EXPECT().GetTokens(gomock.Any(), test.wantTokens, test.specs).Return(test.getTokensErr)
 			}
@@ -402,7 +385,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 	logTree := *testonly.LogTree
 	logTree.TreeId = 10
 
-	user := "llama"
 	tests := []struct {
 		desc                         string
 		req, resp                    interface{}
@@ -414,7 +396,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			desc: "badRequest",
 			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Read, User: user},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
 			},
@@ -427,7 +408,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId, Leaf: &trillian.LogLeaf{}},
 			resp: &trillian.QueueLeafResponse{QueuedLeaf: &trillian.QueuedLogLeaf{}},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -442,7 +422,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 				},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -459,7 +438,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 				QueuedLeaves: []*trillian.QueuedLogLeaf{{}, {}, {}}, // No explicit Status means OK
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -479,7 +457,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 				},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -493,7 +470,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
 			},
 			specs: []quota.Spec{
-				{Group: quota.User, Kind: quota.Write, User: user},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
 			},
@@ -527,7 +503,6 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantDeadline := time.Now().Add(PutTokensTimeout)
 
 			qm := quota.NewMockManager(ctrl)
-			qm.EXPECT().GetUser(gomock.Any(), test.req).MaxTimes(1).Return(user)
 			if test.wantGetTokens > 0 {
 				qm.EXPECT().GetTokens(gomock.Any(), test.wantGetTokens, test.specs).Return(nil)
 			}


### PR DESCRIPTION
Taken as a whole, this PR removes `QuotaManager.GetUser` as it's not used.

An alternative approach is the first commit on its own, which just copes with `GetUser` returning an empty quota user; personally I prefer the wholesale removal but see what you think.