### PR TITLE
Remove todo regarding lookup table

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -198,8 +198,6 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 
 // SetBit sets the ith bit to true if b is non-zero, and false otherwise.
 func (n *NodeID) SetBit(i int, b uint) {
-	// TODO(al): investigate whether having lookup tables for these might be
-	// faster.
 	bIndex := (n.PathLenBits() - i - 1) / 8
 	if b == 0 {
 		n.Path[bIndex] &= ^(1 << uint(i%8))


### PR DESCRIPTION
I benchmarked a lookup table and it's under 10% faster. I don't think
it's really worth doing.

```
BenchmarkSetBit-12          	300000000	         4.36 ns/op
BenchmarkSetBitLookup-12    	300000000	         4.15 ns/op
```
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
