### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # Default
 *                          @google/certificate-transparency
-*.proto                    @Martin2112 @daviddrysdale
+*.proto                    @Martin2112 @daviddrysdale @AlCutter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Default
-*				@google/certificate-transparency
-*.proto				@Martin2112 @daviddrysdale
+*                          @google/certificate-transparency
+*.proto                    @Martin2112 @daviddrysdale

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+
+# Default
+*				@google/certificate-transparency
+*.proto				@Martin2112 @daviddrysdale


### PR DESCRIPTION
A CODEOWERS file will allow github to automatically assign reviewers to PRs so
incoming PRs from the community don't get lost.

A CODEOWNERS file will also require an LGTM from one of the indicated owners
before PRs get merged.  

This could help ensure that the right people sign off on PRs and make it clear
who the appropriate stakeholders are.