### PR TITLE
Introduce Compact Range data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,10 +160,13 @@ until process exit if any error occurred.
 gometalinter has been replaced with golangci-lint for improved performance and
 Go module support.
 
-### CompactMerkleTree moved
+### Compact Merkle tree data structures
 
 The CompactMerkleTree has been moved from `github.com/google/trillian/merkle` to
 `github.com/google/trillian/merkle/compact` and renamed `Tree`.
+
+A new powerful data structure named Compact Range has been added to the same
+package. It is a generalization of the previous compact Merkle tree structure.
 
 ### Storage API changes
 

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -1,0 +1,260 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compact
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+// HashFn computes a node's hash using the hashes of its child nodes.
+type HashFn func(left, right []byte) []byte
+
+// VisitFn visits the (level, index) node with the specified hash. The level is
+// the distance from the node down to the leaves, and index is its horizontal
+// position within the level. For example, see the diagram below where the
+// nodes of a 4-leaves tree are numbered with [<level> <index>] labels.
+//
+//            [2 0]
+//           /     \
+//        [1 0]   [1 1]
+//       /   \     /   \
+//   [0 0] [0 1] [0 2] [0 3]
+type VisitFn func(level uint, index uint64, hash []byte)
+
+// Factory allows creating compact ranges with the specified hash function,
+// which must not be nil, and must not be changed.
+type Factory struct {
+	Hash HashFn
+}
+
+// NewRange creates a Range for [begin, end) with the given set of hashes. The
+// hashes correspond to the roots of the minimal set of perfect sub-trees
+// covering the [begin, end) leaves range, ordered left to right.
+func (f *Factory) NewRange(begin, end uint64, hashes [][]byte) (*Range, error) {
+	if end < begin {
+		return nil, fmt.Errorf("invalid range: end=%d, want >= %d", end, begin)
+	}
+	left, right := decompose(begin, end)
+	ones := bits.OnesCount64(left) + bits.OnesCount64(right)
+	if ln := len(hashes); ln != ones {
+		return nil, fmt.Errorf("invalid hashes: got %d values, want %d", ln, ones)
+	}
+	return &Range{f: f, begin: begin, end: end, hashes: hashes}, nil
+}
+
+// NewEmptyRange returns a new Range for an empty [begin, begin) range. The
+// value of begin defines where the range will start growing from when entries
+// are appended to it.
+func (f *Factory) NewEmptyRange(begin uint64) *Range {
+	return &Range{f: f, begin: begin, end: begin}
+}
+
+// Range represents a compact Merkle tree range for leaf indices [begin, end).
+//
+// It contains the minimal set of perfect subtrees whose leaves comprise this
+// range. The structure is efficiently mergeable with with other compact ranges
+// that share one of the endpoints with it.
+//
+// TODO(pavelkalinnikov): Add document with more details on how it works, and
+// what it can be used for.
+type Range struct {
+	f      *Factory
+	begin  uint64
+	end    uint64
+	hashes [][]byte
+}
+
+// Begin returns the first index covered by the range (inclusive).
+func (r *Range) Begin() uint64 {
+	return r.begin
+}
+
+// End returns the last index covered by the range (exclusive).
+func (r *Range) End() uint64 {
+	return r.end
+}
+
+// Hashes returns sub-tree hashes corresponding to the minimal set of perfect
+// sub-trees covering the [begin, end) range, ordered left to right.
+func (r *Range) Hashes() [][]byte {
+	return r.hashes
+}
+
+// Append extends the compact range by appending the passed in hash to it. It
+// uses the tree hasher to calculate hashes of newly created nodes, and reports
+// them through the visitor function (if non-nil).
+func (r *Range) Append(hash []byte, visitor VisitFn) error {
+	return r.appendImpl(r.end+1, hash, nil, visitor)
+}
+
+// AppendRange extends the compact range by merging in the other compact range
+// from the right. It uses the tree hasher to calculate hashes of newly created
+// nodes, and reports them through the visitor function (if non-nil).
+func (r *Range) AppendRange(other *Range, visitor VisitFn) error {
+	if other.f != r.f {
+		return errors.New("incompatible ranges")
+	}
+	if got, want := other.begin, r.end; got != want {
+		return fmt.Errorf("ranges are disjoint: other.begin=%d, want %d", got, want)
+	}
+	if len(other.hashes) == 0 { // The other range is empty, merging is trivial.
+		return nil
+	}
+	return r.appendImpl(other.end, other.hashes[0], other.hashes[1:], visitor)
+}
+
+// GetRootHash returns the root hash of the Merkle tree represented by
+// this compact range. Requires the range to start at index 0. If the
+// range is empty, returns nil.
+func (r *Range) GetRootHash() ([]byte, error) {
+	if r.begin != 0 {
+		return nil, fmt.Errorf("begin=%d, want 0", r.begin)
+	}
+	ln := len(r.hashes)
+	if ln == 0 {
+		return nil, nil
+	}
+	hash := r.hashes[ln-1]
+	for i := ln - 2; i >= 0; i-- {
+		hash = r.f.Hash(r.hashes[i], hash)
+	}
+	return hash, nil
+}
+
+// Equal compares two Range for equality.
+func (r *Range) Equal(other *Range) bool {
+	if r.f != other.f || r.begin != other.begin || r.end != other.end {
+		return false
+	}
+	if len(r.hashes) != len(other.hashes) {
+		return false
+	}
+	for i := range r.hashes {
+		if !bytes.Equal(r.hashes[i], other.hashes[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// appendImpl extends the compact range by merging the [r.end, end) compact
+// range into it. The other compact range is decomposed into a seed hash and
+// all the other hashes (possibly none). The method uses the tree hasher to
+// calculate hashes of newly created nodes, and reports them through the
+// visitor function (if non-nil).
+func (r *Range) appendImpl(end uint64, seed []byte, hashes [][]byte, visitor VisitFn) error {
+	// Bits [low, high) of r.end encode the merge path, i.e. the sequence of node
+	// merges that transforms the two compact ranges into one.
+	low, high := getMergePath(r.begin, r.end, end)
+	if high < low {
+		high = low
+	}
+	index := r.end >> low
+	// Now bits [0, high-low) of index encode the merge path.
+
+	// The number of one bits in index is the number of nodes from the left range
+	// that will be merged, and zero bits correspond to the nodes in the right
+	// range. Below we make sure that both ranges have enough hashes, which can
+	// be false only in case the data is corrupted in some way.
+	ones := bits.OnesCount64(index & (1<<(high-low) - 1))
+	if ln := len(r.hashes); ln < ones {
+		return fmt.Errorf("corrupted lhs range: got %d hashes, want >= %d", ln, ones)
+	}
+	if ln, zeros := len(hashes), int(high-low)-ones; ln < zeros {
+		return fmt.Errorf("corrupted rhs range: got %d hashes, want >= %d", ln+1, zeros+1)
+	}
+
+	// Some of the trailing nodes of the left compact range, and some of the
+	// leading nodes of the right range, are sequentially merged with the seed,
+	// according to the mask. All new nodes are reported through the visitor.
+	idx1, idx2 := len(r.hashes), 0
+	for h := low; h < high; h++ {
+		if index&1 == 0 {
+			seed = r.f.Hash(seed, hashes[idx2])
+			idx2++
+		} else {
+			idx1--
+			seed = r.f.Hash(r.hashes[idx1], seed)
+		}
+		index >>= 1
+		if visitor != nil {
+			visitor(h+1, index, seed)
+		}
+	}
+
+	// All nodes from both ranges that have not been merged are bundled together
+	// with the "merged" seed node.
+	r.hashes = append(append(r.hashes[:idx1], seed), hashes[idx2:]...)
+	r.end = end
+	return nil
+}
+
+// getMergePath returns the merging path between the compact range [begin, mid)
+// and [mid, end). The path is represented as a submask of mid, with bit
+// indices [low, high). A bit value of 1 on level i of mid means that the node
+// on this level merges with the corresponding node in the left compact range,
+// whereas 0 represents merging with the right compact range. If the path is
+// empty then high <= low.
+//
+// The output is not specified if begin <= mid <= end doesn't hold, but the
+// function never panics.
+func getMergePath(begin, mid, end uint64) (uint, uint) {
+	low := bits.TrailingZeros64(mid)
+	high := 64
+	if begin != 0 {
+		high = bits.Len64(mid ^ (begin - 1))
+	}
+	if high2 := bits.Len64((mid - 1) ^ end); high2 < high {
+		high = high2
+	}
+	return uint(low), uint(high - 1)
+}
+
+// decompose splits the [begin, end) range into a minimal number of sub-ranges,
+// each of which is of the form [m * 2^k, (m+1) * 2^k), i.e. of length 2^k, for
+// some integers m, k >= 0.
+//
+// The sequence of sizes is returned encoded as bitmasks left and right, where:
+//  - a 1 bit in a bitmask denotes a sub-range of the corresponding size 2^k
+//  - left mask bits in LSB-to-MSB order encode the left part of the sequence
+//  - right mask bits in MSB-to-LSB order encode the right part
+//
+// The corresponding values of m are not returned (they can be calculated from
+// begin and the sub-range sizes).
+//
+// For example, (left,right) values of 0b101, 0b1001 would indicate a sequence
+// of tree sizes: 1,4; 8,1.
+//
+// The output is not specified if begin > end, but the function never panics.
+func decompose(begin, end uint64) (uint64, uint64) {
+	// Special case, as the code below works only if begin != 0, or end < 2^63.
+	if begin == 0 {
+		return 0, end
+	}
+	xbegin := begin - 1
+	// Find where paths to leaves #begin-1 and #end diverge, and mask the upper
+	// bits away, as only the nodes strictly below this point are in the range.
+	d := bits.Len64(xbegin^end) - 1
+	mask := uint64(1)<<uint(d) - 1
+	// The left part of the compact range consists of all nodes strictly below
+	// and to the right from the path to leaf #begin-1, corresponding to zero
+	// bits in the masked part of begin-1. Likewise, the right part consists of
+	// nodes below and to the left from the path to leaf #end, corresponding to
+	// ones in the masked part of end.
+	return ^xbegin & mask, end & mask
+}

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -36,16 +36,16 @@ type HashFn func(left, right []byte) []byte
 //   [0 0] [0 1] [0 2] [0 3]
 type VisitFn func(level uint, index uint64, hash []byte)
 
-// Factory allows creating compact ranges with the specified hash function,
-// which must not be nil, and must not be changed.
-type Factory struct {
+// RangeFactory allows creating compact ranges with the specified hash
+// function, which must not be nil, and must not be changed.
+type RangeFactory struct {
 	Hash HashFn
 }
 
 // NewRange creates a Range for [begin, end) with the given set of hashes. The
 // hashes correspond to the roots of the minimal set of perfect sub-trees
 // covering the [begin, end) leaves range, ordered left to right.
-func (f *Factory) NewRange(begin, end uint64, hashes [][]byte) (*Range, error) {
+func (f *RangeFactory) NewRange(begin, end uint64, hashes [][]byte) (*Range, error) {
 	if end < begin {
 		return nil, fmt.Errorf("invalid range: end=%d, want >= %d", end, begin)
 	}
@@ -60,7 +60,7 @@ func (f *Factory) NewRange(begin, end uint64, hashes [][]byte) (*Range, error) {
 // NewEmptyRange returns a new Range for an empty [begin, begin) range. The
 // value of begin defines where the range will start growing from when entries
 // are appended to it.
-func (f *Factory) NewEmptyRange(begin uint64) *Range {
+func (f *RangeFactory) NewEmptyRange(begin uint64) *Range {
 	return &Range{f: f, begin: begin, end: begin}
 }
 
@@ -73,7 +73,7 @@ func (f *Factory) NewEmptyRange(begin uint64) *Range {
 // TODO(pavelkalinnikov): Add document with more details on how it works, and
 // what it can be used for.
 type Range struct {
-	f      *Factory
+	f      *RangeFactory
 	begin  uint64
 	end    uint64
 	hashes [][]byte

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -21,7 +21,7 @@ import (
 	"math/bits"
 )
 
-// HashFn computes a node's hash using the hashes of its child nodes.
+// HashFn computes an internal node's hash using the hashes of its child nodes.
 type HashFn func(left, right []byte) []byte
 
 // VisitFn visits the (level, index) node with the specified hash. The level is
@@ -136,7 +136,7 @@ func (r *Range) GetRootHash() ([]byte, error) {
 	return hash, nil
 }
 
-// Equal compares two Range for equality.
+// Equal compares two Ranges for equality.
 func (r *Range) Equal(other *Range) bool {
 	if r.f != other.f || r.begin != other.begin || r.end != other.end {
 		return false
@@ -205,11 +205,11 @@ func (r *Range) appendImpl(end uint64, seed []byte, hashes [][]byte, visitor Vis
 }
 
 // getMergePath returns the merging path between the compact range [begin, mid)
-// and [mid, end). The path is represented as a submask of mid, with bit
-// indices [low, high). A bit value of 1 on level i of mid means that the node
-// on this level merges with the corresponding node in the left compact range,
-// whereas 0 represents merging with the right compact range. If the path is
-// empty then high <= low.
+// and [mid, end). The path is represented as a range of bits within mid, with
+// bit indices [low, high). A bit value of 1 on level i of mid means that the
+// node on this level merges with the corresponding node in the left compact
+// range, whereas 0 represents merging with the right compact range. If the
+// path is empty then high <= low.
 //
 // The output is not specified if begin <= mid <= end doesn't hold, but the
 // function never panics.
@@ -237,8 +237,8 @@ func getMergePath(begin, mid, end uint64) (uint, uint) {
 // The corresponding values of m are not returned (they can be calculated from
 // begin and the sub-range sizes).
 //
-// For example, (left,right) values of 0b101, 0b1001 would indicate a sequence
-// of tree sizes: 1,4; 8,1.
+// For example, (begin, end) values of (0b110, 0b11101) would indicate a
+// sequence of tree sizes: 2,8; 8,4,1.
 //
 // The output is not specified if begin > end, but the function never panics.
 func decompose(begin, end uint64) (uint64, uint64) {

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	hashChildren = rfc6962.DefaultHasher.HashChildren
-	factory      = &Factory{Hash: hashChildren}
+	factory      = &RangeFactory{Hash: hashChildren}
 )
 
 // treeNode represents a Merkle tree node which roots a full binary subtree.
@@ -296,7 +296,7 @@ func TestNewRange(t *testing.T) {
 }
 
 func TestAppendRangeErrors(t *testing.T) {
-	anotherFactory := &Factory{Hash: hashChildren}
+	anotherFactory := &RangeFactory{Hash: hashChildren}
 	nonEmpty1, _ := factory.NewRange(7, 8, [][]byte{[]byte("hash")})
 	nonEmpty2, _ := factory.NewRange(0, 6, [][]byte{[]byte("hash0"), []byte("hash1")})
 	nonEmpty3, _ := factory.NewRange(6, 7, [][]byte{[]byte("hash")})
@@ -513,7 +513,7 @@ func TestEqual(t *testing.T) {
 				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
 			},
 			rhs: &Range{
-				f:      &Factory{Hash: hashChildren},
+				f:      &RangeFactory{Hash: hashChildren},
 				begin:  17,
 				end:    23,
 				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -1,0 +1,625 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compact
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/trillian/merkle/rfc6962"
+)
+
+var (
+	hashChildren = rfc6962.DefaultHasher.HashChildren
+	factory      = &Factory{Hash: hashChildren}
+)
+
+// treeNode represents a Merkle tree node which roots a full binary subtree.
+type treeNode struct {
+	hash   []byte // The Merkle hash of the subtree.
+	visits int    // The number of times this node was visited.
+}
+
+// tree contains a static Merkle tree, for testing.
+type tree struct {
+	size  uint64       // The number of leaves.
+	nodes [][]treeNode // All perfect subtrees indexed by (level, index).
+}
+
+// newTree creates a new Merkle tree of the given size.
+func newTree(t *testing.T, size uint64) (*tree, VisitFn) {
+	levels := bits.Len64(size)
+	// Allocate the nodes.
+	nodes := make([][]treeNode, levels)
+	tr := &tree{size: size, nodes: nodes}
+	// Attach a visitor to the nodes and the testing handler.
+	visit := func(level uint, index uint64, hash []byte) {
+		if err := tr.visit(level, index, hash); err != nil {
+			t.Errorf("visit(%d,%d): %v", level, index, err)
+		}
+	}
+
+	for lvl := range nodes {
+		nodes[lvl] = make([]treeNode, size>>uint(lvl))
+	}
+	// Compute leaf hashes.
+	for i := uint64(0); i < size; i++ {
+		nodes[0][i].hash = hashLeaf([]byte(fmt.Sprintf("data: %d", i)))
+	}
+	// Compute internal node hashes.
+	for lvl := 1; lvl < levels; lvl++ {
+		for i := range nodes[lvl] {
+			nodes[lvl][i].hash = hashChildren(nodes[lvl-1][i*2].hash, nodes[lvl-1][i*2+1].hash)
+		}
+	}
+
+	return tr, visit
+}
+
+// rootHash returns a canonical hash of the whole (possibly imperfect) tree.
+func (tr *tree) rootHash() []byte {
+	var hash []byte
+	for _, level := range tr.nodes {
+		if len(level)%2 == 1 {
+			root := level[len(level)-1].hash
+			if hash == nil {
+				hash = root
+			} else {
+				hash = hashChildren(root, hash)
+			}
+		}
+	}
+	return hash
+}
+
+func (tr *tree) leaf(index uint64) []byte {
+	return tr.nodes[0][index].hash
+}
+
+func (tr *tree) visit(level uint, index uint64, hash []byte) error {
+	if level >= uint(len(tr.nodes)) || index >= uint64(len(tr.nodes[level])) {
+		return errors.New("node does not exist")
+	}
+	tr.nodes[level][index].visits++
+	if want := tr.nodes[level][index].hash; !bytes.Equal(hash, want) {
+		return fmt.Errorf("hash mismatch: got %08x, want %08x", shorten(hash), shorten(want))
+	}
+	return nil
+}
+
+// verifyRange checks that the compact range's hashes match the tree.
+func (tr *tree) verifyRange(t *testing.T, r *Range, wantMatch bool) {
+	t.Helper()
+	pos := r.Begin()
+	if r.End() > tr.size {
+		t.Fatalf("range is too long: %d > %d", r.End(), tr.size)
+	}
+
+	// Naively build the expected list of hashes comprising the compact range.
+	left, right := decompose(pos, r.End())
+	var hashes [][]byte
+	for lvl := uint(0); lvl < 64; lvl++ {
+		if left&(1<<lvl) != 0 {
+			hashes = append(hashes, tr.nodes[lvl][pos>>lvl].hash)
+			pos += 1 << lvl
+		}
+	}
+	for lvl := uint(63); lvl < 64; lvl-- { // Overflows on the last iteration.
+		if right&(1<<lvl) != 0 {
+			hashes = append(hashes, tr.nodes[lvl][pos>>lvl].hash)
+			pos += 1 << lvl
+		}
+	}
+
+	if pos != r.End() {
+		t.Fatalf("decompose: range [%d,%d) is not covered; end=%d", r.Begin(), r.End(), pos)
+	}
+	if match := reflect.DeepEqual(r.Hashes(), hashes); match != wantMatch {
+		t.Errorf("hashes match: %v, expected %v", match, wantMatch)
+	}
+}
+
+// verifyAllVisited checks that all nodes of the tree are visited exactly once.
+// This is to verify the efficiency property of compact ranges: any merging
+// process resulting in a single range generates *all* internal nodes, and each
+// node is generated only once.
+func (tr *tree) verifyAllVisited(t *testing.T, r *Range) {
+	t.Helper()
+	if r.Begin() != 0 || r.End() != tr.size {
+		t.Errorf("range mismatch: got [%d,%d), want [%d,%d)", r.Begin(), r.End(), 0, tr.size)
+	}
+	for lvl, level := range tr.nodes {
+		for index, node := range level {
+			if got, want := node.visits, 1; got != want {
+				t.Errorf("Node (%d,%d) visited %d times, want %d", lvl, index, got, want)
+			}
+		}
+	}
+}
+
+// Merge up from [0,0) to [0, 177) by appending single entries.
+func TestMergeForward(t *testing.T) {
+	const numNodes = uint64(177)
+	tree, visit := newTree(t, numNodes)
+	rng := factory.NewEmptyRange(0)
+	tree.verifyRange(t, rng, true)
+	for i := uint64(0); i < numNodes; i++ {
+		visit(0, i, tree.leaf(i))
+		rng.Append(tree.leaf(i), visit)
+		tree.verifyRange(t, rng, true)
+	}
+	tree.verifyAllVisited(t, rng)
+}
+
+// Merge down from [339,340) to [0,340) by prepending single entries.
+func TestMergeBackwards(t *testing.T) {
+	const numNodes = uint64(340)
+	tree, visit := newTree(t, numNodes)
+	rng := factory.NewEmptyRange(numNodes)
+	tree.verifyRange(t, rng, true)
+	for i := numNodes; i > 0; i-- {
+		visit(0, i-1, tree.leaf(i-1))
+		prepend := factory.NewEmptyRange(i - 1)
+		tree.verifyRange(t, prepend, true)
+		prepend.Append(tree.leaf(i-1), visit)
+		tree.verifyRange(t, prepend, true)
+		if err := prepend.AppendRange(rng, visit); err != nil {
+			t.Fatalf("AppendRange: %v", err)
+		}
+		rng = prepend
+		tree.verifyRange(t, rng, true)
+	}
+	tree.verifyAllVisited(t, rng)
+}
+
+// Build ranges [0, 13), [13, 26), ... [208,220) by appending single entries to
+// each. Then append those ranges one by one to [0,0), to get [0,220).
+func TestMergeInBatches(t *testing.T) {
+	const numNodes = uint64(220)
+	const batch = uint64(13)
+	tree, visit := newTree(t, numNodes)
+
+	batches := make([]*Range, 0)
+	// Merge all the nodes within the batches.
+	for i := uint64(0); i < numNodes; i += batch {
+		rng := factory.NewEmptyRange(i)
+		tree.verifyRange(t, rng, true)
+		for node := i; node < i+batch && node < numNodes; node++ {
+			visit(0, node, tree.leaf(node))
+			if err := rng.Append(tree.leaf(node), visit); err != nil {
+				t.Fatalf("Append: %v", err)
+			}
+			tree.verifyRange(t, rng, true)
+		}
+		batches = append(batches, rng)
+	}
+
+	total := factory.NewEmptyRange(0)
+	// Merge the batches.
+	for _, batch := range batches {
+		if err := total.AppendRange(batch, visit); err != nil {
+			t.Fatalf("AppendRange: %v", err)
+		}
+		tree.verifyRange(t, total, true)
+	}
+	tree.verifyAllVisited(t, total)
+}
+
+// Build many trees of random size by randomly merging their sub-ranges.
+func TestMergeRandomly(t *testing.T) {
+	for seed := int64(1); seed < 100; seed++ {
+		t.Run(fmt.Sprintf("seed:%d", seed), func(t *testing.T) {
+			rnd := rand.New(rand.NewSource(seed))
+			numNodes := rand.Uint64() % 500
+			t.Logf("Tree size: %d", numNodes)
+
+			tree, visit := newTree(t, numNodes)
+			var mergeAll func(begin, end uint64) *Range // Enable recursion.
+			mergeAll = func(begin, end uint64) *Range {
+				rng := factory.NewEmptyRange(begin)
+				if begin+1 == end {
+					visit(0, begin, tree.leaf(begin))
+					if err := rng.Append(tree.leaf(begin), visit); err != nil {
+						t.Fatalf("Append(%d): %v", begin, err)
+					}
+				} else if begin < end {
+					mid := begin + uint64(rnd.Int63n(int64(end-begin)))
+					if err := rng.AppendRange(mergeAll(begin, mid), visit); err != nil {
+						t.Fatalf("AppendRange(%d,%d): %v", begin, mid, err)
+					}
+					if err := rng.AppendRange(mergeAll(mid, end), visit); err != nil {
+						t.Fatalf("AppendRange(%d,%d): %v", mid, end, err)
+					}
+				}
+				tree.verifyRange(t, rng, true)
+				return rng
+			}
+			rng := mergeAll(0, numNodes)
+			tree.verifyAllVisited(t, rng)
+		})
+	}
+}
+
+func TestNewRange(t *testing.T) {
+	const numNodes = uint64(123)
+	tree, visit := newTree(t, numNodes)
+	rng := factory.NewEmptyRange(0)
+	for i := uint64(0); i < numNodes; i++ {
+		rng.Append(tree.leaf(i), visit)
+	}
+
+	if _, err := factory.NewRange(10, 5, nil); err == nil {
+		t.Error("NewRange succeeded unexpectedly")
+	}
+
+	rng1, err := factory.NewRange(rng.Begin(), rng.End(), rng.Hashes())
+	if err != nil {
+		t.Fatalf("NewRange: %v", err)
+	}
+	tree.verifyRange(t, rng1, true)
+
+	// The number of hashes is incorrect.
+	_, err = factory.NewRange(rng.Begin(), rng.End(), append(rng.Hashes(), nil))
+	if err == nil {
+		t.Error("NewRange succeeded unexpectedly")
+	}
+	// The number of hashes does not correspond to the range.
+	_, err = factory.NewRange(rng.Begin(), rng.End()-1, rng.Hashes())
+	if err == nil {
+		t.Error("NewRange succeeded unexpectedly")
+	}
+
+	rng.Hashes()[0][0] ^= 1 // Corrupt the original hashes.
+	rng1, err = factory.NewRange(rng.Begin(), rng.End(), rng.Hashes())
+	if err != nil {
+		t.Fatalf("NewRange: %v", err)
+	}
+	tree.verifyRange(t, rng1, false)
+}
+
+func TestAppendRangeErrors(t *testing.T) {
+	anotherFactory := &Factory{Hash: hashChildren}
+	nonEmpty1, _ := factory.NewRange(7, 8, [][]byte{[]byte("hash")})
+	nonEmpty2, _ := factory.NewRange(0, 6, [][]byte{[]byte("hash0"), []byte("hash1")})
+	nonEmpty3, _ := factory.NewRange(6, 7, [][]byte{[]byte("hash")})
+	corrupt := func(rng *Range, dBegin, dEnd int64) *Range {
+		rng.begin = uint64(int64(rng.begin) + dBegin)
+		rng.end = uint64(int64(rng.end) + dEnd)
+		return rng
+	}
+	for _, tc := range []struct {
+		desc    string
+		l, r    *Range
+		wantErr string
+	}{
+		{
+			desc: "ok",
+			l:    factory.NewEmptyRange(0),
+			r:    factory.NewEmptyRange(0),
+		},
+		{
+			desc:    "incompatible",
+			l:       factory.NewEmptyRange(0),
+			r:       anotherFactory.NewEmptyRange(0),
+			wantErr: "incompatible ranges",
+		},
+		{
+			desc:    "disjoint",
+			l:       factory.NewEmptyRange(0),
+			r:       factory.NewEmptyRange(1),
+			wantErr: "ranges are disjoint",
+		},
+		{
+			desc:    "left_corrupted",
+			l:       corrupt(factory.NewEmptyRange(7), -7, 0),
+			r:       nonEmpty1,
+			wantErr: "corrupted lhs range",
+		},
+		{
+			desc:    "right_corrupted",
+			l:       nonEmpty2,
+			r:       corrupt(nonEmpty3, 0, 20),
+			wantErr: "corrupted rhs range",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.l.AppendRange(tc.r, nil)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("AppendRange: %v; want nil", err)
+				}
+			} else if err == nil || !strings.HasPrefix(err.Error(), tc.wantErr) {
+				t.Fatalf("AppendRange: %v; want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetRootHash(t *testing.T) {
+	for size := uint64(0); size < 16; size++ {
+		t.Run(fmt.Sprintf("size:%d", size), func(t *testing.T) {
+			tree, _ := newTree(t, size)
+			rng := factory.NewEmptyRange(0)
+			for i := uint64(0); i < size; i++ {
+				rng.Append(tree.leaf(i), nil)
+			}
+			root, err := rng.GetRootHash()
+			if err != nil {
+				t.Fatalf("GetRootHash: %v", err)
+			}
+			if want := tree.rootHash(); !bytes.Equal(root, want) {
+				t.Fatalf("GetRootHash: got %08x, want %08x", shorten(root), shorten(want))
+			}
+		})
+	}
+
+	// Should accept only [0, N) ranges.
+	rng := factory.NewEmptyRange(10)
+	if _, err := rng.GetRootHash(); err == nil {
+		t.Error("GetRootHash succeeded unexpectedly")
+	}
+}
+
+func TestDecomposeCases(t *testing.T) {
+	for _, tc := range []struct {
+		begin, end   uint64
+		wantL, wantR uint64
+	}{
+		{begin: 0, end: 0, wantL: 0x00, wantR: 0x00},   // subtree sizes [],[]
+		{begin: 0, end: 2, wantL: 0x00, wantR: 0x02},   // subtree sizes [], [2]
+		{begin: 0, end: 4, wantL: 0x00, wantR: 0x04},   // subtree sizes [], [4]
+		{begin: 1, end: 3, wantL: 0x01, wantR: 0x01},   // subtree sizes [1], [1]
+		{begin: 3, end: 7, wantL: 0x01, wantR: 0x03},   // subtree sizes [1], [2, 1]
+		{begin: 3, end: 17, wantL: 0x0d, wantR: 0x01},  // subtree sizes [1, 4, 8], [1]
+		{begin: 4, end: 28, wantL: 0x0c, wantR: 0x0c},  // subtree sizes [4, 8], [8, 4]
+		{begin: 8, end: 24, wantL: 0x08, wantR: 0x08},  // subtree sizes [8], [8]
+		{begin: 8, end: 28, wantL: 0x08, wantR: 0x0c},  // subtree sizes [8], [8, 4]
+		{begin: 11, end: 25, wantL: 0x05, wantR: 0x09}, // subtree sizes [1, 4], [8, 1]
+		{begin: 31, end: 45, wantL: 0x01, wantR: 0x0d}, // subtree sizes [1], [8, 4, 1]
+	} {
+		t.Run(fmt.Sprintf("[%d,%d)", tc.begin, tc.end), func(t *testing.T) {
+			gotL, gotR := decompose(tc.begin, tc.end)
+			if gotL != tc.wantL || gotR != tc.wantR {
+				t.Errorf("decompose(%d,%d)=0b%b,0b%b, want 0b%b,0b%b", tc.begin, tc.end, gotL, gotR, tc.wantL, tc.wantR)
+			}
+		})
+	}
+}
+
+func verifyDecompose(begin, end uint64) error {
+	left, right := decompose(begin, end)
+	// Smoke test the sum of decomposition masks.
+	if left+right != uint64(end-begin) {
+		return fmt.Errorf("%d+%d != %d-%d", left, right, begin, end)
+	}
+
+	pos := begin
+	for lvl := uint(0); lvl < 64; lvl++ {
+		if size := uint64(1) << lvl; left&size != 0 {
+			if pos%size != 0 {
+				return fmt.Errorf("left: level %d not aligned", lvl)
+			}
+			pos += size
+		}
+	}
+	for lvl := uint(63); lvl < 64; lvl-- { // Overflows on the last iteration.
+		if size := uint64(1) << lvl; right&size != 0 {
+			if pos%size != 0 {
+				return fmt.Errorf("right: level %d not aligned", lvl)
+			}
+			pos += size
+		}
+	}
+	if pos != end {
+		return fmt.Errorf("decomposition covers up to %d, want %d", pos, end)
+	}
+	return nil
+}
+
+func TestDecompose(t *testing.T) {
+	const n = uint64(100)
+	for i := uint64(0); i <= n; i++ {
+		for j := i; j <= n; j++ {
+			if err := verifyDecompose(i, j); err != nil {
+				t.Fatalf("verifyDecompose(%d,%d): %v", i, j, err)
+			}
+		}
+	}
+}
+
+func TestDecomposePow2(t *testing.T) {
+	for p := 0; p < 64; p++ {
+		t.Run(fmt.Sprintf("2^%d", p), func(t *testing.T) {
+			end := uint64(1) << uint(p)
+			if err := verifyDecompose(0, end); err != nil {
+				t.Fatalf("verifyDecompose(%d,%d): %v", 0, end, err)
+			}
+			end += end - 1
+			if err := verifyDecompose(0, end); err != nil {
+				t.Fatalf("verifyDecompose(%d,%d): %v", 0, end, err)
+			}
+		})
+	}
+}
+
+func TestGetMergePath(t *testing.T) {
+	for _, tc := range []struct {
+		begin, mid, end uint64
+		wantLow         uint
+		wantHigh        uint
+		wantEmpty       bool
+	}{
+		{begin: 0, mid: 0, end: 0, wantEmpty: true},
+		{begin: 0, mid: 0, end: 1, wantEmpty: true},
+		{begin: 0, mid: 0, end: uint64(1) << 63, wantEmpty: true},
+		{begin: 0, mid: 1, end: 1, wantEmpty: true},
+		{begin: 0, mid: 1, end: 2, wantLow: 0, wantHigh: 1},
+		{begin: 0, mid: 16, end: 32, wantLow: 4, wantHigh: 5},
+		{begin: 0, mid: uint64(1) << 63, end: ^uint64(0), wantEmpty: true},
+		{begin: 0, mid: uint64(1) << 63, end: uint64(1)<<63 + 100500, wantEmpty: true},
+		{begin: 2, mid: 9, end: 13, wantLow: 0, wantHigh: 2},
+		{begin: 6, mid: 13, end: 17, wantLow: 0, wantHigh: 3},
+		{begin: 4, mid: 8, end: 16, wantEmpty: true},
+		{begin: 8, mid: 12, end: 16, wantLow: 2, wantHigh: 3},
+		{begin: 4, mid: 6, end: 12, wantLow: 1, wantHigh: 2},
+		{begin: 8, mid: 10, end: 16, wantLow: 1, wantHigh: 3},
+		{begin: 11, mid: 17, end: 27, wantLow: 0, wantHigh: 3},
+		{begin: 11, mid: 16, end: 27, wantEmpty: true},
+	} {
+		t.Run(fmt.Sprintf("%d:%d:%d", tc.begin, tc.mid, tc.end), func(t *testing.T) {
+			low, high := getMergePath(tc.begin, tc.mid, tc.end)
+			if tc.wantEmpty {
+				if low < high {
+					t.Fatalf("getMergePath(%d,%d,%d)=%d,%d; want empty", tc.begin, tc.mid, tc.end, low, high)
+				}
+			} else if low != tc.wantLow || high != tc.wantHigh {
+				t.Fatalf("getMergePath(%d,%d,%d)=%d,%d; want %d,%d", tc.begin, tc.mid, tc.end, low, high, tc.wantLow, tc.wantHigh)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		lhs       *Range
+		rhs       *Range
+		wantEqual bool
+	}{
+		{
+			desc: "incompatible trees",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      &Factory{Hash: hashChildren},
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal begin",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  18,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal end",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    24,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal number of hashes",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1")},
+			},
+		},
+
+		{
+			desc: "mismatched hash",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("not hash 2")},
+			},
+		},
+
+		{
+			desc: "equal ranges",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			wantEqual: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if got, want := test.lhs.Equal(test.rhs), test.wantEqual; got != want {
+				t.Errorf("%+v.Equal(%+v) = %v, want %v", test.lhs, test.rhs, got, want)
+			}
+		})
+	}
+}
+
+func hashLeaf(data []byte) []byte {
+	hash, err := rfc6962.DefaultHasher.HashLeaf(data)
+	if err != nil {
+		panic(fmt.Sprintf("rfc6962: HashLeaf: %v", err))
+	}
+	return hash
+}
+
+func shorten(hash []byte) []byte {
+	if len(hash) < 4 {
+		return hash
+	}
+	return hash[:4]
+}

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/google/trillian/testonly"
 )
 
 var (
@@ -375,6 +376,47 @@ func TestGetRootHash(t *testing.T) {
 	rng := factory.NewEmptyRange(10)
 	if _, err := rng.GetRootHash(); err == nil {
 		t.Error("GetRootHash succeeded unexpectedly")
+	}
+}
+
+func TestGetRootHashGolden(t *testing.T) {
+	// TODO(pavelkalinnikov): Values are copied from tree_test. Commonize them.
+	for _, tc := range []struct {
+		size     int
+		wantRoot []byte
+	}{
+		{10, testonly.MustDecodeBase64("VjWMPSYNtCuCNlF/RLnQy6HcwSk6CIipfxm+hettA+4=")},
+		{15, testonly.MustDecodeBase64("j4SulYmocFuxdeyp12xXCIgK6PekBcxzAIj4zbQzNEI=")},
+		{16, testonly.MustDecodeBase64("c+4Uc6BCMOZf/v3NZK1kqTUJe+bBoFtOhP+P3SayKRE=")},
+		{100, testonly.MustDecodeBase64("dUh9hYH88p0CMoHkdr1wC2szbhcLAXOejWpINIooKUY=")},
+		{255, testonly.MustDecodeBase64("SmdsuKUqiod3RX2jyF2M6JnbdE4QuTwwipfAowI4/i0=")},
+		{256, testonly.MustDecodeBase64("qFI0t/tZ1MdOYgyPpPzHFiZVw86koScXy9q3FU5casA=")},
+		{1000, testonly.MustDecodeBase64("RXrgb8xHd55Y48FbfotJwCbV82Kx22LZfEbmBGAvwlQ=")},
+		{4095, testonly.MustDecodeBase64("cWRFdQhPcjn9WyBXE/r1f04ejxIm5lvg40DEpRBVS0w=")},
+		{4096, testonly.MustDecodeBase64("6uU/phfHg1n/GksYT6TO9aN8EauMCCJRl3dIK0HDs2M=")},
+		{10000, testonly.MustDecodeBase64("VZcav65F9haHVRk3wre2axFoBXRNeUh/1d9d5FQfxIg=")},
+		{65535, testonly.MustDecodeBase64("iPuVYJhP6SEE4gUFp8qbafd2rYv9YTCDYqAxCj8HdLM=")},
+	} {
+		t.Run(fmt.Sprintf("size:%v", tc.size), func(t *testing.T) {
+			rng := factory.NewEmptyRange(0)
+			for i := 0; i < tc.size; i++ {
+				data := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
+				hash, err := rfc6962.DefaultHasher.HashLeaf(data)
+				if err != nil {
+					t.Fatalf("HashLeaf(%x): %v", data, err)
+				}
+				if err := rng.Append(hash, nil); err != nil {
+					t.Fatalf("Append(%d): %v", i, err)
+				}
+			}
+			got, err := rng.GetRootHash()
+			if err != nil {
+				t.Fatalf("GetRootHash: %v", err)
+			}
+			if !bytes.Equal(got, tc.wantRoot) {
+				t.Errorf("root hash mismatch: got %x, want %x", got, tc.wantRoot)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Compact range is a data structure that represents an arbitrary range of
leaf indices in a Merkle tree. It has many useful properties, such as:

1. it has a size of O(log N) hashes
2. it can be merged with other ranges in O(log N) time
3. merge operation is associative
4. a series of merges produces all tree nodes in O(N) time

These properties enable us to use compact ranges for constructing Merkle
trees in a parallel/distributed way. Other properties include an ability
to construct multi-entry and range inclusion proofs, and consistency
proofs, using compact range as a building block.

Addresses #1338

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
