### PR TITLE
Add dependencies to Trillian Docker images

### DIFF
--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 RUN go get ./server/trillian_log_server
+# Delete the .git directories from the Go packages to minimise their size
+# ahead of copying them into the final image.
+RUN ["find", "/go/src", "-name", ".git", "-prune", "-exec", "rm", "-rf", "{}", ";"]
 
 FROM gcr.io/distroless/base
 

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -9,5 +9,9 @@ RUN go get ./server/trillian_log_server
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_log_server /
+# Include the source code for Trillian and all of its transitive dependencies.
+# This ensures that we meet their license requirements to redistribute their
+# licenses, copyright notices and, in some cases, source code.
+COPY --from=build /go/src /go/src
 
 ENTRYPOINT ["/trillian_log_server"]

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -9,5 +9,9 @@ RUN go get ./server/trillian_log_signer
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_log_signer /
+# Include the source code for Trillian and all of its transitive dependencies.
+# This ensures that we meet their license requirements to redistribute their
+# licenses, copyright notices and, in some cases, source code.
+COPY --from=build /go/src /go/src
 
 ENTRYPOINT ["/trillian_log_signer"]

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 RUN go get ./server/trillian_log_signer
+# Delete the .git directories from the Go packages to minimise their size
+# ahead of copying them into the final image.
+RUN ["find", "/go/src", "-name", ".git", "-prune", "-exec", "rm", "-rf", "{}", ";"]
 
 FROM gcr.io/distroless/base
 

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -9,5 +9,9 @@ RUN go get ./server/trillian_map_server
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_map_server /
+# Include the source code for Trillian and all of its transitive dependencies.
+# This ensures that we meet their license requirements to redistribute their
+# licenses, copyright notices and, in some cases, source code.
+COPY --from=build /go/src /go/src
 
 ENTRYPOINT ["/trillian_map_server"]

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 RUN go get ./server/trillian_map_server
+# Delete the .git directories from the Go packages to minimise their size
+# ahead of copying them into the final image.
+RUN ["find", "/go/src", "-name", ".git", "-prune", "-exec", "rm", "-rf", "{}", ";"]
 
 FROM gcr.io/distroless/base
 


### PR DESCRIPTION
By including the source for all of our dependencies, we ensure that we're redistributing their licenses and copyright notices, as required by many of their licenses. Some of our dependencies also require that we redistribute their source code, which this achieves as well.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
