### PR TITLE
storage/mysql/queue.go: Properly defer statement close in removeSequencedLeaves

### DIFF
--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -119,6 +119,7 @@ func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, leaves []dequeued
 		glog.Warningf("Failed to prep delete statement for sequenced work: %v", err)
 		return err
 	}
+	defer stx.Close()
 	for _, dql := range leaves {
 		result, err := stx.ExecContext(ctx, t.treeID, dql.queueTimestampNanos, dql.leafIdentityHash)
 		err = checkResultOkAndRowCountIs(result, err, int64(1))


### PR DESCRIPTION
Fixes a possible leak of statements in `removeSequencedLeaves` when executing the statement fails. I think I may have introduced this leak when adding the batched queue/dequeue mode, so sorry about that.

(Not sure this is a big enough change to need a mention in the changelog, but happy to add one if you folks feel otherwise!)

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
