### PR TITLE
Fix create.sh to use config file provided.

### DIFF
--- a/examples/deployment/kubernetes/README.md
+++ b/examples/deployment/kubernetes/README.md
@@ -25,7 +25,7 @@ deployment on Google Cloud using Kubernetes and Cloud Spanner.
 1. Create a new project
 1. Edit the [example-config.sh](example-config.sh) file, set `PROJECT_ID` to
    the ID of your project
-1. Run: `./create.sh`.
+1. Run: `./create.sh example-config.sh`.
    This script will create the Kubernetes cluster, node pools, and Spanner
    database, service account and etcd cluster.
    It should take about 5 to 10 minutes to finish and must complete without

--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -3,10 +3,28 @@
 # This script (optionally) creates and then prepares a Google Cloud project to host a
 # Trillian instance using Kubernetes.
 
+function checkEnv() {
+  if [ -z ${PROJECT_ID+x} ] ||
+     [ -z ${CLUSTER_NAME+x} ] ||
+     [ -z ${REGION+x} ] ||
+     [ -z ${NODE_LOCATIONS+x} ] ||
+     [ -z ${MASTER_ZONE+x} ] ||
+     [ -z ${CONFIGMAP+x} ] ||
+     [ -z ${POOLSIZE+x} ] ||
+     [ -z ${MACHINE_TYPE+x} ]; then
+    echo "You must either pass an argument which is a config file, or set all the required environment variables" >&2
+    exit 1
+  fi
+}
+
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/config.sh
+if [ $# -eq 1 ]; then
+  source $1
+else
+  checkEnv
+fi
 
 # Check required binaries are installed
 if ! gcloud --help > /dev/null; then


### PR DESCRIPTION
create.sh was still using config.sh, which has been deleted.  Update it
to take in a config file name as a command-line argument.

Update the README to reflect this.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
