### PR TITLE
Added missing CHANGELOG entries since v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ GetInclusionProofByHash would return a NotFound error.
 
 ### Map client
 
-A MapClient has been added to simplify interacting with the map server.
+A [MapClient](client/map_client.go) has been added to simplify interacting with
+the map server.
 
 ### Database Schema
 


### PR DESCRIPTION
I looked at all of the commits between 2a92e37717a20799efea838a2a4fe5f23afe2b35 and 2e961d86feaa962e568aff731a8d3560fc3bda89 in order to write these entries.