### PR TITLE
election2/etcd: Proclaim resignation

### DIFF
--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -99,7 +99,10 @@ func (e *Election) WithMastership(ctx context.Context) (context.Context, error) 
 // again using Await. Idempotent, might be useful to retry if fails.
 func (e *Election) Resign(ctx context.Context) error {
 	// Trigger Observe callers to see the update, and cancel mastership contexts.
-	if err := e.election.Proclaim(ctx, resignID); err != nil {
+	err := e.election.Proclaim(ctx, resignID)
+	if err == concurrency.ErrElectionNotLeader {
+		return nil // Resigning if not master is a no-op.
+	} else if err != nil {
 		return err
 	}
 	return e.election.Resign(ctx)

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/trillian/util/election2"
 )
 
+const resignID = "<resign>"
+
 // Election is an implementation of election2.Election based on etcd.
 type Election struct {
 	resourceID string
@@ -59,8 +61,9 @@ func (e *Election) WithMastership(ctx context.Context) (context.Context, error) 
 		cancel()
 		return nil, ctx.Err()
 	case rsp, ok := <-ch:
-		if !ok || rsp.Kvs[0].CreateRevision != etcdRev {
-			// Mastership has been overtaken in the meantime, or not capturead at all.
+		kv := rsp.Kvs[0]
+		if !ok || kv.CreateRevision != etcdRev || string(kv.Value) == resignID {
+			// Mastership has been overtaken, released, or not capturead at all.
 			cancel()
 			return cctx, nil
 		}
@@ -75,9 +78,15 @@ func (e *Election) WithMastership(ctx context.Context) (context.Context, error) 
 		}()
 
 		for rsp := range ch {
-			if rsp.Kvs[0].CreateRevision != etcdRev {
-				conquerorID := string(rsp.Kvs[0].Value)
+			kv := rsp.Kvs[0]
+			if kv.CreateRevision != etcdRev {
+				conquerorID := string(kv.Value)
+				// TODO(pavelkalinnikov): conquerorID can be resignID too. Serialize a
+				// protobuf with all mastership details instead of ID string.
 				glog.Warningf("%s: mastership overtaken by %s", e.resourceID, conquerorID)
+				break
+			} else if string(kv.Value) == resignID {
+				glog.Infof("%s: canceling context due to resignation", e.resourceID)
 				break
 			}
 		}
@@ -89,6 +98,10 @@ func (e *Election) WithMastership(ctx context.Context) (context.Context, error) 
 // Resign releases mastership for this instance. The instance can be elected
 // again using Await. Idempotent, might be useful to retry if fails.
 func (e *Election) Resign(ctx context.Context) error {
+	// Trigger Observe callers to see the update, and cancel mastership contexts.
+	if err := e.election.Proclaim(ctx, resignID); err != nil {
+		return err
+	}
 	return e.election.Resign(ctx)
 }
 


### PR DESCRIPTION
The issue that this change addresses is the possibility of leaking mastership contexts if they are not used properly (due to bugs or exceptional cases). `Observe` method of `etcd` election package does not report leadership resignation (i.e. DELETE events in election directory). As a result, the monitoring loop in `WithMastership` doesn't terminate until other instance captures mastership. If there is no other instance, the loop can hang forever, leaving mastership context open.

Caught by tests in #1386.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
