### PR TITLE
Always require the root parameter when creating new LogClients

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -47,6 +47,16 @@ func New(logID int64, client trillian.TrillianLogClient, verifier *LogVerifier) 
 	}
 }
 
+// NewWithRoot returns a new LogClient.
+func NewWithRoot(logID int64, client trillian.TrillianLogClient, verifier *LogVerifier, root types.LogRootV1) *LogClient {
+	return &LogClient{
+		LogVerifier: verifier,
+		LogID:       logID,
+		client:      client,
+		root:        root,
+	}
+}
+
 // NewFromTree creates a new LogClient given a tree config.
 func NewFromTree(client trillian.TrillianLogClient, config *trillian.Tree) (*LogClient, error) {
 	verifier, err := NewLogVerifierFromTree(config)

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -39,16 +39,7 @@ type LogClient struct {
 }
 
 // New returns a new LogClient.
-func New(logID int64, client trillian.TrillianLogClient, verifier *LogVerifier) *LogClient {
-	return &LogClient{
-		LogVerifier: verifier,
-		LogID:       logID,
-		client:      client,
-	}
-}
-
-// NewWithRoot returns a new LogClient.
-func NewWithRoot(logID int64, client trillian.TrillianLogClient, verifier *LogVerifier, root types.LogRootV1) *LogClient {
+func New(logID int64, client trillian.TrillianLogClient, verifier *LogVerifier, root types.LogRootV1) *LogClient {
 	return &LogClient{
 		LogVerifier: verifier,
 		LogID:       logID,
@@ -58,13 +49,13 @@ func NewWithRoot(logID int64, client trillian.TrillianLogClient, verifier *LogVe
 }
 
 // NewFromTree creates a new LogClient given a tree config.
-func NewFromTree(client trillian.TrillianLogClient, config *trillian.Tree) (*LogClient, error) {
+func NewFromTree(client trillian.TrillianLogClient, config *trillian.Tree, root types.LogRootV1) (*LogClient, error) {
 	verifier, err := NewLogVerifierFromTree(config)
 	if err != nil {
 		return nil, err
 	}
 
-	return New(config.GetTreeId(), client, verifier), nil
+	return New(config.GetTreeId(), client, verifier, root), nil
 }
 
 // AddSequencedLeafAndWait adds a leaf at a specific index to the log.

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/testonly/integration"
+	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -67,7 +68,7 @@ func TestGetByIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client, err := NewFromTree(env.Log, tree)
+	client, err := NewFromTree(env.Log, tree, types.LogRootV1{})
 	if err != nil {
 		t.Fatalf("NewFromTree(): %v", err)
 	}
@@ -109,7 +110,7 @@ func TestListByIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client, err := NewFromTree(env.Log, tree)
+	client, err := NewFromTree(env.Log, tree, types.LogRootV1{})
 	if err != nil {
 		t.Fatalf("NewFromTree(): %v", err)
 	}
@@ -151,7 +152,7 @@ func TestVerifyInclusion(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client, err := NewFromTree(env.Log, tree)
+	client, err := NewFromTree(env.Log, tree, types.LogRootV1{})
 	if err != nil {
 		t.Fatalf("NewFromTree(): %v", err)
 	}
@@ -187,7 +188,7 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client, err := NewFromTree(env.Log, tree)
+	client, err := NewFromTree(env.Log, tree, types.LogRootV1{})
 	if err != nil {
 		t.Fatalf("NewFromTree(): %v", err)
 	}
@@ -236,7 +237,7 @@ func TestWaitForInclusion(t *testing.T) {
 			client: &MockLogClient{c: env.Log, mGetInclusionProof: true}, wantErr: true},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			client, err := NewFromTree(test.client, tree)
+			client, err := NewFromTree(test.client, tree, types.LogRootV1{})
 			if err != nil {
 				t.Fatalf("NewFromTree(): %v", err)
 			}
@@ -276,7 +277,7 @@ func TestUpdateRoot(t *testing.T) {
 		t.Fatalf("Failed to create log: %v", err)
 	}
 
-	client, err := NewFromTree(env.Log, tree)
+	client, err := NewFromTree(env.Log, tree, types.LogRootV1{})
 	if err != nil {
 		t.Fatalf("NewFromTree(): %v", err)
 	}


### PR DESCRIPTION
Currently, users have no way of setting a starting root for the
LogClient. This means that whenever LogClient is used, the current
latest root returned by Trillian is implicitly trusted.

This change allows users to instead start verification from a known
good state. This is useful for recovering from restarts/downtime without
losing verifiability.

Clients that want the old behavior should call `New` with an empty initial
trusted log root.
    
```
New(..., types.LogRootV1{})
NewFromTree(..., types.LogRootV1{})
```