### PR TITLE
Fix small typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ they lead to excessive storage requirements for Trillian metrics).
 ### Fix Operation Loop Hang
 
 Resolved a bug that would hide errors and cause the `OperationLoop` to hang
-until process exit if any error occured.
+until process exit if any error occurred.
 
 ### Linting toolchain migration
 


### PR DESCRIPTION
Small spelling/typo fix.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
