### PR TITLE
integration: export mapInfo.RunIntegration

### DIFF
--- a/integration/map.go
+++ b/integration/map.go
@@ -54,8 +54,23 @@ type mapInfo struct {
 	contents *testonly.MapContents
 }
 
+// New builds a mapInfo to track the progress of an integration test run.
+func New(cl trillian.TrillianMapClient, tree *trillian.Tree) (*mapInfo, error) {
+	verifier, err := client.NewMapVerifierFromTree(tree)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create map verifier: %v", err)
+	}
+	return &mapInfo{
+		cl:       cl,
+		id:       tree.TreeId,
+		tree:     tree,
+		verifier: verifier,
+		contents: &testonly.MapContents{},
+	}, nil
+}
+
 // nolint: gocyclo
-func (mi *mapInfo) runIntegration(ctx context.Context) error {
+func (mi *mapInfo) RunIntegration(ctx context.Context) error {
 	fmt.Printf("%d: ================ Revision 0 ==================\n", mi.id)
 	// Map should be empty at revision 0.
 	fmt.Printf("%d: Get SMR\n", mi.id)

--- a/integration/map.go
+++ b/integration/map.go
@@ -46,7 +46,8 @@ var (
 	value2 = []byte("value-0002")
 )
 
-type mapInfo struct {
+// MapInfo describes an in-progress integration test.
+type MapInfo struct {
 	cl       trillian.TrillianMapClient
 	id       int64
 	tree     *trillian.Tree
@@ -54,13 +55,13 @@ type mapInfo struct {
 	contents *testonly.MapContents
 }
 
-// New builds a mapInfo to track the progress of an integration test run.
-func New(cl trillian.TrillianMapClient, tree *trillian.Tree) (*mapInfo, error) {
+// New builds a MapInfo to track the progress of an integration test run.
+func New(cl trillian.TrillianMapClient, tree *trillian.Tree) (*MapInfo, error) {
 	verifier, err := client.NewMapVerifierFromTree(tree)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create map verifier: %v", err)
 	}
-	return &mapInfo{
+	return &MapInfo{
 		cl:       cl,
 		id:       tree.TreeId,
 		tree:     tree,
@@ -69,8 +70,9 @@ func New(cl trillian.TrillianMapClient, tree *trillian.Tree) (*mapInfo, error) {
 	}, nil
 }
 
+// RunIntegration runs a simple Map integration test.
 // nolint: gocyclo
-func (mi *mapInfo) RunIntegration(ctx context.Context) error {
+func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 	fmt.Printf("%d: ================ Revision 0 ==================\n", mi.id)
 	// Map should be empty at revision 0.
 	fmt.Printf("%d: Get SMR\n", mi.id)
@@ -213,7 +215,7 @@ func (mi *mapInfo) RunIntegration(ctx context.Context) error {
 	return nil
 }
 
-func (mi *mapInfo) checkMapRoot(smr *trillian.SignedMapRoot) (*types.MapRootV1, error) {
+func (mi *MapInfo) checkMapRoot(smr *trillian.SignedMapRoot) (*types.MapRootV1, error) {
 	root, err := mi.verifier.VerifySignedMapRoot(smr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify SMR: %v", err)
@@ -234,7 +236,7 @@ func (mi *mapInfo) checkMapRoot(smr *trillian.SignedMapRoot) (*types.MapRootV1, 
 
 // expectEmptyValues retrieves the current map values for a set of keys, and check that
 // all of the corresponding values are empty.
-func (mi *mapInfo) expectEmptyValues(ctx context.Context, keys ...[]byte) error {
+func (mi *MapInfo) expectEmptyValues(ctx context.Context, keys ...[]byte) error {
 	fmt.Printf("%d: GetLeaves(keys=%x)\n", mi.id, keys)
 	leavesRsp, err := mi.cl.GetLeaves(ctx, &trillian.GetMapLeavesRequest{MapId: mi.id, Index: keys})
 	if err != nil {
@@ -266,7 +268,7 @@ func (mi *mapInfo) expectEmptyValues(ctx context.Context, keys ...[]byte) error 
 
 // expectValue retrieves the current map value for a particular key and checks that the
 // associated LeafValue is the specified value.
-func (mi *mapInfo) expectValue(ctx context.Context, key, want []byte) error {
+func (mi *MapInfo) expectValue(ctx context.Context, key, want []byte) error {
 	fmt.Printf("%d: GetLeaves(key=%x)\n", mi.id, key)
 	leavesRsp, err := mi.cl.GetLeaves(ctx, &trillian.GetMapLeavesRequest{MapId: mi.id, Index: [][]byte{key}})
 	if err != nil {
@@ -277,7 +279,7 @@ func (mi *mapInfo) expectValue(ctx context.Context, key, want []byte) error {
 
 // expectValueAtRev retrieves the current map value for a particular key and checks that the
 // associated LeafValue is the specified value.
-func (mi *mapInfo) expectValueAtRev(ctx context.Context, rev int64, key, want []byte) error {
+func (mi *MapInfo) expectValueAtRev(ctx context.Context, rev int64, key, want []byte) error {
 	fmt.Printf("%d: GetLeavesAtRevision(rev=%d, key=%x)\n", mi.id, rev, key)
 	leavesRsp, err := mi.cl.GetLeavesByRevision(ctx, &trillian.GetMapLeavesByRevisionRequest{MapId: mi.id, Revision: rev, Index: [][]byte{key}})
 	if err != nil {
@@ -287,7 +289,7 @@ func (mi *mapInfo) expectValueAtRev(ctx context.Context, rev int64, key, want []
 }
 
 // checkSingleLeaf response checks a response has exactly the leaf info expected.
-func (mi *mapInfo) checkSingleLeafResponse(rsp *trillian.GetMapLeavesResponse, key, want []byte) error {
+func (mi *MapInfo) checkSingleLeafResponse(rsp *trillian.GetMapLeavesResponse, key, want []byte) error {
 	root, err := mi.verifier.VerifySignedMapRoot(rsp.MapRoot)
 	if err != nil {
 		return fmt.Errorf("failed to verify SMR in get-map-leaves-rsp: %v", err)

--- a/integration/map_integration_test.go
+++ b/integration/map_integration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package integration_test
 
 import (
 	"context"
@@ -21,9 +21,9 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
+	"github.com/google/trillian/integration"
 	"github.com/google/trillian/storage/testdb"
-	"github.com/google/trillian/testonly"
-	"github.com/google/trillian/testonly/integration"
+	tintegration "github.com/google/trillian/testonly/integration"
 
 	_ "github.com/google/trillian/crypto/keys/der/proto" // Register PrivateKey ProtoHandler
 	stestonly "github.com/google/trillian/storage/testonly"
@@ -34,7 +34,7 @@ var singleTX = flag.Bool("single_transaction", false, "Experimental: whether to 
 func TestInProcessMapIntegration(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
-	env, err := integration.NewMapEnv(ctx, *singleTX)
+	env, err := tintegration.NewMapEnv(ctx, *singleTX)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,19 +44,12 @@ func TestInProcessMapIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create log: %v", err)
 	}
-
-	verifier, err := client.NewMapVerifierFromTree(tree)
+	info, err := integration.New(env.Map, tree)
 	if err != nil {
-		t.Fatalf("Failed to create map verifier: %v", err)
+		t.Fatalf("Failed to create mapInfo for test: %v", err)
 	}
-	info := mapInfo{
-		cl:       env.Map,
-		id:       tree.TreeId,
-		tree:     tree,
-		verifier: verifier,
-		contents: &testonly.MapContents{},
-	}
-	if err := info.runIntegration(ctx); err != nil {
+
+	if err := info.RunIntegration(ctx); err != nil {
 		t.Fatalf("[%d] map integration test failed: %v", tree.TreeId, err)
 	}
 }

--- a/integration/map_integration_test.go
+++ b/integration/map_integration_test.go
@@ -46,7 +46,7 @@ func TestInProcessMapIntegration(t *testing.T) {
 	}
 	info, err := integration.New(env.Map, tree)
 	if err != nil {
-		t.Fatalf("Failed to create mapInfo for test: %v", err)
+		t.Fatalf("Failed to create MapInfo for test: %v", err)
 	}
 
 	if err := info.RunIntegration(ctx); err != nil {


### PR DESCRIPTION
Allow external drivers to run the Map integration test.