### PR TITLE
Client: AddSequencedLeaves

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -358,7 +358,16 @@ func (c *LogClient) AddSequencedLeaf(ctx context.Context, data []byte, index int
 }
 
 // AddSequencedLeaves adds any number of pre-sequenced leaves to the log.
-func (c *LogClient) AddSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
+func (c *LogClient) AddSequencedLeaves(ctx context.Context, dataByIndex map[int64][]byte) error {
+	leaves := make([]*trillian.LogLeaf, 0, len(dataByIndex))
+	for index, data := range dataByIndex {
+		leaf, err := c.BuildLeaf(data)
+		if err != nil {
+			return err
+		}
+		leaf.LeafIndex = index
+		leaves = append(leaves, leaf)
+	}
 	_, err := c.client.AddSequencedLeaves(ctx, &trillian.AddSequencedLeavesRequest{
 		LogId:  c.LogID,
 		Leaves: leaves,

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -357,6 +357,15 @@ func (c *LogClient) AddSequencedLeaf(ctx context.Context, data []byte, index int
 	return err
 }
 
+// AddSequencedLeaves adds any number of pre-sequenced leaves to the log.
+func (c *LogClient) AddSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
+	_, err := c.client.AddSequencedLeaves(ctx, &trillian.AddSequencedLeavesRequest{
+		LogId:  c.LogID,
+		Leaves: leaves,
+	})
+	return err
+}
+
 // QueueLeaf adds a leaf to a Trillian log without blocking.
 // AlreadyExists is considered a success case by this function.
 func (c *LogClient) QueueLeaf(ctx context.Context, data []byte) error {

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -363,7 +363,7 @@ func (c *LogClient) AddSequencedLeaves(ctx context.Context, dataByIndex map[int6
 	for index, data := range dataByIndex {
 		leaf, err := c.BuildLeaf(data)
 		if err != nil {
-			return err
+			return fmt.Errorf("error building leaf %x: %v", index, err)
 		}
 		leaf.LeafIndex = index
 		leaves = append(leaves, leaf)


### PR DESCRIPTION
Allow others to use the connection to the log server to call methods
that the thick log client doesn't explicitly wrap.
