### PR TITLE
Extend the tests for the InitLog() RPC to include admin server

### DIFF
--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -755,7 +755,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 	logID := req.LogId
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, optsLogInit)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "getTreeAndHasher(): %v", err)
+		return nil, status.Errorf(codes.FailedPrecondition, "getTreeAndHasher()=%v", err)
 	}
 
 	var newRoot *trillian.SignedLogRoot
@@ -764,7 +764,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 
 		latestRoot, err := tx.LatestSignedLogRoot(ctx)
 		if err != nil && err != storage.ErrTreeNeedsInit {
-			return status.Errorf(codes.FailedPrecondition, "LatestSignedLogRoot(): %v", err)
+			return status.Errorf(codes.FailedPrecondition, "LatestSignedLogRoot()=%v", err)
 		}
 
 		// Belt and braces check.
@@ -774,7 +774,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 
 		signer, err := trees.Signer(ctx, tree)
 		if err != nil {
-			return status.Errorf(codes.FailedPrecondition, "Signer() :%v", err)
+			return status.Errorf(codes.FailedPrecondition, "Signer()=%v", err)
 		}
 
 		root, err := signer.SignLogRoot(&types.LogRootV1{
@@ -787,7 +787,7 @@ func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLo
 		newRoot = root
 
 		if err := tx.StoreSignedLogRoot(ctx, *newRoot); err != nil {
-			return status.Errorf(codes.FailedPrecondition, "StoreSignedLogRoot(): %v", err)
+			return status.Errorf(codes.FailedPrecondition, "StoreSignedLogRoot()=%v", err)
 		}
 
 		return nil


### PR DESCRIPTION
failures, failure to sign and failure to store the new root. Make some of the error strings returned more standard format.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
