### PR TITLE
Fix OperationLoop error hiding hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Fix Operation Loop Hang
+
+Resolved a bug that would hide errors and cause the `OperationLoop` to hang
+until process exit if any error occured.
+
 ### Linting toolchain migration
 
 gometalinter has been replaced with golangci-lint for improved performance and

--- a/server/log_operation_manager.go
+++ b/server/log_operation_manager.go
@@ -307,8 +307,8 @@ loop:
 		// TODO(alcutter): want a child context with deadline here?
 		start := l.info.TimeSource.Now()
 		if err := l.getLogsAndExecutePass(ctx); err != nil {
-			// Suppress the error if ctx is done (ok==false) as we're exiting.
-			if _, ok := <-ctx.Done(); ok {
+			// Suppress the error if ctx is done (ctx.Err != nil) as we're exiting.
+			if ctx.Err() != nil {
 				glog.Errorf("failed to execute operation on logs: %v", err)
 			}
 		}


### PR DESCRIPTION
`_, ok <-ctx.Done()` will block until the context is canceled.
This particular context, however, will not close until the binary exits,
effectively hiding the error message and hanging the goroutine.

- [x] I have updated the [CHANGELOG](CHANGELOG.md).