### PR TITLE
More efficient Equivalent method for storage.NodeID

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -344,10 +344,8 @@ func (n *NodeID) Equivalent(other NodeID) bool {
 
 	// The first depthBytes must be identical.
 	depthBytes := n.PrefixLenBits / 8
-	for i := 0; i < depthBytes; i++ {
-		if n.Path[i] != other.Path[i] {
-			return false
-		}
+	if !bytes.Equal(n.Path[:depthBytes], other.Path[:depthBytes]) {
+		return false
 	}
 
 	// There may not be a leftover partial byte to compare.


### PR DESCRIPTION
This code was converting them to binary strings and somewhat obfuscating the underlying comparison by the fact that the Bit method counts from the right.

This version does the comparison without memory allocation on the raw path bytes.

This method has been used in a few places where performance matters a bit more, including comparing results in the map hashing code.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
