### PR TITLE
Add a tool to generate LaTeX diagrams of merkle trees.

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -50,16 +50,6 @@ const (
 \definecolor{perfect}{rgb}{1,0.9,0.5}
 \definecolor{target}{rgb}{0.5,0.5,0.9}
 \definecolor{target_path}{rgb}{0.7,0.7,0.9}
-\definecolor{mega}{rgb}{0.9,0.9,0.9}
-
-\forestset{
-	perfect/.style={edge path={%
-			\noexpand\path[fill=mega, \forestoption{edge}]
-			(.parent first)--(!u.children)--(.parent last)--cycle
-			\forestoption{edge label};
-		}
-	},
-}
 
 \begin{forest}
 `
@@ -159,7 +149,6 @@ func openInnerNode(prefix string, height, index int64) func() {
 
 // perfectInner renders the nodes of a perfect internal subtree.
 func perfectInner(prefix string, height, index int64, top bool) {
-
 	nk := nodeKey(height, index)
 	modifyNodeInfo(nk, func(n *nodeInfo) {
 		n.leaf = height == 0
@@ -178,14 +167,15 @@ func perfectInner(prefix string, height, index int64, top bool) {
 }
 
 // renderTree renders a tree node and recurses if necessary.
-func renderTree(prefix string, treeSize, height, index int64) {
-	if height < 0 {
+func renderTree(prefix string, treeSize, index int64) {
+	height := int64(bits.Len64(uint64(treeSize)) - 1)
+	if height < 0 || treeSize <= 0 {
 		return
 	}
+
 	// Look at the bit of the treeSize corresponding to the current level:
 	b := (1 << uint(height)) & treeSize
 	rest := treeSize - b
-
 	if b > 0 {
 		// left child is a perfect subtree
 
@@ -202,10 +192,7 @@ func renderTree(prefix string, treeSize, height, index int64) {
 		perfect(prefix+" ", height, index>>uint(height))
 		index += b
 	}
-	if rest == 0 {
-		return
-	}
-	renderTree(prefix+" ", rest, height-1, index)
+	renderTree(prefix+" ", rest, index)
 }
 
 // nodeKey returns a stable node identifier for the passed in node coordinate.
@@ -244,6 +231,6 @@ func main() {
 	// TODO(al): structify this into a util, and add ability to output to an
 	// arbitrary stream.
 	fmt.Print(preamble)
-	renderTree("", *treeSize, height, 0)
+	renderTree("", *treeSize, 0)
 	fmt.Println(postfix)
 }

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -138,7 +138,7 @@ func drawLeaf(prefix string, index int64) {
 
 // openInnerNode renders TeX code to open an internal node.
 // The caller may emit any number of child nodes before calling the returned
-// func to clode the node.
+// func to close the node.
 // Returns a func to be called to close the node.
 //
 func openInnerNode(prefix string, height, index int64) func() {
@@ -168,30 +168,28 @@ func perfectInner(prefix string, height, index int64, top bool) {
 
 // renderTree renders a tree node and recurses if necessary.
 func renderTree(prefix string, treeSize, index int64) {
-	height := int64(bits.Len64(uint64(treeSize)) - 1)
-	if height < 0 || treeSize <= 0 {
+	if treeSize <= 0 {
 		return
 	}
 
 	// Look at the bit of the treeSize corresponding to the current level:
+	height := int64(bits.Len64(uint64(treeSize)) - 1)
 	b := (1 << uint(height)) & treeSize
 	rest := treeSize - b
-	if b > 0 {
-		// left child is a perfect subtree
+	// left child is a perfect subtree
 
-		// if there's a right-hand child, then we'll emit this node to be the
-		// parent. (Otherwise we'll just keep quiet, and recurse down - this is how
-		// we arrange for leaves to always be on the bottom level.)
-		if rest > 0 {
-			ch := height + 1
-			ci := index >> uint(ch)
-			modifyNodeInfo(nodeKey(ch, ci), func(n *nodeInfo) { n.ephemeral = true })
-			c := openInnerNode(prefix, ch, ci)
-			defer c()
-		}
-		perfect(prefix+" ", height, index>>uint(height))
-		index += b
+	// if there's a right-hand child, then we'll emit this node to be the
+	// parent. (Otherwise we'll just keep quiet, and recurse down - this is how
+	// we arrange for leaves to always be on the bottom level.)
+	if rest > 0 {
+		ch := height + 1
+		ci := index >> uint(ch)
+		modifyNodeInfo(nodeKey(ch, ci), func(n *nodeInfo) { n.ephemeral = true })
+		c := openInnerNode(prefix, ch, ci)
+		defer c()
 	}
+	perfect(prefix+" ", height, index>>uint(height))
+	index += b
 	renderTree(prefix+" ", rest, index)
 }
 

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -1,0 +1,117 @@
+/* treetek is a command to produce LaTeX documents representing merkle trees.
+ * Uses the Forest package.
+ *
+ * Usage: go run main.go | xelatex
+ * This should generate a PDF file called treetek.pdf containing a drawing of
+ * the tree.
+ */
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/bits"
+)
+
+const (
+	preamble = `
+% Hash-tree
+% Author: treetek
+\documentclass[convert]{standalone}
+\usepackage[dvipsnames]{xcolor}
+\usepackage{forest}
+
+
+\begin{document}
+
+\begin{forest}
+`
+
+	postfix = `\end{forest}
+\end{document}
+`
+)
+
+var (
+	treeSize = flag.Int("tree_size", 23, "Size of tree to produce")
+)
+
+/* perfect renders a perfect subtree.
+ */
+func perfect(prefix string, height, tier, index int) {
+	perfectInner(prefix, height, tier, index, true)
+}
+
+/* drawLeaf emits TeX code to render a leaf.
+ */
+func drawLeaf(prefix string, index, tier int) {
+	fmt.Printf("%s [%d, draw, tier=%d]\n", prefix, index, tier)
+}
+
+/* openInnerNode renders tex code to open an internal node.
+ * The caller may emit any number of child nodes before calling the returned
+ * func to clode the node.
+ * returns a func to be called to close the node.
+ */
+func openInnerNode(prefix string, height, index, tier int, attr string) func() {
+	fmt.Printf("%s [%d.%d, %s, tier=%d\n", prefix, height, index, attr, tier)
+	return func() { fmt.Printf("%s ]\n", prefix) }
+}
+
+/* perfectInner renders the nodes of a perfect internal subtree.
+ */
+func perfectInner(prefix string, height, tier, index int, top bool) {
+	if height == 0 {
+		drawLeaf(prefix, index, tier)
+		return
+	}
+	attr := "draw, circle, fill="
+	if top {
+		attr += "Goldenrod"
+	} else {
+		attr += "white"
+	}
+	c := openInnerNode(prefix, height, index, tier, attr)
+	childIndex := index << 1
+	perfectInner(prefix+" ", height-1, tier-1, childIndex, false)
+	perfectInner(prefix+" ", height-1, tier-1, childIndex+1, false)
+	c()
+}
+
+/* node renders a tree node.
+ */
+func node(prefix string, treeSize, height, tier, index int) {
+	if height < 0 {
+		return
+	}
+	// Look at the bit of the treeSize corresponding to the current level:
+	b := (1 << uint(height)) & treeSize
+	rest := treeSize - b
+
+	if b > 0 {
+		// left child is a perfect subtree
+
+		// if there's a right-hand child, then we'll emit this node to be the
+		// parent. (Otherwise we'll just keep quiet, and recurse down - this is how
+		// we arrange for leaves to always be on the bottom level.)
+		if rest > 0 {
+			c := openInnerNode(prefix, height+1, index>>uint(height+1), tier, "")
+			defer c()
+		}
+		perfect(prefix+" ", height, tier-1, index>>uint(tier))
+		index += b
+	}
+	if rest == 0 {
+		return
+	}
+	node(prefix+" ", rest, height-1, tier-1, index)
+}
+
+func main() {
+	flag.Parse()
+	height := bits.Len(uint(*treeSize))
+
+	fmt.Print(preamble)
+	node("", *treeSize, height, height, 0)
+	fmt.Println(postfix)
+}

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -133,7 +133,7 @@ func openInnerNode(prefix string, height, index, tier int64) func() {
 func perfectInner(prefix string, height, tier, index int64, top bool) {
 	nk := nodeKey(height, index)
 	setNodeInfo(nk, func(n *nodeInfo) { n.leaf = height == 0 })
-	setNodeInfo(nodeKey(height, index), func(n *nodeInfo) { n.perfectRoot = top && (height > 0) })
+	setNodeInfo(nodeKey(height, index), func(n *nodeInfo) { n.perfectRoot = top })
 
 	if height == 0 {
 		drawLeaf(prefix, index)

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -174,7 +174,7 @@ func renderTree(prefix string, treeSize, index int64) {
 
 	// Look at the bit of the treeSize corresponding to the current level:
 	height := int64(bits.Len64(uint64(treeSize)) - 1)
-	b := (1 << uint(height)) & treeSize
+	b := int64(1) << uint(height)
 	rest := treeSize - b
 	// left child is a perfect subtree
 

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // treetek is a command to produce LaTeX documents representing merkle trees.
 // Uses the Forest package.
 //

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -195,7 +195,7 @@ func toNodeKey(n storage.NodeID) string {
 // Whee - here we go!
 func main() {
 	flag.Parse()
-	height := int64(bits.Len(uint(*treeSize)))
+	height := int64(bits.Len(uint(*treeSize-1)) + 1)
 
 	if *inclusion > 0 {
 		setNodeInfo(nodeKey(0, *inclusion), func(n *nodeInfo) { n.target = true })

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -87,7 +87,9 @@ func (n nodeInfo) String() string {
 		attr = append(attr, "draw")
 	}
 	if !n.leaf {
-		attr = append(attr, "circle")
+		attr = append(attr, "circle, minimum size=3em")
+	} else {
+		attr = append(attr, "minimum size=1.5em")
 	}
 	return strings.Join(attr, ", ")
 }


### PR DESCRIPTION
Adds the first cut of a tool for generating LaTeX merkle tree diagrams like this:

![texput](https://user-images.githubusercontent.com/7648032/53350646-6bf8a880-3917-11e9-9f46-d84f6b431e19.png)

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.