### PR TITLE
Test MySQL error persistence with a garbage DSN

### DIFF
--- a/server/mysql_storage_provider_test.go
+++ b/server/mysql_storage_provider_test.go
@@ -23,11 +23,11 @@ import (
 
 func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
 	defer flagsaver.Save().Restore()
-	if err := flag.Set("mysql_uri", ""); err != nil {
+	if err := flag.Set("mysql_uri", "&bogus*:::?"); err != nil {
 		t.Errorf("Failed to set flag: %v", err)
 	}
 
-	// First call: This should fail due to the Database URL being empty.
+	// First call: This should fail due to the Database URL being garbage.
 	_, err1 := NewStorageProvider("mysql", nil)
 	if err1 == nil {
 		t.Fatalf("Expected 'server.NewStorageProvider' to fail")


### PR DESCRIPTION
An empty DSN is no longer an error when opening a MySQL DB, so instead use a garbage DSN in the error persistence test.

From https://github.com/go-sql-driver/mysql:
```
DSN (Data Source Name)
The Data Source Name has a common format, like e.g. PEAR DB uses it, but without type-prefix (optional parts marked by squared brackets):

[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
A DSN in its fullest form:

username:password@protocol(address)/dbname?param=value
Except for the databasename, all values are optional. So the minimal DSN is:

/dbname
If you do not want to preselect a database, leave dbname empty:

/
This has the same effect as an empty DSN string:


Alternatively, Config.FormatDSN can be used to create a DSN string by filling a struct.
```

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
