### PR TITLE
Make monitoring test packages consistent + fix dup package comment lint.

### DIFF
--- a/monitoring/buckets.go
+++ b/monitoring/buckets.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package monitoring
 
 import (

--- a/monitoring/buckets_test.go
+++ b/monitoring/buckets_test.go
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package monitoring
+
+package monitoring_test
 
 import (
 	"fmt"


### PR DESCRIPTION
A previous PR added a monitoring test in a different package from the existing tests. This fixes that. Also the license header was missing a blank line in the new files so it looked like a package comment.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
