### PR TITLE
Fetch all relevant map nodes in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Parallel Algorithms
+
+* The HStar2 algorithm for reading and writing to the map now processes each
+  subtree concurrently.
+
+### Default MaxSQLConnections Limit
+The default limit on the maximum number of concurrent mysql connections has been
+changed from unlimited to 1024. See ./scripts/mysqlconnlimit.sh
+
 ### Add Profiling Flags to Binaries
 
 The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/functions.sh
 

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/functions.sh
 
@@ -18,7 +19,7 @@ fi
 echo "Running test"
 cd "${INTEGRATION_DIR}"
 set +e
-go test \
+go test ${GOFLAGS} ${GOFLAGS:+-short} \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
   ./maptest  --map_rpc_server="${TRILLIAN_SERVER}"
 RESULT=$?

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -125,7 +125,7 @@ func (s *HStar2) hStar2b(depth, maxDepth int, values []HStar2LeafHash, offset *b
 	if lhs.err != nil {
 		return nil, lhs.err
 	}
-	h := s.hasher.HashChildren(lhs, rhs)
+	h := s.hasher.HashChildren(lhs.value, rhs)
 	if err := s.set(offset, depth, h, set); err != nil {
 		return nil, err
 	}

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -116,15 +116,14 @@ func (s *HStar2) hStar2b(depth, maxDepth int, values []HStar2LeafHash, offset *b
 	split.Add(split, offset)
 	i := sort.Search(len(values), func(i int) bool { return values[i].Index.Cmp(split) >= 0 })
 	lhsFuture := s.hStar2bFuture(depth+1, maxDepth, values[:i], offset, get, set)
-	rhsFuture := s.hStar2bFuture(depth+1, maxDepth, values[i:], split, get, set)
+	rhs, err := s.hStar2b(depth+1, maxDepth, values[i:], split, get, set)
+	if err != nil {
+		return nil, err
+	}
 
 	lhs := <-lhsFuture
-	rhs := <-rhsFuture
 	if lhs.err != nil {
 		return nil, lhs.err
-	}
-	if rhs.err != nil {
-		return nil, rhs.err
 	}
 	h := s.hasher.HashChildren(lhs, rhs)
 	if err := s.set(offset, depth, h, set); err != nil {

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -211,6 +211,7 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 		root = []byte{}
 		leaves := make([]HStar2LeafHash, 0, queueSize)
 		nodesToStore := make([]storage.Node, 0, queueSize*2)
+		var nodesMu sync.Mutex
 
 		// sibs will hold the list of sibling node IDs for all nodes we'll end up
 		// wanting to write - we'll use this to prewarm the subtree cache.
@@ -271,6 +272,8 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
 				glog.V(4).Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
 					index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits, h)
+				nodesMu.Lock()
+				defer nodesMu.Unlock()
 				nodesToStore = append(nodesToStore,
 					storage.Node{
 						NodeID:       nodeID,

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
-	maxConns = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
+	maxConns = flag.Int("mysql_max_conns", 1024, "Maximum connections to the database") // See ./scripts/mysqlconnlimit.sh
 	maxIdle  = flag.Int("mysql_max_idle_conns", -1, "Maximum idle database connections in the connection pool")
 
 	mysqlOnce            sync.Once

--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -35,7 +35,11 @@ var (
 )
 
 func TestInProcessMapHammer(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Hammer is not a short test")
+	}
 	testdb.SkipIfNoMySQL(t)
+
 	ctx := context.Background()
 	env, err := integration.NewMapEnv(ctx, *singleTX)
 	if err != nil {


### PR DESCRIPTION
Create a separate go routine per branch in the HStar2 algorithm to set and get map nodes in parallel. 
This creates a large number of parallel database queries, so we also need to set `MaxConns`. 

#1397 

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
