### PR TITLE
[Election] Move Migrillian election code

### DIFF
--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package election provides master election tools, and interfaces for plugging
+// in a custom underlying mechanism.
+// TODO(pavelkalinnikov): Migrate this package to Trillian.
+package election
+
+import "context"
+
+// Election controls an instance's participation in master election process.
+// Note: Implementations are not intended to be thread-safe.
+type Election interface {
+	// Await blocks until the instance captures mastership. Returns immediately
+	// if it is already the master. Returns an error if capturing fails, or the
+	// passed in context is canceled before mastership is captured. If an error
+	// is returned, the instance might still have become the master. Idempotent,
+	// might be useful to retry in case of an error.
+	Await(ctx context.Context) error
+
+	// Observe returns a "mastership context" which remains active until the
+	// instance stops being the master, or the passed in context is canceled. If
+	// the instance is not the master during this call, returns an already
+	// canceled context. In particular, this will happen if Observe is called
+	// without a preceding Await.
+	//
+	// The resources used for maintaining the mastership context are released
+	// when the latter gets canceled. This happens when the instance loses
+	// mastership, calls Resign, an error occurs in mastership monitoring, or the
+	// context passed in to Observe is explicitly canceled.
+	Observe(ctx context.Context) (context.Context, error)
+
+	// Resign releases mastership for this instance. The instance can be elected
+	// again using Await. Idempotent, might be useful to retry if fails.
+	//
+	// Note: Resign does not guarantee immediate cancelation of the context
+	// returned from Observe. However, the latter will happen *eventually* if
+	// resigning is successful. The caller can force mastership context
+	// cancelation by explicitly canceling the context passed in to Observe.
+	//
+	// The caller is advised to tear down mastership-related work before invoking
+	// Resign to have best protection against double-master situations.
+	Resign(ctx context.Context) error
+
+	// Close permanently stops participating in election, and releases the
+	// resources. It does best effort on resigning despite potential cancelation
+	// of the passed in context, so that other instances can overtake mastership
+	// faster. No other method should be called after Close.
+	//
+	// Note: Does not guarantee immediate mastership context cancelation, see
+	// Resign comment for details.
+	Close(ctx context.Context) error
+}
+
+// Factory encapsulates the creation of an Election instance for a treeID.
+type Factory interface {
+	NewElection(ctx context.Context, treeID int64) (Election, error)
+}

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -14,6 +14,20 @@
 
 // Package election provides master election tools, and interfaces for plugging
 // in a custom underlying mechanism.
+//
+// There are two important abstractions in this package: instance and resource.
+// - An instance is a single client of the library. An instance is represented
+//   by an Election object.
+// - A resource is something guarded by master election (e.g. a piece of data,
+//   or operation). Each resource has at most one (most of the time; see note
+//   below) master instance which is said to own this resource. A single
+//   instance may own multiple resources.
+//
+// Note: Sometimes there can be more than 1 instance "believing" to own a
+// resource. The reason is that the client code operates outside of the
+// election mechanism (e.g. a distributed consensus group), so mastership
+// updates can race with the operation.
+//
 // TODO(pavelkalinnikov): Merge this package with util/election.
 package election
 

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -17,11 +17,11 @@
 //
 // There are two important abstractions in this package: instance and resource.
 // - An instance is a single client of the library. An instance is represented
-//   by an Election object.
+//   by an Election object (possibly multiple).
 // - A resource is something guarded by master election (e.g. a piece of data,
 //   or operation). Each resource has at most one (most of the time; see note
 //   below) master instance which is said to own this resource. A single
-//   instance may own multiple resources.
+//   instance may own multiple resources (one resource per Election object).
 //
 // Note: Sometimes there can be more than 1 instance "believing" to own a
 // resource. The reason is that the client code operates outside of the
@@ -53,6 +53,9 @@ type Election interface {
 	// when the latter gets canceled. This happens when the instance loses
 	// mastership, calls Resign, an error occurs in mastership monitoring, or the
 	// context passed in to WithMastership is explicitly canceled.
+	//
+	// If the passed in ctx is canceled, the instance does not resign mastership.
+	// Use Resign or Close method for that.
 	WithMastership(ctx context.Context) (context.Context, error)
 
 	// Resign releases mastership for this instance. The instance can be elected

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -14,7 +14,7 @@
 
 // Package election provides master election tools, and interfaces for plugging
 // in a custom underlying mechanism.
-// TODO(pavelkalinnikov): Migrate this package to Trillian.
+// TODO(pavelkalinnikov): Merge this package with util/election.
 package election
 
 import "context"

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package election provides master election tools, and interfaces for plugging
-// in a custom underlying mechanism.
+// Package election2 provides master election tools, and interfaces for
+// plugging in a custom underlying mechanism.
 //
 // There are two important abstractions in this package: instance and resource.
 // - An instance is a single client of the library. An instance is represented
@@ -29,7 +29,7 @@
 // updates can race with the operation.
 //
 // TODO(pavelkalinnikov): Merge this package with util/election.
-package election
+package election2
 
 import "context"
 

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -43,25 +43,25 @@ type Election interface {
 	// might be useful to retry in case of an error.
 	Await(ctx context.Context) error
 
-	// Observe returns a "mastership context" which remains active until the
-	// instance stops being the master, or the passed in context is canceled. If
-	// the instance is not the master during this call, returns an already
-	// canceled context. In particular, this will happen if Observe is called
-	// without a preceding Await.
+	// WithMastership returns a "mastership context" which remains active until
+	// the instance stops being the master, or the passed in context is canceled.
+	// If the instance is not the master during this call, returns an already
+	// canceled context. In particular, this will happen if WithMastership is
+	// called without a preceding Await.
 	//
 	// The resources used for maintaining the mastership context are released
 	// when the latter gets canceled. This happens when the instance loses
 	// mastership, calls Resign, an error occurs in mastership monitoring, or the
-	// context passed in to Observe is explicitly canceled.
-	Observe(ctx context.Context) (context.Context, error)
+	// context passed in to WithMastership is explicitly canceled.
+	WithMastership(ctx context.Context) (context.Context, error)
 
 	// Resign releases mastership for this instance. The instance can be elected
 	// again using Await. Idempotent, might be useful to retry if fails.
 	//
 	// Note: Resign does not guarantee immediate cancelation of the context
-	// returned from Observe. However, the latter will happen *eventually* if
+	// returned from WithMastership. However, the latter will happen *eventually* if
 	// resigning is successful. The caller can force mastership context
-	// cancelation by explicitly canceling the context passed in to Observe.
+	// cancelation by explicitly canceling the context passed in to WithMastership.
 	//
 	// The caller is advised to tear down mastership-related work before invoking
 	// Resign to have best protection against double-master situations.

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -63,7 +63,8 @@ type Election interface {
 	Close(ctx context.Context) error
 }
 
-// Factory encapsulates the creation of an Election instance for a treeID.
+// Factory encapsulates the creation of an Election instance for a resource
+// with the specified ID.
 type Factory interface {
-	NewElection(ctx context.Context, treeID int64) (Election, error)
+	NewElection(ctx context.Context, resourceID string) (Election, error)
 }

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -1,0 +1,142 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package etcd provides an implementation of master election based on etcd.
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/golang/glog"
+	"github.com/google/certificate-transparency-go/trillian/migrillian/election"
+)
+
+// Election is an implementation of election.Election based on etcd.
+type Election struct {
+	treeID     int64
+	instanceID string
+	lockFile   string
+
+	client   *clientv3.Client
+	session  *concurrency.Session
+	election *concurrency.Election
+}
+
+// Await blocks until the instance captures mastership.
+func (e *Election) Await(ctx context.Context) error {
+	return e.election.Campaign(ctx, e.instanceID)
+}
+
+// Observe returns a "mastership context" which remains active until the
+// instance stops being the master, or the passed in context is canceled.
+func (e *Election) Observe(ctx context.Context) (context.Context, error) {
+	// Get a channel for notifications of election status (using the cancelable
+	// context so that the monitoring goroutine below and the goroutine started
+	// by Observe will reliably terminate).
+	cctx, cancel := context.WithCancel(ctx)
+	ch := e.election.Observe(cctx)
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	case rsp, ok := <-ch:
+		if !ok || string(rsp.Kvs[0].Value) != e.instanceID {
+			// Mastership has been overtaken in the meantime, or not capturead at all.
+			cancel()
+			return cctx, nil
+		}
+	}
+
+	// At this point we have observed confirmation that we are the master; start
+	// a goroutine to monitor for anyone else overtaking us.
+	go func() {
+		defer func() {
+			cancel()
+			glog.Infof("%d: canceled mastership context", e.treeID)
+		}()
+
+		for rsp := range ch {
+			if string(rsp.Kvs[0].Value) != e.instanceID {
+				glog.Warningf("%d: mastership overtaken", e.treeID)
+				break
+			}
+		}
+	}()
+
+	return cctx, nil
+}
+
+// Resign releases mastership for this instance. The instance can be elected
+// again using Await. Idempotent, might be useful to retry if fails.
+func (e *Election) Resign(ctx context.Context) error {
+	return e.election.Resign(ctx)
+}
+
+// Close resigns and permanently stops participating in election. No other
+// method should be called after Close.
+func (e *Election) Close(ctx context.Context) error {
+	if err := e.Resign(ctx); err != nil {
+		glog.Errorf("%d: Resign(): %v", e.treeID, err)
+	}
+	// Session's Close revokes the underlying lease, which results in removing
+	// the election-related keys. This achieves the effect of resignation even if
+	// the above Resign call failed (e.g. due to ctx cancelation).
+	return e.session.Close()
+}
+
+// Factory creates Election instances.
+type Factory struct {
+	client     *clientv3.Client
+	instanceID string
+	lockDir    string
+}
+
+// NewFactory builds an election factory that uses the given parameters. The
+// passed in etcd client should remain valid for the lifetime of the object.
+func NewFactory(instanceID string, client *clientv3.Client, lockDir string) *Factory {
+	return &Factory{
+		client:     client,
+		instanceID: instanceID,
+		lockDir:    lockDir,
+	}
+}
+
+// NewElection creates a specific Election instance.
+func (f *Factory) NewElection(ctx context.Context, treeID int64) (election.Election, error) {
+	// TODO(pavelkalinnikov): Re-create the session if it expires.
+	// TODO(pavelkalinnikov): Share the same session between Election instances.
+	session, err := concurrency.NewSession(f.client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create etcd session: %v", err)
+	}
+	lockFile := fmt.Sprintf("%s/%d", strings.TrimRight(f.lockDir, "/"), treeID)
+	election := concurrency.NewElection(session, lockFile)
+
+	el := Election{
+		treeID:     treeID,
+		instanceID: f.instanceID,
+		lockFile:   lockFile,
+		client:     f.client,
+		session:    session,
+		election:   election,
+	}
+	glog.Infof("Election created: %+v", el)
+
+	return &el, nil
+}

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -52,6 +52,7 @@ func (e *Election) WithMastership(ctx context.Context) (context.Context, error) 
 	cctx, cancel := context.WithCancel(ctx)
 	ch := e.election.Observe(cctx)
 
+	// Verify mastership before returning context.
 	select {
 	case <-ctx.Done():
 		cancel()

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Package etcd provides an implementation of master election based on etcd.
+// TODO(pavelkalinnikov): Add tests.
 package etcd
 
 import (

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -24,10 +24,10 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/golang/glog"
-	"github.com/google/certificate-transparency-go/trillian/migrillian/election"
+	"github.com/google/trillian/util/election2"
 )
 
-// Election is an implementation of election.Election based on etcd.
+// Election is an implementation of election2.Election based on etcd.
 type Election struct {
 	resourceID string
 	instanceID string
@@ -119,7 +119,7 @@ func NewFactory(instanceID string, client *clientv3.Client, lockDir string) *Fac
 }
 
 // NewElection creates a specific Election instance.
-func (f *Factory) NewElection(ctx context.Context, resourceID string) (election.Election, error) {
+func (f *Factory) NewElection(ctx context.Context, resourceID string) (election2.Election, error) {
 	// TODO(pavelkalinnikov): Re-create the session if it expires.
 	// TODO(pavelkalinnikov): Share the same session between Election instances.
 	session, err := concurrency.NewSession(f.client)

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -43,12 +43,12 @@ func (e *Election) Await(ctx context.Context) error {
 	return e.election.Campaign(ctx, e.instanceID)
 }
 
-// Observe returns a "mastership context" which remains active until the
+// WithMastership returns a "mastership context" which remains active until the
 // instance stops being the master, or the passed in context is canceled.
-func (e *Election) Observe(ctx context.Context) (context.Context, error) {
+func (e *Election) WithMastership(ctx context.Context) (context.Context, error) {
 	// Get a channel for notifications of election status (using the cancelable
 	// context so that the monitoring goroutine below and the goroutine started
-	// by Observe will reliably terminate).
+	// by WithMastership will reliably terminate).
 	cctx, cancel := context.WithCancel(ctx)
 	ch := e.election.Observe(cctx)
 

--- a/util/election2/noop.go
+++ b/util/election2/noop.go
@@ -1,0 +1,48 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import "context"
+
+// NoopElection is a stub Election that always believes to be the master.
+type NoopElection int64
+
+// Await returns immediately, as the instance is always the master.
+func (ne NoopElection) Await(ctx context.Context) error {
+	return nil
+}
+
+// Observe returns the passed in context as a mastership context.
+func (ne NoopElection) Observe(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+// Resign does nothing because NoopElection is always the master.
+func (ne NoopElection) Resign(ctx context.Context) error {
+	return nil
+}
+
+// Close does nothing because NoopElection is always the master.
+func (ne NoopElection) Close(ctx context.Context) error {
+	return nil
+}
+
+// NoopFactory creates NoopElection instances.
+type NoopFactory struct{}
+
+// NewElection creates a specific NoopElection instance.
+func (nf NoopFactory) NewElection(ctx context.Context, treeID int64) (Election, error) {
+	return NoopElection(treeID), nil
+}

--- a/util/election2/noop.go
+++ b/util/election2/noop.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package election
+package election2
 
 import "context"
 

--- a/util/election2/noop.go
+++ b/util/election2/noop.go
@@ -17,7 +17,7 @@ package election
 import "context"
 
 // NoopElection is a stub Election that always believes to be the master.
-type NoopElection int64
+type NoopElection string
 
 // Await returns immediately, as the instance is always the master.
 func (ne NoopElection) Await(ctx context.Context) error {
@@ -43,6 +43,6 @@ func (ne NoopElection) Close(ctx context.Context) error {
 type NoopFactory struct{}
 
 // NewElection creates a specific NoopElection instance.
-func (nf NoopFactory) NewElection(ctx context.Context, treeID int64) (Election, error) {
-	return NoopElection(treeID), nil
+func (nf NoopFactory) NewElection(ctx context.Context, resourceID string) (Election, error) {
+	return NoopElection(resourceID), nil
 }

--- a/util/election2/noop.go
+++ b/util/election2/noop.go
@@ -24,8 +24,8 @@ func (ne NoopElection) Await(ctx context.Context) error {
 	return nil
 }
 
-// Observe returns the passed in context as a mastership context.
-func (ne NoopElection) Observe(ctx context.Context) (context.Context, error) {
+// WithMastership returns the passed in context as a mastership context.
+func (ne NoopElection) WithMastership(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 


### PR DESCRIPTION
This change adds a new election package [taken](https://github.com/google/certificate-transparency-go/tree/fbb522e/trillian/migrillian/election) from Migrillian, with some minor modifications. The plan is to merge it with the previous `util/election` package (see #1191 for more details). Meanwhile `election2` will be used by Migrillian and Key Transparency.

This PR is best of all reviewed commit by commit.