### PR TITLE
Change db_server Docker image to be based on Google's MySQL 5.7 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Deployments
+
+The [db\_server Docker image](examples/deployment/docker/db_server/Dockerfile)
+is now based on
+[the MySQL 5.7 image from the Google Cloud Marketplace](https://console.cloud.google.com/marketplace/details/google/mysql5),
+rather than the [official MySQL 5.7 image](https://hub.docker.com/_/mysql).
+
 ### Dropped metrics
 
 Quota metrics with specs of the form `users/<user>/read` and

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,28 @@ substitutions:
   _CLUSTER_NAME: trillian-opensource-ci
   _MASTER_ZONE: us-central1-a
   _CONFIG_MAP: examples/deployment/kubernetes/trillian-opensource-ci.yaml
+  _MYSQL_TAG: "5.7"
 steps:
+- id: pull_mysql
+  name : gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+- id: tag_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - pull_mysql
+- id: push_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - tag_mysql
 - id: build_db_server
   name: gcr.io/cloud-builders/docker
   args:
@@ -10,7 +31,8 @@ steps:
   - --file=examples/deployment/docker/db_server/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
   - .
-  waitFor: ["-"]
+  waitFor:
+  - push_mysql
 - id: build_log_server
   name: gcr.io/cloud-builders/docker
   args:

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,4 +1,26 @@
+substitutions:
+  _MYSQL_TAG: "5.7"
 steps:
+- id: pull_mysql
+  name : gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+- id: tag_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - pull_mysql
+- id: push_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - tag_mysql
 - id: build_db_server
   name: gcr.io/cloud-builders/docker
   args:
@@ -6,7 +28,8 @@ steps:
   - --file=examples/deployment/docker/db_server/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
   - .
-  waitFor: ["-"]
+  waitFor:
+  - push_mysql
 - id: build_log_server
   name: gcr.io/cloud-builders/docker
   args:

--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM gcr.io/trillian-opensource-ci/mysql5:5.7
 
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY storage/mysql/storage.sql /docker-entrypoint-initdb.d/storage.sql


### PR DESCRIPTION
This base image is already approved for distribution by Google, which makes it easier to get approval for distributing our image.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
