### PR TITLE
Add tests for admin error paths to some RPC methods.

### DIFF
--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -689,11 +689,7 @@ func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTr
 	return fetchNodesAndBuildProof(ctx, tx, hasher, rev, leafIndex, proofNodeIDs)
 }
 
-func (t *TrillianLogRPCServer) getTreeAndHasher(
-	ctx context.Context,
-	treeID int64,
-	opts trees.GetOpts,
-) (*trillian.Tree, hashers.LogHasher, error) {
+func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int64, opts trees.GetOpts) (*trillian.Tree, hashers.LogHasher, error) {
 	tree, err := trees.GetTree(ctx, t.registry.AdminStorage, treeID, opts)
 	if err != nil {
 		return nil, nil, err

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -107,10 +107,28 @@ func TestGetLeavesByIndex(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		setupStorage func(*gomock.Controller, *storage.MockLogStorage)
+		snapErr      error
+		treeErr      error
 		req          *trillian.GetLeavesByIndexRequest
 		errStr       string
 		wantResp     *trillian.GetLeavesByIndexResponse
 	}{
+		{
+			name: "admin snapshot fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &leaf0Request,
+			snapErr: errors.New("admin snap"),
+			errStr:  "admin snap",
+		},
+		{
+			name: "get tree fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &leaf0Request,
+			treeErr: errors.New("tree error"),
+			errStr:  "tree error",
+		},
 		{
 			name: "begin fails",
 			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
@@ -211,7 +229,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}),
+				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -627,10 +645,28 @@ func TestGetLeavesByHash(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		setupStorage func(*gomock.Controller, *storage.MockLogStorage)
+		snapErr      error
+		treeErr      error
 		req          *trillian.GetLeavesByHashRequest
 		errStr       string
 		wantResp     *trillian.GetLeavesByHashResponse
 	}{
+		{
+			name: "admin snapshot fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getByHashRequest1,
+			snapErr: errors.New("admin snap"),
+			errStr:  "admin snap",
+		},
+		{
+			name: "get tree fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getByHashRequest1,
+			treeErr: errors.New("tree error"),
+			errStr:  "tree error",
+		},
 		{
 			name: "begin fails",
 			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
@@ -712,7 +748,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}),
+				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -735,10 +771,28 @@ func TestGetProofByHashErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		setupStorage func(*gomock.Controller, *storage.MockLogStorage)
+		snapErr      error
+		treeErr      error
 		req          *trillian.GetInclusionProofByHashRequest
 		errStr       string
 		wantResp     *trillian.GetInclusionProofByHashResponse
 	}{
+		{
+			name: "admin snapshot fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getInclusionProofByHashRequest25,
+			snapErr: errors.New("admin snap"),
+			errStr:  "admin snap",
+		},
+		{
+			name: "get tree fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getInclusionProofByHashRequest25,
+			treeErr: errors.New("tree error"),
+			errStr:  "tree error",
+		},
 		{
 			name: "begin fails",
 			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
@@ -848,7 +902,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}),
+				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -941,10 +995,28 @@ func TestGetProofByIndex(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		setupStorage func(*gomock.Controller, *storage.MockLogStorage)
+		snapErr      error
+		treeErr      error
 		req          *trillian.GetInclusionProofRequest
 		errStr       string
 		wantResp     *trillian.GetInclusionProofResponse
 	}{
+		{
+			name: "admin snapshot fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getInclusionProofByIndexRequest25,
+			snapErr: errors.New("admin snap"),
+			errStr:  "admin snap",
+		},
+		{
+			name: "get tree fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getInclusionProofByIndexRequest25,
+			treeErr: errors.New("tree error"),
+			errStr:  "tree error",
+		},
 		{
 			name: "begin fails",
 			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
@@ -1079,7 +1151,7 @@ func TestGetProofByIndex(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}),
+				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -1102,10 +1174,28 @@ func TestGetEntryAndProof(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		setupStorage func(*gomock.Controller, *storage.MockLogStorage)
+		snapErr      error
+		treeErr      error
 		req          *trillian.GetEntryAndProofRequest
 		errStr       string
 		wantResp     *trillian.GetEntryAndProofResponse
 	}{
+		{
+			name: "admin snapshot fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getEntryAndProofRequest17,
+			snapErr: errors.New("admin snap"),
+			errStr:  "admin snap",
+		},
+		{
+			name: "get tree fails",
+			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
+			},
+			req:     &getEntryAndProofRequest17,
+			treeErr: errors.New("tree error"),
+			errStr:  "tree error",
+		},
 		{
 			name: "begin fails",
 			setupStorage: func(_ *gomock.Controller, s *storage.MockLogStorage) {
@@ -1270,7 +1360,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}),
+				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -2065,7 +2155,7 @@ type storageParams struct {
 	numSnapshots int
 }
 
-func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.AdminStorage {
+func fakeAdminStorageWithErrs(ctrl *gomock.Controller, params storageParams, snapErr, treeErr error) storage.AdminStorage {
 	tree := *stestonly.LogTree
 	if params.preordered {
 		tree = *stestonly.PreorderedLogTree
@@ -2075,12 +2165,16 @@ func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.Adm
 	adminStorage := storage.NewMockAdminStorage(ctrl)
 	adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 
-	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(params.numSnapshots).Return(adminTX, nil)
-	adminTX.EXPECT().GetTree(gomock.Any(), params.treeID).MaxTimes(params.numSnapshots).Return(&tree, nil)
+	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(params.numSnapshots).Return(adminTX, snapErr)
+	adminTX.EXPECT().GetTree(gomock.Any(), params.treeID).MaxTimes(params.numSnapshots).Return(&tree, treeErr)
 	adminTX.EXPECT().Close().MaxTimes(params.numSnapshots).Return(nil)
 	adminTX.EXPECT().Commit().MaxTimes(params.numSnapshots).Return(nil)
 
 	return adminStorage
+}
+
+func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.AdminStorage {
+	return fakeAdminStorageWithErrs(ctrl, params, nil, nil)
 }
 
 func addTreeID(tree *trillian.Tree, treeID int64) *trillian.Tree {

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -229,7 +229,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -532,7 +532,7 @@ func TestAddSequencedLeaves(t *testing.T) {
 		Return([]*trillian.QueuedLogLeaf{{Status: status.New(codes.OK, "OK").Proto()}}, nil)
 
 	registry := extension.Registry{
-		AdminStorage: fakeAdminStorage(ctrl, storageParams{addSeqRequest0.LogId, true, 1}),
+		AdminStorage: fakeAdminStorage(ctrl, storageParams{addSeqRequest0.LogId, true, 1, nil, nil}),
 		LogStorage:   mockStorage,
 	}
 	server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -748,7 +748,7 @@ func TestGetLeavesByHash(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -902,7 +902,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -1151,7 +1151,7 @@ func TestGetProofByIndex(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -1360,7 +1360,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			fakeStorage := storage.NewMockLogStorage(ctrl)
 			tc.setupStorage(ctrl, fakeStorage)
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorageWithErrs(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1}, tc.snapErr, tc.treeErr),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{treeID: leaf0Request.LogId, numSnapshots: 1, snapErr: tc.snapErr, treeErr: tc.treeErr}),
 				LogStorage:   fakeStorage,
 			}
 			server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -1984,7 +1984,7 @@ func TestInitLog(t *testing.T) {
 			}
 
 			registry := extension.Registry{
-				AdminStorage: fakeAdminStorage(ctrl, storageParams{logID1, tc.preordered, 1}),
+				AdminStorage: fakeAdminStorage(ctrl, storageParams{logID1, tc.preordered, 1, nil, nil}),
 				LogStorage:   fakeStorage,
 			}
 			logServer := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -2063,7 +2063,7 @@ func (p *parameterizedTest) executeCommitFailsTest(t *testing.T, logID int64) {
 	}
 
 	registry := extension.Registry{
-		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1}),
+		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1, nil, nil}),
 		LogStorage:   fakeStorage,
 	}
 	server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -2117,7 +2117,7 @@ func (p *parameterizedTest) executeStorageFailureTest(t *testing.T, logID int64)
 	}
 
 	registry := extension.Registry{
-		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1}),
+		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1, nil, nil}),
 		LogStorage:   fakeStorage,
 	}
 	server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -2139,7 +2139,7 @@ func (p *parameterizedTest) executeBeginFailsTest(t *testing.T, logID int64) {
 	}
 
 	registry := extension.Registry{
-		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1}),
+		AdminStorage: fakeAdminStorage(p.ctrl, storageParams{logID, p.preordered, 1, nil, nil}),
 		LogStorage:   logStorage,
 	}
 	server := NewTrillianLogRPCServer(registry, fakeTimeSource)
@@ -2153,9 +2153,11 @@ type storageParams struct {
 	treeID       int64
 	preordered   bool
 	numSnapshots int
+	snapErr      error
+	treeErr      error
 }
 
-func fakeAdminStorageWithErrs(ctrl *gomock.Controller, params storageParams, snapErr, treeErr error) storage.AdminStorage {
+func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.AdminStorage {
 	tree := *stestonly.LogTree
 	if params.preordered {
 		tree = *stestonly.PreorderedLogTree
@@ -2165,16 +2167,12 @@ func fakeAdminStorageWithErrs(ctrl *gomock.Controller, params storageParams, sna
 	adminStorage := storage.NewMockAdminStorage(ctrl)
 	adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 
-	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(params.numSnapshots).Return(adminTX, snapErr)
-	adminTX.EXPECT().GetTree(gomock.Any(), params.treeID).MaxTimes(params.numSnapshots).Return(&tree, treeErr)
+	adminStorage.EXPECT().Snapshot(gomock.Any()).MaxTimes(params.numSnapshots).Return(adminTX, params.snapErr)
+	adminTX.EXPECT().GetTree(gomock.Any(), params.treeID).MaxTimes(params.numSnapshots).Return(&tree, params.treeErr)
 	adminTX.EXPECT().Close().MaxTimes(params.numSnapshots).Return(nil)
 	adminTX.EXPECT().Commit().MaxTimes(params.numSnapshots).Return(nil)
 
 	return adminStorage
-}
-
-func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.AdminStorage {
-	return fakeAdminStorageWithErrs(ctrl, params, nil, nil)
 }
 
 func addTreeID(tree *trillian.Tree, treeID int64) *trillian.Tree {


### PR DESCRIPTION
These were missing before the test were restructured.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
