### PR TITLE
Add tests for ExecutePass failing in log_operation_manager_test.go

### DIFF
--- a/monitoring/testonly/delta.go
+++ b/monitoring/testonly/delta.go
@@ -24,6 +24,8 @@ import (
 // A CounterSnapshot is useful in tests because counters do not reset between
 // test cases, and so their absolute value is not amenable to testing. Instead,
 // the delta between the value at the start and end of the test should be used.
+// This assumes that multiple tests that all affect the counter are not run in
+// parallel.
 type CounterSnapshot struct {
 	c      monitoring.Counter
 	labels []string

--- a/monitoring/testonly/delta.go
+++ b/monitoring/testonly/delta.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"github.com/google/trillian/monitoring"
+)
+
+// CounterSnapshot records the values of a counter at a specific point in time.
+type CounterSnapshot struct {
+	c      monitoring.Counter
+	values map[string]float64
+}
+
+// SnapshotCounter records the current values of a counter.
+// It will only record values associated with the given labels.
+func SnapshotCounter(c monitoring.Counter, labels ...string) CounterSnapshot {
+	s := CounterSnapshot{
+		c:      c,
+		values: make(map[string]float64, len(labels)),
+	}
+	for _, l := range labels {
+		s.values[l] = c.Value(l)
+	}
+	return s
+}
+
+// Delta returns the difference between the current value of a counter and its
+// value when the snapshot was created.
+func (s CounterSnapshot) Delta(label string) float64 {
+	return s.c.Value(label) - s.values[label]
+}

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -201,29 +201,27 @@ func TestLogOperationManagerExecutePassError(t *testing.T) {
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Return(1, nil)
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Return(0, errors.New("test error"))
 
-	runsSnapshot := testonly.NewCounterSnapshot(signingRuns)
-	runsSnapshot.Record(logID1Label)
-	runsSnapshot.Record(logID2Label)
-	failedRunsSnapshot := testonly.NewCounterSnapshot(failedSigningRuns)
-	failedRunsSnapshot.Record(logID1Label)
-	failedRunsSnapshot.Record(logID2Label)
+	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
+	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
+	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)
+	log2FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID2Label)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 	lom.OperationSingle(ctx)
 
 	// Check that logID1 has 1 successful signing run, 0 failed.
-	if want, got := 1, int(runsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 1, int(log1SigningRuns.Delta()); want != got {
 		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
 	}
-	if want, got := 0, int(failedRunsSnapshot.Delta(logID1Label)); want != got {
-		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
-	}
-	// Check that logID2 has 0 successful signing runs, 1 failed.
-	if want, got := 0, int(runsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 0, int(log1FailedSigningRuns.Delta()); want != got {
 		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
 	}
-	if want, got := 1, int(failedRunsSnapshot.Delta(logID2Label)); want != got {
+	// Check that logID2 has 0 successful signing runs, 1 failed.
+	if want, got := 0, int(log2SigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 1, int(log2FailedSigningRuns.Delta()); want != got {
 		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
 	}
 }
@@ -301,29 +299,27 @@ func TestLogOperationManagerOperationLoopExecutePassError(t *testing.T) {
 		return 0, errors.New("test error")
 	})
 
-	runsSnapshot := testonly.NewCounterSnapshot(signingRuns)
-	runsSnapshot.Record(logID1Label)
-	runsSnapshot.Record(logID2Label)
-	failedRunsSnapshot := testonly.NewCounterSnapshot(failedSigningRuns)
-	failedRunsSnapshot.Record(logID1Label)
-	failedRunsSnapshot.Record(logID2Label)
+	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
+	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
+	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)
+	log2FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID2Label)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 	lom.OperationLoop(ctx)
 
 	// Check that logID1 has 1 successful signing run, 0 failed.
-	if want, got := 1, int(runsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 1, int(log1SigningRuns.Delta()); want != got {
 		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
 	}
-	if want, got := 0, int(failedRunsSnapshot.Delta(logID1Label)); want != got {
-		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
-	}
-	// Check that logID2 has 0 successful signing runs, 1 failed.
-	if want, got := 0, int(runsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 0, int(log1FailedSigningRuns.Delta()); want != got {
 		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
 	}
-	if want, got := 1, int(failedRunsSnapshot.Delta(logID2Label)); want != got {
+	// Check that logID2 has 0 successful signing runs, 1 failed.
+	if want, got := 0, int(log2SigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 1, int(log2FailedSigningRuns.Delta()); want != got {
 		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
 	}
 }

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -201,6 +201,7 @@ func TestLogOperationManagerExecutePassError(t *testing.T) {
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Return(1, nil)
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Return(0, errors.New("test error"))
 
+	// Do not run this test in parallel with any other that affects the signingRuns or failedSigningRuns counters.
 	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
 	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
 	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)
@@ -299,6 +300,7 @@ func TestLogOperationManagerOperationLoopExecutePassError(t *testing.T) {
 		return 0, errors.New("test error")
 	})
 
+	// Do not run this test in parallel with any other that affects the signingRuns or failedSigningRuns counters.
 	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
 	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
 	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -201,25 +201,29 @@ func TestLogOperationManagerExecutePassError(t *testing.T) {
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Return(1, nil)
 	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Return(0, errors.New("test error"))
 
-	signingRunsSnapshot := testonly.SnapshotCounter(signingRuns, logID1Label, logID2Label)
-	failedSigningRunsSnapshot := testonly.SnapshotCounter(failedSigningRuns, logID1Label, logID2Label)
+	runsSnapshot := testonly.NewCounterSnapshot(signingRuns)
+	runsSnapshot.Record(logID1Label)
+	runsSnapshot.Record(logID2Label)
+	failedRunsSnapshot := testonly.NewCounterSnapshot(failedSigningRuns)
+	failedRunsSnapshot.Record(logID1Label)
+	failedRunsSnapshot.Record(logID2Label)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 	lom.OperationSingle(ctx)
 
 	// Check that logID1 has 1 successful signing run, 0 failed.
-	if want, got := 1, int(signingRunsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 1, int(runsSnapshot.Delta(logID1Label)); want != got {
 		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
 	}
-	if want, got := 0, int(failedSigningRunsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 0, int(failedRunsSnapshot.Delta(logID1Label)); want != got {
 		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
 	}
 	// Check that logID2 has 0 successful signing runs, 1 failed.
-	if want, got := 0, int(signingRunsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 0, int(runsSnapshot.Delta(logID2Label)); want != got {
 		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
 	}
-	if want, got := 1, int(failedSigningRunsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 1, int(failedRunsSnapshot.Delta(logID2Label)); want != got {
 		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
 	}
 }
@@ -297,25 +301,29 @@ func TestLogOperationManagerOperationLoopExecutePassError(t *testing.T) {
 		return 0, errors.New("test error")
 	})
 
-	signingRunsSnapshot := testonly.SnapshotCounter(signingRuns, logID1Label, logID2Label)
-	failedSigningRunsSnapshot := testonly.SnapshotCounter(failedSigningRuns, logID1Label, logID2Label)
+	runsSnapshot := testonly.NewCounterSnapshot(signingRuns)
+	runsSnapshot.Record(logID1Label)
+	runsSnapshot.Record(logID2Label)
+	failedRunsSnapshot := testonly.NewCounterSnapshot(failedSigningRuns)
+	failedRunsSnapshot.Record(logID1Label)
+	failedRunsSnapshot.Record(logID2Label)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 	lom.OperationLoop(ctx)
 
 	// Check that logID1 has 1 successful signing run, 0 failed.
-	if want, got := 1, int(signingRunsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 1, int(runsSnapshot.Delta(logID1Label)); want != got {
 		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
 	}
-	if want, got := 0, int(failedSigningRunsSnapshot.Delta(logID1Label)); want != got {
+	if want, got := 0, int(failedRunsSnapshot.Delta(logID1Label)); want != got {
 		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
 	}
 	// Check that logID2 has 0 successful signing runs, 1 failed.
-	if want, got := 0, int(signingRunsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 0, int(runsSnapshot.Delta(logID2Label)); want != got {
 		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
 	}
-	if want, got := 1, int(failedSigningRunsSnapshot.Delta(logID2Label)); want != got {
+	if want, got := 1, int(failedRunsSnapshot.Delta(logID2Label)); want != got {
 		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
 	}
 }


### PR DESCRIPTION
Checks that monitoring counters are updated correctly. This improves test coverage, since the tests previously had all calls to `ExecutePass()` return `(0, nil)`, which only exercised a single code path around `ExecutePass()` calls (the one that handled `ExecutePass()` doing nothing).

In order to check the monitoring counters, this commit adds a `CounterSnapshot` struct that can be used to examine the delta between counter values at different points in a test. This is particularly useful since counters are package variables which do not get reset between tests.