### PR TITLE
crypto: split out a VerifyDigest entrypoint

### DIFF
--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -68,7 +68,12 @@ func Verify(pub crypto.PublicKey, hasher crypto.Hash, data, sig []byte) error {
 	h := hasher.New()
 	h.Write(data)
 	digest := h.Sum(nil)
+	return VerifyDigest(pub, hasher, digest, sig)
+}
 
+// VerifyDigest cryptographically verifies the output of Signer, using an
+// already-generated digest over the source data.
+func VerifyDigest(pub crypto.PublicKey, hasher crypto.Hash, digest, sig []byte) error {
 	switch pub := pub.(type) {
 	case *ecdsa.PublicKey:
 		return verifyECDSA(pub, digest, sig)


### PR DESCRIPTION
This allows verification of the signature against (just) a hash digest
of some source data.

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
