### PR TITLE
Change db_server Docker image to be based on Google's MySQL 5.7 image

### DIFF
--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM marketplace.gcr.io/google/mysql5:5.7
 
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY storage/mysql/storage.sql /docker-entrypoint-initdb.d/storage.sql


### PR DESCRIPTION
This base image is already approved for distribution by Google, which makes it easier to get approval for distributing our image.

Contributes to #1129.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
