### PR TITLE
Fixes for transaction leaks in RPC server and storage level operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Google Cloud Spanner is now a supported storage backend for maps.
 
 The admin API calls to list trees backed by Cloud Spanner trees are fixed.
 
+### RPC Server Transaction Leaks Fixed
+
+There were some cases where the RPC server could leak storage transactions in
+error situations. These have now been fixed. If you have a custom storage
+implementation review the fixes made to the MySQL Log storage to see if they
+need to be applied to your code (`storage/mysq/log_storage.go`).
+
 ### GetLatestSignedLogRoot With Consistency Proof
 
 `GetLatestSignedLogRoot` in the LogServer will return a consistency proof if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ The admin API calls to list trees backed by Cloud Spanner trees are fixed.
 
 ### RPC Server Transaction Leaks Fixed
 
-There were some cases where the RPC server could leak storage transactions in
-error situations. These have now been fixed. If you have a custom storage
+There were some cases where the Log RPC server could leak storage transactions
+in error situations. These have now been fixed. If you have a custom storage
 implementation review the fixes made to the MySQL Log storage to see if they
-need to be applied to your code (`storage/mysq/log_storage.go`).
+need to be applied to your code (`storage/mysql/log_storage.go`).
 
 ### GetLatestSignedLogRoot With Consistency Proof
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ The admin API calls to list trees backed by Cloud Spanner trees are fixed.
 There were some cases where the Log RPC server could leak storage transactions
 in error situations. These have now been fixed. If you have a custom storage
 implementation review the fixes made to the MySQL Log storage to see if they
-need to be applied to your code (`storage/mysql/log_storage.go`).
+need to be applied to your code (`storage/mysql/log_storage.go`). The Map
+server had similar issues but these were fixed without requiring changes to
+storage code.
 
 ### GetLatestSignedLogRoot With Consistency Proof
 

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -817,9 +817,9 @@ func spanFor(ctx context.Context, name string) (context.Context, *trace.Span) {
 
 func (t *TrillianLogRPCServer) snapshotForTree(ctx context.Context, tree *trillian.Tree, method string) (storage.ReadOnlyLogTreeTX, error) {
 	tx, err := t.registry.LogStorage.SnapshotForTree(ctx, tree)
-	if err == storage.ErrTreeNeedsInit {
-		// Special case - We have an error but we still have an open transaction.
-		// To avoid leaking it make sure it's closed and indicate with status code.
+	if err != nil && tx != nil {
+		// Special case to handle ErrTreeNeedsInit, which leaves the TX open.
+		// To avoid leaking it make sure it's closed.
 		defer t.closeAndLog(ctx, tree.TreeId, tx, method)
 	}
 	return tx, err

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -142,12 +142,22 @@ func TestGetLeavesByIndex(t *testing.T) {
 			errStr: "TX",
 		},
 		{
+			name: "not initialized",
+			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
+				tx := storage.NewMockLogTreeTX(c)
+				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, storage.ErrTreeNeedsInit)
+				tx.EXPECT().Close().Return(nil)
+			},
+			req:    &leaf0Request,
+			errStr: "tree needs init",
+		},
+		{
 			name: "storage error",
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return(nil, errors.New("STORAGE"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &leaf0Request,
 			errStr: "STORAGE",
@@ -159,7 +169,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &leaf0Request,
 			errStr: "COMMIT",
@@ -680,12 +690,22 @@ func TestGetLeavesByHash(t *testing.T) {
 			errStr: "TX",
 		},
 		{
+			name: "not initialized",
+			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
+				tx := storage.NewMockLogTreeTX(c)
+				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, storage.ErrTreeNeedsInit)
+				tx.EXPECT().Close().Return(nil)
+			},
+			req:    &getByHashRequest1,
+			errStr: "tree needs init",
+		},
+		{
 			name: "storage error",
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, errors.New("STORAGE"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getByHashRequest1,
 			errStr: "STORAGE",
@@ -698,7 +718,7 @@ func TestGetLeavesByHash(t *testing.T) {
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getByHashRequest1,
 			errStr: "COMMIT",
@@ -818,12 +838,22 @@ func TestGetProofByHashErrors(t *testing.T) {
 			errStr: "TX",
 		},
 		{
+			name: "not initialized",
+			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
+				tx := storage.NewMockLogTreeTX(c)
+				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, storage.ErrTreeNeedsInit)
+				tx.EXPECT().Close().Return(nil)
+			},
+			req:    &getInclusionProofByHashRequest25,
+			errStr: "tree needs init",
+		},
+		{
 			name: "storage error",
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash2}, false).Return(nil, errors.New("STORAGE"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest25,
 			errStr: "STORAGE",
@@ -880,7 +910,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
 			errStr: "COMMIT",
@@ -1051,6 +1081,16 @@ func TestGetProofByIndex(t *testing.T) {
 			},
 			req:    &getInclusionProofByIndexRequest25,
 			errStr: "TX",
+		},
+		{
+			name: "not initialized",
+			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
+				tx := storage.NewMockLogTreeTX(c)
+				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, storage.ErrTreeNeedsInit)
+				tx.EXPECT().Close().Return(nil)
+			},
+			req:    &getInclusionProofByIndexRequest25,
+			errStr: "tree needs init",
 		},
 		{
 			name: "get nodes fails",
@@ -1232,6 +1272,16 @@ func TestGetEntryAndProof(t *testing.T) {
 			errStr: "TX",
 		},
 		{
+			name: "not initialized",
+			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
+				tx := storage.NewMockLogTreeTX(c)
+				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, storage.ErrTreeNeedsInit)
+				tx.EXPECT().Close().Return(nil)
+			},
+			req:    &getEntryAndProofRequest17,
+			errStr: "tree needs init",
+		},
+		{
 			name: "storage error",
 			setupStorage: func(c *gomock.Controller, s *storage.MockLogStorage) {
 				tx := storage.NewMockLogTreeTX(c)
@@ -1243,7 +1293,7 @@ func TestGetEntryAndProof(t *testing.T) {
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return(nil, errors.New("STORAGE"))
-				tx.EXPECT().Close().AnyTimes()
+				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getEntryAndProofRequest7,
 			errStr: "STORAGE",

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -201,9 +201,9 @@ func TestGetSignedMapRoot(t *testing.T) {
 				if test.lsmrErr == nil {
 					mockTX.EXPECT().Commit().Return(nil)
 				}
-				mockTX.EXPECT().Close().Return(nil)
 				mockTX.EXPECT().IsOpen().AnyTimes().Return(false)
 			}
+			mockTX.EXPECT().Close().Return(nil)
 
 			server := NewTrillianMapServer(extension.Registry{
 				AdminStorage: adminStorage,

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -211,6 +211,12 @@ func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, tree *trillian.T
 
 func (m *memoryLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	tx, err := m.beginInternal(ctx, tree, false /* readonly */)
+	if tx != nil {
+		// Ensure we don't leak the transaction. For example if we get an
+		// ErrTreeNeedsInit from beginInternal() or if QueueLeaves fails
+		// below.
+		defer tx.Close()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -273,6 +273,12 @@ func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, tree *trilli
 
 func (m *mySQLLogStorage) AddSequencedLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, timestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	tx, err := m.beginInternal(ctx, tree)
+	if tx != nil {
+		// Ensure we don't leak the transaction. For example if we get an
+		// ErrTreeNeedsInit from beginInternal() or if AddSequencedLeaves fails
+		// below.
+		defer tx.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -296,6 +302,12 @@ func (m *mySQLLogStorage) SnapshotForTree(ctx context.Context, tree *trillian.Tr
 
 func (m *mySQLLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	tx, err := m.beginInternal(ctx, tree)
+	if tx != nil {
+		// Ensure we don't leak the transaction. For example if we get an
+		// ErrTreeNeedsInit from beginInternal() or if QueueLeaves fails
+		// below.
+		defer tx.Close()
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
QueueLeaves / AddSequenced leaves (Storage Level API) in memory / mysql
storage could leak a transaction in 2 ways - on an ErrTreeNeedsInit or
if the operation they call on the transaction failed. Transactions are
created inside these methods.

The log RPC server could leak via the above for write methods or in a
similar manner for read RPCs by not closing a TX when receiving an
ErrTreeNeedsInit from the initial Snapshot() call.

Add tests. Update some tests to ensure Close() is called for errors by
removing AnyTimes().

The Map RPC server had a similar issue to the Log for read methods.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
