### PR TITLE
Bump go version to 1.11 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true  # Only to move mysql onto ramdisk.
 os: linux
 dist: xenial
 language: go
-go: "1.10"
+go: "1.11"
 go_import_path: github.com/google/trillian
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true  # Only to move mysql onto ramdisk.
 os: linux
 dist: xenial
 language: go
-go: "1.11"
+go: "1.11.x"
 go_import_path: github.com/google/trillian
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ cache:
 env:
   - WITH_COVERAGE=true
   - GOFLAGS='-race'
-  - GOFLAGS='-race --tags batched_queue'
+  - `GOFLAGS='-race --tags=batched_queue'`
   - GOFLAGS='-race' WITH_ETCD=true
-  - GOFLAGS='-race --tags pkcs11' WITH_PKCS11=true
+  - `GOFLAGS='-race --tags=pkcs11'` WITH_PKCS11=true
   - WITH_DOCKER_TESTS=true
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ cache:
 env:
   - WITH_COVERAGE=true
   - GOFLAGS='-race'
-  - `GOFLAGS='-race --tags=batched_queue'`
+  - GOFLAGS='-race --tags=batched_queue'
   - GOFLAGS='-race' WITH_ETCD=true
-  - `GOFLAGS='-race --tags=pkcs11'` WITH_PKCS11=true
+  - GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true
   - WITH_DOCKER_TESTS=true
 
 matrix:

--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -30,7 +30,7 @@ else
 fi
 
 echo "Provision log"
-go build ${GOFLAGS} github.com/google/trillian/cmd/createtree/
+go build github.com/google/trillian/cmd/createtree/
 TEST_TREE_ID=$(./createtree \
   --admin_server="${TRILLIAN_SERVER}" \
   ${KEY_ARGS})
@@ -39,7 +39,7 @@ echo "Created tree ${TEST_TREE_ID}"
 echo "Running test"
 pushd "${INTEGRATION_DIR}"
 set +e
-go test ${GOFLAGS} \
+go test \
   -run ".*LiveLog.*" \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
   ./ \

--- a/integration/map_integration_test.sh
+++ b/integration/map_integration_test.sh
@@ -18,7 +18,7 @@ fi
 echo "Running test"
 cd "${INTEGRATION_DIR}"
 set +e
-go test ${GOFLAGS} \
+go test \
   -timeout=${GO_TEST_TIMEOUT:-5m} \
   ./maptest  --map_rpc_server="${TRILLIAN_SERVER}"
 RESULT=$?

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -85,18 +85,13 @@ main() {
   fi
 
   if [[ "${run_build}" -eq 1 ]]; then
-    local goflags=''
-    if [[ "${GOFLAGS:+x}" ]]; then
-      goflags="${GOFLAGS}"
-    fi
-
     echo 'running go build'
-    go build ${goflags} ./...
+    go build ./...
 
     echo 'running go test'
     # Install test deps so that individual test runs below can reuse them.
     echo 'installing test deps'
-    go test ${goflags} -i ./...
+    go test -i ./...
 
     if [[ ${coverage} -eq 1 ]]; then
         local coverflags="-covermode=atomic -coverprofile=coverage.txt"
@@ -105,13 +100,11 @@ main() {
             -short \
             -timeout=${GO_TEST_TIMEOUT:-5m} \
             ${coverflags} \
-            ${goflags} \
 	    ./... -alsologtostderr
     else
       go test \
         -short \
         -timeout=${GO_TEST_TIMEOUT:-5m} \
-        ${goflags} \
         ./... -alsologtostderr
     fi
   fi


### PR DESCRIPTION
Looks like there's an incompatible change affecting "go list", which is used by stringer. This is causing builds to fail. Try it on Go 1.11.

```
running go generate
stringer: unsupported version of go: exit status 2: flag provided but
not defined: -compiled
usage: list [-e] [-f format] [-json] [build flags] [packages]
Run 'go help list' for details.
quota/gen.go:18: running "stringer": exit status 1
stringer: unsupported version of go: exit status 2: flag provided but
not defined: -compiled
usage: list [-e] [-f format] [-json] [build flags] [packages]
Run 'go help list' for details.
trees/gen.go:17: running "stringer": exit status 1
```

This error is produced here at line 756:

https://github.com/golang/tools/blob/master/go/packages/golist.go

Fixes #1276.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
