### PR TITLE
Don't spam the entire team on each pull request

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Default
-*                          @google/certificate-transparency
 *.proto                    @Martin2112 @daviddrysdale @AlCutter


### PR DESCRIPTION
CODEOWERS files automatically assign reviewers.
This is useful when open source contributors open pull requests because they cannot assign a reviewer themselves.

However, this has become spamy during the course of normal operation because the entire team is added as a reviewer to every PR.