### PR TITLE
Copy update_changelog.sh from certificate-transparency-go

### DIFF
--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,17 +1,16 @@
-#! /bin/bash
+#!/bin/bash
 #
-# Run this script from the top level directory of the trillian repo e.g.
+# Run this script from the top level directory of the ct-go repo e.g.
 # with scripts/update_changelog.sh.
-#
-# GOPATH must be set.
 
-set +e
-d=${GOPATH[0]}
+# Get and build the correct fork that includes markdown output.
+# TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81
+# is merged.
+go get -u github.com/Martin2112/github-release
 
-# Get and build the correct branch that includes markdown output
-# TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81 is merged
-go install github.com/Martin2112/github-release
-
-# Generate the changelog
-${d}/bin/github-release info -r trillian -u google --markdown > CHANGELOG.md
+# Generate the changelog.
+github-release info \
+  -r trillian \
+  -u google \
+  --markdown > CHANGELOG.md
 


### PR DESCRIPTION
Copies over improvements made to that version of the script. The only edit was to change the "github-release -r" flag from "certificate-transparency-go" to "trillian".