### PR TITLE
Add some additional tests for storage/types.go

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -320,7 +320,7 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	if b > suffixBits {
 		panic(fmt.Sprintf("storage Split: %x(n.PrefixLenBits: %v - prefixBytes: %v *8) > %v", n.Path, n.PrefixLenBits, prefixBytes, suffixBits))
 	}
-	if b == 0 {
+	if b <= 0 {
 		panic(fmt.Sprintf("storage Split: %x(n.PrefixLenBits: %v - prefixBytes: %v *8) == 0", n.Path, n.PrefixLenBits, prefixBytes))
 	}
 	suffixBytes := bytesForBits(b)

--- a/storage/types.go
+++ b/storage/types.go
@@ -68,7 +68,7 @@ func NewNodeIDFromHash(h []byte) NodeID {
 // capacity to store a maximum of maxLenBits.
 func NewEmptyNodeID(maxLenBits int) NodeID {
 	if got, want := maxLenBits%8, 0; got != want {
-		panic(fmt.Sprintf("storeage: NewEmptyNodeID() maxLenBits mod 8: %v, want %v", got, want))
+		panic(fmt.Sprintf("storage: NewEmptyNodeID() maxLenBits mod 8: %v, want %v", got, want))
 	}
 	return NodeID{
 		Path:          make([]byte, maxLenBits/8),
@@ -308,7 +308,7 @@ func NewNodeIDFromPrefixSuffix(prefix []byte, suffix Suffix, maxPathBits int) No
 	}
 }
 
-// Split splits a NodeID into a prefix and a suffix at prefixSplit
+// Split splits a NodeID into a prefix and a suffix at prefixBytes.
 func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	if n.PrefixLenBits == 0 {
 		return []byte{}, Suffix{Bits: 0, Path: []byte{0}}

--- a/storage/types.go
+++ b/storage/types.go
@@ -321,7 +321,7 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 		panic(fmt.Sprintf("storage Split: %x(n.PrefixLenBits: %v - prefixBytes: %v *8) > %v", n.Path, n.PrefixLenBits, prefixBytes, suffixBits))
 	}
 	if b <= 0 {
-		panic(fmt.Sprintf("storage Split: %x(n.PrefixLenBits: %v - prefixBytes: %v *8) == 0", n.Path, n.PrefixLenBits, prefixBytes))
+		panic(fmt.Sprintf("storage Split: %x(n.PrefixLenBits: %v - prefixBytes: %v *8) <= 0", n.Path, n.PrefixLenBits, prefixBytes))
 	}
 	suffixBytes := bytesForBits(b)
 	sfx := Suffix{

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -279,6 +279,9 @@ func TestSplitPanics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The 2 cases where split should panic are 1.) There are more bits left
+	// after the prefix point than have been requested. 2.) Trying to split zero
+	// (or -ve) bits off the end of the NodeID.
 	for _, tc := range []struct {
 		name      string
 		pBytes    int
@@ -330,11 +333,6 @@ func TestSplitPanics(t *testing.T) {
 			}()
 			_, _ = n.Split(tc.pBytes, tc.sBits)
 		})
-	}
-	// The 2 cases where split should panic are 1.) There are more bits left
-	// after the prefix point than have been requested. 2.) Trying to split zero
-	// bits off the end of the NodeID.
-	for b := 0; b < 64; b++ {
 	}
 }
 


### PR DESCRIPTION
Strengthen the tests for Equivalent NodeIDs. Add new tests and also check that n1.Equivalent(n2) matches n2.Equivalent(n1). Boost code coverage for storage/types.go.

New tests: 

* Check that 'nearby' in log coordinate tree node IDs don't compare equal but same ones do at 8 levels, exercising all 'leftover' number of bits.
* Construct some ids with 56 significant bits out of 64, mess with the last 8 bits.
* Test NewNodeIDFromHash() and Equivalent() on different length input.
* Add tests for all the cases where the NodeID code should panic on bad input.
* Add tests for a couple of methods that are used but weren't tested.
* Fix a couple of typos in the doc strings for types.go.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
