### PR TITLE
Require docker-compose v3.1 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ testing and experimental purposes:
 docker-compose -f examples/deployment/docker-compose.yml up
 ```
 
+Docker Compose v3.1 or higher is required.
+
 The Terraform, Kubernetes and Docker configuration files, as well as various
 scripts, all now use the same, consistently-named environment variables for
 MySQL-related data (e.g. `MYSQL_DATABASE`). The variable names are based on

--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   mysql:
     build:


### PR DESCRIPTION
This is for compatibility with the upcoming CTFE docker-compose manifest,
which uses secrets and so requires docker-compose v3.1. If they don't
have the same version requirement, they won't be compatible.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
