### PR TITLE
Update and clarify some NodeID docs.

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -42,7 +42,9 @@ type NodeID struct {
 	// this NodeID.
 	//
 	// e.g. if Path contains two bytes, and PrefixLenBits is 9, then the 8 bits
-	// in Path[0] are included, along with the lowest bit of Path[1]
+	// in Path[0] are included, along with the MSB of Path[1]. However, note
+	// that some of the APIs count bits with 0 being the rightmost as this
+	// is a natural ordering to use when working from the leaves upwards.
 	PrefixLenBits int
 }
 
@@ -197,6 +199,7 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 }
 
 // SetBit sets the ith bit to true if b is non-zero, and false otherwise.
+// Note that the bit index 0 is the right most valid bit in the path.
 func (n *NodeID) SetBit(i int, b uint) {
 	bIndex := (n.PathLenBits() - i - 1) / 8
 	if b == 0 {


### PR DESCRIPTION
Clarify that the storage of NodeIDs uses an MSB first representation and
that some APIs use a bit indexing from the rightmost significant bit (of the whole path bytes, not all of these may be significant).

I'm hoping these additional explanations will help people understand the code.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
