### PR TITLE
Support testing against a locally running mysql docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Testing
+
+Support has been added for testing against a locally running mysql docker image,
+in addition to a locally running mysql instance.
+
 ### Configurable number of idle connections on MySQL
 
 This version adds a new flag `-mysql_max_idle_conns` to specify the number of

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	trillianSQL = testonly.RelativeToPackage("../mysql/storage.sql")
-	dataSource  = "root@/"
+	dataSource  = "root@tcp(127.0.0.1)/"
 )
 
 // MySQLAvailable indicates whether a default MySQL database is available.


### PR DESCRIPTION
Allow testing against a local docker image running mysql.  

Some testers prefer to run the docker db image for ease of setup, rather than installing mysql locally. 
This change should be compatible with both a local installation as well as a local docker image.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
