### PR TITLE
Rollback if QueueLeaves runs on uninitialized log

### DIFF
--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -212,6 +212,7 @@ func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, tree *trillian.T
 func (m *memoryLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	tx, err := m.beginInternal(ctx, tree, false /* readonly */)
 	if err != nil {
+		tx.Rollback()
 		return nil, err
 	}
 	existing, err := tx.QueueLeaves(ctx, leaves, queueTimestamp)


### PR DESCRIPTION
Not sure how common this is to encounter but if QueueLeaves is called on an
uninitialized log the tx isn't closed. This makes the next call trying to
acquire the mutex to deadlock.

Example of the issue is here
  https://gist.github.com/davbo/99a01ce5ffe482b55698e74a10f94af6

This change rolls back on all errors, not just uninitialized logs.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
