### PR TITLE
Make storage.Suffix immutable and share instances for 8 bit values.

### DIFF
--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -89,7 +89,7 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []HStar2Lea
 		return nil, ErrSubtreeOverrun
 	}
 	sort.Sort(ByIndex{values})
-	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.Suffix{}, s.hasher.BitLen()).BigInt()
+	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, s.hasher.BitLen()).BigInt()
 	return s.hStar2b(depth, totalDepth, values, offset, get, set)
 }
 

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -89,7 +89,7 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []HStar2Lea
 		return nil, ErrSubtreeOverrun
 	}
 	sort.Sort(ByIndex{values})
-	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, s.hasher.BitLen()).BigInt()
+	offset := storage.NewNodeIDFromPrefixSuffix(prefix, &storage.EmptySuffix, s.hasher.BitLen()).BigInt()
 	return s.hStar2b(depth, totalDepth, values, offset, get, set)
 }
 

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -89,7 +89,7 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []HStar2Lea
 		return nil, ErrSubtreeOverrun
 	}
 	sort.Sort(ByIndex{values})
-	offset := storage.NewNodeIDFromPrefixSuffix(prefix, &storage.EmptySuffix, s.hasher.BitLen()).BigInt()
+	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, s.hasher.BitLen()).BigInt()
 	return s.hStar2b(depth, totalDepth, values, offset, get, set)
 }
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -156,7 +156,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HS
 		}
 
 		ret = append(ret, HStar2LeafHash{
-			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, storage.Suffix{}, hasher.BitLen()).BigInt(),
+			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, hasher.BitLen()).BigInt(),
 			LeafHash: root,
 		})
 	}

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -156,7 +156,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HS
 		}
 
 		ret = append(ret, HStar2LeafHash{
-			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, &storage.EmptySuffix, hasher.BitLen()).BigInt(),
+			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, hasher.BitLen()).BigInt(),
 			LeafHash: root,
 		})
 	}

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -156,7 +156,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []HStar2LeafHash) []HS
 		}
 
 		ret = append(ret, HStar2LeafHash{
-			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, hasher.BitLen()).BigInt(),
+			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, &storage.EmptySuffix, hasher.BitLen()).BigInt(),
 			LeafHash: root,
 		})
 	}

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -220,7 +220,7 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 			if err != nil {
 				return err
 			}
-			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.Suffix{}, s.hasher.BitLen())
+			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.EmptySuffix, s.hasher.BitLen())
 			sibs = append(sibs, nodeID.Siblings()...)
 
 			leaves = append(leaves, HStar2LeafHash{

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -220,7 +220,7 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 			if err != nil {
 				return err
 			}
-			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, &storage.EmptySuffix, s.hasher.BitLen())
+			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.EmptySuffix, s.hasher.BitLen())
 			sibs = append(sibs, nodeID.Siblings()...)
 
 			leaves = append(leaves, HStar2LeafHash{

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -220,7 +220,7 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 			if err != nil {
 				return err
 			}
-			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.EmptySuffix, s.hasher.BitLen())
+			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, &storage.EmptySuffix, s.hasher.BitLen())
 			sibs = append(sibs, nodeID.Siblings()...)
 
 			leaves = append(leaves, HStar2LeafHash{

--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -46,8 +46,8 @@ func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 				return err
 			}
 			// TODO(gdbelvin): test against subtree depth.
-			if sfx.Bits%depthQuantum != 0 {
-				return fmt.Errorf("unexpected non-leaf suffix found: %x", sfx.Bits)
+			if sfx.Bits()%depthQuantum != 0 {
+				return fmt.Errorf("unexpected non-leaf suffix found: %x", sfx.Bits())
 			}
 
 			leaves = append(leaves, merkle.HStar2LeafHash{

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -293,7 +293,7 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 	// subtree depth then this is a leaf. For example if the subtree is depth 8 its leaves
 	// have 8 significant suffix bits.
 	sfxKey := sx.String()
-	if int32(sx.Bits) == c.Depth {
+	if int32(sx.Bits()) == c.Depth {
 		nh = c.Leaves[sfxKey]
 	} else {
 		nh = c.InternalNodes[sfxKey]
@@ -341,7 +341,7 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 	// Determine whether we're being asked to store a leaf node, or an internal
 	// node, and store it accordingly.
 	sfxKey := sx.String()
-	if int32(sx.Bits) == c.Depth {
+	if int32(sx.Bits()) == c.Depth {
 		// If the value being set is identical to the one we read from storage, then
 		// leave the cache state alone, and return.  This will prevent a write (and
 		// subtree revision bump) for identical data.

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -131,7 +131,7 @@ func (s *SubtreeCache) stratumInfoForPrefixLength(numBits int) stratumInfo {
 
 // splitNodeID breaks a NodeID out into its prefix and suffix parts.
 // unless ID is 0 bits long, Suffix must always contain at least one bit.
-func (s *SubtreeCache) splitNodeID(id storage.NodeID) ([]byte, storage.Suffix) {
+func (s *SubtreeCache) splitNodeID(id storage.NodeID) ([]byte, *storage.Suffix) {
 	sInfo := s.stratumInfoForPrefixLength(id.PrefixLenBits - 1)
 	return id.Split(sInfo.prefixBytes, sInfo.depth)
 }

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -71,11 +71,11 @@ func TestSplitNodeID(t *testing.T) {
 			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
 			continue
 		}
-		if got, want := int(s.Bits), tc.outSuffixBits; got != want {
+		if got, want := int(s.Bits()), tc.outSuffixBits; got != want {
 			t.Errorf("splitNodeID(%v): suffix.Bits %v, want %v", n, got, want)
 			continue
 		}
-		if got, want := s.Path, tc.outSuffix; !bytes.Equal(got, want) {
+		if got, want := s.Path(), tc.outSuffix; !bytes.Equal(got, want) {
 			t.Errorf("splitNodeID(%v): suffix.Path %x, want %x", n, got, want)
 		}
 	}

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -61,11 +61,11 @@ func (s Suffix) String() string {
 }
 
 // ParseSuffix converts a suffix string back into a Suffix.
-func ParseSuffix(s string) (Suffix, error) {
+func ParseSuffix(s string) (*Suffix, error) {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return EmptySuffix, err
+		return &EmptySuffix, err
 	}
 
-	return *NewSuffix(byte(b[0]), b[1:]), nil
+	return NewSuffix(byte(b[0]), b[1:]), nil
 }

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -23,18 +23,28 @@ import (
 type Suffix struct {
 	// bits is the number of bits in the node ID suffix.
 	// TODO(gdbelvin): make bits an integer.
-	Bits byte
+	bits byte
 	// path is the suffix itself.
-	Path []byte
+	path []byte
+}
+
+// Bits returns the number of significant bits in the Suffix path.
+func (s Suffix) Bits() byte {
+	return s.bits
+}
+
+// Path returns a copy of the Suffix path.
+func (s Suffix) Path() []byte {
+	return append([]byte(nil), s.path...)
 }
 
 // String returns a string that represents Suffix.
 // This is a base64 encoding of the following format:
 // [ 1 byte for depth || path bytes ]
 func (s Suffix) String() string {
-	r := make([]byte, 1, 1+(len(s.Path)))
-	r[0] = s.Bits
-	r = append(r, s.Path...)
+	r := make([]byte, 1, 1+(s.bits/8))
+	r[0] = s.bits
+	r = append(r, s.path...)
 	return base64.StdEncoding.EncodeToString(r)
 }
 
@@ -46,7 +56,7 @@ func ParseSuffix(s string) (Suffix, error) {
 	}
 
 	return Suffix{
-		Bits: byte(b[0]),
-		Path: b[1:],
+		bits: byte(b[0]),
+		path: b[1:],
 	}, nil
 }

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -18,11 +18,14 @@ import (
 	"encoding/base64"
 )
 
-// EmptySuffix is a reusable suffix of zero bits.
-var EmptySuffix = Suffix{path: []byte{0}}
-
-var byteToSuffix = make(map[byte]*Suffix)
-var strToSuffix = make(map[string]*Suffix)
+var (
+	// EmptySuffix is a reusable suffix of zero bits.
+	EmptySuffix = NewSuffix(0, []byte{0})
+	// byteToSuffix maps a single byte suffix (8 bits length) to a Suffix.
+	byteToSuffix = make(map[byte]*Suffix)
+	// strToSuffix maps a base64 encoded string representation to a Suffix.
+	strToSuffix = make(map[string]*Suffix)
+)
 
 // Suffix represents the tail of a NodeID. It is the path within the subtree.
 // The portion of the path that extends beyond the subtree is not part of this suffix.
@@ -48,7 +51,7 @@ func NewSuffix(bits byte, path []byte) *Suffix {
 		}
 	}
 
-	r := make([]byte, 1, 1+(bits/8))
+	r := make([]byte, 1, len(path)+1)
 	r[0] = bits
 	r = append(r, path...)
 	s := base64.StdEncoding.EncodeToString(r)
@@ -63,7 +66,7 @@ func (s Suffix) Bits() byte {
 
 // Path returns a copy of the Suffix path.
 func (s Suffix) Path() []byte {
-	return append([]byte(nil), s.path...)
+	return append(make([]byte, 0, len(s.path)), s.path...)
 }
 
 // String returns a string that represents Suffix.
@@ -82,7 +85,7 @@ func ParseSuffix(s string) (*Suffix, error) {
 
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return &EmptySuffix, err
+		return nil, err
 	}
 
 	return NewSuffix(byte(b[0]), b[1:]), nil

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -243,14 +243,15 @@ func Test8BitSuffixCache(t *testing.T) {
 		path      []byte
 		wantCache bool
 	}{
-		// below 8 bits should not be cached.
-		{b: 1, path: []byte{020}, wantCache: false},
-		{b: 2, path: []byte{0x20}, wantCache: false},
-		{b: 3, path: []byte{0x40}, wantCache: false},
-		{b: 4, path: []byte{0x40}, wantCache: false},
-		{b: 5, path: []byte{0x40}, wantCache: false},
-		{b: 6, path: []byte{0x40}, wantCache: false},
-		{b: 7, path: []byte{0x40}, wantCache: false},
+		// below 8 bits should be cached.
+		{b: 1, path: []byte{0x80}, wantCache: true},
+		{b: 1, path: []byte{0x40}, wantCache: false}, // bit set is outside the length.
+		{b: 2, path: []byte{0x40}, wantCache: true},
+		{b: 3, path: []byte{0x40}, wantCache: true},
+		{b: 4, path: []byte{0x40}, wantCache: true},
+		{b: 5, path: []byte{0x40}, wantCache: true},
+		{b: 6, path: []byte{0x40}, wantCache: true},
+		{b: 7, path: []byte{0x40}, wantCache: true},
 		// 8 bits suffix should be cached.
 		{b: 8, path: []byte{0x76}, wantCache: true},
 		// above 8 bits should not be cached.

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -195,7 +195,12 @@ func TestSuffixSerialize(t *testing.T) {
 		want string
 	}{
 		// Pre-existing format. This test vector must NOT change or existing data will be inaccessible.
+		{s: NewSuffix(1, []byte{0xae}), want: "Aa4="},
 		{s: NewSuffix(5, []byte{0xae}), want: "Ba4="},
+		{s: NewSuffix(8, []byte{0xae}), want: "CK4="},
+		{s: NewSuffix(15, []byte{0xae, 0x27}), want: "D64n"},
+		{s: NewSuffix(16, []byte{0xae, 0x27}), want: "EK4n"},
+		{s: NewSuffix(23, []byte{0xae, 0x27, 0x49}), want: "F64nSQ=="},
 	} {
 		if got, want := tc.s.String(), tc.want; got != want {
 			t.Errorf("%v.serialize(): %v, want %v", tc.s, got, want)
@@ -237,8 +242,8 @@ func Test8BitSuffixCache(t *testing.T) {
 		{b: 7, path: []byte{0x40}, wantCache: false},
 		// 8 bits suffix should be cached.
 		{b: 8, path: []byte{0x76}, wantCache: true},
-		{b: 9, path: []byte{0x40}, wantCache: false},
 		// above 8 bits should not be cached.
+		{b: 9, path: []byte{0x40}, wantCache: false},
 		{b: 9, path: []byte{0x40, 0x80}, wantCache: false},
 		{b: 12, path: []byte{0x40, 0x80}, wantCache: false},
 		{b: 15, path: []byte{0x40, 0xf0}, wantCache: false},

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -185,17 +185,17 @@ func makeSuffixKey(depth int, index int64) (string, error) {
 	if index < 0 {
 		return "", fmt.Errorf("invalid negative index %d", index)
 	}
-	sfx := Suffix{byte(depth), []byte{byte(index)}}
+	sfx := NewSuffix(byte(depth), []byte{byte(index)})
 	return sfx.String(), nil
 }
 
 func TestSuffixSerialize(t *testing.T) {
 	for _, tc := range []struct {
-		s    Suffix
+		s    *Suffix
 		want string
 	}{
-		// Prexisting format. This test vector must NOT change or existing data will be inaccessible.
-		{s: Suffix{5, []byte{0xae}}, want: "Ba4="},
+		// Pre-existing format. This test vector must NOT change or existing data will be inaccessible.
+		{s: NewSuffix(5, []byte{0xae}), want: "Ba4="},
 	} {
 		if got, want := tc.s.String(), tc.want; got != want {
 			t.Errorf("%v.serialize(): %v, want %v", tc.s, got, want)
@@ -204,8 +204,8 @@ func TestSuffixSerialize(t *testing.T) {
 }
 
 func TestSuffixPathImmutable(t *testing.T) {
-	s1 := Suffix{bits: 8, path: []byte{0x97}}
-	s2 := Suffix{bits: 8, path: []byte{0x97}}
+	s1 := NewSuffix(8, []byte{0x97})
+	s2 := NewSuffix(8, []byte{0x97})
 
 	p1 := s1.Path()
 	p2 := s2.Path()

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -53,10 +53,10 @@ func TestParseSuffix(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if got, want := sfx.Bits, tc.wantBits; got != want {
+		if got, want := sfx.Bits(), tc.wantBits; got != want {
 			t.Errorf("ParseSuffix(%s).Bits: %v, want %v", tc.suffix, got, want)
 		}
-		if got, want := sfx.Path, tc.wantPath; !bytes.Equal(got, want) {
+		if got, want := sfx.Path(), tc.wantPath; !bytes.Equal(got, want) {
 			t.Errorf("ParseSuffix(%s).Path: %x, want %x", tc.suffix, got, want)
 		}
 	}
@@ -80,10 +80,10 @@ func TestSplitParseSuffixRoundtrip(t *testing.T) {
 			t.Errorf("ParseSuffix(%s): %v", sfxKey, err)
 			continue
 		}
-		if got, want := sfx.Bits, sfxP.Bits; got != want {
+		if got, want := sfx.Bits(), sfxP.Bits(); got != want {
 			t.Errorf("ParseSuffix(%s).Bits: %v, want %v", sfxKey, got, want)
 		}
-		if got, want := sfx.Path, sfxP.Path; !bytes.Equal(got, want) {
+		if got, want := sfx.Path(), sfxP.Path(); !bytes.Equal(got, want) {
 			t.Errorf("ParseSuffix(%s).Path: %x, want %x", sfxKey, got, want)
 		}
 	}
@@ -176,7 +176,7 @@ func TestSuffixKey(t *testing.T) {
 }
 
 // makeSuffixKey creates a suffix key for indexing into the subtree's Leaves and InternalNodes maps.
-// This function documents existing log storage behavior. Any new code that emits Sufix objects must
+// This function documents existing log storage behavior. Any new code that emits Suffix objects must
 // produce the exact same outputs as this function would for Logs.
 func makeSuffixKey(depth int, index int64) (string, error) {
 	if depth < 0 {
@@ -200,5 +200,23 @@ func TestSuffixSerialize(t *testing.T) {
 		if got, want := tc.s.String(), tc.want; got != want {
 			t.Errorf("%v.serialize(): %v, want %v", tc.s, got, want)
 		}
+	}
+}
+
+func TestSuffixPathImmutable(t *testing.T) {
+	s1 := Suffix{bits: 8, path: []byte{0x97}}
+	s2 := Suffix{bits: 8, path: []byte{0x97}}
+
+	p1 := s1.Path()
+	p2 := s2.Path()
+
+	// Modifying the paths should leave the underlying objects still equal.
+	p1[0] = 0xff
+	if !bytes.Equal(s1.Path(), s2.Path()) {
+		t.Errorf("suffix path is not immutable")
+	}
+	p2[0] = 0xff
+	if !bytes.Equal(s1.Path(), s2.Path()) {
+		t.Errorf("suffix path is not immutable")
 	}
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -360,7 +360,7 @@ func NewNodeIDFromPrefixSuffix(prefix []byte, suffix Suffix, maxPathBits int) No
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
 func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	if n.PrefixLenBits == 0 {
-		return []byte{}, Suffix{bits: 0, path: []byte{0}}
+		return []byte{}, EmptySuffix
 	}
 	a := make([]byte, len(n.Path))
 	copy(a, n.Path)
@@ -377,12 +377,9 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	maskLowBits := (b-1)%8 + 1
 	path := a[prefixBytes : prefixBytes+suffixBytes]
 	path[maskIndex] &= ((0x01 << uint(maskLowBits)) - 1) << uint(8-maskLowBits)
-	sfx := Suffix{
-		bits: byte(b),
-		path: path,
-	}
+	sfx := NewSuffix(byte(b), path)
 
-	return a[:prefixBytes], sfx
+	return a[:prefixBytes], *sfx
 }
 
 // Equivalent return true iff the other represents the same path prefix as this NodeID.

--- a/storage/types.go
+++ b/storage/types.go
@@ -346,7 +346,7 @@ func (n *NodeID) Siblings() []NodeID {
 }
 
 // NewNodeIDFromPrefixSuffix undoes Split() and returns the NodeID.
-func NewNodeIDFromPrefixSuffix(prefix []byte, suffix Suffix, maxPathBits int) NodeID {
+func NewNodeIDFromPrefixSuffix(prefix []byte, suffix *Suffix, maxPathBits int) NodeID {
 	path := make([]byte, maxPathBits/8)
 	copy(path, prefix)
 	copy(path[len(prefix):], suffix.Path())
@@ -358,9 +358,9 @@ func NewNodeIDFromPrefixSuffix(prefix []byte, suffix Suffix, maxPathBits int) No
 }
 
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
-func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
+func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	if n.PrefixLenBits == 0 {
-		return []byte{}, EmptySuffix
+		return []byte{}, &EmptySuffix
 	}
 	a := make([]byte, len(n.Path))
 	copy(a, n.Path)
@@ -379,7 +379,7 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, Suffix) {
 	path[maskIndex] &= ((0x01 << uint(maskLowBits)) - 1) << uint(8-maskLowBits)
 	sfx := NewSuffix(byte(b), path)
 
-	return a[:prefixBytes], *sfx
+	return a[:prefixBytes], sfx
 }
 
 // Equivalent return true iff the other represents the same path prefix as this NodeID.

--- a/storage/types.go
+++ b/storage/types.go
@@ -349,7 +349,7 @@ func (n *NodeID) Siblings() []NodeID {
 func NewNodeIDFromPrefixSuffix(prefix []byte, suffix *Suffix, maxPathBits int) NodeID {
 	path := make([]byte, maxPathBits/8)
 	copy(path, prefix)
-	copy(path[len(prefix):], suffix.Path())
+	copy(path[len(prefix):], suffix.path)
 
 	return NodeID{
 		Path:          path,
@@ -360,7 +360,7 @@ func NewNodeIDFromPrefixSuffix(prefix []byte, suffix *Suffix, maxPathBits int) N
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
 func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	if n.PrefixLenBits == 0 {
-		return []byte{}, &EmptySuffix
+		return []byte{}, EmptySuffix
 	}
 	a := make([]byte, len(n.Path))
 	copy(a, n.Path)
@@ -375,9 +375,9 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	suffixBytes := bytesForBits(b)
 	maskIndex := (b - 1) / 8
 	maskLowBits := (b-1)%8 + 1
-	path := a[prefixBytes : prefixBytes+suffixBytes]
-	path[maskIndex] &= ((0x01 << uint(maskLowBits)) - 1) << uint(8-maskLowBits)
-	sfx := NewSuffix(byte(b), path)
+	sfxPath := a[prefixBytes : prefixBytes+suffixBytes]
+	sfxPath[maskIndex] &= ((0x01 << uint(maskLowBits)) - 1) << uint(8-maskLowBits)
+	sfx := NewSuffix(byte(b), sfxPath)
 
 	return a[:prefixBytes], sfx
 }

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -249,12 +249,12 @@ func TestSplit(t *testing.T) {
 				tc.inPathLenBits, tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
 			continue
 		}
-		if got, want := int(s.Bits), tc.outSuffixBits; got != want {
+		if got, want := int(s.Bits()), tc.outSuffixBits; got != want {
 			t.Errorf("%d, %x.Split(%v, %v): suffix.Bits %v, want %d",
 				tc.inPathLenBits, tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
 			continue
 		}
-		if got, want := s.Path, tc.outSuffix; !bytes.Equal(got, want) {
+		if got, want := s.Path(), tc.outSuffix; !bytes.Equal(got, want) {
 			t.Errorf("%d, %x.Split(%v, %v).Path: %x, want %x",
 				tc.inPathLenBits, tc.inPath, tc.splitBytes, tc.suffixBits, got, want)
 			continue


### PR DESCRIPTION
Profiling shows that tree hashing is spending a lot of time in alloc / gc of small objects. This tries to fix one case by making Suffix an immutable object and then sharing pre-allocated instances for the <=8 bit Suffix values used by logs. The internal APIs have been changed to use *Suffix in a few places.

This should gain the following benefits:

* Log rehashing does not constantly allocate the same Suffix objects over and over.
* String() is computed once so for cached values we don't incur base64 / string allocation repeatedly.
* Use of pointers avoids making copies and thus more overhead.
* User code doesn't manipulate these things so external APIs don't change.

Should make sense to look at it commit by commit.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
