### PR TITLE
Add metric that tracks the % size of a log for inclusion proof indices

### DIFF
--- a/monitoring/buckets.go
+++ b/monitoring/buckets.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/buckets.go
+++ b/monitoring/buckets.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package monitoring
+
+import (
+	"math"
+)
+
+// This file contains helpers for constructing buckets for use with
+// Histogram metrics.
+
+// PercentileBuckets returns a range of buckets for 0.0-100.0% use cases.
+// in specified integer increments. The increment must be at least 1%, which
+// prevents creating very large metric exports.
+func PercentileBuckets(inc int64) []float64 {
+	if inc <= 0 || inc > 100 {
+		return nil
+	}
+	r := make([]float64, 0, 100/inc)
+	var v int64
+	for v < 100 {
+		r = append(r, float64(v))
+		v += inc
+	}
+	return r
+}
+
+// LatencyBuckets returns a reasonable range of histogram upper limits for most
+// latency-in-seconds usecases.
+func LatencyBuckets() []float64 {
+	// These parameters give an exponential range from 0.04 seconds to ~1 day.
+	num := 300
+	b := 1.05
+	scale := 0.04
+
+	r := make([]float64, 0, num)
+	for i := 0; i < num; i++ {
+		r = append(r, math.Pow(b, float64(i))*scale)
+	}
+	return r
+}

--- a/monitoring/buckets_test.go
+++ b/monitoring/buckets_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package monitoring
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestPercentileBucketsInvalid(t *testing.T) {
+	for _, inc := range []int64{0, -1, -50, 300, 40000000} {
+		t.Run(fmt.Sprintf("increment %d", inc), func(t *testing.T) {
+			if got := PercentileBuckets(inc); got != nil {
+				t.Errorf("PercentileBuckets: got: %v for invalid case, want: nil", got)
+			}
+		})
+	}
+}
+
+func TestPercentileBuckets(t *testing.T) {
+	for _, inc := range []int64{1, 2, 10, 25, 46, 97} {
+		t.Run(fmt.Sprintf("increment %d", inc), func(t *testing.T) {
+			buckets := PercentileBuckets(inc)
+			// The number of buckets expected to be created is fixed.
+			if got, want := len(buckets), int(100/inc); math.Abs(float64(got-want)) > 1 {
+				t.Errorf("PercentileBuckets(): got len: %d, want: %d", got, want)
+			}
+			// The first bucket should always be close to 0%.
+			if buckets[0] < 0 || buckets[0] > 0.0001 {
+				t.Errorf("PercentileBuckets(): got first bucket: %v, want: ~0.0", buckets[0])
+			}
+			// The last bucket should be on the way towards 100%. It doesn't make a
+			// lot of sense to create an extremely coarse grained distribution but
+			// it's not actually wrong so no reason to reject it.
+			if got, want := math.Abs(buckets[len(buckets)-1]-75.0), 25.0; got > want {
+				t.Errorf("PercentileBuckets(): got last bucket diff: %v, want: <%v", got, want)
+			}
+			// Percentile buckets should increase monotonically.
+			for i := 0; i < len(buckets)-1; i++ {
+				if buckets[i] > buckets[i+1] {
+					t.Errorf("PercentileBuckets(): buckets out of order at index: %d", i)
+				}
+			}
+		})
+	}
+}
+
+func TestLatencyBuckets(t *testing.T) {
+	// Just do some probes on the result to make sure it looks sensible.
+	buckets := LatencyBuckets()
+	// Lowest bucket should be about 0.04 sec.
+	if math.Abs(buckets[0]-0.04) > 0.001 {
+		t.Errorf("PercentileBuckets(): got first bucket: %v, want: ~0.04", buckets[0])
+	}
+	// Highest bucket should be about 86400 sec = 1 day (allow some leeway)/
+	if got, want := math.Abs(buckets[len(buckets)-1]-86400.0), 300.0; got > want {
+		t.Errorf("PercentileBuckets(): got last bucket diff: %v, want: <%v", got, want)
+	}
+	// Latency buckets should increase monotonically.
+	for i := 0; i < len(buckets)-1; i++ {
+		if buckets[i] > buckets[i+1] {
+			t.Errorf("LatencyBuckets(): buckets out of order at index: %d", i)
+		}
+	}
+}

--- a/monitoring/inert.go
+++ b/monitoring/inert.go
@@ -50,6 +50,12 @@ func (imf InertMetricFactory) NewHistogram(name, help string, labelNames ...stri
 	}
 }
 
+// NewHistogramWithBuckets creates a new inert Histogram with supplied buckets.
+// The buckets are not actually used.
+func (imf InertMetricFactory) NewHistogramWithBuckets(name, help string, _ []float64, labelNames ...string) Histogram {
+	return imf.NewHistogram(name, help, labelNames...)
+}
+
 // InertFloat is an internal-only implementation of both the Counter and Gauge interfaces.
 type InertFloat struct {
 	labelCount int

--- a/monitoring/metrics.go
+++ b/monitoring/metrics.go
@@ -19,6 +19,7 @@ type MetricFactory interface {
 	NewCounter(name, help string, labelNames ...string) Counter
 	NewGauge(name, help string, labelNames ...string) Gauge
 	NewHistogram(name, help string, labelNames ...string) Histogram
+	NewHistogramWithBuckets(name, help string, buckets []float64, labelNames ...string) Histogram
 }
 
 // Counter is a metric class for numeric values that increase.


### PR DESCRIPTION
To be used to verify assumptions that proofs for recent entries are requested far more often than earlier ones. Adds a metrics option to specify Histogram buckets

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
