### PR TITLE
Add tests for ExecutePass failing in log_operation_manager_test.go

### DIFF
--- a/monitoring/testonly/delta.go
+++ b/monitoring/testonly/delta.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"github.com/google/trillian/monitoring"
+)
+
+// CounterSnapshot records the latest value from a time series in a counter.
+// This value can then be compared with future values. Note that a counter can
+// contain many time series, but a CounterSnapshot will track only one.
+// A CounterSnapshot is useful in tests because counters do not reset between
+// test cases, and so their absolute value is not amenable to testing. Instead,
+// the delta between the value at the start and end of the test should be used.
+// This assumes that multiple tests that all affect the counter are not run in
+// parallel.
+type CounterSnapshot struct {
+	c      monitoring.Counter
+	labels []string
+	value  float64
+}
+
+// NewCounterSnapshot records the latest value of a time series in c identified
+// by the given labels. This value can be compared to future values to determine
+// how it has changed over time.
+func NewCounterSnapshot(c monitoring.Counter, labels ...string) CounterSnapshot {
+	return CounterSnapshot{
+		c:      c,
+		labels: labels,
+		value:  c.Value(labels...),
+	}
+}
+
+// Delta returns the difference between the latest value of the time series
+// and the value when the CounterSnapshot was created.
+func (s CounterSnapshot) Delta() float64 {
+	return s.c.Value(s.labels...) - s.value
+}

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -247,18 +247,16 @@ func TestLogOperationManagerOperationLoopPassesIDs(t *testing.T) {
 
 	mockLogOp := NewMockLogOperation(ctrl)
 	infoMatcher := logOpInfoMatcher{50}
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
-		return 1, nil
-	})
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+	}).Return(1, nil)
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
-		return 0, nil
-	})
+	}).Return(0, nil)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
@@ -287,18 +285,16 @@ func TestLogOperationManagerOperationLoopExecutePassError(t *testing.T) {
 
 	mockLogOp := NewMockLogOperation(ctrl)
 	infoMatcher := logOpInfoMatcher{50}
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
-		return 1, nil
-	})
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+	}).Return(1, nil)
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
-		return 0, errors.New("test error")
-	})
+	}).Return(0, errors.New("test error"))
 
 	// Do not run this test in parallel with any other that affects the signingRuns or failedSigningRuns counters.
 	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)

--- a/server/log_operation_manager_test.go
+++ b/server/log_operation_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/trillian"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/monitoring/testonly"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/election"
@@ -171,13 +172,59 @@ func TestLogOperationManagerPassesIDs(t *testing.T) {
 
 	mockLogOp := NewMockLogOperation(ctrl)
 	infoMatcher := logOpInfoMatcher{50}
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher)
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher)
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Return(1, nil)
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Return(0, nil)
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 
 	lom.OperationSingle(ctx)
+}
+
+func TestLogOperationManagerExecutePassError(t *testing.T) {
+	ctx := context.Background()
+	logID1 := int64(451)
+	logID2 := int64(145)
+	logID1Label := strconv.FormatInt(logID1, 10)
+	logID2Label := strconv.FormatInt(logID2, 10)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{451: "LogID1", 145: "LogID2"})
+	registry := extension.Registry{
+		LogStorage:   fakeStorage,
+		AdminStorage: mockAdmin,
+	}
+
+	mockLogOp := NewMockLogOperation(ctrl)
+	infoMatcher := logOpInfoMatcher{50}
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Return(1, nil)
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Return(0, errors.New("test error"))
+
+	// Do not run this test in parallel with any other that affects the signingRuns or failedSigningRuns counters.
+	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
+	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
+	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)
+	log2FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID2Label)
+
+	info := defaultLogOperationInfo(registry)
+	lom := NewLogOperationManager(info, mockLogOp)
+	lom.OperationSingle(ctx)
+
+	// Check that logID1 has 1 successful signing run, 0 failed.
+	if want, got := 1, int(log1SigningRuns.Delta()); want != got {
+		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 0, int(log1FailedSigningRuns.Delta()); want != got {
+		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
+	}
+	// Check that logID2 has 0 successful signing runs, 1 failed.
+	if want, got := 0, int(log2SigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 1, int(log2FailedSigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
+	}
 }
 
 func TestLogOperationManagerOperationLoopPassesIDs(t *testing.T) {
@@ -200,20 +247,83 @@ func TestLogOperationManagerOperationLoopPassesIDs(t *testing.T) {
 
 	mockLogOp := NewMockLogOperation(ctrl)
 	infoMatcher := logOpInfoMatcher{50}
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
+		return 1, nil
 	})
-	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).Do(func(_ context.Context, _ int64, _ *LogOperationInfo) {
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
 		if atomic.AddInt64(&logCount, 1) == 2 {
 			cancel()
 		}
+		return 0, nil
 	})
 
 	info := defaultLogOperationInfo(registry)
 	lom := NewLogOperationManager(info, mockLogOp)
 	lom.OperationLoop(ctx)
+}
+
+func TestLogOperationManagerOperationLoopExecutePassError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logID1 := int64(451)
+	logID2 := int64(145)
+	logID1Label := strconv.FormatInt(logID1, 10)
+	logID2Label := strconv.FormatInt(logID2, 10)
+
+	var logCount int64
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeStorage, mockAdmin := setupLogIDs(ctrl, map[int64]string{451: "LogID1", 145: "LogID2"})
+	registry := extension.Registry{
+		LogStorage:   fakeStorage,
+		AdminStorage: mockAdmin,
+	}
+
+	mockLogOp := NewMockLogOperation(ctrl)
+	infoMatcher := logOpInfoMatcher{50}
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID1, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+		if atomic.AddInt64(&logCount, 1) == 2 {
+			cancel()
+		}
+		return 1, nil
+	})
+	mockLogOp.EXPECT().ExecutePass(gomock.Any(), logID2, infoMatcher).DoAndReturn(func(_ context.Context, _ int64, _ *LogOperationInfo) (int, error) {
+		if atomic.AddInt64(&logCount, 1) == 2 {
+			cancel()
+		}
+		return 0, errors.New("test error")
+	})
+
+	// Do not run this test in parallel with any other that affects the signingRuns or failedSigningRuns counters.
+	log1SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID1Label)
+	log1FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID1Label)
+	log2SigningRuns := testonly.NewCounterSnapshot(signingRuns, logID2Label)
+	log2FailedSigningRuns := testonly.NewCounterSnapshot(failedSigningRuns, logID2Label)
+
+	info := defaultLogOperationInfo(registry)
+	lom := NewLogOperationManager(info, mockLogOp)
+	lom.OperationLoop(ctx)
+
+	// Check that logID1 has 1 successful signing run, 0 failed.
+	if want, got := 1, int(log1SigningRuns.Delta()); want != got {
+		t.Errorf("want signingRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 0, int(log1FailedSigningRuns.Delta()); want != got {
+		t.Errorf("want signingRuns[logID2] == %d, got %d", want, got)
+	}
+	// Check that logID2 has 0 successful signing runs, 1 failed.
+	if want, got := 0, int(log2SigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID1] == %d, got %d", want, got)
+	}
+	if want, got := 1, int(log2FailedSigningRuns.Delta()); want != got {
+		t.Errorf("want failedSigningRuns[logID2] == %d, got %d", want, got)
+	}
 }
 
 func TestHeldInfo(t *testing.T) {


### PR DESCRIPTION
Checks that monitoring counters are updated correctly. This improves test coverage, since the tests previously had all calls to `ExecutePass()` return `(0, nil)`, which only exercised a single code path around
`ExecutePass()` calls (the one that handled `ExecutePass()` doing nothing).

In order to check the monitoring counters, this commit adds a `CounterSnapshot` struct that can be used to examine the delta between counter values at different points in a test. This is particularly useful since counters are package variables which do not get reset between tests.