### PR TITLE
[election2] Add etcd client creation wrapper

### DIFF
--- a/util/election2/etcd/client.go
+++ b/util/election2/etcd/client.go
@@ -20,13 +20,17 @@ import (
 	"github.com/coreos/etcd/clientv3"
 )
 
-// NewClient returns an etcd client connecting to the passed in servers'
+// NewClient returns an etcd Client connecting to the passed in servers'
 // endpoints, with the specified dialing timeout.
 //
-// TODO(pavelkalinnikov): Remove this function, and create Client directly. At
-// the moment we can't do this as there are external repos depending on this
-// package, and it's not clear how they could import etcd package vendored into
-// this repo. Maybe go modules could help when we switch to Go 1.11+.
+// The return type belongs to etcd package in Trillian vendor/ directory, which
+// allows external clients/codebases to build an object that matches the
+// Trillian internal implementation (a clientv3.Client built from a different
+// codebase/location, even if it's the same code, wouldn't have the required
+// matching type).
+//
+// TODO(pavelkalinnikov): Remove this when there is a way to compatibly import
+// the same version of etcd in external codebases. Could Go modules help?
 func NewClient(endpoints []string, dialTimeout time.Duration) (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,

--- a/util/election2/etcd/client.go
+++ b/util/election2/etcd/client.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+// NewClient returns an etcd client connecting to the passed in servers'
+// endpoints, with the specified dialing timeout.
+//
+// TODO(pavelkalinnikov): Remove this function, and create Client directly. At
+// the moment we can't do this as there are external repos depending on this
+// package, and it's not clear how they could import etcd package vendored into
+// this repo. Maybe go modules could help when we switch to Go 1.11+.
+func NewClient(endpoints []string, dialTimeout time.Duration) (*clientv3.Client, error) {
+	return clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: dialTimeout,
+	})
+}


### PR DESCRIPTION
NewClient helps external repos create etcd Client from this repo's
vendored package, and use it with the election library, without
explicitly importing trillian/vendor/.../etcd (if that is at all possible).