### PR TITLE
Updates rpc stats interceptor to guard against nil metric factory

### DIFF
--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -41,6 +41,9 @@ type RPCStatsInterceptor struct {
 // NewRPCStatsInterceptor creates a new RPCStatsInterceptor for the given application/component, with
 // a specified time source.
 func NewRPCStatsInterceptor(timeSource util.TimeSource, prefix string, mf MetricFactory) *RPCStatsInterceptor {
+	if mf == nil {
+		mf = InertMetricFactory{}
+	}
 	interceptor := RPCStatsInterceptor{
 		prefix:            prefix,
 		timeSource:        timeSource,

--- a/monitoring/rpc_stats_interceptor_test.go
+++ b/monitoring/rpc_stats_interceptor_test.go
@@ -178,3 +178,12 @@ func TestMultipleErrorRequestsTotalLatency(t *testing.T) {
 		t.Errorf("stats.ReqSuccessLatency.Info=%v,%v; want %v,%v", count, sum, wantCount, wantSum)
 	}
 }
+
+func TestCanInitializeNilMetricFactory(t *testing.T) {
+	ts := util.IncrementingFakeTimeSource{
+		BaseTime:   fakeTime,
+		Increments: []time.Duration{},
+	}
+	monitoring.NewRPCStatsInterceptor(&ts, "test_nil_metric_factory", nil)
+	// Should reach here without throwing an exception
+}


### PR DESCRIPTION
Addresses https://github.com/google/trillian/issues/1286, I wasn't sure whether or not to add a `MetricsProvider` to set a metrics factory from flags similar to the storage and quota providers. I'd be happy to make that change instead.