### PR TITLE
Revert "Change db_server Docker image to be based on Google's MySQL 5.7 image"

### DIFF
--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/mysql5:5.7
+FROM mysql:5.7
 
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY storage/mysql/storage.sql /docker-entrypoint-initdb.d/storage.sql


### PR DESCRIPTION
This reverts commit 39306244a9abd6f66781765073b28257c1fc041b.

This was done because it results in the following error message on Travis following #1403:

```
ERROR: Service 'mysql' failed to build: unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```