### PR TITLE
Simplify GKE configs

### DIFF
--- a/examples/deployment/kubernetes/README.md
+++ b/examples/deployment/kubernetes/README.md
@@ -41,18 +41,13 @@ You should now have a working Trilian Log deployment in Kubernetes.
 To do something useful with it, you'll need provision one or more trees into
 the Trillian log, and run a "personality" layer.
 
-To provision a tree into Trillian, you can use the Trillian admin API, like so:
+To provision a tree into Trillian, use the `provision_tree.sh` script like so:
 
 ```bash
-curl -X POST ${LOG_URL}/v1beta1/trees -d '{ "tree":{ "tree_state":"ACTIVE", "tree_type":"LOG", "hash_strategy":"RFC6962_SHA256", "signature_algorithm":"ECDSA", "max_root_duration":"0", "hash_algorithm":"SHA256" }, "key_spec":{ "ecdsa_params":{ "curve":"P256" } } }'
-{... tree_id: <large number here> ...}
-curl -X POST ${LOG_URL}/v1beta1/logs/${tree_id}:init
-
+./provision_tree.sh config.sh
 ```
 
-The easiest way to do this is probably to use `kubectl exec <name of one of the logserver pods> -ti -- /bin/bash` to get a shell on a logserver Pod, and use curl from there.
-
-(Use `kubectl get pods` to retrieve a list of all the Pods.)
+This script uses `kubectl` to forward requests to the log's admin API.
 
 **NOTE: none of the Trillian APIs are exposed to the internet with this config,
 this is intentional since the only access to Trillian should be via a

--- a/examples/deployment/kubernetes/README.md
+++ b/examples/deployment/kubernetes/README.md
@@ -30,10 +30,10 @@ Process
    It should take about 5 to 10 minutes to finish and must complete without
    error.
 1. Now you can deploy the Trillian services.
-   Run: `./deploy.sh`
+   Run: `./deploy.sh config.sh`
    This will build the Trillian Docker images, tag them, and create/update the
    Kubernetes deployment.
-1. To update a running deployment, simply re-run `./deploy.sh` at any time.
+1. To update a running deployment, simply re-run `./deploy.sh config.sh` at any time.
 
 Next steps
 ----------

--- a/examples/deployment/kubernetes/config.sh
+++ b/examples/deployment/kubernetes/config.sh
@@ -1,9 +1,11 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 export PROJECT_NAME=trillian-ct-log
 export CLUSTER_NAME=trillian
 export REGION=us-east4
 export MASTER_ZONE="${REGION}-a"
 export NODE_LOCATIONS="${REGION}-a,${REGION}-b,${REGION}-c"
-export CONFIGMAP=trillian-cloudspanner.yaml
+export CONFIGMAP=${DIR}/trillian-cloudspanner.yaml
 
 export POOLSIZE=2
-export MACHINE_TYPE="n1-standard-4"
+export MACHINE_TYPE="n1-standard-2"

--- a/examples/deployment/kubernetes/config.sh
+++ b/examples/deployment/kubernetes/config.sh
@@ -1,5 +1,9 @@
-export PROJECT_NAME=trillian-opensource-ci
-export CLUSTER_NAME=trillian-opensource-ci
-export REGION=us-central1
-export ZONE=${REGION}-a
+export PROJECT_NAME=trillian-ct-log
+export CLUSTER_NAME=trillian
+export REGION=us-east4
+export MASTER_ZONE="${REGION}-a"
+export NODE_LOCATIONS="${REGION}-a,${REGION}-b,${REGION}-c"
 export CONFIGMAP=trillian-cloudspanner.yaml
+
+export POOLSIZE=2
+export MACHINE_TYPE="n1-standard-4"

--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -22,13 +22,22 @@ if ! jq --help > /dev/null; then
   exit 1
 fi
 
+echo "Creating new Trillian deployment"
+echo "  Project name: ${PROJECT_NAME}"
+echo "  Cluster name: ${CLUSTER_NAME}"
+echo "  Region:       ${REGION}"
+echo "  Node Locs:    ${NODE_LOCATIONS}"
+echo "  Config:       ${CONFIGMAP}"
+echo "  Pool:         ${POOLSIZE} * ${MACHINE_TYPE}"
+echo
+
 # Uncomment this to create a GCE project from scratch, or you can create it
 # manually through the web UI.
 # gcloud projects create ${PROJECT_NAME}
 
 # Connect to gcloud
 gcloud config set project "${PROJECT_NAME}"
-gcloud config set compute/zone "${ZONE}"
+gcloud config set compute/zone ${MASTER_ZONE}
 gcloud config set container/cluster "${CLUSTER_NAME}"
 
 # Ensure Kubernetes Engine (container) and Cloud Spanner (spanner) services are enabled
@@ -36,11 +45,9 @@ for SERVICE in container spanner; do
   gcloud services enable ${SERVICE}.googleapis.com --project=${PROJECT_NAME}
 done
 
-# Create cluster & node pools
-gcloud container clusters create "${CLUSTER_NAME}" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "2" --enable-autorepair --enable-autoupgrade
-gcloud container node-pools create "logserver-pool" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "4" --enable-autorepair --enable-autoupgrade
-gcloud container node-pools create "signer-pool" --machine-type "n1-standard-2" --image-type "COS" --num-nodes "1" --enable-autorepair --enable-autoupgrade
-gcloud container node-pools create "ctfe-pool" --machine-type "n1-standard-1" --image-type "COS" --num-nodes "4" --enable-autorepair --enable-autoupgrade
+# Create cluster
+# TODO(https://github.com/google/trillian/issues/1183): Add support for priorities and preemption when Kubernetes 1.11 is GA.
+gcloud container clusters create "${CLUSTER_NAME}" --machine-type "${MACHINE_TYPE}" --image-type "COS" --num-nodes "${POOLSIZE}" --enable-autorepair --enable-autoupgrade --node-locations="${NODE_LOCATIONS}"
 gcloud container clusters get-credentials "${CLUSTER_NAME}"
 
 # Create spanner instance & DB

--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -51,7 +51,7 @@ gcloud container clusters create "${CLUSTER_NAME}" --machine-type "${MACHINE_TYP
 gcloud container clusters get-credentials "${CLUSTER_NAME}"
 
 # Create spanner instance & DB
-gcloud spanner instances create trillian-spanner --description "Trillian Spanner instance" --nodes=5 --config="regional-${REGION}"
+gcloud spanner instances create trillian-spanner --description "Trillian Spanner instance" --nodes=1 --config="regional-${REGION}"
 gcloud spanner databases create trillian-db --instance trillian-spanner --ddl="$(cat ${DIR}/../../../storage/cloudspanner/spanner.sdl | grep -v '^--.*$')"
 
 # Create service account

--- a/examples/deployment/kubernetes/delete.sh
+++ b/examples/deployment/kubernetes/delete.sh
@@ -23,7 +23,7 @@ fi
 
 # Connect to gcloud
 gcloud config set project ${PROJECT_NAME}
-gcloud config set compute/zone ${ZONE}
+gcloud config set compute/zone ${MASTER_ZONE}
 
 # Delete cluster & node pools
 gcloud beta container clusters delete ${CLUSTER_NAME} --quiet

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -12,39 +12,46 @@ export LOG_URL=TODO
 export MAP_URL=TODO
 export TAG=$(git rev-parse HEAD)
 
-# Get Trillian
-go get github.com/google/trillian/...
-cd $GOPATH/src/github.com/google/trillian
-
-# Build docker images
-docker build -f examples/deployment/docker/log_server/Dockerfile -t gcr.io/$PROJECT_NAME/log_server:$TAG .
-docker build -f examples/deployment/docker/log_signer/Dockerfile -t gcr.io/$PROJECT_NAME/log_signer:$TAG .
-# TODO(al): when cloudspanner supports maps:
-# docker build -f examples/deployment/docker/map_server/Dockerfile -t us.gcr.io/$PROJECT_NAME/map_server:$TAG .
-
 # Connect to gcloud
 gcloud config set project "${PROJECT_NAME}"
-gcloud config set compute/zone "${ZONE}"
+gcloud config set compute/zone "${MASTER_ZONE}"
 
 # Configure Docker to use gcloud credentials with Google Container Registry
 gcloud auth configure-docker
 
-# Push docker images
-docker push "gcr.io/${PROJECT_NAME}/log_server:${TAG}"
-docker push "gcr.io/${PROJECT_NAME}/log_signer:${TAG}"
+# Get Trillian
+go get github.com/google/trillian/...
+cd $GOPATH/src/github.com/google/trillian
+
+echo "Building docker images..."
+docker build --quiet -f examples/deployment/docker/log_server/Dockerfile -t gcr.io/$PROJECT_NAME/log_server:$TAG .
+docker build --quiet -f examples/deployment/docker/log_signer/Dockerfile -t gcr.io/$PROJECT_NAME/log_signer:$TAG .
+# TODO(al): when cloudspanner supports maps:
+# docker build -f examples/deployment/docker/map_server/Dockerfile -t us.gcr.io/$PROJECT_NAME/map_server:$TAG .
+
+echo "Pushing docker images..."
+gcloud docker -- push gcr.io/${PROJECT_NAME}/log_server:${TAG}
+gcloud docker -- push gcr.io/${PROJECT_NAME}/log_signer:${TAG}
+
+echo "Tagging docker images..."
+gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_server:${TAG} gcr.io/${PROJECT_NAME}/log_server:latest
+gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_signer:${TAG} gcr.io/${PROJECT_NAME}/log_signer:latest
 
 # TODO(al): when cloudspanner supports maps:
 # gcloud docker -- push "us.gcr.io/${PROJECT_NAME}/map_server:${TAG}"
 
+echo "Updating jobs..."
 # Prepare configmap:
-kubectl delete configmap deploy-config
-envsubst < examples/deployment/kubernetes/trillian-cloudspanner.yaml | kubectl create -f -
+kubectl delete configmap deploy-config || true
+envsubst < ${DIR}/${CONFIGMAP} | kubectl create -f -
 
 # Launch with kubernetes
-envsubst < examples/deployment/kubernetes/trillian-log-deployment.yaml | kubectl apply -f -
-envsubst < examples/deployment/kubernetes/trillian-log-service.yaml | kubectl apply -f -
-envsubst < examples/deployment/kubernetes/trillian-log-signer-deployment.yaml | kubectl apply -f -
-envsubst < examples/deployment/kubernetes/trillian-log-signer-service.yaml | kubectl apply -f -
+envsubst < ${DIR}/trillian-log-deployment.yaml | kubectl apply -f -
+envsubst < ${DIR}/trillian-log-service.yaml | kubectl apply -f -
+envsubst < ${DIR}/trillian-log-signer-deployment.yaml | kubectl apply -f -
+envsubst < ${DIR}/trillian-log-signer-service.yaml | kubectl apply -f -
+kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${TAG}
+kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${TAG}
 kubectl get all
 kubectl get services
 

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -25,7 +25,12 @@ fi
 
 export LOG_URL=TODO
 export MAP_URL=TODO
-export IMAGE_TAG=${IMAGE_TAG:-$(git rev-parse HEAD)}
+
+# if IMAGE_TAG is unset, we'll create one using the git HEAD hash, with an
+# optional "-dirty" suffix if any objects have been modified.
+GIT_HASH=$(git rev-parse HEAD)
+GIT_DIRTY=$(git diff --quiet || echo '-dirty')
+export IMAGE_TAG=${IMAGE_TAG:-${GIT_HASH}${GIT_DIRTY}}
 
 # Connect to gcloud
 gcloud --quiet config set project ${PROJECT_NAME}

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -3,18 +3,35 @@
 # - Cluster has already been created & configured using the create.sh script
 # - Go 1.9 is installed
 
+function checkEnv() {
+  if [ -z ${PROJECT_NAME+x} ] ||
+     [ -z ${CLUSTER_NAME+x} ] ||
+     [ -z ${MASTER_ZONE+x} ] ||
+     [ -z ${CONFIG_MAP+x} ]; then
+    echo "You must either pass an argument which is a config file, or set all the required environment variables"
+    exit 1
+  fi
+}
+
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/config.sh
+if [ $# -eq 1 ]; then
+  source $1
+else
+  checkEnv
+fi
+
 
 export LOG_URL=TODO
 export MAP_URL=TODO
-export TAG=$(git rev-parse HEAD)
+export IMAGE_TAG=${IMAGE_TAG:-$(git rev-parse HEAD)}
 
 # Connect to gcloud
-gcloud config set project "${PROJECT_NAME}"
-gcloud config set compute/zone "${MASTER_ZONE}"
+gcloud --quiet config set project ${PROJECT_NAME}
+gcloud --quiet config set container/cluster ${CLUSTER_NAME}
+gcloud --quiet config set compute/zone ${MASTER_ZONE}
+gcloud --quiet container clusters get-credentials ${CLUSTER_NAME}
 
 # Configure Docker to use gcloud credentials with Google Container Registry
 gcloud auth configure-docker
@@ -24,18 +41,18 @@ go get github.com/google/trillian/...
 cd $GOPATH/src/github.com/google/trillian
 
 echo "Building docker images..."
-docker build --quiet -f examples/deployment/docker/log_server/Dockerfile -t gcr.io/$PROJECT_NAME/log_server:$TAG .
-docker build --quiet -f examples/deployment/docker/log_signer/Dockerfile -t gcr.io/$PROJECT_NAME/log_signer:$TAG .
+docker build --quiet -f examples/deployment/docker/log_server/Dockerfile -t gcr.io/$PROJECT_NAME/log_server:$IMAGE_TAG .
+docker build --quiet -f examples/deployment/docker/log_signer/Dockerfile -t gcr.io/$PROJECT_NAME/log_signer:$IMAGE_TAG .
 # TODO(al): when cloudspanner supports maps:
 # docker build -f examples/deployment/docker/map_server/Dockerfile -t us.gcr.io/$PROJECT_NAME/map_server:$TAG .
 
 echo "Pushing docker images..."
-gcloud docker -- push gcr.io/${PROJECT_NAME}/log_server:${TAG}
-gcloud docker -- push gcr.io/${PROJECT_NAME}/log_signer:${TAG}
+gcloud docker -- push gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG}
+gcloud docker -- push gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG}
 
 echo "Tagging docker images..."
-gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_server:${TAG} gcr.io/${PROJECT_NAME}/log_server:latest
-gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_signer:${TAG} gcr.io/${PROJECT_NAME}/log_signer:latest
+gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG} gcr.io/${PROJECT_NAME}/log_server:latest
+gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG} gcr.io/${PROJECT_NAME}/log_signer:latest
 
 # TODO(al): when cloudspanner supports maps:
 # gcloud docker -- push "us.gcr.io/${PROJECT_NAME}/map_server:${TAG}"
@@ -43,17 +60,15 @@ gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_signer:${TAG}
 echo "Updating jobs..."
 # Prepare configmap:
 kubectl delete configmap deploy-config || true
-envsubst < ${DIR}/${CONFIGMAP} | kubectl create -f -
+envsubst < ${CONFIGMAP} | kubectl create -f -
 
 # Launch with kubernetes
 envsubst < ${DIR}/trillian-log-deployment.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-log-service.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-log-signer-deployment.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-log-signer-service.yaml | kubectl apply -f -
-kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${TAG}
-kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${TAG}
-kubectl get all
-kubectl get services
+kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG}
+kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG}
 
 # TODO(al): Create trees
 # curl -X POST ${LOG_URL}/v1beta1/trees -d '{ "tree":{ "tree_state":"ACTIVE", "tree_type":"LOG", "hash_strategy":"RFC6962_SHA256", "signature_algorithm":"ECDSA", "max_root_duration":"0", "hash_algorithm":"SHA256" }, "key_spec":{ "ecdsa_params":{ "curve":"P256" } } }'

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -7,8 +7,8 @@ function checkEnv() {
   if [ -z ${PROJECT_NAME+x} ] ||
      [ -z ${CLUSTER_NAME+x} ] ||
      [ -z ${MASTER_ZONE+x} ] ||
-     [ -z ${CONFIG_MAP+x} ]; then
-    echo "You must either pass an argument which is a config file, or set all the required environment variables"
+     [ -z ${CONFIGMAP+x} ]; then
+    echo "You must either pass an argument which is a config file, or set all the required environment variables" >&2
     exit 1
   fi
 }
@@ -69,10 +69,3 @@ envsubst < ${DIR}/trillian-log-signer-deployment.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-log-signer-service.yaml | kubectl apply -f -
 kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG}
 kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG}
-
-# TODO(al): Create trees
-# curl -X POST ${LOG_URL}/v1beta1/trees -d '{ "tree":{ "tree_state":"ACTIVE", "tree_type":"LOG", "hash_strategy":"RFC6962_SHA256", "signature_algorithm":"ECDSA", "max_root_duration":"0", "hash_algorithm":"SHA256" }, "key_spec":{ "ecdsa_params":{ "curve":"P256" } } }'
-#  ... tree_id: ....
-# curl -X POST ${LOG_URL}/v1beta1/logs/${tree_id}:init
-#
-# curl -X POST ${MAP_URL}/v1beta1/trees -d '{ "tree":{ "tree_state":"ACTIVE", "tree_type":"MAP", "hash_strategy":"CONIKS_SHA512_256", "signature_algorithm":"ECDSA", "max_root_duration":"0", "hash_algorithm":"SHA256" }, "key_spec":{ "ecdsa_params":{ "curve":"P256" } } }'

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -17,8 +17,6 @@ spec:
         secret:
           secretName: trillian-key
       restartPolicy: Always
-      nodeSelector:
-        cloud.google.com/gke-nodepool: logserver-pool
       containers:
       - name: trillian-logserver
         args: [

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -17,8 +17,6 @@ spec:
       - name: google-cloud-key
         secret:
           secretName: trillian-key
-      nodeSelector:
-        cloud.google.com/gke-nodepool: signer-pool
       restartPolicy: Always
       containers:
       - args: [

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            cpu: "1.5"
+            cpu: "1"
           requests:
             cpu: "1"
         livenessProbe:

--- a/scripts/deploy_gce_ci.sh
+++ b/scripts/deploy_gce_ci.sh
@@ -13,4 +13,4 @@ export MASTER_ZONE=us-central1-a
 export CONFIGMAP=${DIR}/examples/kubernetes/trillian-opensource-ci.yaml
 export IMAGE_TAG=${TRAVIS_COMMIT}
 
-./examples/kubernetes/deploy.sh
+${DIR}/../examples/kubernetes/deploy.sh

--- a/scripts/deploy_gce_ci.sh
+++ b/scripts/deploy_gce_ci.sh
@@ -9,34 +9,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PROJECT_NAME=trillian-opensource-ci
 export CLUSTER_NAME=trillian-opensource-ci
 export REGION=us-central1
-export ZONE=us-central1-a
-export CONFIGMAP=trillian-opensource-ci.yaml
+export MASTER_ZONE=us-central1-a
+export CONFIGMAP=${DIR}/examples/kubernetes/trillian-opensource-ci.yaml
+export IMAGE_TAG=${TRAVIS_COMMIT}
 
-gcloud --quiet config set project ${PROJECT_NAME}
-gcloud --quiet config set container/cluster ${CLUSTER_NAME}
-gcloud --quiet config set compute/zone ${ZONE}
-gcloud --quiet container clusters get-credentials ${CLUSTER_NAME}
-
-echo "Building docker images..."
-cd $GOPATH/src/github.com/google/trillian
-docker build --quiet -f examples/deployment/docker/log_server/Dockerfile -t gcr.io/${PROJECT_NAME}/log_server:${TRAVIS_COMMIT} .
-docker build --quiet -f examples/deployment/docker/log_signer/Dockerfile -t gcr.io/${PROJECT_NAME}/log_signer:${TRAVIS_COMMIT} .
-
-echo "Pushing docker images..."
-gcloud docker -- push gcr.io/${PROJECT_NAME}/log_server:${TRAVIS_COMMIT}
-gcloud docker -- push gcr.io/${PROJECT_NAME}/log_signer:${TRAVIS_COMMIT}
-
-echo "Tagging docker images..."
-gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_server:${TRAVIS_COMMIT} gcr.io/${PROJECT_NAME}/log_server:latest
-gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/log_signer:${TRAVIS_COMMIT} gcr.io/${PROJECT_NAME}/log_signer:latest
-
-echo "Updating jobs..."
-kubectl delete configmap deploy-config
-envsubst < ${DIR}/../examples/deployment/kubernetes/${CONFIGMAP} | kubectl create -f -
-
-envsubst < ${DIR}/../examples/deployment/kubernetes/trillian-log-deployment.yaml | kubectl apply -f -
-envsubst < ${DIR}/../examples/deployment/kubernetes/trillian-log-service.yaml | kubectl apply -f -
-envsubst < ${DIR}/../examples/deployment/kubernetes/trillian-log-signer-deployment.yaml | kubectl apply -f -
-envsubst < ${DIR}/../examples/deployment/kubernetes/trillian-log-signer-service.yaml | kubectl apply -f -
-kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${TRAVIS_COMMIT}
-kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${TRAVIS_COMMIT}
+./examples/kubernetes/deploy.sh


### PR DESCRIPTION
- Remove node-pools (they add complexity, and we'll use priority/preemption instead)
- Reuse a single `deploy.sh` to push to CI too.

_This is going to break CI, but I'll come back and fix that after the fact_