### PR TITLE
Basic bazel build targets for proto files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.tfstate.backup
 *~
 /.idea
+/bazel-*
 /commit_log
 /coverage.txt
 /createtree

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - GOFLAGS='-race' WITH_ETCD=true
   - GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true
   - WITH_DOCKER_TESTS=true
+  - BAZEL_VERSION='0.18.0'
 
 matrix:
   fast_finish: true
@@ -70,6 +71,14 @@ install:
   # install vendored etcd binary
   - go install ./vendor/github.com/coreos/etcd/cmd/etcd
   - go install ./vendor/github.com/coreos/etcd/cmd/etcdctl
+  # install bazel
+  - |
+    (
+      URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+      wget -O install.sh ${URL}
+      sh install.sh --user
+      rm -f install.sh
+    )
 
 
 before_script:
@@ -104,6 +113,7 @@ script:
       if [[ "${WITH_DOCKER_TESTS}" == "true" ]]; then
         ./integration/docker_compose_integration_test.sh
       fi
+  - bazel --batch build //:*
   - set +e
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   - GOFLAGS='-race' WITH_ETCD=true
   - GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true
   - WITH_DOCKER_TESTS=true
-  - BAZEL_VERSION='0.18.0'
 
 matrix:
   fast_finish: true
@@ -74,12 +73,13 @@ install:
   # install bazel
   - |
     (
+      BAZEL_VERSION='0.18.0'
       URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
       wget -O install.sh ${URL}
-      sh install.sh --user
+      chmod +x install.sh
+      ./install.sh --user
       rm -f install.sh
     )
-
 
 before_script:
   - ./scripts/resetdb.sh --force

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,16 @@
-# This is a sensible default for the API build targets
+# This BUILD file contains Bazel build targets for clients of the Trillian API.
+# Bazel can be obtained from www.bazel.build
+#
+# Even where Bazel is not being used by client builds, these targets provide
+# a mechanism to determine which proto files are required for the API. For
+# example, the following command will list the proto files required to use
+# the Trillian Admin gRPC interface:
+#
+# bazel query --nohost_deps --noimplicit_deps \
+#   'kind("source file", deps(:trillian_admin_api_proto))'
 package(default_visibility = ["//visibility:public"])
 
+# A proto library for the Trillian Admin gRPC API.
 proto_library(
     name = "trillian_admin_api_proto",
     srcs = [
@@ -14,6 +24,7 @@ proto_library(
     ],
 )
 
+# A proto library for the Trillian Log gRPC API.
 proto_library(
     name = "trillian_log_api_proto",
     srcs = [
@@ -28,6 +39,7 @@ proto_library(
     ],
 )
 
+# Common proto definitions used within the Trillian gRPC APIs.
 proto_library(
     name = "trillian_proto",
     srcs = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,45 @@
+# This is a sensible default for the API build targets
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "trillian_admin_api_proto",
+    srcs = [
+        "trillian_admin_api.proto",
+    ],
+    deps = [
+        ":trillian_proto",
+        "@googleapi//google/api:annotations_proto",
+        "@googleapi//google/rpc:status_proto",
+        "@com_google_protobuf//:field_mask_proto",
+    ],
+)
+
+proto_library(
+    name = "trillian_log_api_proto",
+    srcs = [
+        "trillian_log_api.proto",
+    ],
+    deps = [
+        ":trillian_proto",
+        "@googleapi//google/api:annotations_proto",
+        "@googleapi//google/rpc:status_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "trillian_proto",
+    srcs = [
+        "trillian.proto",
+        "crypto/keyspb/keyspb.proto",
+        "crypto/sigpb/sigpb.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,37 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(minimum_bazel_version = "0.5.4")
+
+# This com_google_protobuf repository is required for proto_library rule.
+# It provides the protocol compiler binary (i.e., protoc).
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-master",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "googleapi",
+    url = "https://github.com/googleapis/googleapis/archive/master.zip",
+    strip_prefix = "googleapis-master",
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    strip_prefix = "rules_go-7d17d496a6b32f6a573c6c22e29c58204eddf3d4",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/7d17d496a6b32f6a573c6c22e29c58204eddf3d4.zip"],
+)
+


### PR DESCRIPTION
This allows clients integrating with Trillian from languages such as Python and Java to easily compile the proto definitions if using Bazel.
It also provides a way to query for all proto files that may be needed to build a target:

bazel query --nohost_deps --noimplicit_deps \
  'kind("source file", deps(:trillian_admin_api_proto))'

This is documented within the BUILD file.