### PR TITLE
Add a module for managing Trillian client connection options

### DIFF
--- a/client/rpcflags/rpcflags.go
+++ b/client/rpcflags/rpcflags.go
@@ -16,7 +16,6 @@ package rpcflags
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
@@ -39,7 +38,7 @@ func NewClientDialOptionsFromFlags() ([]grpc.DialOption, error) {
 	} else {
 		creds, err := credentials.NewClientTLSFromFile(*tlsCertFile, "")
 		if err != nil {
-			return nil, fmt.Errorf("failed to get credentials: %v. Please make sure that %s is the correct TLS certificate file", err, *tlsCertFile)
+			return nil, err
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
 	}

--- a/client/rpcflags/rpcflags.go
+++ b/client/rpcflags/rpcflags.go
@@ -1,0 +1,48 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcflags
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+var (
+	// tlsCertFile is the flag-assigned value for the path to the Trillian server's TLS certificate.
+	tlsCertFile = flag.String("tls_cert_file", "", "Path to the file containing the Trillian server's PEM-encoded public TLS certificate. If unset, unsecured connections will be used")
+)
+
+// NewClientDialOptionsFromFlags returns a list of grpc.DialOption values to be
+// passed as DialOption arguments to grpc.Dial
+func NewClientDialOptionsFromFlags() ([]grpc.DialOption, error) {
+	dialOpts := []grpc.DialOption{}
+
+	if *tlsCertFile == "" {
+		glog.Warning("Using an insecure gRPC connection to Trillian")
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	} else {
+		creds, err := credentials.NewClientTLSFromFile(*tlsCertFile, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get credentials: %v. Please make sure that %s is the correct TLS certificate file", err, *tlsCertFile)
+		}
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	}
+
+	return dialOpts, nil
+}

--- a/client/rpcflags/rpcflags_test.go
+++ b/client/rpcflags/rpcflags_test.go
@@ -54,8 +54,7 @@ func TestNewClientDialOptionsFromFlagsWithTLSCertFileNotSet(t *testing.T) {
 	defer conn.Close()
 
 	adminClient := trillian.NewTrillianAdminClient(conn)
-	_, err = adminClient.ListTrees(context.Background(), &trillian.ListTreesRequest{})
-	if err != nil {
+	if _, err = adminClient.ListTrees(context.Background(), &trillian.ListTreesRequest{}); err != nil {
 		t.Errorf("failed to request trees from the Admin Server: %v", err)
 	}
 }

--- a/client/rpcflags/rpcflags_test.go
+++ b/client/rpcflags/rpcflags_test.go
@@ -109,6 +109,9 @@ func TestNewClientDialOptionsFromFlagsWithTLSCertFileSet(t *testing.T) {
 	// Set up the flag.
 	defer flagsaver.Save().Restore()
 	err = flag.Set("tls_cert_file", crtFile.Name())
+	if err != nil {
+		t.Errorf("Failed to set -tls_cert_file flag: %v", err)
+	}
 
 	dialOpts, err := NewClientDialOptionsFromFlags()
 	if err != nil {

--- a/client/rpcflags/rpcflags_test.go
+++ b/client/rpcflags/rpcflags_test.go
@@ -1,0 +1,131 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcflags
+
+import (
+	"context"
+	"encoding/pem"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/google/trillian"
+	"github.com/google/trillian/testonly/integration"
+	"github.com/google/trillian/testonly/setup"
+	"github.com/google/trillian/util/flagsaver"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestNewClientDialOptionsFromFlagsWithTLSCertFileNotSet(t *testing.T) {
+	// Set up Trillian servers
+	const numSequencers = 2
+	serverOpts := []grpc.ServerOption{}
+	clientOpts := []grpc.DialOption{grpc.WithInsecure()}
+	logEnv, err := integration.NewLogEnvWithGRPCOptions(context.Background(), numSequencers, serverOpts, clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logEnv.Close()
+
+	dialOpts, err := NewClientDialOptionsFromFlags()
+	if err != nil {
+		t.Errorf("Got an unexpected error: %v", err)
+	}
+
+	// Check that the returned dial options can be used to connect and make
+	// requests against the Trillian services created above.
+	conn, err := grpc.Dial(logEnv.Address, dialOpts...)
+	if err != nil {
+		t.Errorf("failed to dial %v: %v", logEnv.Address, err)
+	}
+	defer conn.Close()
+
+	adminClient := trillian.NewTrillianAdminClient(conn)
+	_, err = adminClient.ListTrees(context.Background(), &trillian.ListTreesRequest{})
+	if err != nil {
+		t.Errorf("failed to request trees from the Admin Server: %v", err)
+	}
+}
+
+func TestNewClientDialOptionsFromFlagsWithTLSCertFileMissing(t *testing.T) {
+	defer flagsaver.Save().Restore()
+	err := flag.Set("tls_cert_file", "/a/missing/file")
+	if err != nil {
+		t.Errorf("Failed to set flag: %v", err)
+	}
+
+	dialOpts, err := NewClientDialOptionsFromFlags()
+	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("Expected to get an error due to the file not being found, instead got: %v", err)
+	}
+
+	if dialOpts != nil {
+		t.Errorf("Expected returned dialOpts to be nil, instead got: %v", dialOpts)
+	}
+}
+
+func TestNewClientDialOptionsFromFlagsWithTLSCertFileSet(t *testing.T) {
+	// Create new TLS certificates for the test services, and write the Client
+	// certificate to a file (so we can refer to it using the flag).
+	crtFile, cleanupCrtFile := setup.TempFile(t, "test.crt.")
+	defer cleanupCrtFile()
+
+	tlsCert := setup.NewTLSCertificate(t)
+
+	// Certificate file and client dial options.
+	err := pem.Encode(crtFile, &pem.Block{Type: "CERTIFICATE", Bytes: tlsCert.Certificate[0]})
+	if err != nil {
+		t.Fatalf("Failed to encode the test TLS certificate %v", err)
+	}
+	clientCreds, err := credentials.NewClientTLSFromFile(crtFile.Name(), "")
+	if err != nil {
+		t.Fatalf("Failed to get credentials: %v", err)
+	}
+
+	// Set up Trillian servers (with TLS enabled)
+	const numSequencers = 2
+	serverCreds := credentials.NewServerTLSFromCert(&tlsCert)
+	serverOpts := []grpc.ServerOption{grpc.Creds(serverCreds)}
+	clientOpts := []grpc.DialOption{grpc.WithTransportCredentials(clientCreds)}
+	logEnv, err := integration.NewLogEnvWithGRPCOptions(context.Background(), numSequencers, serverOpts, clientOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logEnv.Close()
+
+	// Set up the flag.
+	defer flagsaver.Save().Restore()
+	err = flag.Set("tls_cert_file", crtFile.Name())
+
+	dialOpts, err := NewClientDialOptionsFromFlags()
+	if err != nil {
+		t.Errorf("Got an unexpected error: %v", err)
+	}
+
+	// Check that the returned dial options can be used to connect and make
+	// requests against the Trillian services created above.
+	conn, err := grpc.Dial(logEnv.Address, dialOpts...)
+	if err != nil {
+		t.Errorf("failed to dial %v: %v", logEnv.Address, err)
+	}
+	defer conn.Close()
+
+	adminClient := trillian.NewTrillianAdminClient(conn)
+	_, err = adminClient.ListTrees(context.Background(), &trillian.ListTreesRequest{})
+	if err != nil {
+		t.Errorf("failed to request trees from the Admin Server: %v", err)
+	}
+}

--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -79,7 +79,7 @@ func createTree(ctx context.Context) (*trillian.Tree, error) {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to determine dial options: %v", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)

--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
+	"github.com/google/trillian/client/rpcflags"
 	"github.com/google/trillian/cmd"
 	"github.com/google/trillian/cmd/createtree/keys"
 	"github.com/google/trillian/crypto/keyspb"
@@ -76,7 +77,12 @@ func createTree(ctx context.Context) (*trillian.Tree, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.Dial(*adminServerAddr, grpc.WithInsecure())
+	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %v: %v", *adminServerAddr, err)
 	}

--- a/cmd/deletetree/main.go
+++ b/cmd/deletetree/main.go
@@ -40,18 +40,18 @@ func main() {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		glog.Exitf("failed to determine dial options: %v", err)
+		glog.Exitf("Failed to determine dial options: %v", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
-		glog.Exitf("failed to dial %v: %v", *adminServerAddr, err)
+		glog.Exitf("Failed to dial %v: %v", *adminServerAddr, err)
 	}
 	defer conn.Close()
 
 	a := trillian.NewTrillianAdminClient(conn)
 	_, err = a.DeleteTree(context.Background(), &trillian.DeleteTreeRequest{TreeId: *logID})
 	if err != nil {
-		glog.Exitf("delete failed: %v", err)
+		glog.Exitf("Delete failed: %v", err)
 	}
 }

--- a/cmd/deletetree/main.go
+++ b/cmd/deletetree/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return nil, err
+		glog.Exitf("failed to determine dial options: %v", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)

--- a/cmd/deletetree/main.go
+++ b/cmd/deletetree/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
+	"github.com/google/trillian/client/rpcflags"
 	"google.golang.org/grpc"
 )
 
@@ -37,7 +38,12 @@ func main() {
 	flag.Parse()
 	defer glog.Flush()
 
-	conn, err := grpc.Dial(*adminServerAddr, grpc.WithInsecure())
+	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
 		glog.Exitf("failed to dial %v: %v", *adminServerAddr, err)
 	}

--- a/cmd/updatetree/main.go
+++ b/cmd/updatetree/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
+	"github.com/google/trillian/client/rpcflags"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -73,7 +74,12 @@ func updateTree(ctx context.Context) (*trillian.Tree, error) {
 		UpdateMask: treeStateMask,
 	}
 
-	conn, err := grpc.Dial(*adminServerAddr, grpc.WithInsecure())
+	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %v: %v", *adminServerAddr, err)
 	}

--- a/cmd/updatetree/main.go
+++ b/cmd/updatetree/main.go
@@ -76,7 +76,7 @@ func updateTree(ctx context.Context) (*trillian.Tree, error) {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to determine dial options: %v", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)

--- a/testonly/setup/files.go
+++ b/testonly/setup/files.go
@@ -27,7 +27,7 @@ func TempFile(t *testing.T, prefix string) (*os.File, func()) {
 
 	file, err := ioutil.TempFile("", prefix)
 	if err != nil {
-		t.Fatalf("Failed to generate a fake audit log file: %v", err)
+		t.Fatalf("Failed to generate a temporary file: %v", err)
 	}
 
 	cleanup := func() {

--- a/testonly/setup/files.go
+++ b/testonly/setup/files.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// TempFile creates a temporary file to be used in a test, and returns its
+// *os.File handler, as well as a cleanup function.
+func TempFile(t *testing.T, prefix string) (*os.File, func()) {
+	t.Helper()
+
+	file, err := ioutil.TempFile("", prefix)
+	if err != nil {
+		t.Fatalf("Failed to generate a fake audit log file: %v", err)
+	}
+
+	cleanup := func() {
+		if err := os.Remove(file.Name()); err != nil {
+			t.Fatalf("Failed to remove temporary file '%s': %v", file.Name(), err)
+		}
+
+		if err := file.Close(); err != nil {
+			t.Fatalf("Failed to close temporary file handler '%v': %v", file, err)
+		}
+	}
+
+	return file, cleanup
+}

--- a/testonly/setup/tls.go
+++ b/testonly/setup/tls.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// NewTLSCertificate returns a random TLS Certificate for testing.
+func NewTLSCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Errorf("failed to generate RSA key: %s", err)
+	}
+
+	privBytes := x509.MarshalPKCS1PrivateKey(priv)
+	key := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+
+	// Generate public certificate.
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Errorf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		NotBefore:    time.Time{},
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+	pubBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Errorf("failed to generate TLS public certificate: %s", err)
+	}
+
+	crt := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pubBytes})
+
+	c, err := tls.X509KeyPair(crt, key)
+	if err != nil {
+		t.Errorf("failed to parse the public/private key pair: %s", err)
+	}
+
+	return c
+}


### PR DESCRIPTION
This change adds a `-tls_cert_file` flag to the following binaries, making it possible for them to talk to Trillian services configured to use TLS:
- createtree
- deletetree
- updatetree

Also, it adds the following test helper methods, under a new `testonly/setup` module:
- `TempFile`: Returns a new temporary file and a cleanup method to
  delete it, which should be called with `defer`.
- `NewTLSCertificate`: Creates a random new TLS certificate that can be
  used in tests.
