### PR TITLE
Refactor the memory storage provider

### DIFF
--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -117,10 +117,11 @@ func TestInProcessLogIntegration(t *testing.T) {
 func TestInProcessLogIntegrationDuplicateLeaves(t *testing.T) {
 	ctx := context.Background()
 	const numSequencers = 2
-	ms := memory.NewLogStorage(nil)
+	ts := memory.NewTreeStorage()
+	ms := memory.NewLogStorage(ts, nil)
 
 	reggie := extension.Registry{
-		AdminStorage: memory.NewAdminStorage(ms),
+		AdminStorage: memory.NewAdminStorage(ts),
 		LogStorage:   ms,
 		QuotaManager: quota.Noop(),
 	}

--- a/server/memory_storage_provider.go
+++ b/server/memory_storage_provider.go
@@ -29,21 +29,18 @@ func init() {
 
 type memProvider struct {
 	mf monitoring.MetricFactory
-	ls storage.LogStorage
-	as storage.AdminStorage
+	ts *memory.TreeStorage
 }
 
 func newMemoryStorageProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
-	ls := memory.NewLogStorage(mf)
 	return &memProvider{
 		mf: mf,
-		ls: ls,
-		as: memory.NewAdminStorage(ls),
+		ts: memory.NewTreeStorage(),
 	}, nil
 }
 
 func (s *memProvider) LogStorage() storage.LogStorage {
-	return s.ls
+	return memory.NewLogStorage(s.ts, s.mf)
 }
 
 func (s *memProvider) MapStorage() storage.MapStorage {
@@ -51,7 +48,7 @@ func (s *memProvider) MapStorage() storage.MapStorage {
 }
 
 func (s *memProvider) AdminStorage() storage.AdminStorage {
-	return s.as
+	return memory.NewAdminStorage(s.ts)
 }
 
 func (s *memProvider) Close() error {

--- a/server/memory_storage_provider_test.go
+++ b/server/memory_storage_provider_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+)
+
+func TestMemoryStorageProvider(t *testing.T) {
+	sp, err := NewStorageProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("Got an unexpected error: %v", err)
+	}
+	if sp == nil {
+		t.Fatal("Got a nil storage provider.")
+	}
+}
+
+func TestMemoryStorageProviderLogStorage(t *testing.T) {
+	sp, err := NewStorageProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("Got an unexpected error: %v", err)
+	}
+
+	ls := sp.LogStorage()
+	if ls == nil {
+		t.Fatal("Got a nil log storage interface.")
+	}
+}
+
+func TestMemoryStorageProviderMapStorage(t *testing.T) {
+	sp, err := NewStorageProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("Got an unexpected error: %v", err)
+	}
+
+	as := sp.MapStorage()
+	if as == nil {
+		t.Skip("Memory map storage is not implemented yet.")
+	}
+}
+
+func TestMemoryStorageProviderAdminStorage(t *testing.T) {
+	sp, err := NewStorageProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("Got an unexpected error: %v", err)
+	}
+
+	as := sp.AdminStorage()
+	if as == nil {
+		t.Fatal("Got a nil admin storage interface.")
+	}
+}
+
+func TestMemoryStorageProviderClose(t *testing.T) {
+	sp, err := NewStorageProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("Got an unexpected error: %v", err)
+	}
+
+	err = sp.Close()
+	if err != nil {
+		t.Fatalf("Failed to close the memory storage provider: %v", err)
+	}
+}

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -27,14 +27,14 @@ import (
 )
 
 // NewAdminStorage returns a storage.AdminStorage implementation backed by
-// memoryTreeStorage.
-func NewAdminStorage(ms storage.LogStorage) storage.AdminStorage {
-	return &memoryAdminStorage{ms.(*memoryLogStorage).memoryTreeStorage}
+// TreeStorage.
+func NewAdminStorage(ms *TreeStorage) storage.AdminStorage {
+	return &memoryAdminStorage{ms}
 }
 
 // memoryAdminStorage implements storage.AdminStorage
 type memoryAdminStorage struct {
-	ms *memoryTreeStorage
+	ms *TreeStorage
 }
 
 func (s *memoryAdminStorage) Snapshot(ctx context.Context) (storage.ReadOnlyAdminTX, error) {
@@ -55,7 +55,7 @@ func (s *memoryAdminStorage) CheckDatabaseAccessible(ctx context.Context) error 
 }
 
 type adminTX struct {
-	ms *memoryTreeStorage
+	ms *TreeStorage
 	// mu guards reads/writes on closed, which happen only on
 	// Commit/Rollback/IsClosed/Close methods.
 	// We don't check closed on *all* methods (apart from the ones above),

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -239,8 +239,9 @@ func Main(args Options) string {
 	leafHashesFlag = args.LeafHashes
 
 	glog.Info("Initializing memory log storage")
-	ls := memory.NewLogStorage(monitoring.InertMetricFactory{})
-	as := memory.NewAdminStorage(ls)
+	ts := memory.NewTreeStorage()
+	ls := memory.NewLogStorage(ts, monitoring.InertMetricFactory{})
+	as := memory.NewAdminStorage(ts)
 	tree, tSigner := createTree(as, ls)
 
 	seq := log.NewSequencer(rfc6962.DefaultHasher,


### PR DESCRIPTION
This refactoring makes the memory storage provider more similar to how
the other storage providers work by directly holding a reference to its
in-memory database object rather than doing that indirectly through a
`storage.LogStorage` instance.