### PR TITLE
Improve the logic around updating the trusted root

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -132,7 +132,7 @@ func (c *LogClient) WaitForRootUpdate(ctx context.Context) (*types.LogRootV1, er
 	}
 
 	for {
-		newTrusted, err := c.getLatestRoot(ctx, c.GetRoot())
+		newTrusted, err := c.getAndVerifyLatestRoot(ctx, c.GetRoot())
 		switch status.Code(err) {
 		case codes.OK:
 			if c.updateRootIfNewer(newTrusted) {
@@ -152,9 +152,9 @@ func (c *LogClient) WaitForRootUpdate(ctx context.Context) (*types.LogRootV1, er
 	}
 }
 
-// getLatestRoot fetches and verifies the latest root against a trusted root, seen in the past.
+// getAndVerifyLatestRoot fetches and verifies the latest root against a trusted root, seen in the past.
 // Pass nil for trusted if this is the first time querying this log.
-func (c *LogClient) getLatestRoot(ctx context.Context, trusted *types.LogRootV1) (*types.LogRootV1, error) {
+func (c *LogClient) getAndVerifyLatestRoot(ctx context.Context, trusted *types.LogRootV1) (*types.LogRootV1, error) {
 	resp, err := c.client.GetLatestSignedLogRoot(ctx,
 		&trillian.GetLatestSignedLogRootRequest{LogId: c.LogID})
 	if err != nil {
@@ -237,7 +237,7 @@ func (c *LogClient) updateRootIfNewer(newTrusted *types.LogRootV1) bool {
 // newer than the currently trusted root.
 func (c *LogClient) UpdateRoot(ctx context.Context) (*types.LogRootV1, error) {
 	currentlyTrusted := c.GetRoot()
-	newTrusted, err := c.getLatestRoot(ctx, currentlyTrusted)
+	newTrusted, err := c.getAndVerifyLatestRoot(ctx, currentlyTrusted)
 	if err != nil {
 		return nil, err
 	}

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -58,7 +58,7 @@ func NewFromTree(client trillian.TrillianLogClient, config *trillian.Tree) (*Log
 }
 
 // AddSequencedLeafAndWait adds a leaf at a specific index to the log.
-// Blocks until it has been included in a signed log root.
+// Blocks and continuously updates the trusted root until it has been included in a signed log root.
 func (c *LogClient) AddSequencedLeafAndWait(ctx context.Context, data []byte, index int64) error {
 	if err := c.AddSequencedLeaf(ctx, data, index); err != nil {
 		return fmt.Errorf("QueueLeaf(): %v", err)
@@ -70,7 +70,7 @@ func (c *LogClient) AddSequencedLeafAndWait(ctx context.Context, data []byte, in
 }
 
 // AddLeaf adds leaf to the append only log.
-// Blocks until it gets a verifiable response.
+// Blocks and continuously updates the trusted root until it gets a verifiable response.
 func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 	if err := c.QueueLeaf(ctx, data); err != nil {
 		return fmt.Errorf("QueueLeaf(): %v", err)

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -202,6 +202,14 @@ func (c *LogClient) getLatestRoot(ctx context.Context, trusted *types.LogRootV1)
 	return &logRoot, nil
 }
 
+// GetRoot returns a copy of the latest trusted root.
+func (c *LogClient) GetRoot() types.LogRootV1 {
+	c.rootLock.Lock()
+	defer c.rootLock.Unlock()
+
+	return c.root
+}
+
 // UpdateRoot retrieves the current SignedLogRoot, verifying it against roots this client has
 // seen in the past, and updating the currently trusted root if the new root verifies.
 func (c *LogClient) UpdateRoot(ctx context.Context) (*types.LogRootV1, error) {

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -248,9 +248,14 @@ func (c *LogClient) UpdateRoot(ctx context.Context) (*types.LogRootV1, error) {
 	return nil, nil
 }
 
-// WaitForInclusion blocks until the requested data has been verified with an inclusion proof.
-// This assumes that the data has already been submitted.
-// Best practice is to call this method with a context that will timeout.
+// WaitForInclusion blocks until the requested data has been verified with an
+// inclusion proof.
+//
+// It will continuously update the root to the latest one available until the
+// data is found, or an error is returned.
+//
+// It is best to call this method with a context that will timeout to avoid
+// waiting forever.
 func (c *LogClient) WaitForInclusion(ctx context.Context, data []byte) error {
 	leaf, err := c.BuildLeaf(data)
 	if err != nil {
@@ -272,7 +277,7 @@ func (c *LogClient) WaitForInclusion(ctx context.Context, data []byte) error {
 		}
 
 		// If not found or tree is empty, wait for a root update before retrying again.
-		if root, err = c.WaitForRootUpdate(ctx); err != nil {
+		if _, err = c.WaitForRootUpdate(ctx); err != nil {
 			return err
 		}
 

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -203,11 +203,13 @@ func (c *LogClient) getLatestRoot(ctx context.Context, trusted *types.LogRootV1)
 }
 
 // GetRoot returns a copy of the latest trusted root.
-func (c *LogClient) GetRoot() types.LogRootV1 {
+func (c *LogClient) GetRoot() *types.LogRootV1 {
 	c.rootLock.Lock()
 	defer c.rootLock.Unlock()
 
-	return c.root
+	// Copy the internal trusted root in order to prevent clients from modifying it.
+	ret := c.root
+	return &ret
 }
 
 // UpdateRoot retrieves the current SignedLogRoot, verifying it against roots this client has

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -285,16 +285,13 @@ func (c *LogClient) WaitForInclusion(ctx context.Context, data []byte) error {
 	}
 }
 
-// VerifyInclusion updates the log root and ensures that the given leaf data has been included in the log.
+// VerifyInclusion ensures that the given leaf data has been included in the log.
 func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 	leaf, err := c.BuildLeaf(data)
 	if err != nil {
 		return err
 	}
-	root, err := c.UpdateRoot(ctx)
-	if err != nil {
-		return fmt.Errorf("UpdateRoot(): %v", err)
-	}
+	root := c.GetRoot()
 	ok, err := c.getAndVerifyInclusionProof(ctx, leaf.MerkleLeafHash, root)
 	if err != nil {
 		return err
@@ -305,12 +302,9 @@ func (c *LogClient) VerifyInclusion(ctx context.Context, data []byte) error {
 	return nil
 }
 
-// GetAndVerifyInclusionAtIndex updates the log root and ensures that the given leaf data has been included in the log at a particular index.
+// GetAndVerifyInclusionAtIndex ensures that the given leaf data has been included in the log at a particular index.
 func (c *LogClient) GetAndVerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
-	root, err := c.UpdateRoot(ctx)
-	if err != nil {
-		return fmt.Errorf("UpdateRoot(): %v", err)
-	}
+	root := c.GetRoot()
 	resp, err := c.client.GetInclusionProof(ctx,
 		&trillian.GetInclusionProofRequest{
 			LogId:     c.LogID,

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -165,10 +165,6 @@ func TestVerifyInclusion(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
-	if _, err := client.WaitForRootUpdate(ctx); err != nil {
-		t.Errorf("UpdateRoot(): %v", err)
-	}
-
 	for _, l := range leafData {
 		if err := client.VerifyInclusion(ctx, l); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)
@@ -205,11 +201,7 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
-	root, err := client.WaitForRootUpdate(ctx)
-	if err != nil {
-		t.Errorf("UpdateRoot(): %v", err)
-	}
-
+	root := client.GetRoot()
 	for i, l := range leafData {
 		if err := client.GetAndVerifyInclusionAtIndex(ctx, l, int64(i), root); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -165,6 +165,10 @@ func TestVerifyInclusion(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
+	if _, err := client.UpdateRoot(ctx); err != nil {
+		t.Errorf("UpdateRoot(): %v", err)
+	}
+
 	for _, l := range leafData {
 		if err := client.VerifyInclusion(ctx, l); err != nil {
 			t.Errorf("VerifyInclusion(%s) = %v, want nil", l, err)

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -165,7 +165,7 @@ func TestVerifyInclusion(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
-	if _, err := client.UpdateRoot(ctx); err != nil {
+	if _, err := client.WaitForRootUpdate(ctx); err != nil {
 		t.Errorf("UpdateRoot(): %v", err)
 	}
 
@@ -205,7 +205,7 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 		t.Fatalf("Failed to add leaves: %v", err)
 	}
 
-	root, err := client.UpdateRoot(ctx)
+	root, err := client.WaitForRootUpdate(ctx)
 	if err != nil {
 		t.Errorf("UpdateRoot(): %v", err)
 	}


### PR DESCRIPTION
- Add a `GetRoot` method that returns a (pointer to a) copy of the latest trusted root.

- Introduce an update lock to prevent root updates from happening concurrently. This is because multiple `UpdateRoot`s running concurrently can result in an invalid update if the Trillian log was forked and each update was given a different branch of the fork.

- Remove the `waitForTreeSize` argument from `WaitForRootUpdate`. This argument makes the function harder to use and adds complexity to it.

  This complexity had introduced the following subtle bug:
  If `WaitForRootUpdate` was called with `waitForTreeSize >= current size + 2`, then the root might be updated (ex. to `current size + 1`) and then an error encountered during the next update. When this happens, the method returns with an error and with `nil` for the new root (incorrectly indicating no root update).

- Stop `VerifyInclusion` and `GetAndVerifyInclusionAtIndex` from updating the trusted root under the hood. Users who do require an update can do so by calling `UpdateRoot` or `WaitForRootUpdate` explicitly before calling those methods.

- Update the documentation for `AddSequencedLeafAndWait` and `AddLeaf` to clarify that they update the trusted root under the hood.

- Rename `getLatestRoot` to `getAndVerifyLatestRoot`.