### PR TITLE
election2: Add rigorous Election testing

### DIFF
--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // Package etcd provides an implementation of master election based on etcd.
-// TODO(pavelkalinnikov): Add tests.
 package etcd
 
 import (

--- a/util/election2/etcd/election_test.go
+++ b/util/election2/etcd/election_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/trillian/testonly/integration/etcd"
+	"github.com/google/trillian/util/election2/testonly"
+)
+
+func TestElection(t *testing.T) {
+	_, client, cleanup, err := etcd.StartEtcd()
+	if err != nil {
+		t.Fatalf("StartEtcd(): %v", err)
+	}
+	defer cleanup()
+
+	for _, nt := range testonly.Tests {
+		// Create a new Factory for each test for better isolation.
+		fact := NewFactory("testID", client, fmt.Sprintf("%s/resources/", nt.Name))
+		t.Run(nt.Name, func(t *testing.T) {
+			nt.Run(t, fact)
+		})
+	}
+}

--- a/util/election2/testonly/decorator.go
+++ b/util/election2/testonly/decorator.go
@@ -1,0 +1,112 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/trillian/util/election2"
+)
+
+// Errs contains errors to be returned by each of Election methods.
+type Errs struct {
+	Await          error
+	WithMastership error
+	Resign         error
+	Close          error
+}
+
+// Decorator is an election2.Election decorator injecting errors, for testing.
+type Decorator struct {
+	e     election2.Election
+	errs  Errs
+	block bool
+	mu    sync.Mutex
+	cond  *sync.Cond
+}
+
+// NewDecorator returns a Decorator wrapping the passed in Election object.
+func NewDecorator(e election2.Election) *Decorator {
+	d := &Decorator{e: e}
+	d.cond = sync.NewCond(&d.mu)
+	return d
+}
+
+// Update updates errors returned by interface methods.
+func (d *Decorator) Update(errs Errs) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.errs = errs
+}
+
+// BlockAwait enables or disables Await method blocking.
+func (d *Decorator) BlockAwait(block bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.block = block
+	d.cond.Broadcast()
+}
+
+// Await blocks until the instance captures mastership.
+func (d *Decorator) Await(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.errs.Await; err != nil {
+		return err
+	}
+	_, cancel := watchContext(ctx, &d.mu, d.cond)
+	defer cancel()
+	for d.block && ctx.Err() == nil {
+		d.cond.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return d.e.Await(ctx)
+}
+
+// WithMastership returns a mastership context.
+func (d *Decorator) WithMastership(ctx context.Context) (context.Context, error) {
+	if err := d.connect(ctx, &d.errs.WithMastership); err != nil {
+		return nil, err
+	}
+	return d.e.WithMastership(ctx)
+}
+
+// Resign releases mastership for this instance.
+func (d *Decorator) Resign(ctx context.Context) error {
+	if err := d.connect(ctx, &d.errs.Resign); err != nil {
+		return err
+	}
+	return d.e.Resign(ctx)
+}
+
+// Close permanently stops participating in election.
+func (d *Decorator) Close(ctx context.Context) error {
+	if err := d.connect(ctx, &d.errs.Close); err != nil {
+		return err
+	}
+	return d.e.Close(ctx)
+}
+
+func (d *Decorator) connect(ctx context.Context, err *error) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if *err != nil {
+		return *err
+	}
+	return nil
+}

--- a/util/election2/testonly/decorator.go
+++ b/util/election2/testonly/decorator.go
@@ -80,7 +80,9 @@ func (d *Decorator) Await(ctx context.Context) error {
 
 // WithMastership returns a mastership context.
 func (d *Decorator) WithMastership(ctx context.Context) (context.Context, error) {
-	if err := d.connect(ctx, &d.errs.WithMastership); err != nil {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.errs.WithMastership; err != nil {
 		return nil, err
 	}
 	return d.e.WithMastership(ctx)
@@ -88,7 +90,9 @@ func (d *Decorator) WithMastership(ctx context.Context) (context.Context, error)
 
 // Resign releases mastership for this instance.
 func (d *Decorator) Resign(ctx context.Context) error {
-	if err := d.connect(ctx, &d.errs.Resign); err != nil {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.errs.Resign; err != nil {
 		return err
 	}
 	return d.e.Resign(ctx)
@@ -96,17 +100,10 @@ func (d *Decorator) Resign(ctx context.Context) error {
 
 // Close permanently stops participating in election.
 func (d *Decorator) Close(ctx context.Context) error {
-	if err := d.connect(ctx, &d.errs.Close); err != nil {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.errs.Close; err != nil {
 		return err
 	}
 	return d.e.Close(ctx)
-}
-
-func (d *Decorator) connect(ctx context.Context, err *error) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if *err != nil {
-		return *err
-	}
-	return nil
 }

--- a/util/election2/testonly/election.go
+++ b/util/election2/testonly/election.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testonly contains an Election implementation for testing.
+package testonly
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/trillian/util/election2"
+)
+
+// Factory allows creating Election instances for testing.
+var Factory factory
+
+// Election implements election2.Election interface for testing.
+type Election struct {
+	isMaster bool
+	revision int
+	mu       sync.Mutex
+	cond     *sync.Cond
+}
+
+// NewElection returns a new initialized Election for testing.
+func NewElection() *Election {
+	e := &Election{}
+	e.cond = sync.NewCond(&e.mu)
+	return e
+}
+
+// update updates this instance's mastership status. Must be called under lock.
+func (e *Election) update(isMaster bool) {
+	e.isMaster = isMaster
+	e.revision++
+	e.cond.Broadcast()
+}
+
+// Await sets this instance to be the master. It always succeeds. To imitate
+// errors and/or blocking behavior use the Decorator type.
+func (e *Election) Await(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.isMaster {
+		e.update(true)
+	}
+	return nil
+}
+
+// WithMastership returns mastership context, which gets canceled if / when
+// this instance is not / stops being the master.
+func (e *Election) WithMastership(ctx context.Context) (context.Context, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.isMaster {
+		cctx, cancel := context.WithCancel(ctx)
+		cancel()
+		return cctx, nil
+	}
+
+	cctx, cancel := watchContext(ctx, &e.mu, e.cond) // Notify e.cond on ctx cancelation.
+	rev := e.revision
+	go func() { // Watch mastership and the context in the background.
+		defer cancel()
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		for e.isMaster && e.revision == rev && ctx.Err() == nil {
+			e.cond.Wait()
+		}
+	}()
+	return cctx, nil
+}
+
+// Resign resets mastership.
+func (e *Election) Resign(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.update(false)
+	return nil
+}
+
+// Close resets mastership permanently.
+func (e *Election) Close(ctx context.Context) error {
+	return e.Resign(ctx)
+}
+
+func watchContext(ctx context.Context, l sync.Locker, cond *sync.Cond) (context.Context, context.CancelFunc) {
+	cctx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer cancel()
+		<-cctx.Done()
+		l.Lock() // Avoid racing with cond waiters on ctx status.
+		defer l.Unlock()
+		cond.Broadcast()
+	}()
+	return cctx, cancel
+}
+
+// factory allows creating Election instances.
+type factory struct{}
+
+// NewElection creates a new Election instance.
+// TODO(pavelkalinnikov): Use resourceID in tests with multiple resources.
+func (f factory) NewElection(ctx context.Context, resourceID string) (election2.Election, error) {
+	return NewElection(), nil
+}

--- a/util/election2/testonly/election_test.go
+++ b/util/election2/testonly/election_test.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly_test
+
+import (
+	"testing"
+
+	"github.com/google/trillian/util/election2/testonly"
+)
+
+func TestElection(t *testing.T) {
+	for _, test := range testonly.Tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Run(t, testonly.Factory)
+		})
+	}
+}

--- a/util/election2/testonly/tests.go
+++ b/util/election2/testonly/tests.go
@@ -1,0 +1,284 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/trillian/util/clock"
+	"github.com/google/trillian/util/election2"
+)
+
+// Tests is the full list of available Election tests.
+// TODO(pavelkalinnikov): Add tests for unexpected mastership loss.
+var Tests = []NamedTest{
+	{Name: "RunElectionAwait", Run: runElectionAwait},
+	{Name: "RunElectionWithMastership", Run: runElectionWithMastership},
+	{Name: "RunElectionResign", Run: runElectionResign},
+	{Name: "RunElectionClose", Run: runElectionClose},
+	{Name: "RunElectionLoop", Run: runElectionLoop},
+}
+
+// NamedTest is a test function paired with its string name.
+type NamedTest struct {
+	Name string
+	Run  func(t *testing.T, f election2.Factory)
+}
+
+// checkNotDone ensures that the context is not done for some time.
+func checkNotDone(ctx context.Context, t *testing.T) {
+	t.Helper()
+	if err := clock.SleepContext(ctx, 10*time.Millisecond); err != nil {
+		t.Error("unexpected context cancelation")
+	}
+}
+
+// checkDone ensures that the context is done within the specified duration.
+func checkDone(ctx context.Context, t *testing.T, wait time.Duration) {
+	t.Helper()
+	if wait == 0 {
+		select {
+		case <-ctx.Done(): // Ok.
+		default:
+			t.Error("expected context done")
+		}
+	} else if err := clock.SleepContext(ctx, wait); err == nil {
+		t.Errorf("expected context done within %v", wait)
+	}
+}
+
+// runElectionAwait tests the Await call with different pre-conditions.
+func runElectionAwait(t *testing.T, f election2.Factory) {
+	awaitErr := errors.New("Await error")
+	for _, tc := range []struct {
+		desc    string
+		block   bool
+		cancel  bool
+		err     error
+		wantErr error
+	}{
+		{desc: "ok", wantErr: nil},
+		{desc: "cancel", block: true, cancel: true, wantErr: context.Canceled},
+		{desc: "deadline", block: true, cancel: false, wantErr: context.DeadlineExceeded},
+		{desc: "error", err: awaitErr, wantErr: awaitErr},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			e, err := f.NewElection(ctx, tc.desc)
+			if err != nil {
+				t.Fatalf("NewElection(): %v", err)
+			}
+			d := NewDecorator(e)
+			d.Update(Errs{Await: tc.err})
+			d.BlockAwait(tc.block)
+
+			if tc.cancel {
+				cancel()
+			}
+			if got, want := d.Await(ctx), tc.wantErr; got != want {
+				t.Errorf("Await(): %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// runElectionWithMastership tests the WithMastership call.
+func runElectionWithMastership(t *testing.T, f election2.Factory) {
+	ctxErr := errors.New("WithMastership error")
+	for _, tc := range []struct {
+		desc     string
+		beMaster bool
+		cancel   bool
+		err      error
+		wantErr  error
+	}{
+		{desc: "master", beMaster: true},
+		{desc: "master-cancel", beMaster: true, cancel: true},
+		{desc: "not-master", beMaster: false},
+		{desc: "not-master-cancel", cancel: true},
+		{desc: "error", err: ctxErr, wantErr: ctxErr},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			e, err := f.NewElection(ctx, tc.desc)
+			if err != nil {
+				t.Fatalf("NewElection(): %v", err)
+			}
+			d := NewDecorator(e)
+			d.Update(Errs{WithMastership: tc.err})
+			if tc.beMaster {
+				if err := d.Await(ctx); err != nil {
+					t.Fatalf("Await(): %v", err)
+				}
+			}
+			mctx, err := d.WithMastership(ctx)
+			if want := tc.wantErr; err != want {
+				t.Fatalf("WithMastership(): %v, want %v", err, want)
+			}
+			if err != nil {
+				return
+			}
+			if tc.cancel {
+				cancel()
+			}
+			if tc.beMaster && !tc.cancel {
+				checkNotDone(mctx, t)
+			} else {
+				checkDone(mctx, t, 0)
+			}
+		})
+	}
+}
+
+// runElectionResign tests the Resign call.
+func runElectionResign(t *testing.T, f election2.Factory) {
+	resignErr := errors.New("Resign error")
+	for _, tc := range []struct {
+		desc     string
+		beMaster bool
+		err      error
+		wantErr  error
+	}{
+		{desc: "master", beMaster: true, wantErr: nil},
+		{desc: "master-error", beMaster: true, err: resignErr, wantErr: resignErr},
+		{desc: "not-master", beMaster: false, wantErr: nil},
+		{desc: "not-master-error", err: resignErr, wantErr: resignErr},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			e, err := f.NewElection(ctx, tc.desc)
+			if err != nil {
+				t.Fatalf("NewElection(): %v", err)
+			}
+			d := NewDecorator(e)
+			d.Update(Errs{Resign: tc.err})
+
+			if tc.beMaster {
+				if err := d.Await(ctx); err != nil {
+					t.Fatalf("Await(): %v", err)
+				}
+			}
+			mctx, err := d.WithMastership(ctx)
+			if err != nil {
+				t.Fatalf("WithMastership(): %v", err)
+			}
+			if got, want := d.Resign(ctx), tc.wantErr; got != want {
+				if tc.beMaster {
+					t.Errorf("Resign(): %v, want %v", got, want)
+				}
+				// Otherwise the implementation might return some error indicating that
+				// we can't resign if not the master.
+			}
+			if tc.beMaster && tc.wantErr == nil {
+				checkDone(mctx, t, 200*time.Millisecond)
+			} else if tc.beMaster {
+				checkNotDone(mctx, t)
+			} else {
+				checkDone(mctx, t, 0)
+			}
+		})
+	}
+}
+
+// runElectionClose tests the Close call.
+func runElectionClose(t *testing.T, f election2.Factory) {
+	closeErr := errors.New("Close error")
+	for _, tc := range []struct {
+		desc     string
+		beMaster bool
+		cancel   bool
+		err      error
+		wantErr  error
+	}{
+		{desc: "master", beMaster: true, wantErr: nil},
+		{desc: "master-error", beMaster: true, err: closeErr, wantErr: closeErr},
+		{desc: "not-master", beMaster: false, wantErr: nil},
+		{desc: "not-master-error", err: closeErr, wantErr: closeErr},
+		{desc: "cancel", cancel: true, wantErr: nil},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			e, err := f.NewElection(ctx, tc.desc)
+			if err != nil {
+				t.Fatalf("NewElection(): %v", err)
+			}
+			d := NewDecorator(e)
+			d.Update(Errs{Close: tc.err})
+
+			if tc.beMaster {
+				if err := d.Await(ctx); err != nil {
+					t.Fatalf("Await(): %v", err)
+				}
+			}
+			mctx, err := d.WithMastership(ctx)
+			if err != nil {
+				t.Fatalf("WithMastership(): %v", err)
+			}
+
+			cctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+			if got, want := d.Close(cctx), tc.wantErr; got != want {
+				t.Errorf("Close(): %v, want %v", got, want)
+			}
+			if tc.beMaster && tc.wantErr == nil {
+				checkDone(mctx, t, 200*time.Millisecond)
+			} else if tc.beMaster {
+				checkNotDone(mctx, t)
+			} else {
+				checkDone(mctx, t, 0)
+			}
+		})
+	}
+}
+
+// runElectionLoop runs a typical mastership loop.
+func runElectionLoop(t *testing.T, f election2.Factory) {
+	ctx := context.Background()
+	e, err := f.NewElection(ctx, "testID")
+	if err != nil {
+		t.Fatalf("NewElection(): %v", err)
+	}
+	d := NewDecorator(e)
+
+	defer func() {
+		if err := d.Close(ctx); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		t.Logf("Mastership iteration: %d", i)
+		if err := d.Await(ctx); err != nil {
+			t.Fatalf("Await(): %v", err)
+		}
+		mctx, err := d.WithMastership(ctx)
+		if err != nil {
+			t.Fatalf("WithMastership(): %v", err)
+		}
+		checkNotDone(mctx, t) // Do some work as master.
+		if err := d.Resign(ctx); err != nil {
+			t.Errorf("Resign(): %v", err)
+		}
+		checkDone(mctx, t, 200*time.Millisecond) // The mastership context should close.
+	}
+}

--- a/util/election2/testonly/tests.go
+++ b/util/election2/testonly/tests.go
@@ -180,11 +180,7 @@ func runElectionResign(t *testing.T, f election2.Factory) {
 				t.Fatalf("WithMastership(): %v", err)
 			}
 			if got, want := d.Resign(ctx), tc.wantErr; got != want {
-				if tc.beMaster {
-					t.Errorf("Resign(): %v, want %v", got, want)
-				}
-				// Otherwise the implementation might return some error indicating that
-				// we can't resign if not the master.
+				t.Errorf("Resign(): %v, want %v", got, want)
 			}
 			if tc.beMaster && tc.wantErr == nil {
 				checkDone(mctx, t, 200*time.Millisecond)


### PR DESCRIPTION
This change adds a test-only `Election` implementation and tests for it. It also introduces a `Decorator` that allows injecting errors into `Election` implementations during testing, and controlling how long `Await` method is blocked. The decorator and the bulk of the tests code is re-used by both `testonly.Election` and `etcd.Election` implementations.

Depends on: #1387, #1388

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
