### PR TITLE
Remove trillian-db-seed from docker-compose.yml

### DIFF
--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -1,24 +1,15 @@
 version: '3'
 services:
   mysql:
-    image: mariadb:10.1
-    environment:
-      - MYSQL_ROOT_PASSWORD=zaphod
-  trillian-db-seed:
     build:
       context: ../..
-      dockerfile: ./examples/deployment/docker/db_client/Dockerfile
+      dockerfile: ./examples/deployment/docker/db_server/Dockerfile
     environment:
-      - MYSQL_ROOT_USER=root
       - MYSQL_ROOT_PASSWORD=zaphod
-      - MYSQL_HOST=mysql
       - MYSQL_DATABASE=test
       - MYSQL_USER=test
       - MYSQL_PASSWORD=zaphod
-      - MYSQL_USER_HOST=%
-    command: ./wait-for-it.sh -t 0 mysql:3306 -- ./scripts/resetdb.sh --verbose --force
-    depends_on:
-      - mysql
+    restart: always # keep the MySQL server running
   trillian-log-server:
     build:
       context: ../..
@@ -37,7 +28,7 @@ services:
       - "8090:8090"
       - "8091:8091"
     depends_on:
-      - trillian-db-seed
+      - mysql
   trillian-log-signer:
     build:
       context: ../..
@@ -56,5 +47,5 @@ services:
     ports:
       - "8092:8091"
     depends_on:
-      - trillian-db-seed
+      - mysql
 


### PR DESCRIPTION
Originally, docker-compose was:
1) Starting a MariaDB server.
2) Connecting to that server using the db_client Docker image and executing scripts/resetdb.sh.

This was unnecessarily complicated and resulted in the database being wiped whenever the containers were restarted by docker-compose. Instead, it will now just start a MySQL server using the db_server Docker image. This image does the same work as resetdb.sh (creates the database and user that Trillian needs), but will not reset the database unexpectedly.