### PR TITLE
GetAndVerifyMapLeavesByRevision

### DIFF
--- a/client/map_client.go
+++ b/client/map_client.go
@@ -81,3 +81,33 @@ func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte)
 	}
 	return leaves, nil
 }
+
+// GetAndVerifyMapLeavesByRevision verifies and returns the requested map leaves at a specific revision.
+func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, error) {
+	getResp, err := c.Conn.GetLeavesByRevision(ctx, &trillian.GetMapLeavesByRevisionRequest{
+		MapId:    c.MapID,
+		Index:    indexes,
+		Revision: revision,
+	})
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "map.GetLeaves(): %v", err)
+	}
+	if got, want := len(getResp.MapLeafInclusion), len(indexes); got != want {
+		return nil, status.Errorf(status.Code(err), "got %v leaves, want %v", got, want)
+	}
+	mapRoot, err := c.VerifySignedMapRoot(getResp.GetMapRoot())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "VerifySignedMapRoot(%v): %v", c.MapID, err)
+	}
+	if int64(mapRoot.Revision) != revision {
+		return nil, status.Errorf(codes.Internal, "got map revision %v, want %v", mapRoot.Revision, revision)
+	}
+	leaves := make([]*trillian.MapLeaf, 0, len(getResp.MapLeafInclusion))
+	for _, m := range getResp.MapLeafInclusion {
+		if err := c.VerifyMapLeafInclusionHash(mapRoot.RootHash, m); err != nil {
+			return nil, status.Errorf(status.Code(err), "map: VerifyMapLeafInclusion(): %v", err)
+		}
+		leaves = append(leaves, m.Leaf)
+	}
+	return leaves, nil
+}


### PR DESCRIPTION
The sequencer needs to read input data for mutations at a specific revision, not just the most recent revision. 