### PR TITLE
mapclient: GetLeaves: Verify Indexes Before Sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Client Verification
+The map client now verifies that every map leaf is being requested at most once.
+This catches potential errors before they go to the server.
+
 ### Database Schema
 
 This version includes a change to the MySQL and Postgres database schemas

--- a/client/map_client.go
+++ b/client/map_client.go
@@ -61,7 +61,7 @@ func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte)
 	// Verify that there are no duplicates
 	set := make(map[string]bool)
 	for _, i := range indexes {
-		if ok := set[string(i)]; ok != false {
+		if set[string(i)] {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"map.GetLeaves(): index %x requested more than once", i)
 		}

--- a/client/map_client.go
+++ b/client/map_client.go
@@ -58,6 +58,16 @@ func (c *MapClient) GetAndVerifyLatestMapRoot(ctx context.Context) (*types.MapRo
 
 // GetAndVerifyMapLeaves verifies and returns the requested map leaves.
 func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte) ([]*trillian.MapLeaf, error) {
+	// Verify that there are no duplicates
+	set := make(map[string]bool)
+	for _, i := range indexes {
+		if ok := set[string(i)]; ok != false {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"map.GetLeaves(): index %x requested more than once", i)
+		}
+		set[string(i)] = true
+	}
+
 	getResp, err := c.Conn.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
 		MapId: c.MapID,
 		Index: indexes,

--- a/client/map_client.go
+++ b/client/map_client.go
@@ -57,17 +57,11 @@ func (c *MapClient) GetAndVerifyLatestMapRoot(ctx context.Context) (*types.MapRo
 }
 
 // GetAndVerifyMapLeaves verifies and returns the requested map leaves.
+// indexes may not contain duplicates.
 func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte) ([]*trillian.MapLeaf, error) {
-	// Verify that there are no duplicates
-	set := make(map[string]bool)
-	for _, i := range indexes {
-		if set[string(i)] {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"map.GetLeaves(): index %x requested more than once", i)
-		}
-		set[string(i)] = true
+	if err := hasDuplicates(indexes); err != nil {
+		return nil, err
 	}
-
 	getResp, err := c.Conn.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
 		MapId: c.MapID,
 		Index: indexes,
@@ -79,7 +73,11 @@ func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte)
 }
 
 // GetAndVerifyMapLeavesByRevision verifies and returns the requested map leaves at a specific revision.
+// indexes may not contain duplicates.
 func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, error) {
+	if err := hasDuplicates(indexes); err != nil {
+		return nil, err
+	}
 	getResp, err := c.Conn.GetLeavesByRevision(ctx, &trillian.GetMapLeavesByRevisionRequest{
 		MapId:    c.MapID,
 		Index:    indexes,
@@ -89,4 +87,17 @@ func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revisio
 		return nil, status.Errorf(status.Code(err), "map.GetLeaves(): %v", err)
 	}
 	return c.VerifyMapLeavesResponse(indexes, revision, getResp)
+}
+
+// hasDuplicates returns an error if there are duplicates in indexes.
+func hasDuplicates(indexes [][]byte) error {
+	set := make(map[string]bool)
+	for _, i := range indexes {
+		if set[string(i)] {
+			return status.Errorf(codes.InvalidArgument,
+				"map.GetLeaves(): index %x requested more than once", i)
+		}
+		set[string(i)] = true
+	}
+	return nil
 }

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -86,17 +86,32 @@ func TestGetLeavesAtRevision(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SetLeaves(): %v", err)
 	}
-	leaves, err := client.GetAndVerifyMapLeaves(ctx, [][]byte{index})
-	if err != nil {
-		t.Fatalf("GetAndVerifyMapLeavesAtRevision(): %v", err)
-	}
-	if got := len(leaves); got != 1 {
-		t.Errorf("len(leaves): %v, want 1", got)
-	}
-	if got, want := leaves[0].LeafValue, []byte("A"); !bytes.Equal(got, want) {
-		t.Errorf("LeafValue: %v, want %v", got, want)
-	}
-	if got, want := leaves[0].Index, index; !bytes.Equal(got, want) {
-		t.Errorf("LeafIndex: %v, want %v", got, want)
+
+	for _, tc := range []struct {
+		desc    string
+		indexes [][]byte
+		wantErr bool
+	}{
+		{desc: "1", indexes: [][]byte{index}},
+		{desc: "2", indexes: [][]byte{index, index}, wantErr: true},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			leaves, err := client.GetAndVerifyMapLeaves(ctx, tc.indexes)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("GetAndVerifyMapLeavesAtRevision(): %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got := len(leaves); got != 1 {
+				t.Errorf("len(leaves): %v, want 1", got)
+			}
+			if got, want := leaves[0].LeafValue, []byte("A"); !bytes.Equal(got, want) {
+				t.Errorf("LeafValue: %v, want %v", got, want)
+			}
+			if got, want := leaves[0].Index, index; !bytes.Equal(got, want) {
+				t.Errorf("LeafIndex: %v, want %v", got, want)
+			}
+		})
 	}
 }

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly/integration"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNewMapVerifier(t *testing.T) {
@@ -119,17 +121,17 @@ func TestGetLeavesAtRevision(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc    string
-		indexes [][]byte
-		wantErr bool
+		desc     string
+		indexes  [][]byte
+		wantCode codes.Code
 	}{
 		{desc: "1", indexes: [][]byte{index}},
-		{desc: "2", indexes: [][]byte{index, index}, wantErr: true},
+		{desc: "2", indexes: [][]byte{index, index}, wantCode: codes.InvalidArgument},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			leaves, err := client.GetAndVerifyMapLeaves(ctx, tc.indexes)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("GetAndVerifyMapLeavesAtRevision(): %v, wantErr %v", err, tc.wantErr)
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("GetAndVerifyMapLeavesAtRevision(): %v, wantErr %v", err, tc.wantCode)
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
Verify that no duplicate map indexes are being requested by the client before sending requests to the server.  

If the client requests the same index more than once, the server is happy to oblige by returning the same leaf more than once in return. However, this will immediately fail the client verification that ensures there is only one returned value per index. 

Question: should the server be doing a similar check?
### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
