### PR TITLE
compact: Implement Tree using Range

### DIFF
--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -32,8 +32,7 @@ import (
 // TODO(pavelkalinnikov): Remove it, use compact.Range instead.
 type Tree struct {
 	hasher hashers.LogHasher
-	nodes  [][]byte
-	size   int64
+	rng    *Range
 }
 
 func isPerfectTree(size int64) bool {
@@ -56,13 +55,6 @@ type GetNodesFunc func(ids []NodeID) ([][]byte, error)
 // compact Tree. The expectedRoot is the known-good tree root of the tree at
 // the specified size, and is used to verify the initial state.
 func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesFunc, expectedRoot []byte) (*Tree, error) {
-	sizeBits := bits.Len64(uint64(size))
-	r := Tree{
-		hasher: hasher,
-		nodes:  make([][]byte, sizeBits),
-		size:   size,
-	}
-
 	ids := make([]NodeID, 0, bits.OnesCount64(uint64(size)))
 	// Iterate over perfect subtrees along the right border of the tree. Those
 	// correspond to the bits of the tree size that are set to one.
@@ -78,12 +70,20 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 	if got, want := len(hashes), len(ids); got != want {
 		return nil, fmt.Errorf("got %d hashes, needed %d", got, want)
 	}
-	for i, id := range ids {
-		r.nodes[id.Level] = hashes[i]
+	// Note: Right border nodes of compact.Range are ordered top-to-bottom.
+	for i, j := 0, len(hashes)-1; i < j; i, j = i+1, j-1 {
+		hashes[i], hashes[j] = hashes[j], hashes[i]
+	}
+
+	fact := RangeFactory{Hash: hasher.HashChildren}
+	rng, err := fact.NewRange(0, uint64(size), hashes)
+	if err != nil {
+		return nil, err
 	}
 
 	// TODO(pavelkalinnikov): This check should be done externally.
-	root, err := r.CurrentRoot()
+	t := Tree{hasher: hasher, rng: rng}
+	root, err := t.CurrentRoot()
 	if err != nil {
 		return nil, err
 	}
@@ -92,17 +92,15 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 		return nil, fmt.Errorf("root hash mismatch: got %v, expected %v", root, expectedRoot)
 	}
 
-	glog.V(1).Infof("Resuming at size %d, with root: %s", r.size, base64.StdEncoding.EncodeToString(root))
-	return &r, nil
+	glog.V(1).Infof("Loaded tree at size %d, root: %s", rng.End(), base64.StdEncoding.EncodeToString(root))
+	return &t, nil
 }
 
 // NewTree creates a new compact Tree with size zero.
 func NewTree(hasher hashers.LogHasher) *Tree {
-	return &Tree{
-		hasher: hasher,
-		nodes:  make([][]byte, 0),
-		size:   0,
-	}
+	fact := RangeFactory{Hash: hasher.HashChildren}
+	rng := fact.NewEmptyRange(0)
+	return &Tree{hasher: hasher, rng: rng}
 }
 
 // CurrentRoot returns the current root hash.
@@ -111,14 +109,17 @@ func (t *Tree) CurrentRoot() ([]byte, error) {
 }
 
 // String describes the internal state of the compact Tree.
+//
+// TODO(pavelkalinnikov): Remove this method, or move String to Range type.
 func (t *Tree) String() string {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("Tree Nodes @ %d\n", t.size))
-	mask := int64(1)
-	numBits := bits.Len64(uint64(t.size))
-	for bit := 0; bit < numBits; bit++ {
-		if t.size&mask != 0 {
-			buf.WriteString(fmt.Sprintf("%d:  %s\n", bit, base64.StdEncoding.EncodeToString(t.nodes[bit][:])))
+	buf.WriteString(fmt.Sprintf("Tree Nodes @ %d\n", t.rng.End()))
+	mask := uint64(1)
+	numBits := bits.Len64(t.rng.End())
+	for bit, idx := 0, 0; bit < numBits; bit++ {
+		if t.rng.End()&mask != 0 {
+			buf.WriteString(fmt.Sprintf("%d:  %s\n", bit, base64.StdEncoding.EncodeToString(t.rng.hashes[idx])))
+			idx++
 		} else {
 			buf.WriteString(fmt.Sprintf("%d:  -\n", bit))
 		}
@@ -132,32 +133,10 @@ func (t *Tree) String() string {
 // border of the tree (also called "ephemeral" nodes), ordered from lowest to
 // highest levels.
 func (t *Tree) CalculateRoot(visit VisitFn) ([]byte, error) {
-	if t.size == 0 {
+	if t.rng.End() == 0 {
 		return t.hasher.EmptyRoot(), nil
 	}
-
-	index := uint64(t.size)
-
-	var hash []byte
-	first := true
-	mask := int64(1)
-	numBits := uint(bits.Len64(uint64(t.size)))
-	for bit := uint(0); bit < numBits; bit++ {
-		index >>= 1
-		if t.size&mask != 0 {
-			if first {
-				hash = t.nodes[bit]
-				first = false
-			} else {
-				hash = t.hasher.HashChildren(t.nodes[bit], hash)
-				if visit != nil {
-					visit(NewNodeID(bit+1, index), hash)
-				}
-			}
-		}
-		mask <<= 1
-	}
-	return hash, nil
+	return t.rng.GetRootHash(visit)
 }
 
 // AppendLeaf calculates the Merkle leaf hash of the given leaf data and
@@ -182,68 +161,17 @@ func (t *Tree) AppendLeaf(data []byte, visit VisitFn) ([]byte, error) {
 //
 // If returns an error then the Tree is no longer usable.
 func (t *Tree) AppendLeafHash(leafHash []byte, visit VisitFn) error {
-	defer func() { t.size++ }()
-
-	assignedSeq := t.size
-	index := uint64(assignedSeq)
-
+	// Report the leaf hash, as the compact.Range doesn't.
 	if visit != nil {
-		visit(NewNodeID(0, index), leafHash)
+		visit(NewNodeID(0, t.rng.End()), leafHash)
 	}
-
-	if t.size == 0 {
-		// new tree
-		t.nodes = append(t.nodes, leafHash)
-		return nil
-	}
-
-	// Initialize our running hash value to the leaf hash.
-	hash := leafHash
-	bit := uint(0)
-	// Iterate over the bits in our existing tree size.
-	for mask := t.size; mask > 0; mask >>= 1 {
-		index >>= 1
-		if mask&1 == 0 {
-			// Just store the running hash here; we're done.
-			t.nodes[bit] = hash
-			// Don't re-write the leaf hash node (we've done it above already)
-			if bit > 0 && visit != nil {
-				// Store the (non-leaf) hash node
-				visit(NewNodeID(bit, index), hash)
-			}
-			return nil
-		}
-		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
-		hash = t.hasher.HashChildren(t.nodes[bit], hash)
-		// Store the resulting parent hash.
-		if visit != nil {
-			visit(NewNodeID(bit+1, index), hash)
-		}
-		// Now, clear this position in the nodes list as the hash it formerly contained will be propagated upwards.
-		t.nodes[bit] = nil
-		// Figure out if we're done:
-		if bit+1 >= uint(len(t.nodes)) {
-			// If we're extending the node list then add a new entry with our
-			// running hash, and we're done.
-			t.nodes = append(t.nodes, hash)
-			return nil
-		} else if mask&0x02 == 0 {
-			// If the node above us is unused at this tree size, then store our
-			// running hash there, and we're done.
-			t.nodes[bit+1] = hash
-			return nil
-		}
-		// Otherwise, go around again.
-		bit++
-	}
-	// We should never get here, because that'd mean we had a running hash which
-	// we've not stored somewhere.
-	return fmt.Errorf("AddLeaf failed running hash not cleared: h: %v seq: %d", leafHash, assignedSeq)
+	// Report all new perfect internal nodes.
+	return t.rng.Append(leafHash, visit)
 }
 
 // Size returns the current size of the tree.
 func (t *Tree) Size() int64 {
-	return t.size
+	return int64(t.rng.End())
 }
 
 // hashes returns the set of node hashes that comprise the compact
@@ -252,7 +180,7 @@ func (t *Tree) Size() int64 {
 //
 // TODO(pavelkalinnikov): Get rid of this format, it is only used internally.
 func (t *Tree) hashes() [][]byte {
-	if isPerfectTree(t.size) {
+	if isPerfectTree(int64(t.rng.End())) {
 		return nil
 	}
 	return t.getNodes()
@@ -273,7 +201,12 @@ func (t *Tree) hashes() [][]byte {
 // For a tree whose size is a perfect power of two, only the last entry in
 // nodes is set, and it also matches the tree root hash.
 func (t *Tree) getNodes() [][]byte {
-	n := make([][]byte, len(t.nodes))
-	copy(n, t.nodes)
+	size := t.rng.End()
+	hashes := t.rng.Hashes()
+	n := make([][]byte, bits.Len64(size))
+	for i := len(hashes) - 1; size != 0; i, size = i-1, size&(size-1) {
+		level := bits.TrailingZeros64(size)
+		n[level] = hashes[i]
+	}
 	return n
 }

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -70,7 +70,7 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 	if got, want := len(hashes), len(ids); got != want {
 		return nil, fmt.Errorf("got %d hashes, needed %d", got, want)
 	}
-	// Note: Right border nodes of compact.Range are ordered top-to-bottom.
+	// Note: Right border nodes of compact.Range are ordered from root to leaves.
 	for i, j := 0, len(hashes)-1; i < j; i, j = i+1, j-1 {
 		hashes[i], hashes[j] = hashes[j], hashes[i]
 	}
@@ -110,7 +110,7 @@ func (t *Tree) CurrentRoot() ([]byte, error) {
 
 // String describes the internal state of the compact Tree.
 //
-// TODO(pavelkalinnikov): Remove this method, or move String to Range type.
+// TODO(pavelkalinnikov): Remove this method, or move it to Range type.
 func (t *Tree) String() string {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("Tree Nodes @ %d\n", t.rng.End()))

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -246,12 +246,12 @@ func (t *Tree) Size() int64 {
 	return t.size
 }
 
-// Hashes returns a copy of the set of node hashes that comprise the compact
-// representation of the tree. A tree whose size is a power of two has no
-// internal node hashes (just the root hash), so returns nil.
+// hashes returns the set of node hashes that comprise the compact
+// representation of the tree, in the old format. A tree whose size is a power
+// of two has no internal node hashes (just the root hash), so nil is returned.
 //
 // TODO(pavelkalinnikov): Get rid of this format, it is only used internally.
-func (t *Tree) Hashes() [][]byte {
+func (t *Tree) hashes() [][]byte {
 	if isPerfectTree(t.size) {
 		return nil
 	}

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -32,17 +32,18 @@ import (
 // This check ensures that the compact Merkle tree contains the correct set of
 // nodes, i.e. the node on level i is present iff i-th bit of tree size is 1.
 func checkUnusedNodesInvariant(t *Tree) error {
-	size := t.size
+	size := t.Size()
+	nodes := t.getNodes()
 	sizeBits := bits.Len64(uint64(size))
-	if got, want := len(t.nodes), sizeBits; got != want {
+	if got, want := len(nodes), sizeBits; got != want {
 		return fmt.Errorf("nodes mismatch: have %v nodes, want %v", got, want)
 	}
 	for level := 0; level < sizeBits; level++ {
 		if size&1 == 1 {
-			if t.nodes[level] == nil {
+			if nodes[level] == nil {
 				return fmt.Errorf("missing node at level %d", level)
 			}
-		} else if t.nodes[level] != nil {
+		} else if nodes[level] != nil {
 			return fmt.Errorf("unexpected node at level %d", level)
 		}
 		size >>= 1

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -98,8 +98,8 @@ func TestAddingLeaves(t *testing.T) {
 					if got, want := mustGetRoot(t, tree), roots[br-1]; !bytes.Equal(got, want) {
 						t.Errorf("root=%v, want %v", got, want)
 					}
-					if diff := pretty.Compare(tree.Hashes(), hashes[br-1]); diff != "" {
-						t.Errorf("post-Hashes() diff:\n%v", diff)
+					if diff := pretty.Compare(tree.hashes(), hashes[br-1]); diff != "" {
+						t.Errorf("post-hashes() diff:\n%v", diff)
 					}
 				} else {
 					if got, want := mustGetRoot(t, tree), testonly.EmptyMerkleTreeRootHash(); !bytes.Equal(got, want) {
@@ -270,7 +270,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 		if isPerfectTree(test.size) {
 			// A perfect tree should have a single hash at the highest bit that is just
 			// the root hash.
-			hashes := tree.Hashes()
+			hashes := tree.hashes()
 			for i, got := range hashes {
 				var want []byte
 				if i == (len(hashes) - 1) {


### PR DESCRIPTION
This change replaces internals of `compact.Tree` with the `compact.Range`.

The old `Hashes` method/format are now used only in tests, and will be removed
in a follow-up after tests refactoring.

#### Benchmarks
No significant changes.
```
Before:
BenchmarkAppendLeaf-12             	     500	   3214217 ns/op
BenchmarkAppendLeafNoVisitor-12    	     500	   3069281 ns/op

After:
BenchmarkAppendLeaf-12             	     500	   3118462 ns/op
BenchmarkAppendLeafNoVisitor-12    	     500	   3089277 ns/op
```

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
