### PR TITLE
Only retry retryable errors.

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -129,7 +129,7 @@ func InitMap(ctx context.Context, tree *trillian.Tree, mapClient trillian.Trilli
 				Revision: 0,
 			})
 		return err
-	})
+	}, codes.FailedPrecondition)
 }
 
 // InitLog initialises a freshly created Log tree.
@@ -175,5 +175,5 @@ func InitLog(ctx context.Context, tree *trillian.Tree, logClient trillian.Trilli
 		_, err := logClient.GetLatestSignedLogRoot(ctx,
 			&trillian.GetLatestSignedLogRootRequest{LogId: tree.TreeId})
 		return err
-	})
+	}, codes.FailedPrecondition)
 }

--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -64,7 +64,7 @@ func (b *Backoff) Reset() {
 // It will backoff if the function returns a retryable error.
 // Once the context is done, retries will end and the most recent error will be returned.
 // Backoff is not reset by this function.
-func (b *Backoff) Retry(ctx context.Context, f func() error) error {
+func (b *Backoff) Retry(ctx context.Context, f func() error, retryableCodes ...codes.Code) error {
 	// If the context is already done, don't make any attempts to call f.
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -72,45 +72,32 @@ func (b *Backoff) Retry(ctx context.Context, f func() error) error {
 
 	// Try calling f while the error is retryable and ctx is not done.
 	for {
-		if err := f(); IsRetryable(err) {
-			select {
-			case <-time.After(b.Duration()):
-				continue
-			case <-ctx.Done():
-				return err
-			}
+		if err := f(); !IsRetryable(err, retryableCodes...) {
+			return err
 		}
-		return nil
+		select {
+		case <-time.After(b.Duration()):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 
-// IsRetryable returns true unless the error is explicitly not retriable per
-// https://godoc.org/google.golang.org/grpc/codes.
-func IsRetryable(err error) bool {
-	switch code := status.Code(err); code {
+// IsRetryable returns false unless the error is explicitly retriable per
+// https://godoc.org/google.golang.org/grpc/codes,
+// or if the error codes is in retriableCodes.
+func IsRetryable(err error, retryableCodes ...codes.Code) bool {
+	code := status.Code(err)
+	for _, c := range retryableCodes {
+		if code == c {
+			return true
+		}
+	}
 
-	// Errors that should not be retried:
-	case codes.OK, // Success = done.
-		codes.InvalidArgument,    // Retrying won't fix an invalid argument.
-		codes.PermissionDenied,   // Retrying won't fix a permission denied error.
-		codes.Unauthenticated,    // Retrying won't fix an unauthenticated error.
-		codes.FailedPrecondition, // Client must wait until the system has been fixed.
-		codes.Unimplemented,      // Retrying won't fix this.
-		codes.Internal,           // Something is very broken.
-		codes.DataLoss,           // Something is very broken.
-		codes.AlreadyExists,      // Retrying won't change this.
-		codes.Canceled:           // The client canceled: stop the retry loop.
-		return false
-
-	// Cases that are debatable:
-	case codes.OutOfRange, // Might be retryable if the server does a lot of work.
-		codes.NotFound: // Retrying might help, but not rapidly.
-		return false
-
-	// Debatable cases. Retry to preserve existing behavior.
+	switch code {
+	// Debatable cases:
 	case codes.DeadlineExceeded, // The client or the server expired a timeout.
-		codes.ResourceExhausted, // Retry with backoff.
-		codes.Unknown:           // Catch-all error code.
+		codes.ResourceExhausted: // Retry with backoff.
 		return true
 
 	// Errors that are explicitly retryable:
@@ -118,8 +105,8 @@ func IsRetryable(err error) bool {
 		codes.Aborted: // Client can retry the read-modify-write function.
 		return true
 
-	// Retry for all unknown errors to preserve existing behavior.
+	// Don't retry for all other errors.
 	default:
-		return true
+		return false
 	}
 }

--- a/client/backoff/backoff_test.go
+++ b/client/backoff/backoff_test.go
@@ -16,9 +16,11 @@ package backoff
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	_ "github.com/golang/glog"
 )
@@ -120,7 +122,7 @@ func TestRetry(t *testing.T) {
 			f: func() error {
 				callCount++
 				if callCount == 1 {
-					return errors.New("error")
+					return status.Errorf(codes.Unavailable, "error")
 				}
 				return nil
 			},
@@ -133,7 +135,7 @@ func TestRetry(t *testing.T) {
 				// being cancelled.
 				if ctx.Err() == nil {
 					cancel()
-					return errors.New("error")
+					return status.Errorf(codes.Unavailable, "error")
 				}
 				return nil
 			},

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/util/flagsaver"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // defaultTree reflects all flag defaults with the addition of a valid private key.
@@ -111,7 +113,7 @@ func TestCreateTree(t *testing.T) {
 		},
 		{
 			desc:      "createErr",
-			createErr: errors.New("create tree failed"),
+			createErr: status.Errorf(codes.Unavailable, "create tree failed"),
 			wantErr:   true,
 		},
 		{
@@ -121,7 +123,7 @@ func TestCreateTree(t *testing.T) {
 				*treeType = nonDefaultTree.TreeType.String()
 			},
 			wantTree: defaultTree,
-			initErr:  errors.New("log init failed"),
+			initErr:  status.Errorf(codes.Unavailable, "log init failed"),
 			wantErr:  true,
 		},
 		{
@@ -131,7 +133,7 @@ func TestCreateTree(t *testing.T) {
 				*treeType = nonDefaultTree.TreeType.String()
 			},
 			wantTree: &nonDefaultTree,
-			initErr:  errors.New("map init failed"),
+			initErr:  status.Errorf(codes.Unavailable, "map init failed"),
 			wantErr:  true,
 		},
 	})


### PR DESCRIPTION
Only retry errors that are retryable. Stop the existing
behavior of retrying unknown errors as this could be dangerous.

Existing callers of Retry() have to return nil to get Retry() to exit,
and lose err in the process.

Add an option for callers of Retry() to explicitly declare what errors
they are expecting to be retryable if they deviate from standard
behavior.