### PR TITLE
Election Runner: Simplify resignation delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ The maphammer test tool for the experimental Trillian Map has been enhanced.
 
 ### Master election refactoring
 
-The `--resign_odds` flag in `logsigner` is deprecated, in favor of a more
-generic `--master_hold_jitter` flag.
+The `--resign_odds` flag in `logsigner` is removed, in favor of a more generic
+`--master_hold_jitter` flag. Operators using this flag are advised to set the
+jitter to `master_check_interval * resign_odds * 2` to achieve similar behavior.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ an optional error.
 
 The maphammer test tool for the experimental Trillian Map has been enhanced.
 
+### Master election refactoring
+
+The `--resign_odds` flag in `logsigner` is deprecated, in favor of a more
+generic `--master_hold_jitter` flag.
+
 ### Other
 
 The `TimeSource` type (and other time utils) moved to a separate `util/clock`

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -69,7 +69,10 @@ var (
 	preElectionPause    = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	masterCheckInterval = flag.Duration("master_check_interval", 5*time.Second, "Interval between checking mastership still held")
 	masterHoldInterval  = flag.Duration("master_hold_interval", 60*time.Second, "Minimum interval to hold mastership for")
-	resignOdds          = flag.Int("resign_odds", 10, "Chance of resigning mastership after each check, the N in 1-in-N")
+	masterHoldJitter    = flag.Duration("master_hold_jitter", 60*time.Second, "Maximal random addition to --master_hold_interval")
+
+	// TODO(pavelkalinnikov): Remove this flag.
+	resignOdds = flag.Int("resign_odds", 10, "Deprecated: Chance of resigning mastership after each check, the N in 1-in-N")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
@@ -155,7 +158,7 @@ func main() {
 			PreElectionPause:    *preElectionPause,
 			MasterCheckInterval: *masterCheckInterval,
 			MasterHoldInterval:  *masterHoldInterval,
-			ResignOdds:          *resignOdds,
+			MasterHoldJitter:    *masterHoldJitter,
 			TimeSource:          clock.System,
 		},
 	}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -71,9 +71,6 @@ var (
 	masterHoldInterval  = flag.Duration("master_hold_interval", 60*time.Second, "Minimum interval to hold mastership for")
 	masterHoldJitter    = flag.Duration("master_hold_jitter", 60*time.Second, "Maximal random addition to --master_hold_interval")
 
-	// TODO(pavelkalinnikov): Remove this flag.
-	resignOdds = flag.Int("resign_odds", 10, "Deprecated: Chance of resigning mastership after each check, the N in 1-in-N")
-
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )
 

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -69,7 +69,7 @@ var (
 	preElectionPause    = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	masterCheckInterval = flag.Duration("master_check_interval", 5*time.Second, "Interval between checking mastership still held")
 	masterHoldInterval  = flag.Duration("master_hold_interval", 60*time.Second, "Minimum interval to hold mastership for")
-	masterHoldJitter    = flag.Duration("master_hold_jitter", 60*time.Second, "Maximal random addition to --master_hold_interval")
+	masterHoldJitter    = flag.Duration("master_hold_jitter", 120*time.Second, "Maximal random addition to --master_hold_interval")
 
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 )


### PR DESCRIPTION
This PR removes the "resign odds" parameter in favor of a more generic "random jitter" parameter that does not assume busy waiting loop of `IsMaster` checks.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
