### PR TITLE
Add flag to limit max idle database connections for mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Configurable number of idle connections on MySQL
+
+This version adds a new flag `-mysql_max_idle_conns` to specify the number of
+idle database connections in the pool. Defaults to -1 which uses the Go default.
+Go default is currently set at 2 but could change in future releases.
+
 ### Client Verification
 The map client now verifies that every map leaf is being requested at most once.
 This catches potential errors before they go to the server.

--- a/server/mysql_storage_provider.go
+++ b/server/mysql_storage_provider.go
@@ -31,6 +31,7 @@ import (
 var (
 	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
 	maxConns = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
+	maxIdle  = flag.Int("mysql_max_idle_conns", -1, "Maximum idle database connections in the connection pool")
 
 	mysqlOnce            sync.Once
 	mysqlOnceErr         error
@@ -57,6 +58,9 @@ func newMySQLStorageProvider(mf monitoring.MetricFactory) (StorageProvider, erro
 		}
 		if *maxConns > 0 {
 			db.SetMaxOpenConns(*maxConns)
+		}
+		if *maxIdle >= 0 {
+			db.SetMaxIdleConns(*maxIdle)
 		}
 		mySQLstorageInstance = &mysqlProvider{
 			db: db,


### PR DESCRIPTION
We've been using Trillian in a serverless (function as a service) context and
using Amazon's Aurora serverless database as a backend. Aurora will scale down
the provisioned databases based upon open connections and CPU usage.

Making this a configurable flag allows us to set the idle pool to 0 and for Aurora
to scale down to 0 running databases. 

See before / after in the CloudWatch metrics here:

<img width="874" alt="screenshot 2019-03-01 at 10 33 42" src="https://user-images.githubusercontent.com/330135/53731442-a95aba00-3e72-11e9-84d9-035037b65d7f.png">


Go currently defaults to pooling 2 idle connections:
  https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns

We have followed Go's current default of 2 but this may change in future
releases.


### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.

Couldn't see anywhere in the docs this could be added. 

Looks like this same feature could be added for PostgreSQL but we're only using MySQL at the moment. If keeping feature parity helps accept the PR we can test it with PostgreSQL too.