### PR TITLE
Stop the MySQL storage provider from losing its mysql.OpenDB error

### DIFF
--- a/server/mysql_storage_provider_test.go
+++ b/server/mysql_storage_provider_test.go
@@ -15,10 +15,18 @@
 package server
 
 import (
+	"flag"
 	"testing"
+
+	"github.com/google/trillian/util/flagsaver"
 )
 
 func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
+	defer flagsaver.Save().Restore()
+	if err := flag.Set("mysql_uri", ""); err != nil {
+		t.Errorf("Failed to set flag: %v", err)
+	}
+
 	// First call: This should fail due to the Database URL being empty.
 	_, err1 := NewStorageProvider("mysql", nil)
 	if err1 == nil {

--- a/server/mysql_storage_provider_test.go
+++ b/server/mysql_storage_provider_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+)
+
+func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
+	// First call: This should fail due to the Database URL being empty.
+	_, err1 := NewStorageProvider("mysql", nil)
+	if err1 == nil {
+		t.Fatalf("Expected 'server.NewStorageProvider' to fail")
+	}
+
+	// Second call: This should fail with the same error.
+	_, err2 := NewStorageProvider("mysql", nil)
+	if err2 == nil {
+		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail")
+	}
+
+	if err2 != err1 {
+		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail with %s, instead got: %s", err1, err2)
+	}
+}

--- a/server/mysql_storage_provider_test.go
+++ b/server/mysql_storage_provider_test.go
@@ -40,6 +40,6 @@ func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
 	}
 
 	if err2 != err1 {
-		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail with %s, instead got: %s", err1, err2)
+		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail with %q, instead got: %q", err1, err2)
 	}
 }


### PR DESCRIPTION
Currently, if `server.NewStorageProvider("mysql", nil)` is called twice
with a bad MySQL URL, the first time, it will fail properly returning a
non-nil error. However, this error is lost afterwards and the second
time it will silently fail and return a nil StorageProvider.

This change fixes that by making the MySQL storage provider hold on to
any initialization errors it encounters, and returning them for every
new storage provider request.