### PR TITLE
Fix the build

### DIFF
--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -339,7 +339,7 @@ loop:
 		if runner == nil {
 			continue
 		}
-		glog.V(1).Infof("cancel election runner for %d", logID)
+		glog.V(1).Infof("cancel election runner for %s", logID)
 		runner.Cancel()
 	}
 	glog.Infof("wait for termination of election runners...")


### PR DESCRIPTION
Currently, building fails with the following error:

```
server/log_operation_manager.go:342: Verbose.Infof format %d has arg
logID of wrong type string
```

This is because `logID` is a string, but `Infof` is being asked to format it
as an integer.