### PR TITLE
cloudbuild config for tagged releases

### DIFF
--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,0 +1,20 @@
+steps:
+- id: build_log_server
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=examples/deployment/docker/log_server/Dockerfile
+  - --tag=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
+  - .
+  waitFor: ["-"]
+- id: build_log_signer
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=examples/deployment/docker/log_signer/Dockerfile
+  - --tag=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
+  - .
+  waitFor: ["-"]
+images:
+- gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
+- gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}


### PR DESCRIPTION
Used together with a "triggered build" in Google Container Registry to ensure that an image is pushed for every new Git tag.

See:
https://cloud.google.com/container-builder/docs/running-builds/automate-builds
https://cloud.google.com/container-builder/docs/configuring-builds/build-test-deploy-artifacts