### PR TITLE
Optimise Subtree query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ The `--master_check_interval` flag is removed from `logsigner`.
 ### Performance
 
 The performance of `SetLeaves` requests on the Map has been slightly improved.
+The performance of `GetConsistencyProof` requests has been improved when using
+MySQL.
 
 ### Logging
 

--- a/storage/mysql/storage.sql
+++ b/storage/mysql/storage.sql
@@ -40,7 +40,9 @@ CREATE TABLE IF NOT EXISTS Subtree(
   TreeId               BIGINT NOT NULL,
   SubtreeId            VARBINARY(255) NOT NULL,
   Nodes                MEDIUMBLOB NOT NULL,
-  SubtreeRevision      INTEGER NOT NULL,  -- negated because DESC indexes aren't supported :/
+  SubtreeRevision      INTEGER NOT NULL,
+  -- Key columns must be in ASC order in order to benefit from group-by/min-max
+  -- optimization in MySQL.
   PRIMARY KEY(TreeId, SubtreeId, SubtreeRevision),
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
 );

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -46,7 +46,7 @@ const (
 	FROM Subtree n
 	WHERE n.SubtreeId IN (` + placeholderSQL + `) AND
 	 n.TreeId = ? AND n.SubtreeRevision <= ?
-	GROUP BY n.SubtreeId
+	GROUP BY n.TreeId, n.SubtreeId
  ) AS x
  INNER JOIN Subtree 
  ON Subtree.SubtreeId = x.SubtreeId 

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -41,7 +41,7 @@ const (
 			FROM subtree n
 			WHERE n.subtree_id IN (` + placeholderSQL + `) AND
 			n.tree_id = ? AND n.subtree_revision <= ?
-			GROUP BY n.subtree_id
+			GROUP BY n.tree_id, n.subtree_id
 		) AS x
 		INNER JOIN subtree
 		ON subtree.subtree_id = x.subtree_id


### PR DESCRIPTION
Adding `TreeId` to the `GROUP BY` clause allows MySQL and MariaDB to optimize the grouping, because the grouping is now over the primary key. See the [MySQL documentation on GROUP BY optimization](https://dev.mysql.com/doc/refman/8.0/en/group-by-optimization.html) for more information. 

Note that this is incompatible with descending indices, so the SubtreeRevision must remain in ascending order in the Subtree primary key for this to work.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
