### PR TITLE
Use specific tag for Docker images in Kubernetes configs

### DIFF
--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -69,12 +69,5 @@ for thing in ${kubeconfigs}; do
   envsubst < ${DIR}/${thing} | kubectl apply -f -
 done
 
-echo "Setting images..."
-kubectl set image deployment.apps/trillian-logserver-deployment trillian-logserver=gcr.io/${PROJECT_ID}/log_server:${IMAGE_TAG}
-kubectl set image deployment.apps/trillian-logsigner-deployment trillian-log-signer=gcr.io/${PROJECT_ID}/log_signer:${IMAGE_TAG}
-if ${RUN_MAP}; then
-  kubectl set image deployment.apps/trillian-mapserver-deployment trillian-mapserver=gcr.io/${PROJECT_ID}/map_server:${IMAGE_TAG}
-fi
-
 kubectl get all
 kubectl get services

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         envFrom:
           - configMapRef:
               name: deploy-config
-        image: gcr.io/${PROJECT_ID}/log_server:latest
+        image: gcr.io/${PROJECT_ID}/log_server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:
           limits:

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           - configMapRef:
               name: deploy-config
         # Update this with the name of your project:
-        image: gcr.io/${PROJECT_ID}/log_signer:latest
+        image: gcr.io/${PROJECT_ID}/log_signer:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:
           limits:

--- a/examples/deployment/kubernetes/trillian-map-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-map-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         envFrom:
           - configMapRef:
               name: deploy-config
-        image: gcr.io/${PROJECT_ID}/map_server:latest
+        image: gcr.io/${PROJECT_ID}/map_server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
The "latest" flag is just whatever the most recently pushed image is, which might not actually be the most up-to-date. It also results in automatic updates of the image used in the Kubernetes cluster, which might be unexpected. It's better to use a specific tag (e.g. a commit hash or release version). This makes it obvious which version of the code is being used in Kubernetes.