### PR TITLE
Add a codecov repository yaml override for Trillian

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Customizations to codecov for Trillian repo. This will be merged into
+# the team / default codecov yaml file.
+
+# Exclude code that's for testing, demos or utilities that aren't really
+# part of production releases.
+ignore:
+  - "cmd/createtree/testonly"
+  - "crypto/keys/testonly"
+  - "docs/**/*"
+  - "examples/**/*"
+  - "integration/**/*"
+  - "monitoring/testonly"
+  - "server/mock_log_operation.go"
+  - "storage/cache/mock_node_storage.go"
+  - "storage/mock_storage.go"
+  - "storage/testonly"
+  - "testonly/**/*"
+  - "util/election2/testonly"
+  - "vendor/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 # Customizations to codecov for Trillian repo. This will be merged into
 # the team / default codecov yaml file.
+#
+# Validate changes with:
+# curl --data-binary @codecov.yml https://codecov.io/validate
 
 # Exclude code that's for testing, demos or utilities that aren't really
 # part of production releases.

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,16 +7,10 @@
 # Exclude code that's for testing, demos or utilities that aren't really
 # part of production releases.
 ignore:
-  - "cmd/createtree/testonly"
-  - "crypto/keys/testonly"
+  - "**/mock_*.go"
+  - "**/testonly"
   - "docs/**/*"
   - "examples/**/*"
   - "integration/**/*"
-  - "monitoring/testonly"
-  - "server/mock_log_operation.go"
-  - "storage/cache/mock_node_storage.go"
-  - "storage/mock_storage.go"
-  - "storage/testonly"
   - "testonly/**/*"
-  - "util/election2/testonly"
   - "vendor/**/*"


### PR DESCRIPTION
Try to ignore code that's related to testing, docs or examples. Possibly we pick up some from the google.org yaml but this does not currently exclude the top level `testonly` directory. If it works this should cut down the noise from code coverage.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
