### PR TITLE
Introduce Timer interface that enables mocking

### DIFF
--- a/util/timer.go
+++ b/util/timer.go
@@ -36,7 +36,7 @@ func (t systemTimer) Chan() <-chan time.Time {
 }
 
 // fakeTimer implements Timer interface for testing. Event firing is controlled
-// by the FakeTimeSource which creates and owns fakeTimer instances.
+// by FakeTimeSource which creates and owns fakeTimer instances.
 type fakeTimer struct {
 	ts   *FakeTimeSource
 	id   int

--- a/util/timer.go
+++ b/util/timer.go
@@ -1,0 +1,56 @@
+package util
+
+import "time"
+
+// Timer represents an event that fires with time passage.
+// See time.Timer type for intuition on how it works.
+type Timer interface {
+	// Chan returns a channel which is used to deliver the event.
+	Chan() <-chan time.Time
+	// Stop prevents the Timer from firing. Returns false if the event has
+	// already fired, or the Timer has been stopped.
+	Stop() bool
+}
+
+// systemTimer is a Timer that uses system time.
+type systemTimer struct {
+	*time.Timer
+}
+
+func (t systemTimer) Chan() <-chan time.Time {
+	return t.C
+}
+
+// fakeTimer implements Timer interface for testing. Event firing is controlled
+// by the FakeTimeSource which creates and owns fakeTimer instances.
+type fakeTimer struct {
+	ts   *FakeTimeSource
+	id   int
+	when time.Time
+	ch   chan time.Time
+	done bool
+}
+
+func newFakeTimer(ts *FakeTimeSource, id int, when time.Time) *fakeTimer {
+	ch := make(chan time.Time, 1)
+	return &fakeTimer{ts: ts, id: id, when: when, ch: ch}
+}
+
+func (t *fakeTimer) Chan() <-chan time.Time {
+	return t.ch
+}
+
+func (t *fakeTimer) Stop() bool {
+	return t.ts.unsubscribe(t.id)
+}
+
+func (t *fakeTimer) tryFire(now time.Time) bool {
+	if t.when.Before(now) || t.when.Equal(now) {
+		select {
+		case t.ch <- now:
+			return true
+		default:
+		}
+	}
+	return false
+}

--- a/util/timer.go
+++ b/util/timer.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import "time"
@@ -28,7 +42,6 @@ type fakeTimer struct {
 	id   int
 	when time.Time
 	ch   chan time.Time
-	done bool
 }
 
 func newFakeTimer(ts *FakeTimeSource, id int, when time.Time) *fakeTimer {

--- a/util/timer_test.go
+++ b/util/timer_test.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func checkNotFiring(t *testing.T, timer Timer) {
+	t.Helper()
+	select {
+	case time := <-timer.Chan():
+		t.Errorf("Timer unexpectedly fired at %v", time)
+	case <-time.After(10 * time.Millisecond): // Give some real time to pass.
+	}
+}
+
+func TestFakeTimerFiresOnce(t *testing.T) {
+	base := time.Date(2018, 12, 12, 18, 00, 00, 00, time.UTC)
+	ts := NewFakeTimeSource(base)
+	timer := ts.NewTimer(10 * time.Millisecond)
+
+	checkNotFiring(t, timer)
+	newTime := base.Add(9 * time.Millisecond)
+	ts.Set(newTime)
+	checkNotFiring(t, timer)
+
+	newTime = newTime.Add(1 * time.Millisecond)
+	ts.Set(newTime)
+	got := <-timer.Chan() // Now it should fire.
+	if !got.Equal(newTime) {
+		t.Errorf("Timer fired at %v, want %v", got, newTime)
+	}
+
+	checkNotFiring(t, timer) // Shouldn't fire any more.
+}
+
+func TestFakeTimerStopBeforeFire(t *testing.T) {
+	base := time.Date(2018, 12, 12, 18, 00, 00, 00, time.UTC)
+	ts := NewFakeTimeSource(base)
+	timer := ts.NewTimer(10 * time.Millisecond)
+
+	checkNotFiring(t, timer)
+	if !timer.Stop() {
+		t.Error("Stop() returns true, want false")
+	}
+
+	newTime := base.Add(20 * time.Millisecond)
+	ts.Set(newTime)
+	checkNotFiring(t, timer) // Shouldn't fire because it was stopped.
+}
+
+func TestFakeTimerStopAfterFire(t *testing.T) {
+	for _, drain := range []bool{false, true} {
+		t.Run(fmt.Sprintf("drain:%v", drain), func(t *testing.T) {
+			base := time.Date(2018, 12, 12, 18, 00, 00, 00, time.UTC)
+			ts := NewFakeTimeSource(base)
+			timer := ts.NewTimer(10 * time.Millisecond)
+			ts.Set(base.Add(20 * time.Millisecond)) // Triggers the event.
+			if drain {
+				<-timer.Chan()
+			}
+			if timer.Stop() {
+				t.Error("Stop() returns false, want true")
+			}
+		})
+	}
+}
+
+func TestManyFakeTimers(t *testing.T) {
+	base := time.Date(2018, 12, 12, 18, 00, 00, 00, time.UTC)
+	ts := NewFakeTimeSource(base)
+	var timers []Timer
+	var times []time.Time
+	for i := 1; i <= 10; i++ {
+		d := time.Duration(i) * time.Second
+		timers = append(timers, ts.NewTimer(d))
+		times = append(times, base.Add(d))
+	}
+	check := func(fire int, want time.Time) {
+		for i, timer := range timers {
+			if i != fire {
+				checkNotFiring(t, timer)
+				continue
+			}
+			got := <-timer.Chan()
+			if !got.Equal(want) {
+				t.Errorf("Timer %d fired at %v, want %v", i, got, want)
+			}
+		}
+	}
+	check(-1, time.Time{}) // No firing before.
+	for i, time := range times {
+		ts.Set(time)
+		check(i, time)
+	}
+	check(-1, time.Time{}) // No firing after.
+}

--- a/util/timer_test.go
+++ b/util/timer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/util/timesource.go
+++ b/util/timesource.go
@@ -24,6 +24,8 @@ import (
 type TimeSource interface {
 	// Now returns the current time in real implementations or a suitable value in others
 	Now() time.Time
+	// NewTimer creates a timer that fires after the specified duration.
+	NewTimer(d time.Duration) Timer
 }
 
 // SecondsSince returns the time in seconds elapsed since t until now, as
@@ -40,31 +42,65 @@ func (s SystemTimeSource) Now() time.Time {
 	return time.Now()
 }
 
-// FakeTimeSource provides a time that can be any arbitrarily set value for use in tests.
-// It should not be used in production code.
+// NewTimer returns a real timer.
+func (s SystemTimeSource) NewTimer(d time.Duration) Timer {
+	return systemTimer{time.NewTimer(d)}
+}
+
+// FakeTimeSource provides time that can be arbitrarily set. For tests only.
 type FakeTimeSource struct {
-	// fakeTime is the value that this fake time source will return.
-	mu       sync.Mutex
-	fakeTime time.Time
+	mu     sync.RWMutex
+	now    time.Time
+	timers map[int]*fakeTimer
+	nextID int
 }
 
-// NewFakeTimeSource creates a FakeTimeSource instance
+// NewFakeTimeSource creates a FakeTimeSource instance.
 func NewFakeTimeSource(t time.Time) *FakeTimeSource {
-	return &FakeTimeSource{fakeTime: t}
+	timers := make(map[int]*fakeTimer)
+	return &FakeTimeSource{now: t, timers: timers}
 }
 
-// Now returns the time value this instance contains
+// Now returns the time value this instance contains.
 func (f *FakeTimeSource) Now() time.Time {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.now
+}
+
+// NewTimer returns a fake Timer.
+func (f *FakeTimeSource) NewTimer(d time.Duration) Timer {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.fakeTime
+	id := f.nextID
+	f.nextID++
+	timer := newFakeTimer(f, id, f.now.Add(d))
+	f.timers[id] = timer
+	return timer
 }
 
-// Set gives the time that this instance will report
+// unsubscribe removes the Timer with the specified ID if it exists, and
+// returns the existence bit.
+func (f *FakeTimeSource) unsubscribe(id int) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.timers[id]
+	if ok {
+		delete(f.timers, id)
+	}
+	return ok
+}
+
+// Set updates the time that this instance will report.
 func (f *FakeTimeSource) Set(t time.Time) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.fakeTime = t
+	f.now = t
+	for id, timer := range f.timers {
+		if timer.tryFire(t) {
+			delete(f.timers, id)
+		}
+	}
 }
 
 // IncrementingFakeTimeSource takes a base time and several increments, which will be applied to
@@ -84,4 +120,8 @@ func (a *IncrementingFakeTimeSource) Now() time.Time {
 	a.NextIncrement++
 
 	return adjustedTime
+}
+
+func (a *IncrementingFakeTimeSource) NewTimer(d time.Duration) Timer {
+	panic("NewTimer: not implemented")
 }

--- a/util/timesource.go
+++ b/util/timesource.go
@@ -122,6 +122,7 @@ func (a *IncrementingFakeTimeSource) Now() time.Time {
 	return adjustedTime
 }
 
+// NewTimer creates a timer with the specified delay. Not implemented.
 func (a *IncrementingFakeTimeSource) NewTimer(d time.Duration) Timer {
 	panic("NewTimer: not implemented")
 }

--- a/util/timesource.go
+++ b/util/timesource.go
@@ -17,10 +17,13 @@ package util
 import (
 	"sync"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 // TimeSource can provide the current time, or be replaced by a mock in tests to return
 // specific values.
+// TODO(pavelkalinnikov): Make a separate package for time types.
 type TimeSource interface {
 	// Now returns the current time in real implementations or a suitable value in others
 	Now() time.Time
@@ -124,5 +127,6 @@ func (a *IncrementingFakeTimeSource) Now() time.Time {
 
 // NewTimer creates a timer with the specified delay. Not implemented.
 func (a *IncrementingFakeTimeSource) NewTimer(d time.Duration) Timer {
-	panic("NewTimer: not implemented")
+	glog.Exitf("IncrementingFakeTimeSource.NewTimer is not implemented")
+	return nil
 }


### PR DESCRIPTION
This change extends the `TimeSource` interface with a method that creates timers. It will allow testing types that have time-dependent behavior, e.g. `select` from multiple channels one of which is a `Timer`.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
