### PR TITLE
Map: Prewarm subtreeCache to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The `--master_check_interval` flag is removed from `logsigner`.
 `util/election2` package. The interfaces in `util/election/election.go` file are
 deprecated.
 
+### Performance
+
+The performance of `SetLeaves` requests on the Map has been slightly improved.
+
 ### Other
 
 The `TimeSource` type (and other time utils) moved to a separate `util/clock`

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -235,14 +235,13 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 				})
 		}
 		// Prewarm the cache:
-		var err error
-		_, err = tx.GetMerkleNodes(ctx, s.treeRevision, sibs)
-		if err != nil {
+		if _, err := tx.GetMerkleNodes(ctx, s.treeRevision, sibs); err != nil {
 			return fmt.Errorf("failed to preload node hash cache: %s", err)
 		}
 
 		// calculate new root, and intermediate nodes:
 		hs2 := NewHStar2(s.treeID, s.hasher)
+		var err error
 		root, err = hs2.HStar2Nodes(s.prefix, s.subtreeDepth, leaves,
 			func(depth int, index *big.Int) ([]byte, error) {
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -481,7 +481,7 @@ func testSparseTreeFetches(ctx context.Context, t *testing.T, vec sparseTestVect
 	// rather than doing that we'll make a note of all the unexpected IDs here
 	// instead, and we can then print them out later on.
 	tx.EXPECT().GetMerkleNodes(ctx, int64(rev), gomock.Any()).AnyTimes().Do(
-		func(rev int64, a []storage.NodeID) {
+		func(_ context.Context, rev int64, a []storage.NodeID) {
 			if a == nil {
 				return
 			}

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -473,7 +473,10 @@ func testSparseTreeFetches(ctx context.Context, t *testing.T, vec sparseTestVect
 
 		state, ok := reads[ids[0].String()]
 		reads[ids[0].String()] = "met"
-		return ok && state == "unmet"
+
+		// Allow re-reads of the same nodes too (state=="met") - this is due to
+		// cache warming:
+		return ok && (state == "unmet" || state == "met")
 	}}).AnyTimes().Return([]storage.Node{}, nil)
 
 	// Now add a general catch-all for any unexpected calls. If we don't do this
@@ -582,7 +585,7 @@ func TestSparseMerkleTreeWriterFetchesMultipleLeaves(t *testing.T) {
 }
 
 func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
-	t.Skip("Disabled: BigBatch takes too long")
+	//t.Skip("Disabled: BigBatch takes too long")
 	ctx := context.Background()
 
 	mockCtrl := gomock.NewController(t)

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -585,7 +585,10 @@ func TestSparseMerkleTreeWriterFetchesMultipleLeaves(t *testing.T) {
 }
 
 func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
-	//t.Skip("Disabled: BigBatch takes too long")
+	if testing.Short() {
+		t.Skip("BigBatch test is not short")
+	}
+
 	ctx := context.Background()
 
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
Attempts to speed up map `SetLeaves` requests by preloading the `subtreeCache` with pages which we already know `hstar2` will want to touch ahead of time.
This works because the existing storage implementations know how best to optimise for loading multiple pages at once.

Against a local MySQL DB on my machine, this provides the following speed up:

```bash
# master
$ ./integration/map_integration_test.sh
ok  	github.com/google/trillian/integration/maptest	24.815s

# This PR
$ ./integration/map_integration_test.sh
ok  	github.com/google/trillian/integration/maptest	17.260s
```

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
