### PR TITLE
Use grpc_middleware.ChainUnaryServer

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -471,21 +471,6 @@ type treeRequest interface {
 	GetTree() *trillian.Tree
 }
 
-// Combine combines unary interceptors.
-// They are nested in order, so interceptor[0] calls on to (and sees the result of) interceptor[1], etc.
-func Combine(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		for i := len(interceptors) - 1; i >= 0; i-- {
-			intercept := interceptors[i]
-			baseHandler := handler
-			handler = func(ctx context.Context, req interface{}) (interface{}, error) {
-				return intercept(ctx, req, info, baseHandler)
-			}
-		}
-		return handler(ctx, req)
-	}
-}
-
 // ErrorWrapper is a grpc.UnaryServerInterceptor that wraps the errors emitted by the underlying handler.
 func ErrorWrapper(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	ctx, span := spanFor(ctx, "ErrorWrapper")

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	serrors "github.com/google/trillian/server/errors"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 )
 
 func TestTrillianInterceptor_TreeInterception(t *testing.T) {
@@ -682,7 +683,7 @@ func TestCombine(t *testing.T) {
 				i.called = false
 				intercepts = append(intercepts, i.run)
 			}
-			intercept := Combine(intercepts...)
+			intercept := grpc_middleware.ChainUnaryServer(intercepts...)
 
 			handler := &fakeHandler{resp: "response", err: test.handlerErr}
 			resp, err := intercept(ctx, req, info, handler.run)


### PR DESCRIPTION
Replace interceptor.Chain with grpc_middlware.ChainUnaryServer.
interceptor is duplicating what should be standard grpc code.

By switching we both reduce code we need to maintain as well as
improve readability by using standard libraries.