### PR TITLE
Retry gometalinter when it times out

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -122,7 +122,7 @@ main() {
       'have you installed github.com/alecthomas/gometalinter?' || exit 1
 
     echo 'running gometalinter'
-    gometalinter --config=gometalinter.json --deadline=5m ./...
+    gometalinter --config=gometalinter.json --deadline=9m ./...
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -11,6 +11,30 @@
 set -eu
 
 
+# Retries running a command N times, with exponential backoff between failures.
+#
+# Usage:
+#   retry N command ...args
+retry() {
+  local retries=$1
+  shift
+
+  local count=0
+  until "$@"; do
+    local exit=$?
+    local wait=$((2 ** $count))
+    local count=$(($count + 1))
+    if [ $count -lt $retries ]; then
+      echo "Attempt $count/$retries: $1 exited $exit, retrying in $wait seconds..."
+      sleep $wait
+    else
+      echo "Attempt $count/$retries: $1 exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+  return 0
+}
+
 check_pkg() {
   local cmd="$1"
   local pkg="$2"
@@ -122,7 +146,7 @@ main() {
       'have you installed github.com/alecthomas/gometalinter?' || exit 1
 
     echo 'running gometalinter'
-    gometalinter --config=gometalinter.json --deadline=9m ./...
+    retry 5 gometalinter --config=gometalinter.json --deadline=2m ./...
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -122,7 +122,7 @@ main() {
       'have you installed github.com/alecthomas/gometalinter?' || exit 1
 
     echo 'running gometalinter'
-    gometalinter --config=gometalinter.json --deadline=2m ./...
+    gometalinter --config=gometalinter.json --deadline=5m ./...
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -122,7 +122,7 @@ main() {
       'have you installed github.com/alecthomas/gometalinter?' || exit 1
 
     echo 'running gometalinter'
-    gometalinter --config=gometalinter.json --deadline=90s ./...
+    gometalinter --config=gometalinter.json --deadline=2m ./...
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then


### PR DESCRIPTION
This has recently been timing out in travis. However increasing the deadline did not seem to decrease the failure rate due to timing out. Perhaps this is because some other factors are at play causing gometalinter to hang.

Therefore, this change attempts to instead retry the failed command (using a reasonable timeout) rather than only run it once with a large timeout.