### PR TITLE
Add a flag (mysql tests only) to set the testdb uri

### DIFF
--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -33,12 +34,12 @@ import (
 
 var (
 	trillianSQL = testonly.RelativeToPackage("../mysql/storage.sql")
-	dataSource  = "root@tcp(127.0.0.1)/"
+	dataSource  = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "mysql data uri to use for tests")
 )
 
 // MySQLAvailable indicates whether a default MySQL database is available.
 func MySQLAvailable() bool {
-	db, err := sql.Open("mysql", dataSource)
+	db, err := sql.Open("mysql", *dataSource)
 	if err != nil {
 		log.Printf("sql.Open(): %v", err)
 		return false
@@ -53,7 +54,7 @@ func MySQLAvailable() bool {
 
 // newEmptyDB creates a new, empty database.
 func newEmptyDB(ctx context.Context) (*sql.DB, error) {
-	db, err := sql.Open("mysql", dataSource)
+	db, err := sql.Open("mysql", *dataSource)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, error) {
 	}
 
 	db.Close()
-	db, err = sql.Open("mysql", dataSource+name)
+	db, err = sql.Open("mysql", *dataSource+name)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -33,13 +33,13 @@ import (
 )
 
 var (
-	trillianSQL = testonly.RelativeToPackage("../mysql/storage.sql")
-	dataSource  = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "mysql data uri to use for tests")
+	trillianSQL   = testonly.RelativeToPackage("../mysql/storage.sql")
+	dataSourceURI = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "The MySQL uri to use when running tests")
 )
 
 // MySQLAvailable indicates whether a default MySQL database is available.
 func MySQLAvailable() bool {
-	db, err := sql.Open("mysql", *dataSource)
+	db, err := sql.Open("mysql", *dataSourceURI)
 	if err != nil {
 		log.Printf("sql.Open(): %v", err)
 		return false
@@ -54,7 +54,7 @@ func MySQLAvailable() bool {
 
 // newEmptyDB creates a new, empty database.
 func newEmptyDB(ctx context.Context) (*sql.DB, error) {
-	db, err := sql.Open("mysql", *dataSource)
+	db, err := sql.Open("mysql", *dataSourceURI)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, error) {
 	}
 
 	db.Close()
-	db, err = sql.Open("mysql", *dataSource+name)
+	db, err = sql.Open("mysql", *dataSourceURI+name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Default it to the current value. It's then easier to run tests locally with different database hosts or passwords.

```
go test -v github.com/google/trillian/storage/mysql \
  --test_mysql_uri="root:secretstuffs@tcp(big_database_server)/"
```

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
