### PR TITLE
Move RunInAdminSnapshot to helpers rather than where types are defined

### DIFF
--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -77,7 +77,8 @@ func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*
 	defer span.End()
 	var updatedTree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
-		_, err := tx.UpdateTree(ctx, treeID, fn)
+		var err error
+		updatedTree, err = tx.UpdateTree(ctx, treeID, fn)
 		return err
 	})
 	return updatedTree, err
@@ -91,7 +92,8 @@ func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*tri
 	defer span.End()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
-		_, err := tx.SoftDeleteTree(ctx, treeID)
+		var err error
+		tree, err = tx.SoftDeleteTree(ctx, treeID)
 		return err
 	})
 	return tree, err
@@ -116,7 +118,8 @@ func UndeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trill
 	defer span.End()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
-		_, err := tx.UndeleteTree(ctx, treeID)
+		var err error
+		tree, err = tx.UndeleteTree(ctx, treeID)
 		return err
 	})
 	return tree, err

--- a/storage/admin_helpers_test.go
+++ b/storage/admin_helpers_test.go
@@ -1,0 +1,175 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/trillian"
+)
+
+// TestGetTree is really testing param / result / error propagation is correct
+// as it wraps RunInAdminSnapshot which has its own tests. The other helpers
+// use admin.RunInTransaction, which is provided by the implementation, so
+// cannot usefully be tested here.
+func TestGetTree(t *testing.T) {
+	dummyTree := &trillian.Tree{TreeId: 999, TreeType: trillian.TreeType_LOG}
+
+	tests := []struct {
+		name       string
+		setup      func(*MockAdminStorage, *MockReadOnlyAdminTX)
+		testFn     func(AdminStorage) (*trillian.Tree, error)
+		snapErr    error
+		wantErrStr string
+		wantTree   *trillian.Tree
+	}{
+		{
+			name:       "get snap fail",
+			snapErr:    errors.New("SNAP"),
+			wantErrStr: "SNAP",
+			setup: func(_ *MockAdminStorage, atx *MockReadOnlyAdminTX) {
+			},
+			testFn: func(as AdminStorage) (*trillian.Tree, error) {
+				return GetTree(context.Background(), as, 999)
+			},
+		},
+		{
+			name:       "get tree fail",
+			wantErrStr: "TREE",
+			setup: func(_ *MockAdminStorage, atx *MockReadOnlyAdminTX) {
+				atx.EXPECT().GetTree(gomock.Any(), int64(999)).Return(nil, errors.New("TREE"))
+			},
+			testFn: func(as AdminStorage) (*trillian.Tree, error) {
+				return GetTree(context.Background(), as, 999)
+			},
+		},
+		{
+			name: "get tree ok",
+			setup: func(_ *MockAdminStorage, atx *MockReadOnlyAdminTX) {
+				atx.EXPECT().GetTree(gomock.Any(), int64(999)).Return(dummyTree, nil)
+				atx.EXPECT().Commit().Return(nil)
+			},
+			testFn: func(as AdminStorage) (*trillian.Tree, error) {
+				return GetTree(context.Background(), as, 999)
+			},
+			wantTree: dummyTree,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup == nil || tc.testFn == nil {
+				t.Fatalf("Bad test case: %v", tc)
+			}
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			as := NewMockAdminStorage(ctrl)
+			atx := NewMockReadOnlyAdminTX(ctrl)
+			as.EXPECT().Snapshot(gomock.Any()).Return(atx, tc.snapErr)
+			if tc.snapErr == nil {
+				atx.EXPECT().Close().Return(nil)
+			}
+
+			tc.setup(as, atx)
+			tree, err := tc.testFn(as)
+			if len(tc.wantErrStr) == 0 {
+				// Expect no error.
+				if err != nil {
+					t.Errorf("GetTree()=%v,%v, want: err=nil", tree, err)
+				}
+				if !reflect.DeepEqual(tc.wantTree, tree) {
+					t.Errorf("GetTree()=%v,%v, want: %v,nil", tree, err, tc.wantTree)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrStr) {
+					t.Errorf("GetTree()=%v,%v, want: err with: %s", tree, err, tc.wantErrStr)
+				}
+			}
+		})
+	}
+}
+
+func TestRunInAdminSnapshot(t *testing.T) {
+	tests := []struct {
+		name       string
+		snapErr    error
+		wantCommit bool
+		commitErr  error
+		wantErrStr string
+		fn         func(tx ReadOnlyAdminTX) error
+	}{
+		{
+			name:       "snap fail",
+			snapErr:    errors.New("SNAP"),
+			wantErrStr: "SNAP",
+		},
+		{
+			name: "tx err",
+			fn: func(tx ReadOnlyAdminTX) error {
+				return errors.New("TX")
+			},
+			wantErrStr: "TX",
+		},
+		{
+			name: "commit err",
+			fn: func(tx ReadOnlyAdminTX) error {
+				return nil
+			},
+			wantCommit: true,
+			commitErr:  errors.New("commit"),
+			wantErrStr: "commit",
+		},
+		{
+			name: "tx ok",
+			fn: func(tx ReadOnlyAdminTX) error {
+				return nil
+			},
+			wantCommit: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			as := NewMockAdminStorage(ctrl)
+			atx := NewMockAdminTX(ctrl)
+			as.EXPECT().Snapshot(gomock.Any()).Return(atx, tc.snapErr)
+			if tc.snapErr == nil {
+				atx.EXPECT().Close().Return(nil)
+			}
+			if tc.wantCommit {
+				atx.EXPECT().Commit().Return(tc.commitErr)
+			}
+
+			err := RunInAdminSnapshot(context.Background(), as, tc.fn)
+			if len(tc.wantErrStr) == 0 {
+				// Expect no error.
+				if err != nil {
+					t.Errorf("RunInAdminSnapshot()=%v, want: nil", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrStr) {
+					t.Errorf("RunInAdminSnapshot()=%v, want: err with: %s", err, tc.wantErrStr)
+				}
+			}
+		})
+	}
+}

--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -126,16 +126,3 @@ type AdminWriter interface {
 	// is returned.
 	UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error)
 }
-
-// RunInAdminSnapshot runs fn against a ReadOnlyAdminTX and commits if no error is returned.
-func RunInAdminSnapshot(ctx context.Context, admin AdminStorage, fn func(tx ReadOnlyAdminTX) error) error {
-	tx, err := admin.Snapshot(ctx)
-	if err != nil {
-		return err
-	}
-	defer tx.Close()
-	if err := fn(tx); err != nil {
-		return err
-	}
-	return tx.Commit()
-}


### PR DESCRIPTION
Add tests for RunInAdminSnapshot and the GetTree helper that uses it. Also convert the admin helpers
to use explicit returns. It's not quite as neat but we don't use this style elsewhere.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
