### PR TITLE
util/etcd: workaround for upstream cancellation problem

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -101,7 +101,7 @@ func main() {
 
 	client, err := etcd.NewClientFromString(*server.EtcdServers)
 	if err != nil {
-		glog.Exitf("Failed to connect to etcd at %v: %v", server.EtcdServers, err)
+		glog.Exitf("Failed to connect to etcd at %v: %v", *server.EtcdServers, err)
 	}
 
 	// Announce our endpoints to etcd if so configured.

--- a/testonly/integration/etcd/etcd.go
+++ b/testonly/integration/etcd/etcd.go
@@ -86,8 +86,10 @@ func StartEtcd() (e *embed.Etcd, c *clientv3.Client, cleanup func(), err error) 
 	}
 
 	c, err = clientv3.New(clientv3.Config{
-		Endpoints:   []string{e.Config().LCUrls[0].String()},
-		DialTimeout: defaultTimeout,
+		Endpoints: []string{e.Config().LCUrls[0].String()},
+		// TODO(daviddrysdale): re-enable dial timeout when upstream client code fixed
+		// for https://github.com/grpc/grpc-go/pull/2733/files#r271705181
+		// DialTimeout: defaultTimeout,
 	})
 	if err != nil {
 		cleanup()

--- a/util/etcd/client.go
+++ b/util/etcd/client.go
@@ -34,8 +34,10 @@ import (
 // the same version of etcd in external codebases. Could Go modules help?
 func NewClient(endpoints []string, dialTimeout time.Duration) (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{
-		Endpoints:   endpoints,
-		DialTimeout: dialTimeout,
+		Endpoints: endpoints,
+		// TODO(daviddrysdale): re-enable dial timeout when upstream client code fixed
+		// for https://github.com/grpc/grpc-go/pull/2733/files#r271705181
+		// DialTimeout: dialTimeout,
 	})
 }
 


### PR DESCRIPTION
Seems like https://github.com/grpc/grpc-go/pull/2733 has resulted
in behaviour where any attempt to gRPC dial with a timeout gives
a cancelled-context error.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
