### PR TITLE
Use the same environment variables as the Postgres Docker image

### DIFF
--- a/scripts/postgres_resetdb.sh
+++ b/scripts/postgres_resetdb.sh
@@ -5,7 +5,7 @@ set -e
 usage() {
   cat <<EOF
 $(basename $0) [--force] [--verbose] ...
-All unrecognised arguments will be passed through to the 'postgres' command.
+All unrecognised arguments will be passed through to the 'psql' command.
 Accepts environment variables:
 - POSTGRES_ROOT_USER: A user with sufficient rights to create/reset the Trillian
   database (default: `postgres`).
@@ -47,7 +47,7 @@ collect_vars() {
 
 main() {
   collect_vars "$@"
-  
+
   readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
 
   echo "Warning: about to destroy and reset database '${POSTGRES_DB}'"

--- a/scripts/postgres_resetdb.sh
+++ b/scripts/postgres_resetdb.sh
@@ -11,8 +11,7 @@ Accepts environment variables:
   database (default: `postgres`).
 - POSTGRES_HOST: The hostname of the PG server (default: localhost).
 - POSTGRES_PORT: The port the PG server is listening on (default: 5432).
-- POSTGRES_DB: The name to give to the new Trillian user and database
-  (default: test).
+- POSTGRES_DB: The name to give to the new Trillian database (default: test).
 EOF
 }
 

--- a/scripts/postgres_resetdb.sh
+++ b/scripts/postgres_resetdb.sh
@@ -7,11 +7,11 @@ usage() {
 $(basename $0) [--force] [--verbose] ...
 All unrecognised arguments will be passed through to the 'postgres' command.
 Accepts environment variables:
-- PG_ROOT_USER: A user with sufficient rights to create/reset the Trillian
+- POSTGRES_ROOT_USER: A user with sufficient rights to create/reset the Trillian
   database (default: `postgres`).
-- PG_HOST: The hostname of the PG server (default: localhost).
-- PG_PORT: The port the PG server is listening on (default: 5432).
-- PG_DATABASE: The name to give to the new Trillian user and database
+- POSTGRES_HOST: The hostname of the PG server (default: localhost).
+- POSTGRES_PORT: The port the PG server is listening on (default: 5432).
+- POSTGRES_DB: The name to give to the new Trillian user and database
   (default: test).
 EOF
 }
@@ -23,15 +23,15 @@ die() {
 
 collect_vars() {
   # set unset environment variables to defaults
-  [ -z ${PG_ROOT_USER+x} ] && PG_ROOT_USER="postgres"
-  [ -z ${PG_HOST+x} ] && PG_HOST="localhost"
-  [ -z ${PG_PORT+x} ] && PG_PORT="5432"
-  [ -z ${PG_DATABASE+x} ] && PG_DATABASE="test"
+  [ -z ${POSTGRES_ROOT_USER+x} ] && POSTGRES_ROOT_USER="postgres"
+  [ -z ${POSTGRES_HOST+x} ] && POSTGRES_HOST="localhost"
+  [ -z ${POSTGRES_PORT+x} ] && POSTGRES_PORT="5432"
+  [ -z ${POSTGRES_DB+x} ] && POSTGRES_DB="test"
   FLAGS=()
 
-  FLAGS+=(-U "${PG_ROOT_USER}")
-  FLAGS+=(--host "${PG_HOST}")
-  FLAGS+=(--port "${PG_PORT}")
+  FLAGS+=(-U "${POSTGRES_ROOT_USER}")
+  FLAGS+=(--host "${POSTGRES_HOST}")
+  FLAGS+=(--port "${POSTGRES_PORT}")
 
   # handle flags
   FORCE=false
@@ -50,7 +50,7 @@ main() {
   
   readonly TRILLIAN_PATH=$(go list -f '{{.Dir}}' github.com/google/trillian)
 
-  echo "Warning: about to destroy and reset database '${PG_DATABASE}'"
+  echo "Warning: about to destroy and reset database '${POSTGRES_DB}'"
 
   [[ ${FORCE} = true ]] || read -p "Are you sure? [Y/N]: " -n 1 -r
   echo # Print newline following the above prompt
@@ -58,12 +58,12 @@ main() {
   if [ -z ${REPLY+x} ] || [[ $REPLY =~ ^[Yy]$ ]]
   then
       echo "Resetting DB..."
-      psql "${FLAGS[@]}" -c "DROP DATABASE IF EXISTS ${PG_DATABASE};" || \
-        die "Error: Failed to drop database '${PG_DATABASE}'."
-      psql "${FLAGS[@]}" -c "CREATE DATABASE ${PG_DATABASE};" || \
-        die "Error: Failed to create database '${PG_DATABASE}'."
-      psql "${FLAGS[@]}" -d ${PG_DATABASE} -f ${TRILLIAN_PATH}/storage/postgres/storage.sql || \
-        die "Error: Failed to create tables in '${PG_DATABASE}' database."
+      psql "${FLAGS[@]}" -c "DROP DATABASE IF EXISTS ${POSTGRES_DB};" || \
+        die "Error: Failed to drop database '${POSTGRES_DB}'."
+      psql "${FLAGS[@]}" -c "CREATE DATABASE ${POSTGRES_DB};" || \
+        die "Error: Failed to create database '${POSTGRES_DB}'."
+      psql "${FLAGS[@]}" -d ${POSTGRES_DB} -f ${TRILLIAN_PATH}/storage/postgres/storage.sql || \
+        die "Error: Failed to create tables in '${POSTGRES_DB}' database."
       echo "Reset Complete"
   fi
 }


### PR DESCRIPTION
Where possible, use the same environment variables in postgres_resetdb.sh as the [official Postgres Docker image](https://hub.docker.com/_/postgres/). This makes it a bit simpler to use them together.