### PR TITLE
Validate hashes passed to GetInclusionProofByHash and GetLeavesByHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This version adds a new flag `-mysql_max_idle_conns` to specify the number of
 idle database connections in the pool. Defaults to -1 which uses the Go default.
 Go default is currently set at 2 but could change in future releases.
 
-### Server Verification
+### Server verification of leaf hashes
 
 The log server now verifies that leaf hashes are the correct length and returns
 an InvalidArgument error if they are not. Previously, GetLeavesByHash would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,14 @@ This version adds a new flag `-mysql_max_idle_conns` to specify the number of
 idle database connections in the pool. Defaults to -1 which uses the Go default.
 Go default is currently set at 2 but could change in future releases.
 
-### Server verification of leaf hashes
+### Server validation of leaf hashes
 
-The log server now verifies that leaf hashes are the correct length and returns
+The log server now checks that leaf hashes are the correct length and returns
 an InvalidArgument error if they are not. Previously, GetLeavesByHash would
 simply not return any matching leaves for invalid hashes, and
-GetInclusionProofByHash would previously have returned a NotFound error.
+GetInclusionProofByHash would return a NotFound error.
 
-### Client Verification
+### Client validation of map leaf requests
 
 The map client now verifies that every map leaf is being requested at most once.
 This catches potential errors before they go to the server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ This version adds a new flag `-mysql_max_idle_conns` to specify the number of
 idle database connections in the pool. Defaults to -1 which uses the Go default.
 Go default is currently set at 2 but could change in future releases.
 
+### Server Verification
+
+The log server now verifies that leaf hashes are the correct length and returns
+an InvalidArgument error if they are not. Previously, GetLeavesByHash would
+simply not return any matching leaves for invalid hashes, and
+GetInclusionProofByHash would previously have returned a NotFound error.
+
 ### Client Verification
 
 The map client now verifies that every map leaf is being requested at most once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ together with this release. Failure to do this can result in 5XX errors being
 returned to clients when the old handler code tries to access fields in
 responses that no longer exist.
 
-All the fields marked as deprecated in this proto have been removed. All
-the same fields are available via the TLS marshalled log root in the proto.
-Updating affected code is straightforward. 
+All the fields marked as deprecated in this proto have been removed. All the
+same fields are available via the TLS marshalled log root in the proto. Updating
+affected code is straightforward.
 
 Normally, clients will want to verify that the signed root is correctly signed.
 This is the preferred way to interact with the root data.
@@ -55,13 +55,14 @@ idle database connections in the pool. Defaults to -1 which uses the Go default.
 Go default is currently set at 2 but could change in future releases.
 
 ### Client Verification
+
 The map client now verifies that every map leaf is being requested at most once.
 This catches potential errors before they go to the server.
 
 ### Database Schema
 
-This version includes a change to the MySQL and Postgres database schemas
-to add an index on the `SequencedLeafData` table.  This improves performance for
+This version includes a change to the MySQL and Postgres database schemas to add
+an index on the `SequencedLeafData` table. This improves performance for
 inclusion proof queries.
 
 ### Deployments
@@ -88,8 +89,8 @@ Invalid value: "": field is immutable`.
 ### Dropped metrics
 
 Quota metrics with specs of the form `users/<user>/read` and
-`users/<user>/write` are no longer exported by the Trillian binaries (as
-they lead to excessive storage requirements for Trillian metrics).
+`users/<user>/write` are no longer exported by the Trillian binaries (as they
+lead to excessive storage requirements for Trillian metrics).
 
 ### Fix Operation Loop Hang
 

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -285,6 +285,10 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 	}
 	ctx = trees.NewContext(ctx, tree)
 
+	if got, want := len(req.LeafHash), hasher.Size(); got != want {
+		return nil, status.Errorf(codes.InvalidArgument, "GetInclusionProofByHash.LeafHash: expected %d bytes, got %d", want, got)
+	}
+
 	// Next we need to make sure the requested tree size corresponds to an STH, so that we
 	// have a usable tree revision
 	tx, err := t.registry.LogStorage.SnapshotForTree(ctx, tree)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -730,6 +730,16 @@ func TestGetLeavesByHash(t *testing.T) {
 			errStr: "not read current log root",
 		},
 		{
+			name: "leaf hash too short",
+			req: &trillian.GetLeavesByHashRequest{
+				LeafHash: [][]byte{
+					[]byte("too-short-to-be-a-hash"),
+				},
+				LogId: logID1,
+			},
+			errStr: "GetLeavesByHashRequest.LeafHash[0]: 22 bytes, want 32",
+		},
+		{
 			name: "ok multiple",
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
@@ -750,7 +760,9 @@ func TestGetLeavesByHash(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			fakeStorage := storage.NewMockLogStorage(ctrl)
-			tc.setupStorage(ctrl, fakeStorage)
+			if tc.setupStorage != nil {
+				tc.setupStorage(ctrl, fakeStorage)
+			}
 			registry := extension.Registry{
 				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
@@ -899,12 +911,23 @@ func TestGetProofByHashErrors(t *testing.T) {
 			req:    &getInclusionProofByHashRequest7,
 			errStr: "not read current log root",
 		},
+		{
+			name: "leaf hash too short",
+			req: &trillian.GetInclusionProofByHashRequest{
+				LeafHash: []byte("too-short-to-be-a-hash"),
+				LogId:    logID1,
+				TreeSize: 7,
+			},
+			errStr: "GetInclusionProofByHashRequest.LeafHash: 22 bytes, want 32",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			fakeStorage := storage.NewMockLogStorage(ctrl)
-			tc.setupStorage(ctrl, fakeStorage)
+			if tc.setupStorage != nil {
+				tc.setupStorage(ctrl, fakeStorage)
+			}
 			registry := extension.Registry{
 				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1796,13 +1796,22 @@ func TestTrillianLogRPCServer_GetInclusionProofByHashErrors(t *testing.T) {
 		},
 	}
 
-	logServer := NewTrillianLogRPCServer(extension.Registry{}, fakeTimeSource)
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := logServer.GetInclusionProofByHash(ctx, test.req)
-		if s, ok := status.FromError(err); !ok || s.Code() != codes.InvalidArgument {
-			t.Errorf("%v: GetInclusionProofByHash() returned err = %v, wantCode = %s", test.desc, err, codes.InvalidArgument)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			registry := extension.Registry{
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: test.req.LogId, numSnapshots: 1}),
+			}
+			logServer := NewTrillianLogRPCServer(registry, fakeTimeSource)
+
+			_, err := logServer.GetInclusionProofByHash(ctx, test.req)
+			if s, ok := status.FromError(err); !ok || s.Code() != codes.InvalidArgument {
+				t.Errorf("%v: GetInclusionProofByHash() returned err = %v, wantCode = %s", test.desc, err, codes.InvalidArgument)
+			}
+		})
 	}
 }
 
@@ -1830,13 +1839,22 @@ func TestTrillianLogRPCServer_GetLeavesByHashErrors(t *testing.T) {
 		},
 	}
 
-	logServer := NewTrillianLogRPCServer(extension.Registry{}, fakeTimeSource)
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := logServer.GetLeavesByHash(ctx, test.req)
-		if s, ok := status.FromError(err); !ok || s.Code() != codes.InvalidArgument {
-			t.Errorf("%v: GetLeavesByHash() returned err = %v, wantCode = %s", test.desc, err, codes.InvalidArgument)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			registry := extension.Registry{
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: test.req.LogId, numSnapshots: 1}),
+			}
+			logServer := NewTrillianLogRPCServer(registry, fakeTimeSource)
+
+			_, err := logServer.GetLeavesByHash(ctx, test.req)
+			if s, ok := status.FromError(err); !ok || s.Code() != codes.InvalidArgument {
+				t.Errorf("%v: GetLeavesByHash() returned err = %v, wantCode = %s", test.desc, err, codes.InvalidArgument)
+			}
+		})
 	}
 }
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -57,9 +57,12 @@ var (
 	logID2 = int64(2)
 	logID3 = int64(3)
 
-	leaf1 = newTestLeaf([]byte("value"), []byte("extra"), 1)
-	leaf2 = newTestLeaf([]byte("value2"), []byte("extra"), 2)
-	leaf3 = newTestLeaf([]byte("value3"), []byte("extra3"), 3)
+	leaf1     = newTestLeaf([]byte("value"), []byte("extra"), 1)
+	leafHash1 = []byte("\xcd\x42\x40\x4d\x52\xad\x55\xcc\xfa\x9a\xca\x4a\xdc\x82\x8a\xa5\x80\x0a\xd9\xd3\x85\xa0\x67\x1f\xbc\xbf\x72\x41\x18\x32\x06\x19")
+	leaf2     = newTestLeaf([]byte("value2"), []byte("extra"), 2)
+	leafHash2 = []byte("\x05\x37\xd4\x81\xf7\x3a\x75\x73\x34\x32\x80\x52\xda\x3a\xf9\x62\x6c\xed\x97\x02\x8e\x20\xb8\x49\xf6\x11\x5c\x22\xcd\x76\x51\x97")
+	leaf3     = newTestLeaf([]byte("value3"), []byte("extra3"), 3)
+	leafHash3 = []byte("\x89\xdc\x6a\xe7\xf0\x6a\x9f\x46\xb5\x65\xaf\x03\xea\xb0\xec\xe0\xbf\x60\x24\xd3\x65\x9b\x7e\x3a\x1d\x03\x57\x3c\xfe\xb0\xb5\x9d")
 
 	leaf0Request  = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0}}
 	leaf03Request = trillian.GetLeavesByIndexRequest{LogId: logID1, LeafIndex: []int64{0, 3}}
@@ -78,10 +81,10 @@ var (
 	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7, Revision: uint64(revision1)}
 	signedRoot1, _     = fixedSigner.SignLogRoot(root1)
 
-	getByHashRequest1 = trillian.GetLeavesByHashRequest{LogId: logID1, LeafHash: [][]byte{[]byte("test"), []byte("data")}}
+	getByHashRequest1 = trillian.GetLeavesByHashRequest{LogId: logID1, LeafHash: [][]byte{leafHash1, leafHash3}}
 
-	getInclusionProofByHashRequest7  = trillian.GetInclusionProofByHashRequest{LogId: logID1, TreeSize: 7, LeafHash: []byte("ahash")}
-	getInclusionProofByHashRequest25 = trillian.GetInclusionProofByHashRequest{LogId: logID1, TreeSize: 25, LeafHash: []byte("ahash")}
+	getInclusionProofByHashRequest7  = trillian.GetInclusionProofByHashRequest{LogId: logID1, TreeSize: 7, LeafHash: leafHash1}
+	getInclusionProofByHashRequest25 = trillian.GetInclusionProofByHashRequest{LogId: logID1, TreeSize: 25, LeafHash: leafHash2}
 
 	getInclusionProofByIndexRequest7  = trillian.GetInclusionProofRequest{LogId: logID1, TreeSize: 7, LeafIndex: 2}
 	getInclusionProofByIndexRequest25 = trillian.GetInclusionProofRequest{LogId: logID1, TreeSize: 50, LeafIndex: 25}
@@ -681,7 +684,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, errors.New("STORAGE"))
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, errors.New("STORAGE"))
 				tx.EXPECT().Close().AnyTimes()
 			},
 			req:    &getByHashRequest1,
@@ -692,7 +695,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().AnyTimes()
@@ -705,7 +708,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(trillian.SignedLogRoot{}, errors.New("SLR"))
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -718,7 +721,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*corruptLogRoot, nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -731,7 +734,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("test"), []byte("data")}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().Commit().Return(nil)
 				tx.EXPECT().Close().Return(nil)
@@ -807,7 +810,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(nil, errors.New("STORAGE"))
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash2}, false).Return(nil, errors.New("STORAGE"))
 				tx.EXPECT().Close().AnyTimes()
 			},
 			req:    &getInclusionProofByHashRequest25,
@@ -820,7 +823,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("STORAGE"))
 				tx.EXPECT().Close().Return(nil)
 			},
@@ -834,7 +837,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// The server expects three nodes from storage but we return only two
 				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 				tx.EXPECT().Close().Return(nil)
@@ -849,7 +852,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// We set this up so one of the returned nodes has the wrong ID
 				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Close().Return(nil)
@@ -862,7 +865,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().AnyTimes()
@@ -875,7 +878,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(trillian.SignedLogRoot{}, errors.New("SLR"))
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -888,7 +891,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
-				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(nil, nil)
+				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*corruptLogRoot, nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
@@ -941,7 +944,7 @@ func TestGetProofByHash(t *testing.T) {
 			fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(mockTX, nil)
 
 			mockTX.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-			mockTX.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{[]byte("ahash")}, false).Return(tc.leavesByHashVal, nil)
+			mockTX.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(tc.leavesByHashVal, nil)
 			mockTX.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil).AnyTimes()
 			mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
 				{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
@@ -963,7 +966,7 @@ func TestGetProofByHash(t *testing.T) {
 				&trillian.GetInclusionProofByHashRequest{
 					LogId:    logID1,
 					TreeSize: 7,
-					LeafHash: []byte("ahash"),
+					LeafHash: leafHash1,
 				})
 			if got, want := status.Code(err), tc.wantCode; got != want {
 				t.Fatalf("GetInclusionProofByHash(): %v, want %v", err, want)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -771,13 +771,13 @@ func TestGetLeavesByHash(t *testing.T) {
 			resp, err := server.GetLeavesByHash(context.Background(), tc.req)
 			if len(tc.errStr) > 0 {
 				if err == nil || !strings.Contains(err.Error(), tc.errStr) {
-					t.Errorf("GetLeavesByHash(%v)=%v, %v want nil, err containing: %s", tc.req, resp, err, tc.errStr)
+					t.Errorf("GetLeavesByHash(%v)=(%v, %v), want (nil, err containing %q)", tc.req, resp, err, tc.errStr)
 				}
 				return
 			}
 
 			if err != nil || !proto.Equal(tc.wantResp, resp) {
-				t.Errorf("GetLeavesByHash(%v)=%v, %v, want: %v, nil", tc.req, resp, err, tc.wantResp)
+				t.Errorf("GetLeavesByHash(%v)=(%v, %v), want (%v, nil)", tc.req, resp, err, tc.wantResp)
 			}
 		})
 	}
@@ -936,13 +936,13 @@ func TestGetProofByHashErrors(t *testing.T) {
 			resp, err := server.GetInclusionProofByHash(context.Background(), tc.req)
 			if len(tc.errStr) > 0 {
 				if err == nil || !strings.Contains(err.Error(), tc.errStr) {
-					t.Errorf("GetInclusionProofByHash(%v)=%v, %v want nil, err containing: %s", tc.req, resp, err, tc.errStr)
+					t.Errorf("GetInclusionProofByHash(%v)=(%v, %v), want (nil, err containing %q)", tc.req, resp, err, tc.errStr)
 				}
 				return
 			}
 
 			if err != nil || !proto.Equal(tc.wantResp, resp) {
-				t.Errorf("GetInclusionProofByHash(%v)=%v, %v, want: %v, nil", tc.req, resp, err, tc.wantResp)
+				t.Errorf("GetInclusionProofByHash(%v)=(%v, %v), want (%v, nil)", tc.req, resp, err, tc.wantResp)
 			}
 		})
 	}


### PR DESCRIPTION
Checks that the hashes are the correct length. This provides more helpful error messages when these endpoints are being used incorrectly, e.g. by sending the base64-encoded hash instead of the raw hash. Previously, GetInclusionProofByHash would return an error saying that no leaf was found, and GetLeavesByHash would simply return no results. Neither of these results indicates to the user that they are providing an invalid argument. Now, an InvalidArgument error will be returned.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
