### PR TITLE
GetAndVerifyInclusionAtIndex to not update the root.

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -273,22 +273,18 @@ func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 	return nil
 }
 
-// GetAndVerifyInclusionAtIndex updates the log root and ensures that the given leaf data has been included in the log at a particular index.
-func (c *LogClient) GetAndVerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
-	root, err := c.UpdateRoot(ctx)
-	if err != nil {
-		return fmt.Errorf("UpdateRoot(): %v", err)
-	}
+// GetAndVerifyInclusionAtIndex ensures that the given leaf data has been included in the log at a particular index.
+func (c *LogClient) GetAndVerifyInclusionAtIndex(ctx context.Context, data []byte, index int64, sth *types.LogRootV1) error {
 	resp, err := c.client.GetInclusionProof(ctx,
 		&trillian.GetInclusionProofRequest{
 			LogId:     c.LogID,
 			LeafIndex: index,
-			TreeSize:  int64(root.TreeSize),
+			TreeSize:  int64(sth.TreeSize),
 		})
 	if err != nil {
 		return err
 	}
-	return c.VerifyInclusionAtIndex(root, data, index, resp.Proof.Hashes)
+	return c.VerifyInclusionAtIndex(sth, data, index, resp.Proof.Hashes)
 }
 
 func (c *LogClient) getAndVerifyInclusionProof(ctx context.Context, leafHash []byte, sth *types.LogRootV1) (bool, error) {

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -201,8 +201,13 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
+	root, err := client.UpdateRoot(ctx)
+	if err != nil {
+		t.Errorf("UpdateRoot(): %v", err)
+	}
+
 	for i, l := range leafData {
-		if err := client.GetAndVerifyInclusionAtIndex(ctx, l, int64(i)); err != nil {
+		if err := client.GetAndVerifyInclusionAtIndex(ctx, l, int64(i), root); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
 		}
 	}


### PR DESCRIPTION
`GetAndVerifyInclusionAtIndex` is useful for requesting inclusion proofs
after a root update has been performed, similar to
`getAndVerifyInclusionProof`.

However, unlike, `getAndVerifyInclusionProof`,
`GetAndVerifyInclusionAtIndex` currently updates the root every time it
is called. This is a surprising side effect that clients cannot disable.

On the other hand, by removing this update, the two get-and-verify
methods will be more consistent, and clients who do require an update
can still do so by calling `UpdateRoot` explicitly.