### PR TITLE
Fix a typo in error message

### DIFF
--- a/server/validate.go
+++ b/server/validate.go
@@ -88,7 +88,7 @@ func validateGetConsistencyProofRequest(req *trillian.GetConsistencyProofRequest
 		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v, want > 0", req.SecondTreeSize)
 	}
 	if req.SecondTreeSize < req.FirstTreeSize {
-		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.FirstTreeSize: %v < GetConsistencyProofRequest.SecondTreeSize: %v, want >= ", req.FirstTreeSize, req.SecondTreeSize)
+		return status.Errorf(codes.InvalidArgument, "GetConsistencyProofRequest.SecondTreeSize: %v < GetConsistencyProofRequest.FirstTreeSize: %v, want >= ", req.SecondTreeSize, req.FirstTreeSize)
 	}
 	return nil
 }


### PR DESCRIPTION
correct validateGetConsistencyProofRequest error string which had conditions inverted
