### PR TITLE
maphammer: use consistent check for empty contents

### DIFF
--- a/testonly/hammer/contents.go
+++ b/testonly/hammer/contents.go
@@ -34,6 +34,9 @@ type mapContents struct {
 type mapKey [sha256.Size]byte
 
 func (m *mapContents) empty() bool {
+	if m == nil {
+		return true
+	}
 	return len(m.data) == 0
 }
 

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -616,7 +616,7 @@ func (s *hammerState) getLeavesRevInvalid(ctx context.Context) error {
 
 	rev := int64(0)
 	var index []byte
-	if contents == nil {
+	if contents.empty() {
 		// No contents so we can't choose a key
 		choice = MalformedKey
 	} else {
@@ -659,7 +659,7 @@ func (s *hammerState) setLeaves(ctx context.Context) error {
 leafloop:
 	for i := 0; i < n; i++ {
 		choice := choices[s.prng.Intn(len(choices))]
-		if contents == nil || contents.empty() {
+		if contents.empty() {
 			choice = CreateLeaf
 		}
 		switch choice {
@@ -719,7 +719,7 @@ func (s *hammerState) setLeavesInvalid(ctx context.Context) error {
 
 	choice := choices[s.prng.Intn(len(choices))]
 	contents := s.prevContents.lastCopy()
-	if contents == nil || contents.empty() {
+	if contents.empty() {
 		choice = MalformedKey
 	}
 	switch choice {


### PR DESCRIPTION
It is possible for the maphammer's local copy of the map contents
to be both non-nil and empty at the same time (e.g. if a single leaf
was added then deleted).

Make contents.empty() cope with nil contents and use it throughout.