### PR TITLE
Add map_server and db_server images to GCP Container Registry

### DIFF
--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -15,6 +15,15 @@ steps:
   - --tag=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
   - .
   waitFor: ["-"]
+- id: build_map_server
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=examples/deployment/docker/map_server/Dockerfile
+  - --tag=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
+  - .
+  waitFor: ["-"]
 images:
 - gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
 - gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
+- gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,4 +1,12 @@
 steps:
+- id: build_db_server
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=examples/deployment/docker/db_server/Dockerfile
+  - --tag=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
+  - .
+  waitFor: ["-"]
 - id: build_log_server
   name: gcr.io/cloud-builders/docker
   args:
@@ -24,6 +32,7 @@ steps:
   - .
   waitFor: ["-"]
 images:
+- gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
 - gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
 - gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
 - gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}


### PR DESCRIPTION
Adding them to cloudbuild_tag.yaml will cause these images to be built and pushed to our GCP Container Registry automatically every time a new Git tag is created.

The db_server image is the simplest way to run Trillian on Kubernetes, because it provides a properly-configured MySQL database for Trillian to use. However, a production setup of Trillian should use a more scalable, reliable solution, such as Cloud SQL or Cloud Spanner.