### PR TITLE
sequencer: update tree size metric regardless

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -324,6 +324,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 			return fmt.Errorf("%v: Sequencer failed to unmarshal latest root: %v", tree.TreeId, err)
 		}
 		seqGetRootLatency.Observe(clock.SecondsSince(s.timeSource, stageStart), label)
+		seqTreeSize.Set(float64(currentRoot.TreeSize), label)
 
 		if currentRoot.RootHash == nil {
 			glog.Warningf("%v: Fresh log - no previous TreeHeads exist.", tree.TreeId)


### PR DESCRIPTION
Always update the tree size metric, even if there are no leaves
to sequence, so the overall aggregated metric stays accurate.

Otherwise, you might get:
 - sequencer A adds leaves up to size 258
 - sequencer B takes over mastership and adds leaves up to size 462
 - sequencer B dies and sequencer C takes over
 - there are no new leaves to add, so C does not populate its metric.

At this point, the aggregated (max) tree size metric is 258, which
is a) wrong and b) has gone backwards from its previous value of 462.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
