### PR TITLE
[storage] Remove log name/desc length limits

### DIFF
--- a/storage/tree_validation.go
+++ b/storage/tree_validation.go
@@ -28,11 +28,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	maxDisplayNameLength = 20
-	maxDescriptionLength = 200
-)
-
 // ValidateTreeForCreation returns nil if tree is valid for insertion, error
 // otherwise.
 // See the documentation on trillian.Tree for reference on which values are
@@ -121,13 +116,8 @@ func ValidateTreeForUpdate(ctx context.Context, storedTree, newTree *trillian.Tr
 }
 
 func validateMutableTreeFields(ctx context.Context, tree *trillian.Tree) error {
-	switch {
-	case tree.TreeState == trillian.TreeState_UNKNOWN_TREE_STATE:
+	if tree.TreeState == trillian.TreeState_UNKNOWN_TREE_STATE {
 		return status.Errorf(codes.InvalidArgument, "invalid tree_state: %v", tree.TreeState)
-	case len(tree.DisplayName) > maxDisplayNameLength:
-		return status.Errorf(codes.InvalidArgument, "display_name too big, max length is %v: %v", maxDisplayNameLength, tree.DisplayName)
-	case len(tree.Description) > maxDescriptionLength:
-		return status.Errorf(codes.InvalidArgument, "description too big, max length is %v: %v", maxDescriptionLength, tree.Description)
 	}
 	if duration, err := ptypes.Duration(tree.MaxRootDuration); err != nil {
 		return status.Errorf(codes.InvalidArgument, "max_root_duration malformed: %v", tree.MaxRootDuration)

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -79,15 +79,6 @@ func TestValidateTreeForCreation(t *testing.T) {
 	invalidSignatureAlgorithm := newTree()
 	invalidSignatureAlgorithm.SignatureAlgorithm = sigpb.DigitallySigned_ANONYMOUS
 
-	invalidDisplayName := newTree()
-	invalidDisplayName.DisplayName = "A Very Long Display Name That Clearly Won't Fit But At Least Mentions Llamas Somewhere"
-
-	invalidDescription := newTree()
-	invalidDescription.Description = `
-		A Very Long Description That Clearly Won't Fit, Also Mentions Llamas, For Some Reason Has Only Capitalized Words And Keeps Repeating Itself.
-		A Very Long Description That Clearly Won't Fit, Also Mentions Llamas, For Some Reason Has Only Capitalized Words And Keeps Repeating Itself.
-		`
-
 	unsupportedPrivateKey := newTree()
 	unsupportedPrivateKey.PrivateKey.TypeUrl = "urn://unknown-type"
 
@@ -172,16 +163,6 @@ func TestValidateTreeForCreation(t *testing.T) {
 		{
 			desc:    "invalidSignatureAlgorithm",
 			tree:    invalidSignatureAlgorithm,
-			wantErr: true,
-		},
-		{
-			desc:    "invalidDisplayName",
-			tree:    invalidDisplayName,
-			wantErr: true,
-		},
-		{
-			desc:    "invalidDescription",
-			tree:    invalidDescription,
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
It seems that length limitation should be storage specific. In fact,
MySQL storage already has these.