### PR TITLE
Implement Interception Filtering

### DIFF
--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -608,14 +608,14 @@ func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
 			intercept := New(admin, qm, false /* quotaDryRun */, nil /* mf */)
 			p := intercept.NewProcessor()
 
-			_, err := p.Before(ctx, test.req)
+			_, err := p.Before(ctx, test.req, "")
 			if gotErr := err != nil; gotErr != test.wantBeforeErr {
 				t.Fatalf("Before() returned err = %v, wantErr = %v", err, test.wantBeforeErr)
 			}
 
 			// Other TrillianInterceptor tests assert After side-effects more in-depth, silently
 			// returning is good enough here.
-			p.After(ctx, test.resp, test.handlerErr)
+			p.After(ctx, test.resp, "", test.handlerErr)
 		})
 	}
 }

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -50,6 +50,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 
 	tests := []struct {
 		desc       string
+		method     string
 		req        interface{}
 		handlerErr error
 		wantErr    bool
@@ -59,44 +60,52 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 		// TODO(codingllama): Admin requests don't benefit from tree-reading logic, but we may read
 		// their tree IDs for auth purposes.
 		{
-			desc: "adminReadByID",
-			req:  &trillian.GetTreeRequest{TreeId: logTree.TreeId},
+			desc:   "adminReadByID",
+			method: "/trillian.TrillianAdmin/GetTree",
+			req:    &trillian.GetTreeRequest{TreeId: logTree.TreeId},
 		},
 		{
-			desc: "adminWriteByID",
-			req:  &trillian.DeleteTreeRequest{TreeId: logTree.TreeId},
+			desc:   "adminWriteByID",
+			method: "/trillian.TrillianAdmin/DeleteTree",
+			req:    &trillian.DeleteTreeRequest{TreeId: logTree.TreeId},
 		},
 		{
-			desc: "adminWriteByTree",
-			req:  &trillian.UpdateTreeRequest{Tree: &trillian.Tree{TreeId: logTree.TreeId}},
+			desc:   "adminWriteByTree",
+			method: "/trillian.TrillianAdmin/UpdateTree",
+			req:    &trillian.UpdateTreeRequest{Tree: &trillian.Tree{TreeId: logTree.TreeId}},
 		},
 		{
 			desc:     "logRPC",
+			method:   "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:      &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			wantTree: logTree,
 		},
 		{
 			desc:     "mapRPC",
+			method:   "/trillian.TrillianMap/GetSignedMapRoot",
 			req:      &trillian.GetSignedMapRootRequest{MapId: mapTree.TreeId},
 			wantTree: mapTree,
 		},
 		{
 			desc:    "unknownRequest",
 			req:     "not-a-request",
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			desc:    "unknownTree",
+			method:  "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:     &trillian.GetLatestSignedLogRootRequest{LogId: unknownTreeID},
 			wantErr: true,
 		},
 		{
 			desc:    "deletedTree",
+			method:  "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:     &trillian.GetLatestSignedLogRootRequest{LogId: deletedTree.TreeId},
 			wantErr: true,
 		},
 		{
 			desc:      "cancelled",
+			method:    "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:       &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			cancelled: true,
 			wantErr:   true,
@@ -128,7 +137,9 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 				ctx = newCtx
 			}
 
-			resp, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run)
+			resp, err := intercept.UnaryInterceptor(ctx, test.req,
+				&grpc.UnaryServerInfo{FullMethod: test.method},
+				handler.run)
 			if hasErr := err != nil && err != test.handlerErr; hasErr != test.wantErr {
 				t.Fatalf("UnaryInterceptor() returned err = %v, wantErr = %v", err, test.wantErr)
 			} else if hasErr {
@@ -175,6 +186,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 	tests := []struct {
 		desc         string
 		dryRun       bool
+		method       string
 		req          interface{}
 		specs        []quota.Spec
 		getTokensErr error
@@ -182,8 +194,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		wantTokens   int
 	}{
 		{
-			desc: "logRead",
-			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
+			desc:   "logRead",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
+			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -191,8 +204,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "logReadIndices",
-			req:  &trillian.GetLeavesByIndexRequest{LogId: logTree.TreeId, LeafIndex: []int64{1, 2, 3}},
+			desc:   "logReadIndices",
+			method: "/trillian.TrillianLog/GetLeavesByIndex",
+			req:    &trillian.GetLeavesByIndexRequest{LogId: logTree.TreeId, LeafIndex: []int64{1, 2, 3}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -200,8 +214,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 3,
 		},
 		{
-			desc: "logReadRange",
-			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 123},
+			desc:   "logReadRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
+			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -209,8 +224,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 123,
 		},
 		{
-			desc: "logReadNegativeRange",
-			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: -123},
+			desc:   "logReadNegativeRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
+			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: -123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -218,8 +234,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "logReadZeroRange",
-			req:  &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 0},
+			desc:   "logReadZeroRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
+			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 0},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -227,8 +244,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "logRead with charges",
-			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId, ChargeTo: charges},
+			desc:   "logRead with charges",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
+			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId, ChargeTo: charges},
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Read, User: charge1},
 				{Group: quota.User, Kind: quota.Read, User: charge2},
@@ -238,8 +256,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "logWrite",
-			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId},
+			desc:   "logWrite",
+			method: "/trillian.TrillianLog/QueueLeaf",
+			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
@@ -247,8 +266,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "logWrite with charges",
-			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId, ChargeTo: charges},
+			desc:   "logWrite with charges",
+			method: "/trillian.TrillianLog/QueueLeaf",
+			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId, ChargeTo: charges},
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Write, User: charge1},
 				{Group: quota.User, Kind: quota.Write, User: charge2},
@@ -258,8 +278,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 1,
 		},
 		{
-			desc: "mapRead",
-			req:  &trillian.GetMapLeavesRequest{MapId: mapTree.TreeId, Index: [][]byte{{0x01}, {0x02}}},
+			desc:   "mapRead",
+			method: "/trillian.TrillianMap/GetLeaves",
+			req:    &trillian.GetMapLeavesRequest{MapId: mapTree.TreeId, Index: [][]byte{{0x01}, {0x02}}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: mapTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -267,14 +288,16 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 2,
 		},
 		{
-			desc: "emptyBatchRequest",
+			desc:   "emptyBatchRequest",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: nil,
 			},
 		},
 		{
-			desc: "batchLogLeavesRequest",
+			desc:   "batchLogLeavesRequest",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -286,7 +309,8 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 3,
 		},
 		{
-			desc: "batchSequencedLogLeavesRequest",
+			desc:   "batchSequencedLogLeavesRequest",
+			method: "/trillian.TrillianLog/AddSequencedLeaves",
 			req: &trillian.AddSequencedLeavesRequest{
 				LogId:  preorderedTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -298,7 +322,8 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 3,
 		},
 		{
-			desc: "batchLogLeavesRequest with charges",
+			desc:   "batchLogLeavesRequest with charges",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:    logTree.TreeId,
 				Leaves:   []*trillian.LogLeaf{{}, {}, {}},
@@ -313,7 +338,8 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 3,
 		},
 		{
-			desc: "batchMapLeavesRequest",
+			desc:   "batchMapLeavesRequest",
+			method: "/trillian.TrillianMap/SetLeaves",
 			req: &trillian.SetMapLeavesRequest{
 				MapId:  mapTree.TreeId,
 				Leaves: []*trillian.MapLeaf{{}, {}, {}, {}, {}},
@@ -325,8 +351,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 5,
 		},
 		{
-			desc: "quotaError",
-			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
+			desc:   "quotaError",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
+			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -338,6 +365,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		{
 			desc:   "quotaDryRunError",
 			dryRun: true,
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -372,7 +400,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 
 			// resp and handler assertions are done by TestTrillianInterceptor_TreeInterception,
 			// we're only concerned with the quota logic here.
-			_, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run)
+			_, err := intercept.UnaryInterceptor(ctx, test.req,
+				&grpc.UnaryServerInfo{FullMethod: test.method},
+				handler.run)
 			if s, ok := status.FromError(err); !ok || s.Code() != test.wantCode {
 				t.Errorf("UnaryInterceptor() returned err = %q, wantCode = %v", err, test.wantCode)
 			}
@@ -387,14 +417,16 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 
 	tests := []struct {
 		desc                         string
+		method                       string
 		req, resp                    interface{}
 		specs                        []quota.Spec
 		handlerErr                   error
 		wantGetTokens, wantPutTokens int
 	}{
 		{
-			desc: "badRequest",
-			req:  &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
+			desc:   "badRequest",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
+			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Read},
@@ -404,9 +436,10 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantPutTokens: 1,
 		},
 		{
-			desc: "newLeaf",
-			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId, Leaf: &trillian.LogLeaf{}},
-			resp: &trillian.QueueLeafResponse{QueuedLeaf: &trillian.QueuedLogLeaf{}},
+			desc:   "newLeaf",
+			method: "/trillian.TrillianLog/QueueLeaf",
+			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId, Leaf: &trillian.LogLeaf{}},
+			resp:   &trillian.QueueLeafResponse{QueuedLeaf: &trillian.QueuedLogLeaf{}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
 				{Group: quota.Global, Kind: quota.Write},
@@ -414,8 +447,9 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantGetTokens: 1,
 		},
 		{
-			desc: "duplicateLeaf",
-			req:  &trillian.QueueLeafRequest{LogId: logTree.TreeId},
+			desc:   "duplicateLeaf",
+			method: "/trillian.TrillianLog/QueueLeaf",
+			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId},
 			resp: &trillian.QueueLeafResponse{
 				QueuedLeaf: &trillian.QueuedLogLeaf{
 					Status: status.New(codes.AlreadyExists, "duplicate leaf").Proto(),
@@ -429,7 +463,8 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantPutTokens: 1,
 		},
 		{
-			desc: "newLeaves",
+			desc:   "newLeaves",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -444,7 +479,8 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantGetTokens: 3,
 		},
 		{
-			desc: "duplicateLeaves",
+			desc:   "duplicateLeaves",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -464,7 +500,8 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			wantPutTokens: 2,
 		},
 		{
-			desc: "badQueueLeavesRequest",
+			desc:   "badQueueLeavesRequest",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -521,7 +558,9 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			handler := &fakeHandler{resp: test.resp, err: test.handlerErr}
 			intercept := New(admin, qm, false /* quotaDryRun */, nil /* mf */)
 
-			if _, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run); err != test.handlerErr {
+			if _, err := intercept.UnaryInterceptor(ctx, test.req,
+				&grpc.UnaryServerInfo{FullMethod: test.method},
+				handler.run); err != test.handlerErr {
 				t.Errorf("UnaryInterceptor() returned err = [%v], want = [%v]", err, test.handlerErr)
 			}
 
@@ -538,24 +577,27 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 
 func TestTrillianInterceptor_NotIntercepted(t *testing.T) {
 	tests := []struct {
-		req interface{}
+		method string
+		req    interface{}
 	}{
 		// Admin
-		{req: &trillian.CreateTreeRequest{}},
-		{req: &trillian.ListTreesRequest{}},
+		{method: "/trillian.TrillianAdmin/CreateTree", req: &trillian.CreateTreeRequest{}},
+		{method: "/trillian.TrillianAdmin/ListTrees", req: &trillian.ListTreesRequest{}},
 		// Quota
-		{req: &quotapb.CreateConfigRequest{}},
-		{req: &quotapb.DeleteConfigRequest{}},
-		{req: &quotapb.GetConfigRequest{}},
-		{req: &quotapb.ListConfigsRequest{}},
-		{req: &quotapb.UpdateConfigRequest{}},
+		{method: "/quotapb.Quota/CreateConfig", req: &quotapb.CreateConfigRequest{}},
+		{method: "/quotapb.Quota/DeleteConfig", req: &quotapb.DeleteConfigRequest{}},
+		{method: "/quotapb.Quota/GetConfig", req: &quotapb.GetConfigRequest{}},
+		{method: "/quotapb.Quota/ListConfigs", req: &quotapb.ListConfigsRequest{}},
+		{method: "/quotapb.Quota/UpdateConfig", req: &quotapb.UpdateConfigRequest{}},
 	}
 
 	ctx := context.Background()
 	for _, test := range tests {
 		handler := &fakeHandler{}
 		intercept := New(nil /* admin */, quota.Noop(), false /* quotaDryRun */, nil /* mf */)
-		if _, err := intercept.UnaryInterceptor(ctx, test.req, &grpc.UnaryServerInfo{}, handler.run); err != nil {
+		if _, err := intercept.UnaryInterceptor(ctx, test.req,
+			&grpc.UnaryServerInfo{FullMethod: test.method},
+			handler.run); err != nil {
 			t.Errorf("UnaryInterceptor(%#v) returned err = %v", test.req, err)
 		}
 		if !handler.called {


### PR DESCRIPTION
The Trillian Interceptor fails all requests that it doesn't recognize. Unfortunately this doesn't play well when other services are hosted on the same server. 

This PR restricts the Trillian interceptor to operating on Trillian services.  