### PR TITLE
Fix CloudSpanner admin.readTrees query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Not yet released; provisionally v2.0.0 (may change).
 
 Google Cloud Spanner is now a supported storage backend for maps.
 
+The admin API calls to list trees backed by Cloud Spanner trees are fixed.
+
 ### GetLatestSignedLogRoot With Consistency Proof
 
 `GetLatestSignedLogRoot` in the LogServer will return a consistency proof if

--- a/storage/cloudspanner/admin.go
+++ b/storage/cloudspanner/admin.go
@@ -328,14 +328,12 @@ func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trilli
 func (t *adminTX) readTrees(ctx context.Context, includeDeleted, idOnly bool, f func(*spanner.Row) error) error {
 	var stmt spanner.Statement
 	if idOnly {
-		stmt = spanner.NewStatement("SELECT idx.TreeID FROM TreeRootsByDeleted idx")
+		stmt = spanner.NewStatement("SELECT t.TreeID FROM TreeRoots t")
 	} else {
-		stmt = spanner.NewStatement(
-			"SELECT t.TreeInfo FROM TreeRootsByDeleted idx" +
-				" INNER JOIN TreeRoots t ON idx.TreeID = t.TreeID")
+		stmt = spanner.NewStatement("SELECT t.TreeInfo FROM TreeRoots t")
 	}
 	if !includeDeleted {
-		stmt.SQL += " WHERE idx.Deleted = @deleted"
+		stmt.SQL += " WHERE t.Deleted = @deleted"
 		stmt.Params["deleted"] = false
 	}
 	rows := t.tx.Query(ctx, stmt)


### PR DESCRIPTION
Fixes the CloudSpanner SQL for reading trees in the admin storage implementation.
 
- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
