### PR TITLE
MAP Experiment: Allow map update in a single transaction

### DIFF
--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -289,6 +289,7 @@ map_prep_test() {
     ./trillian_map_server \
       --rpc_endpoint="localhost:${port}" \
       --http_endpoint="localhost:${http}" \
+      --single_transaction=true \
       --alsologtostderr \
       &
     pid=$!

--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -27,7 +27,10 @@ import (
 	_ "github.com/google/trillian/merkle/maphasher"
 )
 
-var server = flag.String("map_rpc_server", "", "Server address:port")
+var (
+	server   = flag.String("map_rpc_server", "", "Server address:port")
+	singleTX = flag.Bool("single_transaction", false, "Experimental: whether to update the map in a single transaction")
+)
 
 func TestMapIntegration(t *testing.T) {
 
@@ -38,7 +41,7 @@ func TestMapIntegration(t *testing.T) {
 		if !testdb.MySQLAvailable() {
 			t.Skip("Skipping map integration test, MySQL not available")
 		}
-		env, err = integration.NewMapEnv(ctx)
+		env, err = integration.NewMapEnv(ctx, *singleTX)
 	} else {
 		env, err = integration.NewMapEnvFromConn(*server)
 	}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -217,7 +217,8 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 			req.MapId,
 			writeRev,
 			hasher, func(ctx context.Context, f func(context.Context, storage.MapTreeTX) error) error {
-				return t.registry.MapStorage.ReadWriteTransaction(ctx, tree, f)
+				return f(ctx, tx)
+				//return t.registry.MapStorage.ReadWriteTransaction(ctx, tree, f)
 			})
 		if err != nil {
 			return err

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -44,6 +44,8 @@ func TestIsHealthy(t *testing.T) {
 		{"unhealthy", errors.New("DB not happy")},
 	}
 
+	opts := TrillianMapServerOptions{}
+
 	for _, test := range tests {
 		fakeStorage := storage.NewMockMapStorage(ctrl)
 		fakeStorage.EXPECT().CheckDatabaseAccessible(gomock.Any()).Return(test.accessibleErr)
@@ -51,7 +53,7 @@ func TestIsHealthy(t *testing.T) {
 		server := NewTrillianMapServer(extension.Registry{
 			AdminStorage: fakeAdminStorageForMap(ctrl, 1, mapID1),
 			MapStorage:   fakeStorage,
-		})
+		}, opts)
 
 		wantErr := test.accessibleErr != nil
 		err := server.IsHealthy()
@@ -98,7 +100,7 @@ func TestInitMap(t *testing.T) {
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: fakeAdminStorageForMap(ctrl, 2, mapID1),
 				MapStorage:   fakeStorage,
-			})
+			}, TrillianMapServerOptions{})
 
 			c, err := server.InitMap(ctx, &trillian.InitMapRequest{
 				MapId: mapID1,
@@ -138,7 +140,7 @@ func TestGetSignedMapRoot_NotInitialised(t *testing.T) {
 	server := NewTrillianMapServer(extension.Registry{
 		MapStorage:   fakeStorage,
 		AdminStorage: fakeAdmin,
-	})
+	}, TrillianMapServerOptions{})
 	fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
 	mockTX.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
@@ -206,7 +208,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: adminStorage,
 				MapStorage:   fakeStorage,
-			})
+			}, TrillianMapServerOptions{})
 
 			smrResp, err := server.GetSignedMapRoot(ctx, test.req)
 
@@ -237,7 +239,7 @@ func TestGetSignedMapRootByRevision_NotInitialised(t *testing.T) {
 	server := NewTrillianMapServer(extension.Registry{
 		MapStorage:   fakeStorage,
 		AdminStorage: adminStorage,
-	})
+	}, TrillianMapServerOptions{})
 	fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), gomock.Any()).Return(mockTX, nil)
 	mockTX.EXPECT().GetSignedMapRoot(gomock.Any(), gomock.Any()).Return(trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit)
 	mockTX.EXPECT().Close()
@@ -315,7 +317,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: adminStorage,
 				MapStorage:   fakeStorage,
-			})
+			}, TrillianMapServerOptions{})
 
 			smrResp, err := server.GetSignedMapRootByRevision(ctx, test.req)
 

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -64,6 +64,8 @@ var (
 	tracingPercent   = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
+
+	useSingleTransaction = flag.Bool("single_transaction", false, "Experimental: use a single transaction when updating the map")
 )
 
 func main() {
@@ -132,7 +134,10 @@ func main() {
 			return nil
 		},
 		RegisterServerFn: func(s *grpc.Server, registry extension.Registry) error {
-			mapServer := server.NewTrillianMapServer(registry)
+			mapServer := server.NewTrillianMapServer(registry,
+				server.TrillianMapServerOptions{
+					UseSingleTransaction: *useSingleTransaction,
+				})
 			if err := mapServer.IsHealthy(); err != nil {
 				return err
 			}

--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -29,12 +29,15 @@ import (
 	_ "github.com/google/trillian/merkle/maphasher" // register TEST_MAP_HASHER
 )
 
-var operations = flag.Uint64("operations", 20, "Number of operations to perform")
+var (
+	operations = flag.Uint64("operations", 20, "Number of operations to perform")
+	singleTX   = flag.Bool("single_transaction", false, "Experimental: whether to use a single transaction when updating the map")
+)
 
 func TestInProcessMapHammer(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
-	env, err := integration.NewMapEnv(ctx)
+	env, err := integration.NewMapEnv(ctx, *singleTX)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**DANGER: Highly experimental!**
This allows map updates to be performed in a single transaction.
In general, *this is a terrible idea* **but** it is useful for experimentation and correctness tests.

A quick run against MySQL shows that this results in a large decrease in performance in the integration map test, with the time taken to complete the test rising from ~9s (across multiple transactions) to 15s when rolled into a single transaction.