### PR TITLE
Improve error handling in flagsaver.

### DIFF
--- a/client/rpcflags/rpcflags_test.go
+++ b/client/rpcflags/rpcflags_test.go
@@ -60,7 +60,7 @@ func TestNewClientDialOptionsFromFlagsWithTLSCertFileNotSet(t *testing.T) {
 }
 
 func TestNewClientDialOptionsFromFlagsWithTLSCertFileMissing(t *testing.T) {
-	defer flagsaver.Save().Restore()
+	defer flagsaver.Save().MustRestore()
 	if err := flag.Set("tls_cert_file", "/a/missing/file"); err != nil {
 		t.Errorf("Failed to set flag: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestNewClientDialOptionsFromFlagsWithTLSCertFileSet(t *testing.T) {
 	defer logEnv.Close()
 
 	// Set up the flag.
-	defer flagsaver.Save().Restore()
+	defer flagsaver.Save().MustRestore()
 	err = flag.Set("tls_cert_file", crtFile.Name())
 	if err != nil {
 		t.Errorf("Failed to set -tls_cert_file flag: %v", err)

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -157,7 +157,7 @@ func runTest(t *testing.T, tests []*testCase) {
 				t.Fatalf("Error starting fake server: %v", err)
 			}
 			defer stopFakeServer()
-			defer flagsaver.Save().Restore()
+			defer flagsaver.Save().MustRestore()
 			*adminServerAddr = s.Addr
 			if tc.setFlags != nil {
 				tc.setFlags()

--- a/cmd/get_tree_public_key/main_test.go
+++ b/cmd/get_tree_public_key/main_test.go
@@ -50,7 +50,7 @@ func TestGetTreePublicKey(t *testing.T) {
 	}
 
 	// Set the flags.
-	defer flagsaver.Save().Restore()
+	defer flagsaver.Save().MustRestore()
 	setup.SetFlag(t, "admin_server", logEnv.Address)
 	setup.SetFlag(t, "log_id", fmt.Sprint(log.TreeId))
 

--- a/cmd/updatetree/main_test.go
+++ b/cmd/updatetree/main_test.go
@@ -121,7 +121,7 @@ func runTest(t *testing.T, tests []*testCase) {
 				t.Fatalf("Error starting fake server: %v", err)
 			}
 			defer stopFakeServer()
-			defer flagsaver.Save().Restore()
+			defer flagsaver.Save().MustRestore()
 			*adminServerAddr = s.Addr
 			if tc.setFlags != nil {
 				tc.setFlags()

--- a/server/mysql_storage_provider_test.go
+++ b/server/mysql_storage_provider_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
-	defer flagsaver.Save().Restore()
+	defer flagsaver.Save().MustRestore()
 	if err := flag.Set("mysql_uri", "&bogus*:::?"); err != nil {
 		t.Errorf("Failed to set flag: %v", err)
 	}

--- a/util/flagsaver/flagsaver.go
+++ b/util/flagsaver/flagsaver.go
@@ -63,7 +63,7 @@ func Save() *Stash {
 }
 
 // MustRestore calls Restore and exits on failure. It can be used in a defer for
-// tests. If Restore fails then otherwise the flags may be in an arbitrary
+// tests. If Restore fails then the flags may be in an arbitrary
 // state that could cause subsequent tests to misbehave.
 func (s *Stash) MustRestore() {
 	if err := s.Restore(); err != nil {

--- a/util/flagsaver/flagsaver_test.go
+++ b/util/flagsaver/flagsaver_test.go
@@ -38,7 +38,7 @@ func TestRestore(t *testing.T) {
 		flag string
 		// oldValue is the value the flag should have when saved. If empty, this indicates the flag should have its default value.
 		oldValue string
-		// newValue ist he value the flag should have just before being restored to oldValue.
+		// newValue is the value the flag should have just before being restored to oldValue.
 		newValue string
 	}{
 		{
@@ -94,8 +94,12 @@ func TestRestore(t *testing.T) {
 		}
 
 		func() {
-			defer Save().Restore()
-			flag.Set(test.flag, test.newValue)
+			defer Save().MustRestore()
+			// If the Set() fails the value won't have been updated but some of the
+			// test cases set the same value so it's safer to have this check.
+			if err := flag.Set(test.flag, test.newValue); err != nil {
+				t.Errorf("%v: flag.Set(%q)=%v", test.desc, test.flag, err)
+			}
 			if gotValue := f.Value.String(); gotValue != test.newValue {
 				t.Errorf("%v: flag.Lookup(%q).Value.String() = %q, want %q", test.desc, test.flag, gotValue, test.newValue)
 			}

--- a/util/flagsaver/flagsaver_test.go
+++ b/util/flagsaver/flagsaver_test.go
@@ -98,7 +98,7 @@ func TestRestore(t *testing.T) {
 			// If the Set() fails the value won't have been updated but some of the
 			// test cases set the same value so it's safer to have this check.
 			if err := flag.Set(test.flag, test.newValue); err != nil {
-				t.Errorf("%v: flag.Set(%q)=%v", test.desc, test.flag, err)
+				t.Errorf("%v: flag.Set(%q) = %q, want nil", test.desc, test.flag, err)
 			}
 			if gotValue := f.Value.String(); gotValue != test.newValue {
 				t.Errorf("%v: flag.Lookup(%q).Value.String() = %q, want %q", test.desc, test.flag, gotValue, test.newValue)


### PR DESCRIPTION
Exclude saving of "go test" related flags and problematic
log_backtrace_at flag. All other errors related to setting flags are
reported. Add MustRestore() to make tests cleaner.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
