### PR TITLE
Fix Kubernetes README to not refer to non-existent config.sh file

### DIFF
--- a/examples/deployment/kubernetes/README.md
+++ b/examples/deployment/kubernetes/README.md
@@ -23,18 +23,19 @@ deployment on Google Cloud using Kubernetes and Cloud Spanner.
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com)
 1. Create a new project
-1. Edit the [config.sh](config.sh) file, set `PROJECT_ID` to the ID of your
-   project
+1. Edit the [example-config.sh](example-config.sh) file, set `PROJECT_ID` to
+   the ID of your project
 1. Run: `./create.sh`.
    This script will create the Kubernetes cluster, node pools, and Spanner
    database, service account and etcd cluster.
    It should take about 5 to 10 minutes to finish and must complete without
    error.
 1. Now you can deploy the Trillian services.
-   Run: `./deploy.sh config.sh`
+   Run: `./deploy.sh example-config.sh`
    This will build the Trillian Docker images, tag them, and create/update the
    Kubernetes deployment.
-1. To update a running deployment, simply re-run `./deploy.sh config.sh` at any time.
+1. To update a running deployment, simply re-run `./deploy.sh example-config.sh`
+   at any time.
 
 You should now have a working Trilian Log deployment in Kubernetes.
 
@@ -52,7 +53,7 @@ To provision a tree into Trillian, use the `provision_tree.sh` script (which
 uses `kubectl` to forward requests to the Trillian Log's admin API):
 
 ```bash
-./provision_tree.sh config.sh
+./provision_tree.sh example-config.sh
 ```
 
 Make a note of the tree ID for the new tree.

--- a/examples/deployment/kubernetes/example-config.sh
+++ b/examples/deployment/kubernetes/example-config.sh
@@ -1,0 +1,15 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Set the following variables to the correct values for your Google Cloud
+# project and Kubernetes cluster.
+export PROJECT_ID="GOOGLE CLOUD PROJECT ID HERE (https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)"
+export CLUSTER_NAME=trillian
+export REGION=us-east4
+export MASTER_ZONE="${REGION}-a"
+export NODE_LOCATIONS="${REGION}-a,${REGION}-b,${REGION}-c"
+export CONFIGMAP=${DIR}/trillian-cloudspanner.yaml
+
+export POOLSIZE=2
+export MACHINE_TYPE="n1-standard-2"
+
+export RUN_MAP=false


### PR DESCRIPTION
Adds an example-config.sh file and refers to that instead.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
