### PR TITLE
Run docker-compose integration test as separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,12 @@ env:
   - GOFLAGS='-race --tags batched_queue'
   - GOFLAGS='-race' WITH_ETCD=true
   - GOFLAGS='-race --tags pkcs11' WITH_PKCS11=true
+  - WITH_DOCKER_TESTS=true
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: WITH_DOCKER_TESTS=true
 
 services:
   - docker
@@ -107,7 +110,7 @@ script:
       # TODO(RJPercival): Make docker-compose integration test work when PKCS#11
       # support is enabled. This requires running softhsm in a Docker container.
       # See https://github.com/rolandshoemaker/docker-hsm for an example.
-      if [[ "${WITH_PKCS11}" != "true" ]]; then
+      if [[ "${WITH_DOCKER_TESTS}" == "true" ]]; then
         ./integration/docker_compose_integration_test.sh
       fi
   - set +e


### PR DESCRIPTION
This avoids slowing down the jobs that are required to complete in order to merge a pull request, without entirely removing this test. If a pull request author waits the extra 5 minutes or so required by this test, then they can have confidence that their change doesn't break our Docker images or docker-compose configs.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
