### PR TITLE
Move interceptor enabled service check to Before/After

### DIFF
--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -651,7 +651,7 @@ func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
 			intercept := New(admin, qm, false /* quotaDryRun */, nil /* mf */)
 			p := intercept.NewProcessor()
 
-			_, err := p.Before(ctx, test.req, "")
+			_, err := p.Before(ctx, test.req, "/trillian.TrillianLog/foo")
 			if gotErr := err != nil; gotErr != test.wantBeforeErr {
 				t.Fatalf("Before() returned err = %v, wantErr = %v", err, test.wantBeforeErr)
 			}


### PR DESCRIPTION
Non grpc interceptor implementations use Before / After directly.
Enabled service detection needs to be inside Before / After to be
rpc framework independent.