### PR TITLE
Add experimental mysql option to fetch subtrees one at a time

### DIFF
--- a/cmd/merkle_path/main.go
+++ b/cmd/merkle_path/main.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/merkle_path/main.go
+++ b/cmd/merkle_path/main.go
@@ -42,9 +42,7 @@ func main() {
 		glog.Exitf("Failed to build the Merkle path: %v", err)
 	}
 
-	fmt.Printf("Resulting path length: %d\n"+
-		"ls -l"+
-		"", len(path))
+	fmt.Printf("Resulting path length: %d\n", len(path))
 	for _, fetch := range path {
 		nodeID := fetch.NodeID
 		fmt.Printf("%v %v\n", nodeID.CoordString(), fetch.Rehash)

--- a/cmd/merkle_path/main.go
+++ b/cmd/merkle_path/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+
+	"github.com/golang/glog"
+	_ "github.com/golang/protobuf/proto"
+	_ "github.com/google/trillian/crypto/keyspb"
+	_ "github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/merkle"
+	_ "github.com/google/trillian/storage/storagepb"
+)
+
+var (
+	size1    = flag.Int64("size1", 0, "First tree size (or only for inclusion proof)")
+	size2    = flag.Int64("size2", 0, "Second tree size (for consistency proof)")
+	index    = flag.Int64("index", 0, "Desired leaf index (for inclusion proof)")
+	treeSize = flag.Int64("tree_size", 0, "Size of the Merkle tree")
+)
+
+func main() {
+	flag.Parse()
+	defer glog.Flush()
+
+	var err error
+	var path []merkle.NodeFetch
+	subtrees := make(map[string]bool)
+
+	if *size2 == 0 {
+		// Do an inclusion proof
+		fmt.Printf("Inclusion proof for index %d at tree size %d in a tree of size %d\n\n", *index, *size1, *treeSize)
+		path, err = merkle.CalcInclusionProofNodeAddresses(*size1, *index, *treeSize, 64)
+	} else {
+		// It's a consistency proof.
+		fmt.Printf("Consistency proof for tree size %d -> %d in a tree of size %d\n\n", *size1, *size2, *treeSize)
+		path, err = merkle.CalcConsistencyProofNodeAddresses(*size1, *size2, *treeSize, 64)
+	}
+
+	if err != nil {
+		glog.Exitf("Failed to build the Merkle path: %v", err)
+	}
+
+	fmt.Printf("Resulting path length: %d\n"+
+		"ls -l"+
+		"", len(path))
+	for _, fetch := range path {
+		nodeID := fetch.NodeID
+		fmt.Printf("%v %v\n", nodeID.CoordString(), fetch.Rehash)
+		prefixBytes := nodeID.PrefixLenBits >> 3
+		// Might have to split the path if it isn't the root of a subtree.
+		suffixBits := nodeID.PrefixLenBits - (prefixBytes << 3)
+		subtree := nodeID.Path
+		if suffixBits > 0 {
+			subtree, _ = nodeID.Split(prefixBytes, suffixBits)
+		}
+		subtrees[hex.EncodeToString(subtree)] = true
+	}
+
+	fmt.Printf("\nPath traverses %d subtree(s)\n\n", len(subtrees))
+	for subtree := range subtrees {
+		fmt.Printf("%s %d\n", subtree, len(subtree)/2)
+	}
+}

--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -108,7 +108,7 @@ func TestMySQLRateLimiting(t *testing.T) {
 	qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequenced}
 	registry := extension.Registry{
 		AdminStorage: mysql.NewAdminStorage(db),
-		LogStorage:   mysql.NewLogStorage(db, nil),
+		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{}),
 		MapStorage:   mysql.NewMapStorage(db),
 		QuotaManager: qm,
 	}

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -296,7 +296,7 @@ func createTree(ctx context.Context, db *sql.DB) (*trillian.Tree, error) {
 	}
 
 	{
-		ls := mysql.NewLogStorage(db, nil)
+		ls := mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{})
 		err := ls.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 			signer := tcrypto.NewSigner(0, testonly.NewSignerWithFixedSig(nil, []byte("notempty")), crypto.SHA256)
 			slr, err := signer.SignLogRoot(&types.LogRootV1{RootHash: []byte{0}})
@@ -336,7 +336,7 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 		})
 	}
 
-	ls := mysql.NewLogStorage(db, nil)
+	ls := mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{})
 	return ls.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 		_, err := tx.QueueLeaves(ctx, leaves, time.Now())
 		return err

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -72,7 +72,7 @@ func newMySQLStorageProvider(mf monitoring.MetricFactory) (StorageProvider, erro
 
 func (s *mysqlProvider) LogStorage() storage.LogStorage {
 	return mysql.NewLogStorage(s.db, s.mf, mysql.LogStorageOptions{
-		mysql.TreeStorageOptions{
+		TreeStorageOptions: mysql.TreeStorageOptions{
 			FetchSingleSubtrees: *singleFetch,
 		},
 	})

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -29,8 +29,9 @@ import (
 )
 
 var (
-	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
-	maxConns = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
+	mySQLURI    = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	maxConns    = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
+	singleFetch = flag.Bool("mysql_fetch_single_subtrees", false, "If true enables experiment to fetch subtrees avoiding a big JOIN")
 
 	mysqlOnce            sync.Once
 	mysqlOnceErr         error
@@ -70,7 +71,11 @@ func newMySQLStorageProvider(mf monitoring.MetricFactory) (StorageProvider, erro
 }
 
 func (s *mysqlProvider) LogStorage() storage.LogStorage {
-	return mysql.NewLogStorage(s.db, s.mf)
+	return mysql.NewLogStorage(s.db, s.mf, mysql.LogStorageOptions{
+		mysql.TreeStorageOptions{
+			FetchSingleSubtrees: *singleFetch,
+		},
+	})
 }
 
 func (s *mysqlProvider) MapStorage() storage.MapStorage {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -137,15 +137,21 @@ type mySQLLogStorage struct {
 	metricFactory monitoring.MetricFactory
 }
 
+// LogStorageOptions holds tuning parameters and experimental settings for
+// the MySQL log storage code.
+type LogStorageOptions struct {
+	TreeStorageOptions
+}
+
 // NewLogStorage creates a storage.LogStorage instance for the specified MySQL URL.
 // It assumes storage.AdminStorage is backed by the same MySQL database as well.
-func NewLogStorage(db *sql.DB, mf monitoring.MetricFactory) storage.LogStorage {
+func NewLogStorage(db *sql.DB, mf monitoring.MetricFactory, opts LogStorageOptions) storage.LogStorage {
 	if mf == nil {
 		mf = monitoring.InertMetricFactory{}
 	}
 	return &mySQLLogStorage{
 		admin:            NewAdminStorage(db),
-		mySQLTreeStorage: newTreeStorage(db),
+		mySQLTreeStorage: newTreeStorage(db, opts.TreeStorageOptions),
 		metricFactory:    mf,
 	}
 }

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -66,7 +66,7 @@ type mySQLMapStorage struct {
 func NewMapStorage(db *sql.DB) storage.MapStorage {
 	return &mySQLMapStorage{
 		admin:            NewAdminStorage(db),
-		mySQLTreeStorage: newTreeStorage(db),
+		mySQLTreeStorage: newTreeStorage(db, TreeStorageOptions{}),
 	}
 }
 

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -38,10 +38,14 @@ import (
 	storageto "github.com/google/trillian/storage/testonly"
 )
 
+// *****************************************************************
+// TODO(Martin2112): Do something about hardcoded LogStorageOptions.
+// *****************************************************************
+
 func TestNodeRoundTrip(t *testing.T) {
 	cleanTestDB(DB)
 	tree := createTreeOrPanic(DB, storageto.LogTree)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB, nil, LogStorageOptions{TreeStorageOptions{FetchSingleSubtrees: true}})
 
 	const writeRevision = int64(100)
 	nodesToStore := createSomeNodes()
@@ -84,7 +88,7 @@ func TestNodeRoundTrip(t *testing.T) {
 func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 	cleanTestDB(DB)
 	tree := createTreeOrPanic(DB, storageto.LogTree)
-	s := NewLogStorage(DB, nil)
+	s := NewLogStorage(DB, nil, LogStorageOptions{TreeStorageOptions{FetchSingleSubtrees: true}})
 
 	const writeRevision = int64(100)
 	nodesToStore, err := createLogNodesForTreeAtSize(871, writeRevision)
@@ -236,7 +240,7 @@ func createFakeSignedLogRoot(db *sql.DB, tree *trillian.Tree, treeSize uint64) {
 	signer := tcrypto.NewSigner(0, testonly.NewSignerWithFixedSig(nil, []byte("notnil")), crypto.SHA256)
 
 	ctx := context.Background()
-	l := NewLogStorage(db, nil)
+	l := NewLogStorage(DB, nil, LogStorageOptions{TreeStorageOptions{FetchSingleSubtrees: true}})
 	err := l.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 		root, err := signer.SignLogRoot(&types.LogRootV1{TreeSize: treeSize, RootHash: []byte{0}})
 		if err != nil {

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -338,12 +337,12 @@ func (t *treeTX) getSubtreesSingly(ctx context.Context, treeRevision int64, node
 			}
 		}
 		rows.Close()
-		// If we didn't find a usable subtree then the fetch fails.
-		if subtree == nil {
-			glog.Warningf("Failed to find a suitable tree revision")
-			return nil, fmt.Errorf("no revision found for nodeID %s", hex.EncodeToString(nodeIDBytes))
+		// It's OK if we don't have a subtree as we might be prefetching for
+		// the subtree cache. Missing results will be checked by higher level
+		// code when actually reading.
+		if subtree != nil {
+			ret = append(ret, subtree)
 		}
-		ret = append(ret, subtree)
 	}
 
 	// The InternalNodes cache is possibly nil here, but the SubtreeCache (which called

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -264,7 +264,7 @@ func (t *treeTX) getSubtreesJoin(ctx context.Context, treeRevision int64, nodeID
 			glog.Warningf("Failed to scan merkle subtree: %s", err)
 			return nil, err
 		}
-		subtree, err := unpackSubtree(subtreeRev, nodesRaw)
+		subtree, err := unpackSubtree(nodesRaw)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func (t *treeTX) getSubtreesSingly(ctx context.Context, treeRevision int64, node
 			}
 			if subtreeRev <= treeRevision {
 				// This version is the first one before our cutoff so is what we want.
-				subtree, err = unpackSubtree(subtreeRev, nodesRaw)
+				subtree, err = unpackSubtree(nodesRaw)
 				if err != nil {
 					rows.Close()
 					return nil, err
@@ -374,7 +374,7 @@ func maybeLogSubtree(nodeIDBytes []byte, subtree *storagepb.SubtreeProto) {
 	}
 }
 
-func unpackSubtree(rev int64, nodesRaw []byte) (*storagepb.SubtreeProto, error) {
+func unpackSubtree(nodesRaw []byte) (*storagepb.SubtreeProto, error) {
 	var subtree storagepb.SubtreeProto
 	if err := proto.Unmarshal(nodesRaw, &subtree); err != nil {
 		glog.Warningf("Failed to unmarshal SubtreeProto: %s", err)

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -204,10 +204,15 @@ func (t *treeTX) getSubtree(ctx context.Context, treeRevision int64, nodeID stor
 }
 
 func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+	glog.V(4).Infof("getSubtrees(")
 	if t.ts.opts.FetchSingleSubtrees {
 		return t.getSubtreesSingly(ctx, treeRevision, nodeIDs)
 	}
-	glog.V(4).Infof("getSubtrees(")
+	return t.getSubtreesJoin(ctx, treeRevision, nodeIDs)
+}
+
+func (t *treeTX) getSubtreesJoin(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+	glog.V(4).Infof("getSubtreesJoin(")
 	if len(nodeIDs) == 0 {
 		return nil, nil
 	}

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -56,7 +56,8 @@ const (
 	placeholderSQL         = "<placeholder>"
 	selectSingleSubtreeSQL = `
 	SELECT SubtreeRevision, Nodes FROM Subtree 
-      WHERE SubTreeId = ?
+			WHERE TreeID = ?
+      AND SubTreeId = ?
       ORDER BY SubtreeRevision DESC
   `
 )
@@ -315,7 +316,7 @@ func (t *treeTX) getSubtreesSingly(ctx context.Context, treeRevision int64, node
 		nodeIDBytes := nodeID.Path[:nodeID.PrefixLenBits/8]
 		glog.V(4).Infof("  nodeID: %x", nodeIDBytes)
 
-		rows, err := stmt.QueryContext(ctx, nodeIDBytes)
+		rows, err := stmt.QueryContext(ctx, t.treeID, nodeIDBytes)
 		if err != nil {
 			glog.Warningf("Failed to get merkle subtrees: %s", err)
 			return nil, err

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -56,8 +56,8 @@ const (
 	placeholderSQL         = "<placeholder>"
 	selectSingleSubtreeSQL = `
 	SELECT SubtreeRevision, Nodes FROM Subtree 
-			WHERE TreeID = ?
-      AND SubTreeId = ?
+			WHERE TreeId = ?
+      AND SubtreeId = ?
 		  AND SubtreeRevision <= ?
       ORDER BY SubtreeRevision DESC
   `

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -87,7 +87,10 @@ func NewLogEnvWithGRPCOptions(ctx context.Context, numSequencers int, serverOpts
 
 	registry := extension.Registry{
 		AdminStorage: mysql.NewAdminStorage(db),
-		LogStorage:   mysql.NewLogStorage(db, nil),
+		// *****************************************************************
+		// TODO(Martin2112): Do something about hardcoded LogStorageOptions.
+		// *****************************************************************
+		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
 		QuotaManager: quota.Noop(),
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -90,7 +90,7 @@ func NewLogEnvWithGRPCOptions(ctx context.Context, numSequencers int, serverOpts
 		// *****************************************************************
 		// TODO(Martin2112): Do something about hardcoded LogStorageOptions.
 		// *****************************************************************
-		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
+		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{TreeStorageOptions: mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
 		QuotaManager: quota.Noop(),
 		NewKeyProto: func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -30,9 +30,12 @@ func NewRegistryForTests(ctx context.Context) (extension.Registry, error) {
 		return extension.Registry{}, err
 	}
 
+	// *****************************************************************
+	// TODO(Martin2112): Do something about hardcoded LogStorageOptions.
+	// *****************************************************************
 	return extension.Registry{
 		AdminStorage: mysql.NewAdminStorage(db),
-		LogStorage:   mysql.NewLogStorage(db, nil),
+		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
 		MapStorage:   mysql.NewMapStorage(db),
 		QuotaManager: &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: mysqlqm.DefaultMaxUnsequenced},
 	}, nil

--- a/testonly/integration/registry.go
+++ b/testonly/integration/registry.go
@@ -35,7 +35,7 @@ func NewRegistryForTests(ctx context.Context) (extension.Registry, error) {
 	// *****************************************************************
 	return extension.Registry{
 		AdminStorage: mysql.NewAdminStorage(db),
-		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
+		LogStorage:   mysql.NewLogStorage(db, nil, mysql.LogStorageOptions{TreeStorageOptions: mysql.TreeStorageOptions{FetchSingleSubtrees: true}}),
 		MapStorage:   mysql.NewMapStorage(db),
 		QuotaManager: &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: mysqlqm.DefaultMaxUnsequenced},
 	}, nil


### PR DESCRIPTION
Instead of using the potentially expensive join get subtree protos one at time by scanning for the revision. This should be cheaper as we almost always want the most recent version and there is an index by revision. However, we need to test this assumption.

The option is off by default and will be documented if it proves to be useful. At the moment it should not be enabled in production.