### PR TITLE
storage/{mysql,postgres}: add MerkleLeafHash index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Database Schema
+
+This version includes a change to the MySQL and Postgres database schemas
+to add an index on the `SequencedLeafData` table.
+
 ### Deployments
 
 The [db\_server Docker image](examples/deployment/docker/db_server/Dockerfile)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Not yet released; provisionally v2.0.0 (may change).
 ### Database Schema
 
 This version includes a change to the MySQL and Postgres database schemas
-to add an index on the `SequencedLeafData` table.
+to add an index on the `SequencedLeafData` table.  This improves performance for
+inclusion proof queries.
 
 ### Deployments
 

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -111,6 +111,10 @@ CREATE TABLE IF NOT EXISTS SequencedLeafData(
   FOREIGN KEY(TreeId, LeafIdentityHash) REFERENCES LeafData(TreeId, LeafIdentityHash) ON DELETE CASCADE
 );
 
+
+CREATE INDEX SequencedLeafMerkleIdx
+  ON SequencedLeafData(TreeId, MerkleLeafHash);
+
 CREATE TABLE IF NOT EXISTS Unsequenced(
   TreeId               BIGINT NOT NULL,
   -- The bucket field is to allow the use of time based ring bucketed schemes if desired. If

--- a/storage/postgres/storage.sql
+++ b/storage/postgres/storage.sql
@@ -12,24 +12,24 @@ CREATE TYPE E_SIGNATURE_ALGORITHM AS ENUM('ECDSA', 'RSA');
 
 -- Tree parameters should not be changed after creation. Doing so can
 -- render the data in the tree unusable or inconsistent.
-CREATE TABLE IF NOT EXISTS trees ( 
-  tree_id                  BIGINT NOT NULL, 
-  tree_state               E_TREE_STATE NOT NULL, 
-  tree_type                E_TREE_TYPE NOT NULL, 
-  hash_strategy            E_HASH_STRATEGY NOT NULL, 
-  hash_algorithm           E_HASH_ALGORITHM NOT NULL, 
-  signature_algorithm      E_SIGNATURE_ALGORITHM NOT NULL, 
-  display_name             VARCHAR(20), 
-  description              VARCHAR(200), 
-  create_time_millis       BIGINT NOT NULL, 
-  update_time_millis       BIGINT NOT NULL, 
-  max_root_duration_millis BIGINT NOT NULL, 
-  private_key              BYTEA NOT NULL, 
-  public_key               BYTEA NOT NULL, 
+CREATE TABLE IF NOT EXISTS trees (
+  tree_id                  BIGINT NOT NULL,
+  tree_state               E_TREE_STATE NOT NULL,
+  tree_type                E_TREE_TYPE NOT NULL,
+  hash_strategy            E_HASH_STRATEGY NOT NULL,
+  hash_algorithm           E_HASH_ALGORITHM NOT NULL,
+  signature_algorithm      E_SIGNATURE_ALGORITHM NOT NULL,
+  display_name             VARCHAR(20),
+  description              VARCHAR(200),
+  create_time_millis       BIGINT NOT NULL,
+  update_time_millis       BIGINT NOT NULL,
+  max_root_duration_millis BIGINT NOT NULL,
+  private_key              BYTEA NOT NULL,
+  public_key               BYTEA NOT NULL,
   deleted                  BOOLEAN NOT NULL DEFAULT FALSE,
-  delete_time_millis       BIGINT, 
-  PRIMARY KEY(tree_id) 
-); 
+  delete_time_millis       BIGINT,
+  PRIMARY KEY(tree_id)
+);
 
 -- This table contains tree parameters that can be changed at runtime such as for
 -- administrative purposes.
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS subtree(
   tree_id               BIGINT NOT NULL,
   subtree_id            BYTEA NOT NULL,
   nodes                 BYTEA NOT NULL,
-  subtree_revision      INTEGER NOT NULL, 
+  subtree_revision      INTEGER NOT NULL,
   PRIMARY KEY(tree_id, subtree_id, subtree_revision),
   FOREIGN KEY(tree_id) REFERENCES Trees(tree_id) ON DELETE CASCADE
 );
@@ -117,6 +117,8 @@ CREATE TABLE IF NOT EXISTS sequenced_leaf_data(
   FOREIGN KEY(tree_id) REFERENCES trees(tree_id) ON DELETE CASCADE,
   FOREIGN KEY(tree_id, leaf_identity_hash) REFERENCES leaf_data(tree_id, leaf_identity_hash) ON DELETE CASCADE
 );
+
+CREATE INDEX SequencedLeafMerkleIdx ON sequenced_leaf_data(tree_id, merkle_leaf_hash);
 
 CREATE TABLE IF NOT EXISTS unsequenced(
   tree_id               BIGINT NOT NULL,


### PR DESCRIPTION
Requests for inclusion proofs need to look up leaves by their
Merkle leaf hash, but there wasn't an index for this so it
would involve a full table scan.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
