### PR TITLE
Update Go in our Docker images to 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ MySQL-related data (e.g. `MYSQL_DATABASE`). The variable names are based on
 those for the
 [MySQL Docker image](https://hub.docker.com/_/mysql#environment-variables).
 
-Docker images have been upgraded from Go 1.9 to 1.10. They now use ["Distroless"
+Docker images have been upgraded from Go 1.9 to 1.11. They now use ["Distroless"
 base images](https://github.com/GoogleContainerTools/distroless).
 
 ### Dropped metrics

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 
 RUN apt-get update && \
     apt-get install -y mysql-client

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.10 as build
+FROM golang:1.11 as build
 
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
-RUN go get ${GOFLAGS} ./server/trillian_log_server
+RUN go get ./server/trillian_log_server
 
 FROM gcr.io/distroless/base
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.10 as build
+FROM golang:1.11 as build
 
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
-RUN go get ${GOFLAGS} ./server/trillian_log_signer
+RUN go get ./server/trillian_log_signer
 
 FROM gcr.io/distroless/base
 

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.10 as build
+FROM golang:1.11 as build
 
 ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
-RUN go get ${GOFLAGS} ./server/trillian_map_server
+RUN go get ./server/trillian_map_server
 
 FROM gcr.io/distroless/base
 


### PR DESCRIPTION
`$GOFLAGS` is now automatically used by `go` tools (#1276), so it no longer needs to be passed to `go get`.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
