### PR TITLE
Unmarshal tree info in readTrees

### DIFF
--- a/storage/cloudspanner/admin.go
+++ b/storage/cloudspanner/admin.go
@@ -311,8 +311,12 @@ func (t *adminTX) ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64
 func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trillian.Tree, error) {
 	trees := []*trillian.Tree{}
 	err := t.readTrees(ctx, includeDeleted, false /* idOnly */, func(r *spanner.Row) error {
+		var infoBytes []byte
+		if err := r.Columns(&infoBytes); err != nil {
+			return err
+		}
 		info := &spannerpb.TreeInfo{}
-		if err := r.Columns(info); err != nil {
+		if err := proto.Unmarshal(infoBytes, info); err != nil {
 			return err
 		}
 		tree, err := toTrillianTree(info)


### PR DESCRIPTION
Properly unmarshal the treeinfo data from CloudSpanner when reading full `TreeRoot` rows via `readTrees`.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
