### PR TITLE
Remove exit command from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,7 @@ script:
       if [[ -n ${status} ]]; then
         echo "Regenerated files differ from checked-in versions: ${status}"
         git status
-        git diff
-        exit 1
+        git diff --exit-code
       fi
   - |
       if [[ "${WITH_ETCD}" == "true" ]]; then


### PR DESCRIPTION
https://docs.travis-ci.com/user/customizing-the-build/#how-does-this-work-or-why-you-should-not-use-exit-in-build-steps