### PR TITLE
Completes admin storage endpoints for postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
 
 services:
   - docker
+  - postgresql
 
 before_install:
   - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
@@ -81,6 +82,7 @@ install:
 before_script:
   - ./scripts/resetdb.sh --force
   - ./scripts/mysqlconnlimit.sh --force
+  - ./scripts/postgres_resetdb.sh --force
 
 script:
   - set -e

--- a/scripts/postgres_resetdb.sh
+++ b/scripts/postgres_resetdb.sh
@@ -33,7 +33,7 @@ collect_vars() {
   FLAGS+=(--host "${PG_HOST}")
   FLAGS+=(--port "${PG_PORT}")
 
-    # handle flags
+  # handle flags
   FORCE=false
   while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/scripts/postgres_resetdb.sh
+++ b/scripts/postgres_resetdb.sh
@@ -32,6 +32,17 @@ collect_vars() {
   FLAGS+=(-U "${PG_ROOT_USER}")
   FLAGS+=(--host "${PG_HOST}")
   FLAGS+=(--port "${PG_PORT}")
+
+    # handle flags
+  FORCE=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) FORCE=true ;;
+      --help) usage; exit ;;
+      *) FLAGS+=("$1")
+    esac
+    shift 1
+  done
 }
 
 main() {

--- a/storage/postgres/admin_storage.go
+++ b/storage/postgres/admin_storage.go
@@ -52,7 +52,7 @@ const (
 		delete_time_millis
 	FROM trees`
 
-	nonDeletedWhere       = " WHERE (deleted is NULL OR deleted = false)"
+	nonDeletedWhere       = " WHERE deleted = false"
 	selectNonDeletedTrees = selectTrees + nonDeletedWhere
 
 	selectTreeIDs           = "SELECT tree_id FROM trees"

--- a/storage/postgres/admin_storage.go
+++ b/storage/postgres/admin_storage.go
@@ -17,7 +17,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -52,6 +51,13 @@ const (
 		deleted,
 		delete_time_millis
 	FROM trees`
+
+	nonDeletedWhere       = " WHERE (deleted is NULL OR deleted = false)"
+	selectNonDeletedTrees = selectTrees + nonDeletedWhere
+
+	selectTreeIDs           = "SELECT tree_id FROM trees"
+	selectNonDeletedTreeIDs = selectTreeIDs + nonDeletedWhere
+
 	selectTreeByID = selectTrees + " WHERE tree_id = $1"
 
 	insertSQL = `INSERT INTO trees(
@@ -76,11 +82,18 @@ const (
 		sequencing_enabled,
 		sequence_interval_seconds)
 	VALUES($1, $2, $3, $4)`
-)
 
-var (
-	// errNotImplemented is an error indicating a function's implementation has not been completed
-	errNotImplemented = errors.New("not implemented")
+	updateTreeSQL = `UPDATE trees SET tree_state = $1, tree_type = $2, display_name = $3, 
+		description = $4, update_time_millis = $5, max_root_duration_millis = $6, private_key = $7
+		WHERE tree_id = $8`
+
+	softDeleteSQL = "UPDATE trees SET deleted = $1, delete_time_millis = $2 WHERE tree_id = $3"
+
+	selectDeletedSQL = "SELECT deleted FROM trees WHERE tree_id = $1"
+
+	deleteFromTreeControlSQL = "DELETE FROM tree_control WHERE tree_id = $1"
+
+	deleteFromTreesSQL = "DELETE FROM trees WHERE tree_id = $1"
 )
 
 // NewAdminStorage returns a storage.AdminStorage implementation
@@ -188,11 +201,63 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 }
 
 func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trillian.Tree, error) {
-	return nil, errNotImplemented
+	var query string
+	if includeDeleted {
+		query = selectTrees
+	} else {
+		query = selectNonDeletedTrees
+	}
+
+	stmt, err := t.tx.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	trees := []*trillian.Tree{}
+	for rows.Next() {
+		tree, err := storage.ReadTree(rows)
+		if err != nil {
+			return nil, err
+		}
+		trees = append(trees, tree)
+	}
+	return trees, nil
 }
 
 func (t *adminTX) ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64, error) {
-	return nil, errNotImplemented
+	var query string
+	if includeDeleted {
+		query = selectTreeIDs
+	} else {
+		query = selectNonDeletedTreeIDs
+	}
+
+	stmt, err := t.tx.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	treeIDs := []int64{}
+	var treeID int64
+	for rows.Next() {
+		if err := rows.Scan(&treeID); err != nil {
+			return nil, err
+		}
+		treeIDs = append(treeIDs, treeID)
+	}
+	return treeIDs, nil
 }
 
 func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillian.Tree, error) {
@@ -278,19 +343,112 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 }
 
 func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error) {
-	return nil, errNotImplemented
+	tree, err := t.GetTree(ctx, treeID)
+	if err != nil {
+		return nil, err
+	}
+
+	beforeUpdate := *tree
+	updateFunc(tree)
+	if err := storage.ValidateTreeForUpdate(ctx, &beforeUpdate, tree); err != nil {
+		return nil, err
+	}
+	if err := validateStorageSettings(tree); err != nil {
+		return nil, err
+	}
+
+	// Use the time truncated-to-millis throughout, as that's what's stored.
+	nowMillis := storage.ToMillisSinceEpoch(time.Now())
+	now := storage.FromMillisSinceEpoch(nowMillis)
+	tree.UpdateTime, err = ptypes.TimestampProto(now)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build update time: %v", err)
+	}
+	rootDuration, err := ptypes.Duration(tree.MaxRootDuration)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse MaxRootDuration: %v", err)
+	}
+
+	privateKey, err := proto.Marshal(tree.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+	}
+
+	stmt, err := t.tx.PrepareContext(ctx, updateTreeSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	if _, err = stmt.ExecContext(
+		ctx,
+		tree.TreeState.String(),
+		tree.TreeType.String(),
+		tree.DisplayName,
+		tree.Description,
+		nowMillis,
+		rootDuration/time.Millisecond,
+		privateKey,
+		tree.TreeId); err != nil {
+		return nil, err
+	}
+
+	return tree, nil
 }
 
 func (t *adminTX) SoftDeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-	return nil, errNotImplemented
+	return t.updateDeleted(ctx, treeID, true /* deleted */, storage.ToMillisSinceEpoch(time.Now()) /* deleteTimeMillis */)
 }
 
 func (t *adminTX) UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-	return nil, errNotImplemented
+	return t.updateDeleted(ctx, treeID, false /* deleted */, nil /* deleteTimeMillis */)
 }
 
 func (t *adminTX) HardDeleteTree(ctx context.Context, treeID int64) error {
-	return errNotImplemented
+	if err := validateDeleted(ctx, t.tx, treeID, true /* wantDeleted */); err != nil {
+		return err
+	}
+
+	if _, err := t.tx.ExecContext(ctx, deleteFromTreeControlSQL, treeID); err != nil {
+		return err
+	}
+	_, err := t.tx.ExecContext(ctx, deleteFromTreesSQL, treeID)
+	return err
+}
+
+// updateDeleted updates the Deleted and DeleteTimeMillis fields of the specified tree.
+// deleteTimeMillis must be either an int64 (in millis since epoch) or nil.
+func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis interface{}) (*trillian.Tree, error) {
+	if err := validateDeleted(ctx, t.tx, treeID, !deleted); err != nil {
+		return nil, err
+	}
+	if _, err := t.tx.ExecContext(
+		ctx,
+		softDeleteSQL,
+		deleted,
+		deleteTimeMillis,
+		treeID); err != nil {
+		return nil, err
+	}
+	return t.GetTree(ctx, treeID)
+}
+
+func validateDeleted(ctx context.Context, tx *sql.Tx, treeID int64, wantDeleted bool) error {
+	var nullDeleted sql.NullBool
+	switch err := tx.QueryRowContext(ctx, selectDeletedSQL, treeID).Scan(&nullDeleted); {
+	case err == sql.ErrNoRows:
+		return status.Errorf(codes.NotFound, "tree %v not found", treeID)
+	case err != nil:
+		return err
+	}
+
+	switch deleted := nullDeleted.Valid && nullDeleted.Bool; {
+	case wantDeleted && !deleted:
+		return status.Errorf(codes.FailedPrecondition, "tree %v is not soft deleted", treeID)
+	case !wantDeleted && deleted:
+		return status.Errorf(codes.FailedPrecondition, "tree %v already soft deleted", treeID)
+	}
+	return nil
 }
 
 func validateStorageSettings(tree *trillian.Tree) error {

--- a/storage/postgres/admin_storage_test.go
+++ b/storage/postgres/admin_storage_test.go
@@ -220,7 +220,6 @@ func setNulls(ctx context.Context, db *sql.DB, treeID int64) error {
 	UPDATE trees SET
 		display_name = NULL,
 		description = NULL,
-		deleted = NULL,
 		delete_time_millis = NULL
 	WHERE tree_id = $1`)
 	if err != nil {

--- a/storage/postgres/admin_storage_test.go
+++ b/storage/postgres/admin_storage_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/postgres"
 	"github.com/google/trillian/storage/postgres/testdb"
@@ -159,7 +159,7 @@ func TestAdminTX_StorageSettingsNotSupported(t *testing.T) {
 	s := postgres.NewAdminStorage(DB)
 	ctx := context.Background()
 
-	settings, err := ptypes.MarshalAny(&keyspb.PEMKeyFile{})
+	settings, err := ptypes.MarshalAny(&empty.Empty{})
 	if err != nil {
 		t.Fatalf("Error marshaling proto: %v", err)
 	}
@@ -216,7 +216,13 @@ func openTestDBOrDie() *sql.DB {
 }
 
 func setNulls(ctx context.Context, db *sql.DB, treeID int64) error {
-	stmt, err := db.PrepareContext(ctx, "UPDATE trees SET display_name = NULL, description = NULL WHERE tree_id = $1")
+	stmt, err := db.PrepareContext(ctx, `
+	UPDATE trees SET
+		display_name = NULL,
+		description = NULL,
+		deleted = NULL,
+		delete_time_millis = NULL
+	WHERE tree_id = $1`)
 	if err != nil {
 		return err
 	}

--- a/storage/postgres/storage.sql
+++ b/storage/postgres/storage.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS trees (
   max_root_duration_millis BIGINT NOT NULL, 
   private_key              BYTEA NOT NULL, 
   public_key               BYTEA NOT NULL, 
-  deleted                  BOOLEAN, 
+  deleted                  BOOLEAN NOT NULL DEFAULT FALSE,
   delete_time_millis       BIGINT, 
   PRIMARY KEY(tree_id) 
 ); 


### PR DESCRIPTION
Adds missing admin endpoints: ListTrees, ListTreeIDs, UpdateTree, SoftDeleteTree, HardDeleteTree, and UndeleteTree. Most logic is copied from the mysql implementation apart from the sql queries itself. 

Also attempts to add a postgres db to the travis build; will test that to see what effort is necessary to make that happen

Issue: #1298