### PR TITLE
Support unqualified service names in the interceptor.

### DIFF
--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -59,6 +59,9 @@ var (
 		"trillian.TrillianLog":   true,
 		"trillian.TrillianMap":   true,
 		"trillian.TrillianAdmin": true,
+		"TrillianLog":            true,
+		"TrillianMap":            true,
+		"TrillianAdmin":          true,
 	}
 )
 
@@ -274,13 +277,21 @@ func isLeafOK(leaf *trillian.QueuedLogLeaf) bool {
 	return leaf == nil || leaf.Status == nil || leaf.Status.Code == int32(codes.OK)
 }
 
-// serviceName returns "some.package.service" for
-// "/some.package.service/method".
+// serviceName returns the fully qualified service name
+// "some.package.service" for "/some.package.service/method".
+// It returns the unqualified service name "service" for "/service.method".
 func serviceName(fullMethod string) string {
 	if !strings.HasPrefix(fullMethod, "/") {
 		return ""
 	}
-	return strings.Split(fullMethod, "/")[1]
+	bySlash := strings.Split(fullMethod, "/")
+	// Fully qualified: "/some.pakcage.service/method"
+	if len(bySlash) == 3 {
+		return bySlash[1] // some.package.service
+	}
+	// Unqualified: "/service.method"
+	byPeriod := strings.Split(bySlash[1], ".")
+	return byPeriod[0]
 }
 
 type rpcInfo struct {

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -277,7 +277,7 @@ func isLeafOK(leaf *trillian.QueuedLogLeaf) bool {
 	return leaf == nil || leaf.Status == nil || leaf.Status.Code == int32(codes.OK)
 }
 
-var fullyQualifiedRE = regexp.MustCompile(`^/([\w\.]+)/(\w+)$`)
+var fullyQualifiedRE = regexp.MustCompile(`^/([\w.]+)/(\w+)$`)
 var unqualifiedRE = regexp.MustCompile(`^/(\w+)\.(\w+)$`)
 
 // serviceName returns the fully qualified service name

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -40,16 +40,19 @@ import (
 
 func TestServiceName(t *testing.T) {
 	for _, tc := range []struct {
-		Desc       string
-		FullMethod string
-		Want       string
+		desc   string
+		method string
+		want   string
 	}{
-		{Desc: "grpc", FullMethod: "/trillian.TrillianLog/QueueLeaf", Want: "trillian.TrillianLog"},
-		{Desc: "unqualified", FullMethod: "/TrillianLog.QueueLeaf", Want: "TrillianLog"},
+		{desc: "trillian", method: "/trillian.TrillianLog/QueueLeaf", want: "trillian.TrillianLog"},
+		{desc: "fullyqualified", method: "/some.package.service/method", want: "some.package.service"},
+		{desc: "unqualified", method: "/service.method", want: "service"},
+		{desc: "noleadingslash", method: "no.leading.slash/method"},
+		{desc: "malformed", method: "/package.service.method"},
 	} {
-		t.Run(tc.Desc, func(t *testing.T) {
-			if got, want := serviceName(tc.FullMethod), tc.Want; got != want {
-				t.Errorf("serviceName(%v): %v, want %v", tc.FullMethod, got, want)
+		t.Run(tc.desc, func(t *testing.T) {
+			if got, want := serviceName(tc.method), tc.want; got != want {
+				t.Errorf("serviceName(%v): %v, want %v", tc.method, got, want)
 			}
 		})
 	}

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -216,7 +216,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 	}{
 		{
 			desc:   "logRead",
-			method: "/TrillianLog.GetLatestSignedLogRoot",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -226,7 +226,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logReadIndices",
-			method: "/TrillianLog.GetLeavesByIndex",
+			method: "/trillian.TrillianLog/GetLeavesByIndex",
 			req:    &trillian.GetLeavesByIndexRequest{LogId: logTree.TreeId, LeafIndex: []int64{1, 2, 3}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -236,7 +236,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logReadRange",
-			method: "/TrillianLog.GetLeavesByRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -246,7 +246,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logReadNegativeRange",
-			method: "/TrillianLog.GetLeavesByRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: -123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -256,7 +256,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logReadZeroRange",
-			method: "/TrillianLog.GetLeavesByRange",
+			method: "/trillian.TrillianLog/GetLeavesByRange",
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 0},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -266,7 +266,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logRead with charges",
-			method: "/TrillianLog.GetLatestSignedLogRoot",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId, ChargeTo: charges},
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Read, User: charge1},
@@ -278,7 +278,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logWrite",
-			method: "/TrillianLog.QueueLeaf",
+			method: "/trillian.TrillianLog/QueueLeaf",
 			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
@@ -288,7 +288,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "logWrite with charges",
-			method: "/TrillianLog.QueueLeaf",
+			method: "/trillian.TrillianLog/QueueLeaf",
 			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId, ChargeTo: charges},
 			specs: []quota.Spec{
 				{Group: quota.User, Kind: quota.Write, User: charge1},
@@ -300,7 +300,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "mapRead",
-			method: "/TrillianMap.GetLeaves",
+			method: "/trillian.TrillianMap/GetLeaves",
 			req:    &trillian.GetMapLeavesRequest{MapId: mapTree.TreeId, Index: [][]byte{{0x01}, {0x02}}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: mapTree.TreeId},
@@ -310,7 +310,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "emptyBatchRequest",
-			method: "/TrillianLog.QueueLeaves",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: nil,
@@ -318,7 +318,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "batchLogLeavesRequest",
-			method: "/TrillianLog.QueueLeaves",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:  logTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -331,7 +331,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "batchSequencedLogLeavesRequest",
-			method: "/TrillianLog.AddSequencedLeaves",
+			method: "/trillian.TrillianLog/AddSequencedLeaves",
 			req: &trillian.AddSequencedLeavesRequest{
 				LogId:  preorderedTree.TreeId,
 				Leaves: []*trillian.LogLeaf{{}, {}, {}},
@@ -344,7 +344,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "batchLogLeavesRequest with charges",
-			method: "/TrillianLog.QueueLeaves",
+			method: "/trillian.TrillianLog/QueueLeaves",
 			req: &trillian.QueueLeavesRequest{
 				LogId:    logTree.TreeId,
 				Leaves:   []*trillian.LogLeaf{{}, {}, {}},
@@ -360,7 +360,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "batchMapLeavesRequest",
-			method: "/TrillianMap.SetLeaves",
+			method: "/trillian.TrillianMap/SetLeaves",
 			req: &trillian.SetMapLeavesRequest{
 				MapId:  mapTree.TreeId,
 				Leaves: []*trillian.MapLeaf{{}, {}, {}, {}, {}},
@@ -373,7 +373,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		},
 		{
 			desc:   "quotaError",
-			method: "/TrillianLog.GetLatestSignedLogRoot",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
@@ -386,7 +386,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		{
 			desc:   "quotaDryRunError",
 			dryRun: true,
-			method: "/TrillianLog.GetLatestSignedLogRoot",
+			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},


### PR DESCRIPTION
Some rpc frameworks have a slightly different `/service.method` format.