### PR TITLE
Remove warning logging from log/sequencer.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ deprecated.
 
 The performance of `SetLeaves` requests on the Map has been slightly improved.
 
+### Logging
+
+Some warning-level logging has been removed from the sequencer in favour of
+returning the same information via the returned error. The caller may still
+choose to log this information. This allows storage implementations that retry
+transactions to suppress warnings when a transaction initially fails but a retry
+succeeds.
+
 ### Other
 
 The `TimeSource` type (and other time utils) moved to a separate `util/clock`

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -136,14 +136,12 @@ func (s Sequencer) buildMerkleTreeFromStorageAtRoot(ctx context.Context, root *t
 	mt, err := compact.NewTreeWithState(s.hasher, int64(root.TreeSize), func(depth int, index int64) ([]byte, error) {
 		nodeID, err := storage.NewNodeIDForTreeCoords(int64(depth), index, maxTreeDepth)
 		if err != nil {
-			glog.Warningf("%x: Failed to create nodeID: %v", s.signer.KeyHint, err)
-			return nil, err
+			return nil, fmt.Errorf("%x: Failed to create nodeID: %v", s.signer.KeyHint, err)
 		}
 		nodes, err := tx.GetMerkleNodes(ctx, int64(root.Revision), []storage.NodeID{nodeID})
 
 		if err != nil {
-			glog.Warningf("%x: Failed to get Merkle nodes: %v", s.signer.KeyHint, err)
-			return nil, err
+			return nil, fmt.Errorf("%x: Failed to get Merkle nodes: %v", s.signer.KeyHint, err)
 		}
 
 		// We expect to get exactly one node here
@@ -258,8 +256,7 @@ func (s *logSequencingTask) fetch(ctx context.Context, limit int, cutoff time.Ti
 	// Recent leaves inside the guard window will not be available for sequencing.
 	leaves, err := s.tx.DequeueLeaves(ctx, limit, cutoff)
 	if err != nil {
-		glog.Warningf("%v: Sequencer failed to dequeue leaves: %v", s.label, err)
-		return nil, err
+		return nil, fmt.Errorf("%v: Sequencer failed to dequeue leaves: %v", s.label, err)
 	}
 	seqDequeueLatency.Observe(clock.SecondsSince(s.timeSource, start), s.label)
 
@@ -274,8 +271,7 @@ func (s *logSequencingTask) update(ctx context.Context, leaves []*trillian.LogLe
 	start := s.timeSource.Now()
 	// Write the new sequence numbers to the leaves in the DB.
 	if err := s.tx.UpdateSequencedLeaves(ctx, leaves); err != nil {
-		glog.Warningf("%v: Sequencer failed to update sequenced leaves: %v", s.label, err)
-		return err
+		return fmt.Errorf("%v: Sequencer failed to update sequenced leaves: %v", s.label, err)
 	}
 	seqUpdateLeavesLatency.Observe(clock.SecondsSince(s.timeSource, start), s.label)
 	return nil
@@ -290,8 +286,7 @@ func (s *preorderedLogSequencingTask) fetch(ctx context.Context, limit int, cuto
 	start := s.timeSource.Now()
 	leaves, err := s.tx.DequeueLeaves(ctx, limit, cutoff)
 	if err != nil {
-		glog.Warningf("%v: Sequencer failed to load sequenced leaves: %v", s.label, err)
-		return nil, err
+		return nil, fmt.Errorf("%v: Sequencer failed to load sequenced leaves: %v", s.label, err)
 	}
 	seqDequeueLatency.Observe(clock.SecondsSince(s.timeSource, start), s.label)
 	return leaves, nil
@@ -319,16 +314,14 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 		// Get the latest known root from storage
 		sth, err := tx.LatestSignedLogRoot(ctx)
 		if err != nil {
-			glog.Warningf("%v: Sequencer failed to get latest root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Sequencer failed to get latest root: %v", tree.TreeId, err)
 		}
 		// There is no trust boundary between the signer and the
 		// database, so we skip signature verification.
 		// TODO(gbelvin): Add signature checking as a santity check.
 		var currentRoot types.LogRootV1
 		if err := currentRoot.UnmarshalBinary(sth.LogRoot); err != nil {
-			glog.Warningf("%v: Sequencer failed to unmarshal latest root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Sequencer failed to unmarshal latest root: %v", tree.TreeId, err)
 		}
 		seqGetRootLatency.Observe(clock.SecondsSince(s.timeSource, stageStart), label)
 
@@ -355,8 +348,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 
 		sequencedLeaves, err := st.fetch(ctx, limit, start.Add(-guardWindow))
 		if err != nil {
-			glog.Warningf("%v: Sequencer failed to load sequenced batch: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Sequencer failed to load sequenced batch: %v", tree.TreeId, err)
 		}
 		numLeaves = len(sequencedLeaves)
 
@@ -412,15 +404,13 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 		targetNodes, err := s.buildNodesFromNodeMap(nodeMap, newVersion)
 		if err != nil {
 			// Probably an internal error with map building, unexpected.
-			glog.Warningf("%v: Failed to build target nodes in sequencer: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Failed to build target nodes in sequencer: %v", tree.TreeId, err)
 		}
 
 		// Now insert or update the nodes affected by the above, at the new tree
 		// version.
 		if err := tx.SetMerkleNodes(ctx, targetNodes); err != nil {
-			glog.Warningf("%v: Sequencer failed to set Merkle nodes: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Sequencer failed to set Merkle nodes: %v", tree.TreeId, err)
 		}
 		seqSetNodesLatency.Observe(clock.SecondsSince(s.timeSource, stageStart), label)
 		stageStart = s.timeSource.Now()
@@ -435,20 +425,16 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 		}
 
 		if newLogRoot.TimestampNanos <= currentRoot.TimestampNanos {
-			err := fmt.Errorf("refusing to sign root with timestamp earlier than previous root (%d <= %d)", newLogRoot.TimestampNanos, currentRoot.TimestampNanos)
-			glog.Warningf("%v: %s", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: refusing to sign root with timestamp earlier than previous root (%d <= %d)", tree.TreeId, newLogRoot.TimestampNanos, currentRoot.TimestampNanos)
 		}
 
 		newSLR, err = s.signer.SignLogRoot(newLogRoot)
 		if err != nil {
-			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: signer failed to sign root: %v", tree.TreeId, err)
 		}
 
 		if err := tx.StoreSignedLogRoot(ctx, *newSLR); err != nil {
-			glog.Warningf("%v: failed to write updated tree root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: failed to write updated tree root: %v", tree.TreeId, err)
 		}
 		seqStoreRootLatency.Observe(clock.SecondsSince(s.timeSource, stageStart), label)
 
@@ -493,13 +479,11 @@ func (s Sequencer) SignRoot(ctx context.Context, tree *trillian.Tree) error {
 		// Get the latest known root from storage
 		sth, err := tx.LatestSignedLogRoot(ctx)
 		if err != nil {
-			glog.Warningf("%v: signer failed to get latest root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: signer failed to get latest root: %v", tree.TreeId, err)
 		}
 		var currentRoot types.LogRootV1
 		if err := currentRoot.UnmarshalBinary(sth.LogRoot); err != nil {
-			glog.Warningf("%v: Sequencer failed to unmarshal latest root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: Sequencer failed to unmarshal latest root: %v", tree.TreeId, err)
 		}
 
 		// Initialize a Merkle Tree from the state in storage. This should fail if the tree is
@@ -516,14 +500,12 @@ func (s Sequencer) SignRoot(ctx context.Context, tree *trillian.Tree) error {
 		}
 		newSLR, err := s.signer.SignLogRoot(newLogRoot)
 		if err != nil {
-			glog.Warningf("%v: signer failed to sign root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: signer failed to sign root: %v", tree.TreeId, err)
 		}
 
 		// Store the new root and we're done
 		if err := tx.StoreSignedLogRoot(ctx, *newSLR); err != nil {
-			glog.Warningf("%v: signer failed to write updated root: %v", tree.TreeId, err)
-			return err
+			return fmt.Errorf("%v: signer failed to write updated root: %v", tree.TreeId, err)
 		}
 		glog.V(2).Infof("%v: new signed root, size %v, tree-revision %v", tree.TreeId, newLogRoot.TreeSize, newLogRoot.Revision)
 


### PR DESCRIPTION
Removed in favour of including the same information in error messages. The caller can choose to log the error if they wish. This avoids misleading warning messages in logs when the storage implementation retries transaction errors. While storage can swallow the errors when a retry succeeds, it can't cancel the logging.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
