### PR TITLE
Fix ParseKeyHint test.

### DIFF
--- a/types/logroot.go
+++ b/types/logroot.go
@@ -99,7 +99,7 @@ func SerializeKeyHint(logID int64) []byte {
 // ParseKeyHint converts a keyhint into a keyID.
 func ParseKeyHint(hint []byte) (int64, error) {
 	if len(hint) != 8 {
-		return 0, fmt.Errorf("hint is %v bytes, want %v", len(hint), 4)
+		return 0, fmt.Errorf("hint is %v bytes, want %v", len(hint), 8)
 	}
 	keyID := int64(binary.BigEndian.Uint64(hint))
 	if keyID < 0 {


### PR DESCRIPTION
It wasn't testing what it was meant to (for the negative input case as it was being fed 7 bytes) and the error message said it expected 4 bytes when it should be 8.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
