### PR TITLE
quota: don't populate per-user metric labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Not yet released; provisionally v2.0.0 (may change).
 ### Dropped metrics
 
 Quota metrics with specs of the form `users/<user>/read` and
-`users/<user>/write` are no longer exported by the Trillian binaries.
+`users/<user>/write` are no longer exported by the Trillian binaries (as
+they lead to excessive storage requirements for Trillian metrics).
 
 ### Fix Operation Loop Hang
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Dropped metrics
+
+Quota metrics with specs of the form `users/<user>/read` and
+`users/<user>/write` are no longer exported by the Trillian binaries.
+
 ### Fix Operation Loop Hang
 
 Resolved a bug that would hide errors and cause the `OperationLoop` to hang

--- a/quota/metrics.go
+++ b/quota/metrics.go
@@ -59,6 +59,10 @@ func (m *m) add(c monitoring.Counter, tokens int, specs []Spec, success bool) {
 		return
 	}
 	for _, spec := range specs {
+		if spec.Group == User {
+			// Don't populate per-user labels.
+			continue
+		}
 		c.Add(float64(tokens), spec.Name(), fmt.Sprint(success))
 	}
 }


### PR DESCRIPTION
- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly.
