### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,11 @@ script:
         docker-compose -f examples/deployment/docker-compose.yml logs
         travis_terminate 1
       fi
+      if ! ./integration/log_integration_test.sh 127.0.0.1:8090; then
+        echo "Docker logs:"
+        docker-compose -f examples/deployment/docker-compose.yml logs
+        travis_terminate 1
+      fi
       docker-compose -f examples/deployment/docker-compose.yml down
   - set +e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,26 +104,12 @@ script:
       cd $HOME/gopath/src/github.com/google/trillian
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
   - |
-      docker-compose -f examples/deployment/docker-compose.yml up --build -d
-      # Wait until /healthz returns HTTP 200 and the text "ok", or fail after 60
-      # seconds. That should be long enough for the server to start.
-      health=$(wget --retry-connrefused --timeout 60 --output-document - \
-        http://127.0.0.1:8091/healthz)
-      health_exitcode=$?
-      if [[ ${health_exitcode} = 0 ]]; then
-        echo "Health: ${health}"
+      # TODO(RJPercival): Make docker-compose integration test work when PKCS#11
+      # support is enabled. This requires running softhsm in a Docker container.
+      # See https://github.com/rolandshoemaker/docker-hsm for an example.
+      if ! $WITH_PKCS11; then
+        ./integration/docker_compose_integration_test.sh
       fi
-      if [[ ${health_exitcode} != 0 || "${health}" != "ok" ]]; then
-        echo "Docker logs:"
-        docker-compose -f examples/deployment/docker-compose.yml logs
-        travis_terminate 1
-      fi
-      if ! ./integration/log_integration_test.sh 127.0.0.1:8090; then
-        echo "Docker logs:"
-        docker-compose -f examples/deployment/docker-compose.yml logs
-        travis_terminate 1
-      fi
-      docker-compose -f examples/deployment/docker-compose.yml down
   - set +e
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,7 @@ script:
       cd $HOME/gopath/src/github.com/google/trillian
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
   - |
-      MYSQL_ROOT_PASSWORD="zaphod" \
-        docker-compose -f examples/deployment/docker-compose.yml up --build -d
+      docker-compose -f examples/deployment/docker-compose.yml up --build -d
       # Wait until /healthz returns HTTP 200 and the text "ok", or fail after 60
       # seconds. That should be long enough for the server to start.
       health=$(wget --retry-connrefused --timeout 60 --output-document - \

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,23 @@ script:
       ./trillian/integration/integration_test.sh
       cd $HOME/gopath/src/github.com/google/trillian
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
+  - |
+      MYSQL_ROOT_PASSWORD="zaphod" \
+        docker-compose -f examples/deployment/docker-compose.yml up --build -d
+      # Wait until /healthz returns HTTP 200 and the text "ok", or fail after 60
+      # seconds. That should be long enough for the server to start.
+      health=$(wget --retry-connrefused --timeout 60 --output-document - \
+        http://127.0.0.1:8091/healthz)
+      health_exitcode=$?
+      if [[ ${health_exitcode} = 0 ]]; then
+        echo "Health: ${health}"
+      fi
+      if [[ ${health_exitcode} != 0 || "${health}" != "ok" ]]; then
+        echo "Docker logs:"
+        docker-compose -f examples/deployment/docker-compose.yml logs
+        travis_terminate 1
+      fi
+      docker-compose -f examples/deployment/docker-compose.yml down
   - set +e
 
 after_success:

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -29,7 +29,7 @@ schema and the trillian server.
 
 ```shell
 # Set a random password
-export DB_PASSWORD="$(openssl rand -hex 16)"
+export MYSQL_ROOT_PASSWORD="$(openssl rand -hex 16)"
 
 # Bring up services defined in this compose file.  This includes:
 # - local MySQL database

--- a/examples/deployment/aws/terraform.tf
+++ b/examples/deployment/aws/terraform.tf
@@ -1,7 +1,7 @@
 variable "WHITELIST_CIDR" {
   description="Your IP block to whitelist access from"
 }
-variable "DB_PASSWORD" { }
+variable "MYSQL_ROOT_PASSWORD" { }
 
 provider "aws" {
   region     = "us-west-2"
@@ -13,7 +13,7 @@ resource "aws_rds_cluster" "trillian" {
   cluster_identifier      = "trillian"
   database_name           = "test"
   master_username         = "root"
-  master_password         = "${var.DB_PASSWORD}"
+  master_password         = "${var.MYSQL_ROOT_PASSWORD}"
   skip_final_snapshot     = true
   port                    = 3306
   vpc_security_group_ids  = ["${aws_security_group.trillian_db.id}"]
@@ -136,17 +136,19 @@ go get github.com/google/trillian/server/trillian_log_server
 
 # Setup the DB
 cd /go/src/github.com/google/trillian
-export DB_USER=root
-export DB_PASSWORD=${var.DB_PASSWORD}
-export DB_HOST=${aws_rds_cluster.trillian.endpoint}
-export DB_DATABASE=test
-./scripts/resetdb.sh --verbose --force -h $DB_HOST
+export MYSQL_ROOT_USER=root
+export MYSQL_ROOT_PASSWORD=${var.MYSQL_ROOT_PASSWORD}
+export MYSQL_HOST=${aws_rds_cluster.trillian.endpoint}
+export MYSQL_DATABASE=test
+export MYSQL_USER=test
+export MYSQL_PASSWORD=zaphod
+./scripts/resetdb.sh --verbose --force
 
 # Startup the Server
 RPC_PORT=8090
 HTTP_PORT=8091
 /go/bin/trillian_log_server \
-	--mysql_uri="${DB_USER}:${DB_PASSWORD}@tcp(${DB_HOST})/${DB_DATABASE}" \
+	--mysql_uri="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST})/${MYSQL_DATABASE}" \
 	--rpc_endpoint="$HOST:$RPC_PORT" \
 	--http_endpoint="$HOST:$HTTP_PORT" \
 	--alsologtostderr

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       "/trillian_log_signer",
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--force_master",
     ]
     restart: always # retry while mysql is starting up
     ports:

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -3,14 +3,14 @@ services:
   mysql:
     image: mariadb:10.1
     environment:
-      - MYSQL_ROOT_PASSWORD
+      - MYSQL_ROOT_PASSWORD=zaphod
   trillian-db-seed:
     build:
       context: ../..
       dockerfile: ./examples/deployment/docker/db_client/Dockerfile
     environment:
       - MYSQL_ROOT_USER=root
-      - MYSQL_ROOT_PASSWORD
+      - MYSQL_ROOT_PASSWORD=zaphod
       - MYSQL_HOST=mysql
       - MYSQL_DATABASE=test
       - MYSQL_USER=test

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       "/trillian_log_server",
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--rpc_endpoint=0.0.0.0:8090",
+      "--http_endpoint=0.0.0.0:8091",
     ]
     restart: always # retry while mysql is starting up
     ports:
@@ -40,6 +42,8 @@ services:
       "/trillian_log_signer",
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--rpc_endpoint=0.0.0.0:8090",
+      "--http_endpoint=0.0.0.0:8091",
       "--force_master",
     ]
     restart: always # retry while mysql is starting up

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
+      "--alsologtostderr",
     ]
     restart: always # retry while mysql is starting up
     ports:
@@ -45,6 +46,7 @@ services:
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--force_master",
+      "--alsologtostderr",
     ]
     restart: always # retry while mysql is starting up
     ports:

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -23,8 +23,9 @@ services:
     build:
       context: ../..
       dockerfile: examples/deployment/docker/log_server/Dockerfile
-    entrypoint: [
-      "/trillian_log_server",
+      args:
+        - GOFLAGS
+    command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
       "--rpc_endpoint=0.0.0.0:8090",
@@ -41,8 +42,9 @@ services:
     build:
       context: ../..
       dockerfile: examples/deployment/docker/log_signer/Dockerfile
-    entrypoint: [
-      "/trillian_log_signer",
+      args:
+        - GOFLAGS
+    command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
       "--rpc_endpoint=0.0.0.0:8090",

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "8090:8090"
       - "8091:8091"
     depends_on:
-      - mysql
+      - trillian-db-seed
   trillian-log-signer:
     build:
       context: ../..
@@ -46,4 +46,5 @@ services:
     ports:
       - "8092:8091"
     depends_on:
-      - mysql
+      - trillian-db-seed
+

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -21,6 +21,11 @@ services:
     build:
       context: ../..
       dockerfile: examples/deployment/docker/log_server/Dockerfile
+    entrypoint: [
+      "/trillian_log_server",
+      "--storage_system=mysql",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+    ]
     restart: always # retry while mysql is starting up
     ports:
       - "8090:8090"
@@ -31,6 +36,11 @@ services:
     build:
       context: ../..
       dockerfile: examples/deployment/docker/log_signer/Dockerfile
+    entrypoint: [
+      "/trillian_log_signer",
+      "--storage_system=mysql",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+    ]
     restart: always # retry while mysql is starting up
     ports:
       - "8092:8091"

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - MYSQL_PASSWORD=zaphod
       - MYSQL_USER_HOST=%
     command: ./wait-for-it.sh -t 0 mysql:3306 -- ./scripts/resetdb.sh --verbose --force
+    depends_on:
+      - mysql
   trillian-log-server:
     build:
       context: ../..

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -3,15 +3,20 @@ services:
   mysql:
     image: mariadb:10.1
     environment:
-      - MYSQL_ROOT_PASSWORD=$DB_PASSWORD
+      - MYSQL_ROOT_PASSWORD
   trillian-db-seed:
     build:
       context: ../..
       dockerfile: ./examples/deployment/docker/db_client/Dockerfile
     environment:
-      - DB_USER=root
-      - DB_PASSWORD=$DB_PASSWORD
-    command: ./wait-for-it.sh -t 0 mysql:3306 -- ./scripts/resetdb.sh --verbose --force -h mysql
+      - MYSQL_ROOT_USER=root
+      - MYSQL_ROOT_PASSWORD
+      - MYSQL_HOST=mysql
+      - MYSQL_DATABASE=test
+      - MYSQL_USER=test
+      - MYSQL_PASSWORD=zaphod
+      - MYSQL_USER_HOST=%
+    command: ./wait-for-it.sh -t 0 mysql:3306 -- ./scripts/resetdb.sh --verbose --force
   trillian-log-server:
     build:
       context: ../..
@@ -22,9 +27,6 @@ services:
       - "8091:8091"
     depends_on:
       - mysql
-    environment:
-      - DB_USER=root
-      - DB_PASSWORD=$DB_PASSWORD
   trillian-log-signer:
     build:
       context: ../..
@@ -34,6 +36,3 @@ services:
       - "8092:8091"
     depends_on:
       - mysql
-    environment:
-      - DB_USER=root
-      - DB_PASSWORD=$DB_PASSWORD

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -6,10 +6,6 @@ RUN apt-get update && \
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-ENV DB_USER=test \
-    DB_PASSWORD=zaphod \
-    DB_DATABASE=test
-
 # This is used to wait for new MySQL deployments to become ready e.g.
 #  ./wait-for-it.sh localhost:3306 -- mysql
 RUN ./examples/deployment/scripts/download-wait-for-it.sh

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.10 as build
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN go get ./server/trillian_log_server
+ARG GOFLAGS=""
+RUN go get ${GOFLAGS} ./server/trillian_log_server
 
 FROM gcr.io/distroless/base
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.10 as build
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
-RUN go get ./server/trillian_log_signer
+ARG GOFLAGS=""
+RUN go get ${GOFLAGS} ./server/trillian_log_signer
 
 FROM gcr.io/distroless/base
 

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -4,5 +4,5 @@ set -e
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/functions.sh
 
-run_test "Map integration test" "${INTEGRATION_DIR}/map_integration_test.sh"
-run_test "Log integration test" "${INTEGRATION_DIR}/log_integration_test.sh"
+run_test "Map integration test" "${INTEGRATION_DIR}/map_integration_test.sh" "$@"
+run_test "Log integration test" "${INTEGRATION_DIR}/log_integration_test.sh" "$@"

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -3,26 +3,37 @@ set -e
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/functions.sh
 
-echo "Launching core Trillian map components"
-map_prep_test 1
-TO_KILL+=(${RPC_SERVER_PIDS[@]})
+TRILLIAN_SERVER="$1"
+TEST_STARTED_TRILLIAN_SERVER=false
+
+if [ -z "${TRILLIAN_SERVER}" ]; then
+  echo "Launching core Trillian map components"
+  map_prep_test 1
+  TO_KILL+=(${RPC_SERVER_PIDS[@]})
+
+  TRILLIAN_SERVER="${RPC_SERVER_1}"
+  TEST_STARTED_TRILLIAN_SERVER=true
+fi
 
 echo "Running test"
 cd "${INTEGRATION_DIR}"
 set +e
 go test ${GOFLAGS} \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
-  ./maptest  --map_rpc_server="${RPC_SERVER_1}"
+  ./maptest  --map_rpc_server="${TRILLIAN_SERVER}"
 RESULT=$?
 set -e
 
-map_stop_test
-TO_KILL=()
+if $TEST_STARTED_TRILLIAN_SERVER; then
+  map_stop_test
+  TO_KILL=()
 
-if [ $RESULT != 0 ]; then
-    sleep 1
-    echo "Server log:"
-    echo "--------------------"
-    cat "${TMPDIR}"/trillian_map_server.INFO
-    exit $RESULT
+  if [ $RESULT != 0 ]; then
+      sleep 1
+      echo "Server log:"
+      echo "--------------------"
+      cat "${TMPDIR}"/trillian_map_server.INFO
+  fi
 fi
+
+exit $RESULT

--- a/scripts/mysqlconnlimit.sh
+++ b/scripts/mysqlconnlimit.sh
@@ -5,18 +5,18 @@ set -e
 usage() {
   echo "$0 [--force] [--verbose] ..."
   echo "accepts environment variables:"
-  echo " - DB_USER"
-  echo " - DB_PASSWORD"
-  echo " - DB_HOST"
-  echo " - DB_PORT"
+  echo " - MYSQL_USER"
+  echo " - MYSQL_PASSWORD"
+  echo " - MYSQL_HOST"
+  echo " - MYSQL_PORT"
 }
 
 collect_vars() {
   # set unset environment variables to defaults
-  [ -z ${DB_USER+x} ] && DB_USER="root"
-  [ -z ${DB_NAME+x} ] && DB_NAME="test"
-  [ -z ${DB_HOST+x} ] && DB_HOST="localhost"
-  [ -z ${DB_PORT+x} ] && DB_PORT="3306"
+  [ -z ${MYSQL_USER+x} ] && MYSQL_USER="root"
+  [ -z ${MYSQL_NAME+x} ] && MYSQL_NAME="test"
+  [ -z ${MYSQL_HOST+x} ] && MYSQL_HOST="localhost"
+  [ -z ${MYSQL_PORT+x} ] && MYSQL_PORT="3306"
   FLAGS=()
 
   # handle flags
@@ -26,35 +26,34 @@ collect_vars() {
     case "$1" in
       --force) FORCE=true ;;
       --verbose) VERBOSE=true ;;
+      --help) usage; exit ;;
       *) FLAGS+=("$1")
     esac
     shift 1
   done
 
-  FLAGS+=(-u "${DB_USER}")
-  FLAGS+=(--host "${DB_HOST}")
-  FLAGS+=(--port "${DB_PORT}")
+  FLAGS+=(-u "${MYSQL_USER}")
+  FLAGS+=(--host "${MYSQL_HOST}")
+  FLAGS+=(--port "${MYSQL_PORT}")
 
   # Optionally print flags (before appending password)
   [[ ${VERBOSE} = 'true' ]] && echo "- Using MySQL Flags: ${FLAGS[@]}"
 
   # append password if supplied
-  [ -z ${DB_PASSWORD+x} ] || FLAGS+=(-p"${DB_PASSWORD}")
+  [ -z ${MYSQL_PASSWORD+x} ] || FLAGS+=(-p"${MYSQL_PASSWORD}")
 }
 
 main() {
   collect_vars "$@"
-  CONN_LIMIT=1024
+  local CONN_LIMIT=1024
 
-  # what we're about to do
-  echo "Warning: about set MySQL global connection limit to ${CONN_LIMIT}"
+  echo "Warning: about to set MySQL global connection limit to ${CONN_LIMIT}"
 
   [[ ${FORCE} = true ]] || read -p "Are you sure? [Y/N]: " -n 1 -r
   echo # Print newline following the above prompt
 
   if [ -z ${REPLY+x} ] || [[ $REPLY =~ ^[Yy]$ ]]
   then
-      echo "Setting connection limit to ${CONN_LIMIT}..."
       mysql "${FLAGS[@]}" -e "SET GLOBAL max_connections = ${CONN_LIMIT};"
       echo "Set Complete"
   fi

--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -67,7 +67,6 @@ main() {
 
   readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
 
-  # what we're about to do
   echo "Warning: about to destroy and reset database '${MYSQL_DATABASE}'"
 
   [[ ${FORCE} = true ]] || read -p "Are you sure? [Y/N]: " -n 1 -r


### PR DESCRIPTION
Fixes #1263, fixes #1099 and fixes #1164 by:
- Refactoring scripts/resetdb.sh to work when the test database is being accessed from a different container.
- Passing the correct flags to Trillian.
- Adding a docker-compose step to our Travis builds, so that docker-compose.yml can't silently break in the future (at least not completely - it's only a smoke test).