### PR TITLE
Expose Trillian services via load balancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ is now based on
 [the MySQL 5.7 image from the Google Cloud Marketplace](https://console.cloud.google.com/marketplace/details/google/mysql5),
 rather than the [official MySQL 5.7 image](https://hub.docker.com/_/mysql).
 
+The `trillian-log-service` and `trillian-log-signer` Kubernetes services will
+now have load balancers configured for them that expose those services outside
+of the Kubernetes cluster. This makes it easier to access their APIs. When
+deployed on Google Cloud, these will be
+[Internal Load Balancers](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing).
+
 ### Dropped metrics
 
 Quota metrics with specs of the form `users/<user>/read` and

--- a/examples/deployment/kubernetes/trillian-log-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
       cloud.google.com/load-balancer-type: "Internal"
 spec:
-  clusterIP: None
+  type: LoadBalancer
   ports:
   - name: grpclb
     port: 8090
@@ -17,5 +17,3 @@ spec:
     targetPort: 8091
   selector:
     io.kompose.service: trillian-log
-status:
-  loadBalancer: {}

--- a/examples/deployment/kubernetes/trillian-log-signer-service.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-service.yaml
@@ -10,11 +10,10 @@ metadata:
     io.kompose.service: trillian-log-signer
   name: trillian-log-signer
 spec:
+  type: LoadBalancer
   ports:
   - name: "8092"
     port: 8092
     targetPort: 8091
   selector:
     io.kompose.service: trillian-log-signer
-status:
-  loadBalancer: {}


### PR DESCRIPTION
Expose trillian-log-service and trillian-log-signer via load balancer.

On Google Cloud, this will use an internal load balancer.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
