### PR TITLE
Pre-combine child hashes before hashing [rfc6962 hasher]

### DIFF
--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -60,12 +60,26 @@ func (t *Hasher) HashLeaf(leaf []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
+// HashChildrenOld returns the inner Merkle tree node hash of the the two child nodes l and r.
 // The hashed structure is NodeHashPrefix||l||r.
-func (t *Hasher) HashChildren(l, r []byte) []byte {
+func (t *Hasher) HashChildrenOld(l, r []byte) []byte {
 	h := t.New()
 	h.Write([]byte{RFC6962NodeHashPrefix})
 	h.Write(l)
 	h.Write(r)
+	return h.Sum(nil)
+}
+
+// HashChildren returns the inner Merkle tree node hash of the the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+func (t *Hasher) HashChildren(l, r []byte) []byte {
+	h := t.New()
+	b := append(append(append(
+		make([]byte, 0, 1+len(l)+len(r)),
+		RFC6962NodeHashPrefix),
+		l...),
+		r...)
+
+	h.Write(b)
 	return h.Sum(nil)
 }

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -60,9 +60,10 @@ func (t *Hasher) HashLeaf(leaf []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// HashChildrenOld returns the inner Merkle tree node hash of the the two child nodes l and r.
+// hashChildrenOld returns the inner Merkle tree node hash of the the two child nodes l and r.
 // The hashed structure is NodeHashPrefix||l||r.
-func (t *Hasher) HashChildrenOld(l, r []byte) []byte {
+// TODO(al): Remove me.
+func (t *Hasher) hashChildrenOld(l, r []byte) []byte {
 	h := t.New()
 	h.Write([]byte{RFC6962NodeHashPrefix})
 	h.Write(l)

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -105,12 +105,13 @@ func TestRFC6962HasherCollisions(t *testing.T) {
 	}
 }
 
+// TODO(al): Remove me.
 func BenchmarkHashChildrenOld(b *testing.B) {
 	h := DefaultHasher
 	l, _ := h.HashLeaf([]byte("one"))
 	r, _ := h.HashLeaf([]byte("or other"))
 	for i := 0; i < b.N; i++ {
-		_ = h.HashChildrenOld(l, r)
+		_ = h.hashChildrenOld(l, r)
 	}
 }
 
@@ -134,7 +135,7 @@ func TestHashChildrenEquivToOld(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if oldHash, newHash := h.HashChildrenOld(l, r), h.HashChildren(l, r); !bytes.Equal(oldHash, newHash) {
+		if oldHash, newHash := h.hashChildrenOld(l, r), h.HashChildren(l, r); !bytes.Equal(oldHash, newHash) {
 			t.Errorf("%d different hashes: %x vs %x", i, oldHash, newHash)
 		}
 	}

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -16,6 +16,7 @@ package rfc6962
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	_ "github.com/golang/glog"
@@ -104,6 +105,15 @@ func TestRFC6962HasherCollisions(t *testing.T) {
 	}
 }
 
+func BenchmarkHashChildrenOld(b *testing.B) {
+	h := DefaultHasher
+	l, _ := h.HashLeaf([]byte("one"))
+	r, _ := h.HashLeaf([]byte("or other"))
+	for i := 0; i < b.N; i++ {
+		_ = h.HashChildrenOld(l, r)
+	}
+}
+
 func BenchmarkHashChildren(b *testing.B) {
 	h := DefaultHasher
 	l, _ := h.HashLeaf([]byte("one"))
@@ -111,4 +121,22 @@ func BenchmarkHashChildren(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = h.HashChildren(l, r)
 	}
+}
+
+func TestHashChildrenEquivToOld(t *testing.T) {
+	h := DefaultHasher
+	for i := 0; i < 1000; i++ {
+		l, err := h.HashLeaf([]byte(fmt.Sprintf("leaf left %d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := h.HashLeaf([]byte(fmt.Sprintf("leaf right %d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if oldHash, newHash := h.HashChildrenOld(l, r), h.HashChildren(l, r); !bytes.Equal(oldHash, newHash) {
+			t.Errorf("%d different hashes: %x vs %x", i, oldHash, newHash)
+		}
+	}
+
 }

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -103,3 +103,12 @@ func TestRFC6962HasherCollisions(t *testing.T) {
 		t.Errorf("Subtree hash does not depend on the order of leaves")
 	}
 }
+
+func BenchmarkHashChildren(b *testing.B) {
+	h := DefaultHasher
+	l, _ := h.HashLeaf([]byte("one"))
+	r, _ := h.HashLeaf([]byte("or other"))
+	for i := 0; i < b.N; i++ {
+		_ = h.HashChildren(l, r)
+	}
+}


### PR DESCRIPTION
Creates a single buffer for domain separator and child hashes, and calls `hasher.Write` with it, rather than calling `Write` multiple times.

This seems to be roughly 20% faster.

go test --bench=. --benchtime=20s
goos: linux
goarch: amd64
pkg: github.com/google/trillian/merkle/rfc6962
BenchmarkHashChildrenOld-6   	20000000	      1471 ns/op
BenchmarkHashChildren-6      	30000000	      1172 ns/op
PASS
ok  	github.com/google/trillian/merkle/rfc6962	67.312s


### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
