### PR TITLE
Experimental LogHasher API change for performance.

### DIFF
--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -308,7 +308,7 @@ func TestAddSequencedLeaves(t *testing.T) {
 		}, wantErr: true},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c := &LogClient{LogVerifier: &LogVerifier{Hasher: rfc6962.DefaultHasher}}
+			c := &LogClient{LogVerifier: &LogVerifier{Hasher: rfc6962.NewSHA256()}}
 			err := c.AddSequencedLeaves(ctx, tc.dataByIndex)
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Errorf("AddSequencedLeaves(): %v, wantErr: %v", err, tc.wantErr)

--- a/client/log_verifier_test.go
+++ b/client/log_verifier_test.go
@@ -54,7 +54,7 @@ func TestVerifyRootErrors(t *testing.T) {
 		{desc: "trustedNil", trusted: nil, newRoot: signedRoot},
 	}
 	for _, test := range tests {
-		logVerifier := NewLogVerifier(rfc6962.DefaultHasher, pk, crypto.SHA256)
+		logVerifier := NewLogVerifier(rfc6962.NewSHA256(), pk, crypto.SHA256)
 
 		// This also makes sure that no nil pointer dereference errors occur (as this would cause a panic).
 		if _, err := logVerifier.VerifyRoot(test.trusted, test.newRoot, nil); err == nil {

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -255,7 +255,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	if qm == nil {
 		qm = quota.Noop()
 	}
-	sequencer := NewSequencer(rfc6962.DefaultHasher, clock.NewFake(fakeTimeForTest), fakeStorage, signer, nil, qm)
+	sequencer := NewSequencer(rfc6962.NewSHA256(), clock.NewFake(fakeTimeForTest), fakeStorage, signer, nil, qm)
 	return testContext{mockTx: mockTx, fakeStorage: fakeStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 
@@ -551,7 +551,7 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 	defer ctrl.Finish()
 
 	// Needed to create a signer
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 	ts := clock.NewFake(fakeTimeForTest)
 	signer := tcrypto.NewSigner(0, cryptoSigner, crypto.SHA256)
 

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -401,7 +401,7 @@ func TestGetRootHashGolden(t *testing.T) {
 			rng := factory.NewEmptyRange(0)
 			for i := 0; i < tc.size; i++ {
 				data := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
-				hash, err := rfc6962.DefaultHasher.HashLeaf(data)
+				hash, err := rfc6962.NewSHA256().HashLeaf(data)
 				if err != nil {
 					t.Fatalf("HashLeaf(%x): %v", data, err)
 				}
@@ -652,7 +652,7 @@ func TestEqual(t *testing.T) {
 }
 
 func hashLeaf(data []byte) []byte {
-	hash, err := rfc6962.DefaultHasher.HashLeaf(data)
+	hash, err := rfc6962.NewSHA256().HashLeaf(data)
 	if err != nil {
 		panic(fmt.Sprintf("rfc6962: HashLeaf: %v", err))
 	}

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -174,7 +174,7 @@ func (t *Tree) recalculateRoot(setNodeFn setNodeFunc) error {
 				copy(newRoot, t.nodes[bit])
 				first = false
 			} else {
-				t.hasher.HashChildrenInto(t.nodes[bit], newRoot, newRoot)
+				newRoot := t.hasher.HashChildrenInto(t.nodes[bit], newRoot, newRoot)
 				if err := setNodeFn(bit+1, index, newRoot); err != nil {
 					return err
 				}
@@ -251,7 +251,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 			return assignedSeq, nil
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
-		t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
+		hash := t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
 		// Store the resulting parent hash.
 		if err := setNodeFn(bit+1, index, append(make([]byte, 0, len(hash)), hash...)); err != nil {
 			return 0, err

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -253,7 +253,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
 		// Store the resulting parent hash.
-		if err := setNodeFn(bit+1, index, hash); err != nil {
+		if err := setNodeFn(bit+1, index, append(make([]byte, 0, len(hash)), hash...)); err != nil {
 			return 0, err
 		}
 		// Now, clear this position in the nodes list as the hash it formerly contained will be propagated upwards.

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -175,7 +175,8 @@ func (t *Tree) recalculateRoot(setNodeFn setNodeFunc) error {
 				first = false
 			} else {
 				newRoot := t.hasher.HashChildrenInto(t.nodes[bit], newRoot, newRoot)
-				if err := setNodeFn(bit+1, index, newRoot); err != nil {
+				// Must make a copy in case the setNodeFn retains the value.
+				if err := setNodeFn(bit+1, index, append(make([]byte, 0, len(newRoot)), newRoot...)); err != nil {
 					return err
 				}
 			}
@@ -232,7 +233,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 		return assignedSeq, nil
 	}
 
-	// Initialize our running hash value to the leaf hash
+	// Initialize our running hash value to a copy of the leaf hash
 	hash := append(make([]byte, 0, len(leafHash)), leafHash...)
 	bit := 0
 	// Iterate over the bits in our existing tree size.
@@ -252,7 +253,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		hash := t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
-		// Store the resulting parent hash.
+		// Store the resulting parent hash. Make a copy in case the function retains it.
 		if err := setNodeFn(bit+1, index, append(make([]byte, 0, len(hash)), hash...)); err != nil {
 			return 0, err
 		}

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -262,7 +262,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 		if bit+1 >= len(t.nodes) {
 			// If we're extending the node list then add a new entry with our
 			// running hash, and we're done.
-			t.nodes = append(t.nodes, append(make([]byte, 0, len(hash)), hash...))
+			t.nodes = append(t.nodes, hash)
 			return assignedSeq, nil
 		} else if mask&0x02 == 0 {
 			// If the node above us is unused at this tree size, then store our

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -16,6 +16,7 @@ package compact
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -269,5 +270,15 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func BenchmarkAddLeaf(b *testing.B) {
+	tree := NewTree(rfc6962.New(crypto.SHA256))
+	for i := 0; i < b.N; i++ {
+		l := []byte(fmt.Sprintf("This %x is leaf data that we made up %d", i, i))
+		tree.AddLeaf(l, func(int, int64, []byte) error {
+			return nil
+		})
 	}
 }

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -26,8 +26,20 @@ type LogHasher interface {
 	EmptyRoot() []byte
 	// HashLeaf computes the hash of a leaf that exists.
 	HashLeaf(leaf []byte) ([]byte, error)
+	// HashLeafInto computes the hash of a leaf into an existing slice,
+	// which is mutated.
+	// Note: Implementations are not expected to be thread safe. The caller must
+	// ensure that concurrent calls are not made and is responsible for making
+	// copies of slices where necessary to avoid data being overwritten.
+	HashLeafInto(leaf, res []byte) error
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
+	// HashChildrenInto computes interior nodes into an existing slice, which is
+	// mutated.
+	// Note: Implementations are not expected to be thread safe. The caller must
+	// ensure that concurrent calls are not made and is responsible for making
+	// copies of slices where necessary to avoid data being overwritten.
+	HashChildrenInto(l, r, res []byte)
 	// Size is the number of bytes in the underlying hash function.
 	// TODO(gbelvin): Replace Size() with BitLength().
 	Size() int

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -31,7 +31,7 @@ type LogHasher interface {
 	// Note: Implementations are not expected to be thread safe. The caller must
 	// ensure that concurrent calls are not made and is responsible for making
 	// copies of slices where necessary to avoid data being overwritten.
-	HashLeafInto(leaf, res []byte) error
+	HashLeafInto(leaf, res []byte) ([]byte, error)
 	// HashChildren computes interior nodes.
 	HashChildren(l, r []byte) []byte
 	// HashChildrenInto computes interior nodes into an existing slice, which is
@@ -39,7 +39,7 @@ type LogHasher interface {
 	// Note: Implementations are not expected to be thread safe. The caller must
 	// ensure that concurrent calls are not made and is responsible for making
 	// copies of slices where necessary to avoid data being overwritten.
-	HashChildrenInto(l, r, res []byte)
+	HashChildrenInto(l, r, res []byte) []byte
 	// Size is the number of bytes in the underlying hash function.
 	// TODO(gbelvin): Replace Size() with BitLength().
 	Size() int

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -69,13 +69,15 @@ type MapHasher interface {
 	BitLen() int
 }
 
+type NewHasherFunc func() LogHasher
+
 var (
-	logHashers = make(map[trillian.HashStrategy]LogHasher)
+	logHashers = make(map[trillian.HashStrategy]NewHasherFunc)
 	mapHashers = make(map[trillian.HashStrategy]MapHasher)
 )
 
 // RegisterLogHasher registers a hasher for use.
-func RegisterLogHasher(h trillian.HashStrategy, f LogHasher) {
+func RegisterLogHasher(h trillian.HashStrategy, f NewHasherFunc) {
 	if h == trillian.HashStrategy_UNKNOWN_HASH_STRATEGY {
 		panic(fmt.Sprintf("RegisterLogHasher(%s) of unknown hasher", h))
 	}
@@ -97,15 +99,19 @@ func RegisterMapHasher(h trillian.HashStrategy, f MapHasher) {
 }
 
 // NewLogHasher returns a LogHasher.
+// TODO(Martin2112): The name of this func implies it creates a new instance
+// but it doesn't.
 func NewLogHasher(h trillian.HashStrategy) (LogHasher, error) {
 	f := logHashers[h]
 	if f != nil {
-		return f, nil
+		return f(), nil
 	}
 	return nil, fmt.Errorf("LogHasher(%s) is an unknown hasher", h)
 }
 
 // NewMapHasher returns a MapHasher.
+// TODO(Martin2112): The name of this func implies it creates a new instance
+// but it doesn't.
 func NewMapHasher(h trillian.HashStrategy) (MapHasher, error) {
 	f := mapHashers[h]
 	if f != nil {

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -21,6 +21,7 @@ import (
 	"math/bits"
 
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
 // RootMismatchError occurs when an inclusion proof fails.
@@ -40,6 +41,11 @@ type LogVerifier struct {
 
 // NewLogVerifier returns a new LogVerifier for a tree.
 func NewLogVerifier(hasher hashers.LogHasher) LogVerifier {
+	// TODO(Martin2112): Testing if issues are being caused by use of DefaultHasher in ct-go
+	// repo. If so remove this and fix it up properly.
+	if hasher == rfc6962.DefaultHasher {
+		return LogVerifier{rfc6962.NewSHA256()}
+	}
 	return LogVerifier{hasher}
 }
 

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -256,7 +256,7 @@ func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1,
 }
 
 func TestVerifyInclusionProofSingleEntry(t *testing.T) {
-	v := NewLogVerifier(rfc6962.DefaultHasher)
+	v := NewLogVerifier(rfc6962.NewSHA256())
 	data := []byte("data")
 	// Root and leaf hash for 1-entry tree are the same.
 	hash, _ := v.hasher.HashLeaf(data)
@@ -284,7 +284,7 @@ func TestVerifyInclusionProofSingleEntry(t *testing.T) {
 }
 
 func TestVerifyInclusionProof(t *testing.T) {
-	v := NewLogVerifier(rfc6962.DefaultHasher)
+	v := NewLogVerifier(rfc6962.NewSHA256())
 	proof := [][]byte{}
 
 	probes := []struct {
@@ -308,7 +308,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 	for i := 1; i < 6; i++ {
 		p := inclusionProofs[i]
 		t.Run(fmt.Sprintf("proof:%d", i), func(t *testing.T) {
-			leafHash, err := rfc6962.DefaultHasher.HashLeaf(leaves[p.leaf-1])
+			leafHash, err := rfc6962.NewSHA256().HashLeaf(leaves[p.leaf-1])
 			if err != nil {
 				t.Fatalf("HashLeaf(): %v", err)
 			}
@@ -342,7 +342,7 @@ func TestVerifyInclusionProofGenerated(t *testing.T) {
 }
 
 func TestVerifyConsistencyProof(t *testing.T) {
-	v := NewLogVerifier(rfc6962.DefaultHasher)
+	v := NewLogVerifier(rfc6962.NewSHA256())
 
 	root1 := []byte("don't care 1")
 	root2 := []byte("don't care 2")
@@ -513,9 +513,9 @@ func shortHash(hash []byte) string {
 }
 
 func createTree(size int64) (*InMemoryMerkleTree, LogVerifier) {
-	tree := NewInMemoryMerkleTree(rfc6962.DefaultHasher)
+	tree := NewInMemoryMerkleTree(rfc6962.NewSHA256())
 	growTree(tree, size)
-	return tree, NewLogVerifier(rfc6962.DefaultHasher)
+	return tree, NewLogVerifier(rfc6962.NewSHA256())
 }
 
 func growTree(tree *InMemoryMerkleTree, upTo int64) {

--- a/merkle/memory_merkle_tree_test.go
+++ b/merkle/memory_merkle_tree_test.go
@@ -121,7 +121,7 @@ func decodeHexStringOrPanic(hs string) []byte {
 }
 
 func makeEmptyTree() *InMemoryMerkleTree {
-	return NewInMemoryMerkleTree(rfc6962.DefaultHasher)
+	return NewInMemoryMerkleTree(rfc6962.NewSHA256())
 }
 
 func makeFuzzTestData() [][]byte {

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -49,6 +49,10 @@ func New(h crypto.Hash) *Hasher {
 	return &Hasher{Hash: h, hasher: h.New()}
 }
 
+func NewSHA256() *Hasher {
+	return &Hasher{Hash: crypto.SHA256, hasher: crypto.SHA256.New()}
+}
+
 // EmptyRoot returns a special case for an empty tree.
 func (t *Hasher) EmptyRoot() []byte {
 	return t.New().Sum(nil)

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -73,27 +73,18 @@ func (t *Hasher) HashLeaf(leaf []byte) ([]byte, error) {
 // prefixed by the LeafHashPrefix. Note: This function is not thread safe.
 // Calling this on DefaultHasher is not recommended. If in doubt use
 // HashLeaf.
-func (t *Hasher) HashLeafInto(leaf, res []byte) error {
+func (t *Hasher) HashLeafInto(leaf, res []byte) ([]byte, error) {
 	if t == DefaultHasher {
 		glog.Fatal("DefaultHasher.HashLeafInto is unsafe")
 	}
 	t.hasher.Reset()
 	t.hasher.Write([]byte{RFC6962LeafHashPrefix})
 	t.hasher.Write(leaf)
+	if res == nil {
+		res = make([]byte, 0, t.hasher.Size())
+	}
 	res = res[:0]
-	t.hasher.Sum(res)
-	return nil
-}
-
-// hashChildrenOld returns the inner Merkle tree node hash of the two child nodes l and r.
-// The hashed structure is NodeHashPrefix||l||r.
-// TODO(al): Remove me.
-func (t *Hasher) hashChildrenOld(l, r []byte) []byte {
-	h := t.New()
-	h.Write([]byte{RFC6962NodeHashPrefix})
-	h.Write(l)
-	h.Write(r)
-	return h.Sum(nil)
+	return t.hasher.Sum(res), nil
 }
 
 // HashChildren returns the inner Merkle tree node hash of the two child nodes l and r.
@@ -114,7 +105,7 @@ func (t *Hasher) HashChildren(l, r []byte) []byte {
 // l and r into a supplied slice, which can be reused if appropriate. The hashed
 // structure is NodeHashPrefix||l||r. Note: This function is not thread safe.
 // Calling this on DefaultHasher is not recommended. If in doubt use HashChildren.
-func (t *Hasher) HashChildrenInto(l, r, res []byte) {
+func (t *Hasher) HashChildrenInto(l, r, res []byte) []byte {
 	if t == DefaultHasher {
 		glog.Fatal("DefaultHasher.HashChildrenInto is unsafe")
 	}
@@ -128,5 +119,5 @@ func (t *Hasher) HashChildrenInto(l, r, res []byte) {
 	t.hasher.Reset()
 	t.hasher.Write(t.buffer)
 	res = res[:0]
-	t.hasher.Sum(res)
+	return t.hasher.Sum(res)
 }

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -20,6 +20,7 @@ import (
 	_ "crypto/sha256" // SHA256 is the default algorithm.
 	"hash"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
 )
@@ -73,6 +74,9 @@ func (t *Hasher) HashLeaf(leaf []byte) ([]byte, error) {
 // Calling this on DefaultHasher is not recommended. If in doubt use
 // HashLeaf.
 func (t *Hasher) HashLeafInto(leaf, res []byte) error {
+	if t == DefaultHasher {
+		glog.Fatal("DefaultHasher.HashLeafInto is unsafe")
+	}
 	t.hasher.Reset()
 	t.hasher.Write([]byte{RFC6962LeafHashPrefix})
 	t.hasher.Write(leaf)
@@ -111,6 +115,9 @@ func (t *Hasher) HashChildren(l, r []byte) []byte {
 // structure is NodeHashPrefix||l||r. Note: This function is not thread safe.
 // Calling this on DefaultHasher is not recommended. If in doubt use HashChildren.
 func (t *Hasher) HashChildrenInto(l, r, res []byte) {
+	if t == DefaultHasher {
+		glog.Fatal("DefaultHasher.HashChildrenInto is unsafe")
+	}
 	t.buffer = t.buffer[:0]
 	t.buffer = append(append(append(
 		t.buffer,

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestRFC6962Hasher(t *testing.T) {
-	hasher := DefaultHasher
+	hasher := NewSHA256()
 
 	leafHash, err := hasher.HashLeaf([]byte("L123456"))
 	if err != nil {
@@ -79,7 +79,7 @@ func TestRFC6962Hasher(t *testing.T) {
 
 // TODO(pavelkalinnikov): Apply this test to all LogHasher implementations.
 func TestRFC6962HasherCollisions(t *testing.T) {
-	hasher := DefaultHasher
+	hasher := NewSHA256()
 
 	// Check that different leaves have different hashes.
 	leaf1, leaf2 := []byte("Hello"), []byte("World")
@@ -107,7 +107,7 @@ func TestRFC6962HasherCollisions(t *testing.T) {
 
 // TODO(al): Remove me.
 func BenchmarkHashChildrenOld(b *testing.B) {
-	h := DefaultHasher
+	h := NewSHA256()
 	l, _ := h.HashLeaf([]byte("one"))
 	r, _ := h.HashLeaf([]byte("or other"))
 	for i := 0; i < b.N; i++ {
@@ -116,7 +116,7 @@ func BenchmarkHashChildrenOld(b *testing.B) {
 }
 
 func BenchmarkHashChildren(b *testing.B) {
-	h := DefaultHasher
+	h := NewSHA256()
 	l, _ := h.HashLeaf([]byte("one"))
 	r, _ := h.HashLeaf([]byte("or other"))
 	for i := 0; i < b.N; i++ {
@@ -125,7 +125,7 @@ func BenchmarkHashChildren(b *testing.B) {
 }
 
 func TestHashChildrenEquivToOld(t *testing.T) {
-	h := DefaultHasher
+	h := NewSHA256()
 	for i := 0; i < 1000; i++ {
 		l, err := h.HashLeaf([]byte(fmt.Sprintf("leaf left %d", i)))
 		if err != nil {

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -51,7 +51,7 @@ func newTestLeaf(data []byte, extra []byte, index int64) *trillian.LogLeaf {
 }
 
 var (
-	th = rfc6962.DefaultHasher
+	th = rfc6962.NewSHA256()
 
 	logID1 = int64(1)
 	logID2 = int64(2)

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -171,7 +171,7 @@ func TestTree813FetchAll(t *testing.T) {
 
 func TestTree32InclusionProofFetchAll(t *testing.T) {
 	ctx := context.Background()
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -56,7 +56,7 @@ var sn4 = storage.Node{NodeID: storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevi
 var sn5 = storage.Node{NodeID: storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 
 func TestRehasher(t *testing.T) {
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 	rehashTests := []rehashTest{
 		{
 			desc:    "no rehash",
@@ -131,7 +131,7 @@ func TestRehasher(t *testing.T) {
 
 func TestTree813FetchAll(t *testing.T) {
 	ctx := context.Background()
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 	const ts int64 = 813
 
 	mt := treeAtSize(int(ts))
@@ -209,7 +209,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 
 func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 	ctx := context.Background()
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 
 	mt := treeAtSize(32)
 	// The reader is built up with multiple batches, 4 batches x 8 leaves each
@@ -251,7 +251,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 
 func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 	ctx := context.Background()
-	hasher := rfc6962.DefaultHasher
+	hasher := rfc6962.NewSHA256()
 	for ts := 2; ts <= 32; ts++ {
 		mt := treeAtSize(ts)
 		r := testonly.NewMultiFakeNodeReaderFromLeaves([]testonly.LeafBatch{
@@ -302,7 +302,7 @@ func expectedRootAtSize(mt *merkle.InMemoryMerkleTree) []byte {
 
 func treeAtSize(n int) *merkle.InMemoryMerkleTree {
 	leaves := expandLeaves(0, n-1)
-	mt := merkle.NewInMemoryMerkleTree(rfc6962.DefaultHasher)
+	mt := merkle.NewInMemoryMerkleTree(rfc6962.NewSHA256())
 	for _, leaf := range leaves {
 		if _, _, err := mt.AddLeaf([]byte(leaf)); err != nil {
 			panic(err)

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -246,8 +246,8 @@ func TestCacheFlush(t *testing.T) {
 }
 
 func TestRepopulateLogSubtree(t *testing.T) {
-	populateTheThing := populateLogSubtreeNodes(rfc6962.DefaultHasher)
-	cmt := compact.NewTree(rfc6962.DefaultHasher)
+	populateTheThing := populateLogSubtreeNodes(rfc6962.NewSHA256())
+	cmt := compact.NewTree(rfc6962.NewSHA256())
 	cmtStorage := storagepb.SubtreeProto{
 		Leaves:        make(map[string][]byte),
 		InternalNodes: make(map[string][]byte),
@@ -257,13 +257,13 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		Leaves: make(map[string][]byte),
 		Depth:  int32(defaultLogStrata[0]),
 	}
-	c := NewSubtreeCache(defaultLogStrata, populateLogSubtreeNodes(rfc6962.DefaultHasher), prepareLogSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, populateLogSubtreeNodes(rfc6962.NewSHA256()), prepareLogSubtreeWrite())
 	for numLeaves := int64(1); numLeaves <= 256; numLeaves++ {
 		// clear internal nodes
 		s.InternalNodes = make(map[string][]byte)
 
 		leaf := []byte(fmt.Sprintf("this is leaf %d", numLeaves))
-		leafHash, err := rfc6962.DefaultHasher.HashLeaf(leaf)
+		leafHash, err := rfc6962.NewSHA256().HashLeaf(leaf)
 		if err != nil {
 			t.Fatalf("HashLeaf(%v): %v", leaf, err)
 		}

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -128,7 +128,7 @@ func NewMultiFakeNodeReader(readers []FakeNodeReader) *MultiFakeNodeReader {
 // code. To help guard against this we check the tree root hash after each batch has been
 // processed. The supplied batches should be in ascending order of tree revision.
 func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader {
-	tree := compact.NewTree(rfc6962.DefaultHasher)
+	tree := compact.NewTree(rfc6962.NewSHA256())
 	readers := make([]FakeNodeReader, 0, len(batches))
 
 	lastBatchRevision := int64(0)

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -244,7 +244,7 @@ func Main(args Options) string {
 	as := memory.NewAdminStorage(ts)
 	tree, tSigner := createTree(as, ls)
 
-	seq := log.NewSequencer(rfc6962.DefaultHasher,
+	seq := log.NewSequencer(rfc6962.NewSHA256(),
 		clock.System,
 		ls,
 		tSigner,


### PR DESCRIPTION
Allows hash buffers to be reused at the cost of thread safety and the
need to make copies in some places. Apply this to the compact merkle
tree to demonstrate the gains.

Performance improvement is noticeable

```
BenchmarkAddLeaf-12    	  200000	     15023 ns/op
BenchmarkAddLeaf-12    	  200000	     11392 ns/op
```

Also memory profile showed ~20% reduction in memory allocation for the
benchmark run.

```
Showing nodes accounting for 717.58MB, 96.48% of 743.73MB total
Dropped 36 nodes (cum <= 3.72MB)
Showing top 10 nodes out of 32
      flat  flat%   sum%        cum   cum%
  419.06MB 56.35% 56.35%   419.06MB 56.35%  crypto/internal/boring.(*sha256Hash).sum
     150MB 20.17% 76.51%      150MB 20.17%  crypto/internal/boring.(*sha256Hash).Write.func1
   73.51MB  9.88% 86.40%    73.51MB  9.88%  crypto/internal/boring.NewSHA256
      13MB  1.75% 88.15%       14MB  1.88%  testing.(*common).Helper
      13MB  1.75% 89.89%       13MB  1.75%  fmt.Sprintf
      13MB  1.75% 91.64%   432.06MB 58.09%  crypto/internal/boring.(*sha256Hash).Sum
   12.50MB  1.68% 93.32%   449.05MB 60.38%  github.com/google/trillian/merkle/compact.BenchmarkAddLeaf
      10MB  1.34% 94.67%    24.50MB  3.29%  github.com/google/trillian/merkle/compact.(*tree).verifyRange
       7MB  0.94% 95.61%    50.01MB  6.72%  github.com/google/trillian/merkle/rfc6962.(*Hasher).HashChildren
    6.50MB  0.87% 96.48%   475.05MB 63.87%  github.com/google/trillian/merkle/compact.(*Tree).AddLeafHash
```

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
