### PR TITLE
Add support for displaying ranges

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -128,10 +128,10 @@ func (n nodeInfo) String() string {
 	}
 
 	if len(n.rangeIndices) == 1 {
-		// For nodes in a single range just change the fill
+		// For nodes in a single range just change the fill.
 		fill = fmt.Sprintf("range%d!50", n.rangeIndices[0])
 	} else {
-		// Otherwise, we need to be a bit cleverer, and use the shading feature
+		// Otherwise, we need to be a bit cleverer, and use the shading feature.
 		for i, ri := range n.rangeIndices {
 			pos := []string{"left", "right", "middle"}[i]
 			attr = append(attr, fmt.Sprintf("%s color=range%d!50", pos, ri))
@@ -229,7 +229,7 @@ func renderTree(prefix string, treeSize, index int64) {
 	height := int64(bits.Len64(uint64(treeSize)) - 1)
 	b := int64(1) << uint(height)
 	rest := treeSize - b
-	// left child is a perfect subtree
+	// left child is a perfect subtree.
 
 	// if there's a right-hand child, then we'll emit this node to be the
 	// parent. (Otherwise we'll just keep quiet, and recurse down - this is how

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -296,13 +296,13 @@ func parseRanges(ranges string, treeSize int64) ([][2]int64, error) {
 		}
 		var l, r int64
 		if _, err := fmt.Sscanf(rng, "%d:%d", &l, &r); err != nil {
-			return nil, fmt.Errorf("range (%q) is malformed: %s", rng, err)
+			return nil, fmt.Errorf("range %q is malformed: %s", rng, err)
 		}
 		switch {
 		case r > treeSize:
 			return nil, fmt.Errorf("range %q extends past end of tree (%d)", lr, treeSize)
 		case l < 0:
-			return nil, fmt.Errorf("range %q has -ve element", rng)
+			return nil, fmt.Errorf("range %q has negative beginning", rng)
 		case l > r:
 			return nil, fmt.Errorf("range elements in %q are out of order", rng)
 		}

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -331,8 +331,8 @@ func modifyRangeNodeInfo() error {
 		maskL, maskR := decomposeRange(uint64(l), uint64(r))
 		p := l
 		// Do left perfect subtree roots:
-		nBitsL := uint64(bits.Len64(maskL))
-		for i, bit := uint64(0), uint64(1); i < nBitsL; i, bit = i+1, bit<<1 {
+		nBitsL := uint(bits.Len64(maskL))
+		for i, bit := uint(0), uint64(1); i < nBitsL; i, bit = i+1, bit<<1 {
 			if maskL&bit != 0 {
 				if i > 0 {
 					modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -51,9 +51,9 @@ const (
 \definecolor{target}{rgb}{0.5,0.5,0.9}
 \definecolor{target_path}{rgb}{0.7,0.7,0.9}
 \definecolor{mega}{rgb}{0.9,0.9,0.9}
-\definecolor{range1}{rgb}{0.3,0.9,0.3}
-\definecolor{range2}{rgb}{0.3,0.3,0.9}
-\definecolor{range3}{rgb}{0.9,0.3,0.9}
+\definecolor{range0}{rgb}{0.3,0.9,0.3}
+\definecolor{range1}{rgb}{0.3,0.3,0.9}
+\definecolor{range2}{rgb}{0.9,0.3,0.9}
 
 \forestset{
 	% This defines a new "edge" style for drawing the perfect subtrees.
@@ -322,11 +322,10 @@ func modifyRangeNodeInfo() error {
 		return err
 	}
 	for ri, lr := range rng {
-		rStyle := ri + 1
 		l, r := lr[0], lr[1]
 		// Set leaves:
 		for i := l; i < r; i++ {
-			modifyNodeInfo(nodeKey(0, i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, rStyle) })
+			modifyNodeInfo(nodeKey(0, i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
 		}
 
 		// Now perfect roots which comprise the range:
@@ -337,7 +336,7 @@ func modifyRangeNodeInfo() error {
 		for i, bit := uint64(0), uint64(1); i < nBitsL; i, bit = i+1, bit<<1 {
 			if maskL&bit != 0 {
 				if i > 0 {
-					modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, rStyle) })
+					modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
 				}
 				p += int64(bit)
 			}
@@ -346,7 +345,7 @@ func modifyRangeNodeInfo() error {
 		nBitsR := uint(bits.Len64(maskR))
 		for i, bit := nBitsR, uint64(1<<nBitsR); i > 1; i, bit = i-1, bit>>1 {
 			if maskR&bit != 0 {
-				modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, rStyle) })
+				modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
 				p += int64(bit)
 			}
 		}

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -298,13 +298,12 @@ func parseRanges(ranges string, treeSize int64) ([][2]int64, error) {
 		if _, err := fmt.Sscanf(rng, "%d:%d", &l, &r); err != nil {
 			return nil, fmt.Errorf("range (%q) is malformed: %s", rng, err)
 		}
-		if r > treeSize {
+		switch {
+		case r > treeSize:
 			return nil, fmt.Errorf("range %q extends past end of tree (%d)", lr, treeSize)
-		}
-		if l < 0 {
+		case l < 0:
 			return nil, fmt.Errorf("range %q has -ve element", rng)
-		}
-		if l > r {
+		case l > r:
 			return nil, fmt.Errorf("range elements in %q are out of order", rng)
 		}
 		ret = append(ret, [2]int64{l, r})


### PR DESCRIPTION
Allows `treetex` to show ranges.  Supports showing multiple ranges, which may overlap if desired.
e.g.:
`go run main.go --tree_size=61 --ranges=35:45,40:61`
![texput](https://user-images.githubusercontent.com/7648032/54150808-51ebb980-4431-11e9-8e38-a78700c5a466.png)


### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
