### PR TITLE
Replace `gcloud docker` with `docker`

### DIFF
--- a/examples/deployment/kubernetes/config.sh
+++ b/examples/deployment/kubernetes/config.sh
@@ -1,6 +1,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export PROJECT_NAME=trillian-ct-log
+export PROJECT_NAME=key-transparency
 export CLUSTER_NAME=trillian
 export REGION=us-east4
 export MASTER_ZONE="${REGION}-a"

--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -21,6 +21,10 @@ if ! jq --help > /dev/null; then
   echo "Please install the jq command"
   exit 1
 fi
+if ! envsubst --help > /dev/null; then
+  echo "Please install the envsubt command"
+  exit 1
+fi
 
 echo "Creating new Trillian deployment"
 echo "  Project name: ${PROJECT_NAME}"

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -46,7 +46,7 @@ echo "Building and pushing docker images:"
 for thing in log_server log_signer map_server; do
   echo "  - ${thing}"
   docker build --quiet -f examples/deployment/docker/${thing}/Dockerfile -t gcr.io/$PROJECT_NAME/${thing}:$IMAGE_TAG .
-  gcloud docker -- push gcr.io/${PROJECT_NAME}/${thing}:${IMAGE_TAG}
+  docker push gcr.io/${PROJECT_NAME}/${thing}:${IMAGE_TAG}
   gcloud --quiet container images add-tag gcr.io/${PROJECT_NAME}/${thing}:${IMAGE_TAG} gcr.io/${PROJECT_NAME}/${thing}:latest
 done
 

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -62,9 +62,9 @@ envsubst < ${DIR}/trillian-log-signer-deployment.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-log-signer-service.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-map-deployment.yaml | kubectl apply -f -
 envsubst < ${DIR}/trillian-map-service.yaml | kubectl apply -f -
-kubectl set image deployment/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG}
-kubectl set image deployment/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG}
-kubectl set image deployment/trillian-mapserver-deployment trillian-mapserver=gcr.io/${PROJECT_NAME}/map_server:${IMAGE_TAG}
+kubectl set image deployment.apps/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_NAME}/log_server:${IMAGE_TAG}
+kubectl set image deployment.apps/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_NAME}/log_signer:${IMAGE_TAG}
+kubectl set image deployment.apps/trillian-mapserver-deployment trillian-mapserver=gcr.io/${PROJECT_NAME}/map_server:${IMAGE_TAG}
 
 kubectl get all
 kubectl get services

--- a/storage/mysql/kubernetes/image/push.sh
+++ b/storage/mysql/kubernetes/image/push.sh
@@ -42,6 +42,7 @@ while getopts "ht:" opt; do
   esac
 done
 
-gcloud docker -- build -t "$tag" .
-gcloud docker -- push "$tag"
+gcloud auth configure-docker
+docker build -t "$tag" .
+docker push "$tag"
 

--- a/storage/mysql/kubernetes/image/push.sh
+++ b/storage/mysql/kubernetes/image/push.sh
@@ -20,7 +20,7 @@ usage=$(cat <<EOF
 Usage: $(basename $0) [-t tag]
 
 Builds and pushes the image in this directory to a container repository.
-By default, the image will be tagged with "$tag" and
+By default, the image will be tagged with ${tag} and
 pushed to the Google Cloud container repository.
 EOF
 )
@@ -43,6 +43,6 @@ while getopts "ht:" opt; do
 done
 
 gcloud auth configure-docker
-docker build -t "$tag" .
-docker push "$tag"
+docker build -t ${tag} .
+docker push ${tag}
 


### PR DESCRIPTION
`gcloud docker` will be deprecated soon.  This PR cleans up the following warnings: 

WARNING: `gcloud docker` will not be supported for Docker client versions above 18.03.

As an alternative, use `gcloud auth configure-docker` to configure `docker` to
use `gcloud` as a credential helper, then use `docker` as you would for non-GCR
registries, e.g. `docker pull gcr.io/project-id/my-image`. Add
`--verbosity=error` to silence this warning: `gcloud docker
--verbosity=error -- pull gcr.io/project-id/my-image`.

See: https://cloud.google.com/container-registry/docs/support/deprecation-notices#gcloud-docker