### PR TITLE
Experimental hasher API change for performance improvement (2nd time)

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -519,7 +520,7 @@ func makeGetLeavesByIndexRequest(logID int64, startLeaf, numLeaves int64) *trill
 func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParameters) (*merkle.InMemoryMerkleTree, error) {
 	// Build the same tree with two different Merkle implementations as an additional check. We don't
 	// just rely on the compact tree as the server uses the same code so bugs could be masked
-	compactTree := compact.NewTree(rfc6962.DefaultHasher)
+	compactTree := compact.NewTree(rfc6962.NewInplace(crypto.SHA256))
 	merkleTree := merkle.NewInMemoryMerkleTree(rfc6962.DefaultHasher)
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -97,7 +97,7 @@ func createMetrics(mf monitoring.MetricFactory) {
 // There is no strong ordering guarantee but in general entries will be processed
 // in order of submission to the log.
 type Sequencer struct {
-	hasher     hashers.LogHasher
+	hasher     hashers.InplaceLogHasher
 	timeSource clock.TimeSource
 	logStorage storage.LogStorage
 	signer     *tcrypto.Signer
@@ -112,7 +112,7 @@ const maxTreeDepth = 64
 
 // NewSequencer creates a new Sequencer instance for the specified inputs.
 func NewSequencer(
-	hasher hashers.LogHasher,
+	hasher hashers.InplaceLogHasher,
 	timeSource clock.TimeSource,
 	logStorage storage.LogStorage,
 	signer *tcrypto.Signer,

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -332,7 +332,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	if qm == nil {
 		qm = quota.Noop()
 	}
-	sequencer := NewSequencer(rfc6962.DefaultHasher, clock.NewFake(fakeTimeForTest), fakeStorage, signer, nil, qm)
+	sequencer := NewSequencer(rfc6962.NewInplace(crypto.SHA256), clock.NewFake(fakeTimeForTest), fakeStorage, signer, nil, qm)
 	return testContext{mockTx: mockTx, fakeStorage: fakeStorage, signer: signer, sequencer: sequencer}, context.Background()
 }
 
@@ -659,7 +659,6 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 	defer ctrl.Finish()
 
 	// Needed to create a signer
-	hasher := rfc6962.DefaultHasher
 	ts := clock.NewFake(fakeTimeForTest)
 	signer := tcrypto.NewSigner(0, cryptoSigner, crypto.SHA256)
 
@@ -749,7 +748,7 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 				qm.EXPECT().PutTokens(any, test.wantTokens, specs)
 			}
 
-			sequencer := NewSequencer(hasher, ts, logStorage, signer, nil /* mf */, qm)
+			sequencer := NewSequencer(rfc6962.NewInplace(crypto.SHA256), ts, logStorage, signer, nil /* mf */, qm)
 			tree := &trillian.Tree{TreeId: treeID, TreeType: trillian.TreeType_LOG}
 			leaves, err := sequencer.IntegrateBatch(ctx, tree, limit, guardWindow, maxRootDuration)
 			if err != nil {

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -257,7 +257,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, setNodeFn setNodeFunc) (int64, error
 			return assignedSeq, nil
 		}
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
-		hash := t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
+		hash = t.hasher.HashChildrenInto(t.nodes[bit], hash, hash)
 		// Store the resulting parent hash. Make a copy in case the function retains it.
 		if err := setNodeFn(bit+1, index, append(make([]byte, 0, len(hash)), hash...)); err != nil {
 			return 0, err

--- a/merkle/hash_chainer.go
+++ b/merkle/hash_chainer.go
@@ -24,7 +24,7 @@ import (
 //
 // TODO(pavelkalinnikov): Add a Merkle Trees doc with visual explanations.
 type hashChainer struct {
-	hasher hashers.LogHasher
+	hasher hashers.InplaceLogHasher
 }
 
 // chainInner computes a subtree hash for a node on or below the tree's right
@@ -32,33 +32,39 @@ type hashChainer struct {
 // |seed| is the initial subtree/leaf hash on the path located at the specified
 // |index| on its level.
 func (c hashChainer) chainInner(seed []byte, proof [][]byte, index int64) []byte {
+	// Make a copy to begin with, which will be reused throughout.
+	res := append(make([]byte, 0, len(seed)), seed...)
 	for i, h := range proof {
 		if (index>>uint(i))&1 == 0 {
-			seed = c.hasher.HashChildren(seed, h)
+			res = c.hasher.HashChildrenInto(res, h, res)
 		} else {
-			seed = c.hasher.HashChildren(h, seed)
+			res = c.hasher.HashChildrenInto(h, res, res)
 		}
 	}
-	return seed
+	return res
 }
 
 // chainInnerRight computes a subtree hash like chainInner, but only takes
 // hashes to the left from the path into consideration, which effectively means
 // the result is a hash of the corresponding earlier version of this subtree.
 func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, index int64) []byte {
+	// Make a copy to begin with, which will be reused throughout.
+	res := append(make([]byte, 0, len(seed)), seed...)
 	for i, h := range proof {
 		if (index>>uint(i))&1 == 1 {
-			seed = c.hasher.HashChildren(h, seed)
+			res = c.hasher.HashChildrenInto(h, res, res)
 		}
 	}
-	return seed
+	return res
 }
 
 // chainBorderRight chains proof hashes along tree borders. This differs from
 // inner chaining because |proof| contains only left-side subtree hashes.
+// This is always called when a hash computation is in progress so it's not
+// necessary to make a copy of the input.
 func (c hashChainer) chainBorderRight(seed []byte, proof [][]byte) []byte {
 	for _, h := range proof {
-		seed = c.hasher.HashChildren(h, seed)
+		seed = c.hasher.HashChildrenInto(h, seed, seed)
 	}
 	return seed
 }

--- a/merkle/hash_chainer_test.go
+++ b/merkle/hash_chainer_test.go
@@ -17,7 +17,6 @@ package merkle
 import (
 	"bytes"
 	"crypto"
-	"reflect"
 	"testing"
 
 	"github.com/google/trillian/merkle/rfc6962"
@@ -163,7 +162,7 @@ func TestChainInnerRight(t *testing.T) {
 			c := hashChainer{
 				hasher: rfc6962.NewInplace(crypto.SHA256),
 			}
-			if got := c.chainInnerRight(inSeed, tt.args.proof, tt.args.index); !reflect.DeepEqual(got, tt.want) {
+			if got := c.chainInnerRight(inSeed, tt.args.proof, tt.args.index); !bytes.Equal(got, tt.want) {
 				t.Errorf("hashChainer.chainInnerRight() = %v, want %v", got, tt.want)
 			}
 			if got := bytes.Equal(inSeed, tt.args.seed); got != true {
@@ -208,7 +207,7 @@ func TestChainBorderRight(t *testing.T) {
 			c := hashChainer{
 				hasher: rfc6962.NewInplace(crypto.SHA256),
 			}
-			if got := c.chainBorderRight(tt.args.seed, tt.args.proof); !reflect.DeepEqual(got, tt.want) {
+			if got := c.chainBorderRight(tt.args.seed, tt.args.proof); !bytes.Equal(got, tt.want) {
 				t.Errorf("hashChainer.chainBorderRight() = %v, want %v", got, tt.want)
 			}
 		})

--- a/merkle/hash_chainer_test.go
+++ b/merkle/hash_chainer_test.go
@@ -1,0 +1,216 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merkle
+
+import (
+	"bytes"
+	"crypto"
+	"reflect"
+	"testing"
+
+	"github.com/google/trillian/merkle/rfc6962"
+)
+
+var (
+	leaf1 = []byte("this is leaf data 1")
+	leaf2 = []byte("this is leaf data 2")
+	leaf3 = []byte("this is leaf data 3")
+)
+
+// Test that chainInner does not mutate it's input slice and computes hashes correctly.
+// Compare against values produced by rfc6962.DefaultHasher.
+func TestChainInner(t *testing.T) {
+	refHash := rfc6962.DefaultHasher
+
+	type args struct {
+		seed  []byte
+		proof [][]byte
+		index int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "one even",
+			args: args{
+				seed:  leaf1,
+				index: 0,
+				proof: [][]byte{leaf2},
+			},
+			want: refHash.HashChildren(leaf1, leaf2),
+		},
+		{
+			name: "one odd",
+			args: args{
+				seed:  leaf1,
+				index: 1,
+				proof: [][]byte{leaf2},
+			},
+			want: refHash.HashChildren(leaf2, leaf1),
+		},
+		{
+			name: "multiple odd",
+			args: args{
+				seed:  leaf1,
+				index: 3,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(leaf3, refHash.HashChildren(leaf2, leaf1)),
+		},
+		{
+			name: "multiple even",
+			args: args{
+				seed:  leaf1,
+				index: 0,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(refHash.HashChildren(leaf1, leaf2), leaf3),
+		},
+		{
+			name: "mixed",
+			args: args{
+				seed:  leaf1,
+				index: 2,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(leaf3, refHash.HashChildren(leaf1, leaf2)),
+		},
+	}
+	for _, tt := range tests {
+		inSeed := append(make([]byte, 0, len(tt.args.seed)), tt.args.seed...)
+		t.Run(tt.name, func(t *testing.T) {
+			c := hashChainer{
+				hasher: rfc6962.NewInplace(crypto.SHA256),
+			}
+			if got := c.chainInner(inSeed, tt.args.proof, tt.args.index); !bytes.Equal(got, tt.want) {
+				t.Errorf("hashChainer.chainInner(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+			if got := bytes.Equal(inSeed, tt.args.seed); got != true {
+				t.Errorf("hashChainer.chainInner(%s): input slice was mutated", tt.name)
+			}
+		})
+	}
+}
+
+// Test that chainInnerRight does not mutate it's input slice and computes hashes correctly.
+func TestChainInnerRight(t *testing.T) {
+	refHash := rfc6962.DefaultHasher
+
+	type args struct {
+		seed  []byte
+		proof [][]byte
+		index int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "no hashing",
+			args: args{
+				seed:  leaf1,
+				index: 0,
+				proof: [][]byte{leaf2},
+			},
+			want: leaf1,
+		},
+		{
+			name: "hash once",
+			args: args{
+				seed:  leaf1,
+				index: 1,
+				proof: [][]byte{leaf2},
+			},
+			want: refHash.HashChildren(leaf2, leaf1),
+		},
+		{
+			name: "hash once of two",
+			args: args{
+				seed:  leaf1,
+				index: 1,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(leaf2, leaf1),
+		},
+		{
+			name: "hash twice of two",
+			args: args{
+				seed:  leaf1,
+				index: 3,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(leaf3, refHash.HashChildren(leaf2, leaf1)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inSeed := append(make([]byte, 0, len(tt.args.seed)), tt.args.seed...)
+			c := hashChainer{
+				hasher: rfc6962.NewInplace(crypto.SHA256),
+			}
+			if got := c.chainInnerRight(inSeed, tt.args.proof, tt.args.index); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hashChainer.chainInnerRight() = %v, want %v", got, tt.want)
+			}
+			if got := bytes.Equal(inSeed, tt.args.seed); got != true {
+				t.Errorf("hashChainer.chainInnerRight(%s): input slice was mutated", tt.name)
+			}
+		})
+	}
+}
+
+// chainBorderRight is allowed to mutate the input slice.
+func TestChainBorderRight(t *testing.T) {
+	refHash := rfc6962.DefaultHasher
+
+	type args struct {
+		seed  []byte
+		proof [][]byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "hash once",
+			args: args{
+				seed:  leaf1,
+				proof: [][]byte{leaf2},
+			},
+			want: refHash.HashChildren(leaf2, leaf1),
+		},
+		{
+			name: "hash twice",
+			args: args{
+				seed:  leaf1,
+				proof: [][]byte{leaf2, leaf3},
+			},
+			want: refHash.HashChildren(leaf3, refHash.HashChildren(leaf2, leaf1)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := hashChainer{
+				hasher: rfc6962.NewInplace(crypto.SHA256),
+			}
+			if got := c.chainBorderRight(tt.args.seed, tt.args.proof); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hashChainer.chainBorderRight() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -38,23 +38,23 @@ type LogHasher interface {
 // InplaceLogHasher provides the hash functions needed to compute dense merkle
 // trees.
 // Implementations may hold state and are not expected to be thread
-// safe. They should not be shared between multiple callers.
+// safe. They should not be shared between multiple callers. Where performance
+// is not critical the LogHasher interface provides a safer alternative.
+//
+// Note: Implementations are not expected to be thread safe. The caller must
+// ensure that concurrent calls are not made and is responsible for making
+// copies of slices where necessary to avoid data being overwritten.
 type InplaceLogHasher interface {
 	// EmptyRootInto supports returning a special case for the root of an empty tree.
 	// The passed in slice is mutated. The caller is responsible for making copies
-	// where necessary.
+	// where necessary. Not thread safe.
 	EmptyRootInto([]byte) []byte
 	// HashLeafInto computes the hash of a leaf into an existing slice,
-	// which is mutated.
-	// Note: Implementations are not expected to be thread safe. The caller must
-	// ensure that concurrent calls are not made and is responsible for making
-	// copies of slices where necessary to avoid data being overwritten.
+	// which is mutated. The leaf and res slices may be the same. Not thread safe.
 	HashLeafInto(leaf, res []byte) ([]byte, error)
 	// HashChildrenInto computes interior nodes into an existing slice, which is
-	// mutated.
-	// Note: Implementations are not expected to be thread safe. The caller must
-	// ensure that concurrent calls are not made and is responsible for making
-	// copies of slices where necessary to avoid data being overwritten.
+	// mutated. The res slice may be the same as one of the l or r slices. Not
+	// thread safe.
 	HashChildrenInto(l, r, res []byte) []byte
 	// Size is the number of bytes in the underlying hash function.
 	// TODO(gbelvin): Replace Size() with BitLength().

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -48,7 +48,7 @@ type InplaceLogHasher interface {
 	// EmptyRootInto supports returning a special case for the root of an empty tree.
 	// The passed in slice is mutated. The caller is responsible for making copies
 	// where necessary. Not thread safe.
-	EmptyRootInto([]byte) []byte
+	EmptyRootInto(res []byte) []byte
 	// HashLeafInto computes the hash of a leaf into an existing slice,
 	// which is mutated. The leaf and res slices may be the same. Not thread safe.
 	HashLeafInto(leaf, res []byte) ([]byte, error)

--- a/merkle/log_verifier.go
+++ b/merkle/log_verifier.go
@@ -16,11 +16,13 @@ package merkle
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"fmt"
 	"math/bits"
 
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
 // RootMismatchError occurs when an inclusion proof fails.
@@ -35,12 +37,15 @@ func (e RootMismatchError) Error() string {
 
 // LogVerifier verifies inclusion and consistency proofs for append only logs.
 type LogVerifier struct {
-	hasher hashers.LogHasher
+	hasher hashers.InplaceLogHasher
 }
 
 // NewLogVerifier returns a new LogVerifier for a tree.
-func NewLogVerifier(hasher hashers.LogHasher) LogVerifier {
-	return LogVerifier{hasher}
+// TODO(Martin2112): Clean this up if we implement this change. There is a
+// cross-repo dependency to consider if this function signature changes to
+// take an InplaceLogHasher.
+func NewLogVerifier(_ hashers.LogHasher) LogVerifier {
+	return LogVerifier{rfc6962.NewInplace(crypto.SHA256)}
 }
 
 // VerifyInclusionProof verifies the correctness of the proof given the passed

--- a/merkle/log_verifier_test.go
+++ b/merkle/log_verifier_test.go
@@ -259,7 +259,7 @@ func TestVerifyInclusionProofSingleEntry(t *testing.T) {
 	v := NewLogVerifier(rfc6962.DefaultHasher)
 	data := []byte("data")
 	// Root and leaf hash for 1-entry tree are the same.
-	hash, _ := v.hasher.HashLeaf(data)
+	hash, _ := v.hasher.HashLeafInto(data, nil)
 	// The corresponding inclusion proof is empty.
 	proof := [][]byte{}
 	emptyHash := []byte{}

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -93,7 +93,8 @@ func (t *Hasher) HashChildren(l, r []byte) []byte {
 
 // EmptyRootInto returns a special case for an empty tree.
 func (t *InplaceHasher) EmptyRootInto(res []byte) []byte {
-	return t.New().Sum(res)
+	t.hasher.Reset()
+	return t.hasher.Sum(res)
 }
 
 // HashLeafInto places the Merkle tree leaf hash of the data passed in into a

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -15,6 +15,8 @@ package rfc6962
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"testing"
@@ -24,45 +26,82 @@ import (
 
 func TestRFC6962Hasher(t *testing.T) {
 	hasher := DefaultHasher
-
-	leafHash, err := hasher.HashLeaf([]byte("L123456"))
-	if err != nil {
-		t.Fatalf("HashLeaf(): %v", err)
-	}
-	emptyLeafHash, err := hasher.HashLeaf([]byte{})
-	if err != nil {
-		t.Fatalf("HashLeaf(empty): %v", err)
-	}
+	iHasher := NewInplace(crypto.SHA256)
 
 	for _, tc := range []struct {
 		desc string
-		got  []byte
+		got  func() ([]byte, error)
 		want string
 	}{
 		// echo -n | sha256sum
 		{
 			desc: "RFC6962 Empty",
 			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			got:  hasher.EmptyRoot(),
+			got:  func() ([]byte, error) { return hasher.EmptyRoot(), nil },
+		},
+		{
+			desc: "RFC6962 Empty_Inplace",
+			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			got: func() ([]byte, error) {
+				hash := make([]byte, 0, 32)
+				return iHasher.EmptyRootInto(hash), nil
+			},
+		},
+		{
+			desc: "RFC6962 Empty_Inplace_nil",
+			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			got: func() ([]byte, error) {
+				return iHasher.EmptyRootInto(nil), nil
+			},
 		},
 		// Check that the empty hash is not the same as the hash of an empty leaf.
 		// echo -n 00 | xxd -r -p | sha256sum
 		{
 			desc: "RFC6962 Empty Leaf",
 			want: "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
-			got:  emptyLeafHash,
+			got:  func() ([]byte, error) { return hasher.HashLeaf([]byte{}) },
 		},
 		// echo -n 004C313233343536 | xxd -r -p | sha256sum
 		{
 			desc: "RFC6962 Leaf",
 			want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56",
-			got:  leafHash,
+			got:  func() ([]byte, error) { return hasher.HashLeaf([]byte("L123456")) },
+		},
+		{
+			desc: "RFC6962 Leaf_Inplace",
+			want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56",
+			got: func() ([]byte, error) {
+				hash := make([]byte, 0, 32)
+				return iHasher.HashLeafInto([]byte("L123456"), hash)
+			},
+		},
+		{
+			desc: "RFC6962 Leaf_Inplace_nil",
+			want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56",
+			got: func() ([]byte, error) {
+				return iHasher.HashLeafInto([]byte("L123456"), nil)
+			},
 		},
 		// echo -n 014E3132334E343536 | xxd -r -p | sha256sum
 		{
 			desc: "RFC6962 Node",
 			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
-			got:  hasher.HashChildren([]byte("N123"), []byte("N456")),
+			got:  func() ([]byte, error) { return hasher.HashChildren([]byte("N123"), []byte("N456")), nil },
+		},
+		{
+			desc: "RFC6962 Node_Inplace",
+			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
+			got: func() ([]byte, error) {
+				hash := make([]byte, 0, 32)
+				return iHasher.HashChildrenInto([]byte("N123"), []byte("N456"), hash), nil
+			},
+		},
+		{
+			desc: "RFC6962 Node_Inplace_nil",
+			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
+			got: func() ([]byte, error) {
+				return iHasher.HashChildrenInto([]byte("N123"), []byte("N456"), nil), nil
+			},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -70,7 +109,14 @@ func TestRFC6962Hasher(t *testing.T) {
 			if err != nil {
 				t.Fatalf("hex.DecodeString(%x): %v", tc.want, err)
 			}
-			if got, want := tc.got, wantBytes; !bytes.Equal(got, want) {
+			got, err := tc.got()
+			if err != nil {
+				t.Errorf("got: %v, %v, want err=nil", got, err)
+			}
+			if len(got) != 32 {
+				t.Errorf("got result of: %d bytes, want: 32", len(got))
+			}
+			if got, want := got, wantBytes; !bytes.Equal(got, want) {
 				t.Errorf("got %x, want %x", got, want)
 			}
 		})
@@ -105,13 +151,24 @@ func TestRFC6962HasherCollisions(t *testing.T) {
 	}
 }
 
+// hashChildrenOld returns the inner Merkle tree node hash of the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+// TODO(al): Remove me.
+func hashChildrenOld(l, r []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte{RFC6962NodeHashPrefix})
+	h.Write(l)
+	h.Write(r)
+	return h.Sum(nil)
+}
+
 // TODO(al): Remove me.
 func BenchmarkHashChildrenOld(b *testing.B) {
 	h := DefaultHasher
 	l, _ := h.HashLeaf([]byte("one"))
 	r, _ := h.HashLeaf([]byte("or other"))
 	for i := 0; i < b.N; i++ {
-		_ = h.hashChildrenOld(l, r)
+		_ = hashChildrenOld(l, r)
 	}
 }
 
@@ -135,7 +192,7 @@ func TestHashChildrenEquivToOld(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if oldHash, newHash := h.hashChildrenOld(l, r), h.HashChildren(l, r); !bytes.Equal(oldHash, newHash) {
+		if oldHash, newHash := hashChildrenOld(l, r), h.HashChildren(l, r); !bytes.Equal(oldHash, newHash) {
 			t.Errorf("%d different hashes: %x vs %x", i, oldHash, newHash)
 		}
 	}

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -84,6 +84,13 @@ func TestRFC6962Hasher(t *testing.T) {
 				return iHasher.HashLeafInto([]byte("L123456"), nil)
 			},
 		},
+		{
+			desc: "RFC6962 Leaf_Inplace_empty",
+			want: "395aa064aa4c29f7010acfe3f25db9485bbd4b91897b6ad7ad547639252b4d56",
+			got: func() ([]byte, error) {
+				return iHasher.HashLeafInto([]byte("L123456"), make([]byte, 0))
+			},
+		},
 		// echo -n 014E3132334E343536 | xxd -r -p | sha256sum
 		{
 			desc: "RFC6962 Node",
@@ -103,6 +110,13 @@ func TestRFC6962Hasher(t *testing.T) {
 			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
 			got: func() ([]byte, error) {
 				return iHasher.HashChildrenInto([]byte("N123"), []byte("N456"), nil), nil
+			},
+		},
+		{
+			desc: "RFC6962 Node_Inplace_empty",
+			want: "aa217fe888e47007fa15edab33c2b492a722cb106c64667fc2b044444de66bbb",
+			got: func() ([]byte, error) {
+				return iHasher.HashChildrenInto([]byte("N123"), []byte("N456"), make([]byte, 0)), nil
 			},
 		},
 	} {

--- a/merkle/rfc6962/rfc6962_test.go
+++ b/merkle/rfc6962/rfc6962_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	_ "github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/hashers"
 )
 
 func TestRFC6962Hasher(t *testing.T) {
@@ -196,5 +198,14 @@ func TestHashChildrenEquivToOld(t *testing.T) {
 			t.Errorf("%d different hashes: %x vs %x", i, oldHash, newHash)
 		}
 	}
+}
 
+// Tests that the rfc6962 log hashers were registered.
+func TestRegistrations(t *testing.T) {
+	if h, err := hashers.NewLogHasher(trillian.HashStrategy_RFC6962_SHA256); err != nil || h == nil {
+		t.Errorf("NewLogHasher(trillian.HashStrategy_RFC6962_SHA256)=%v, %v, want registered hasher", h, err)
+	}
+	if h, err := hashers.NewInplaceLogHasher(trillian.HashStrategy_RFC6962_SHA256); err != nil || h == nil {
+		t.Errorf("NewInplaceLogHasher(trillian.HashStrategy_RFC6962_SHA256)=%v, %v, want registered hasher", h, err)
+	}
 }

--- a/server/sequencer_manager.go
+++ b/server/sequencer_manager.go
@@ -67,7 +67,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *L
 	}
 	ctx = trees.NewContext(ctx, tree)
 
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := hashers.NewInplaceLogHasher(tree.HashStrategy)
 	if err != nil {
 		return 0, fmt.Errorf("error getting hasher for log %v: %v", logID, err)
 	}

--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -25,13 +25,13 @@ import (
 
 // NewLogSubtreeCache creates and returns a SubtreeCache appropriate for use with a log
 // tree. The caller must supply the strata depths to be used and a suitable LogHasher.
-func NewLogSubtreeCache(logStrata []int, hasher hashers.LogHasher) SubtreeCache {
+func NewLogSubtreeCache(logStrata []int, hasher hashers.InplaceLogHasher) SubtreeCache {
 	return NewSubtreeCache(logStrata, populateLogSubtreeNodes(hasher), prepareLogSubtreeWrite())
 }
 
 // LogPopulateFunc obtains a log storage population function based on a supplied LogHasher.
 // This is intended for use by storage utilities.
-func LogPopulateFunc(hasher hashers.LogHasher) storage.PopulateSubtreeFunc {
+func LogPopulateFunc(hasher hashers.InplaceLogHasher) storage.PopulateSubtreeFunc {
 	return populateLogSubtreeNodes(hasher)
 }
 
@@ -42,7 +42,7 @@ func LogPopulateFunc(hasher hashers.LogHasher) storage.PopulateSubtreeFunc {
 // handle imperfect (but left-hand dense) subtrees. Note that we only rebuild internal
 // nodes when the subtree is fully populated. For an explanation of why see the comments
 // below for PrepareLogSubtreeWrite.
-func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFunc {
+func populateLogSubtreeNodes(hasher hashers.InplaceLogHasher) storage.PopulateSubtreeFunc {
 	return func(st *storagepb.SubtreeProto) error {
 		cmt := compact.NewTree(hasher)
 		if st.Depth < 1 {

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"fmt"
 	"testing"
@@ -246,8 +247,8 @@ func TestCacheFlush(t *testing.T) {
 }
 
 func TestRepopulateLogSubtree(t *testing.T) {
-	populateTheThing := populateLogSubtreeNodes(rfc6962.DefaultHasher)
-	cmt := compact.NewTree(rfc6962.DefaultHasher)
+	populateTheThing := populateLogSubtreeNodes(rfc6962.NewInplace(crypto.SHA256))
+	cmt := compact.NewTree(rfc6962.NewInplace(crypto.SHA256))
 	cmtStorage := storagepb.SubtreeProto{
 		Leaves:        make(map[string][]byte),
 		InternalNodes: make(map[string][]byte),
@@ -257,7 +258,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		Leaves: make(map[string][]byte),
 		Depth:  int32(defaultLogStrata[0]),
 	}
-	c := NewSubtreeCache(defaultLogStrata, populateLogSubtreeNodes(rfc6962.DefaultHasher), prepareLogSubtreeWrite())
+	c := NewSubtreeCache(defaultLogStrata, populateLogSubtreeNodes(rfc6962.NewInplace(crypto.SHA256)), prepareLogSubtreeWrite())
 	for numLeaves := int64(1); numLeaves <= 256; numLeaves++ {
 		// clear internal nodes
 		s.InternalNodes = make(map[string][]byte)

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -128,7 +128,7 @@ func (ls *logStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, erro
 }
 
 func newLogCache(tree *trillian.Tree) (cache.SubtreeCache, error) {
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := hashers.NewInplaceLogHasher(tree.HashStrategy)
 	if err != nil {
 		return cache.SubtreeCache{}, err
 	}

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -151,7 +151,7 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, tree *trillian.Tre
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := hashers.NewInplaceLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -226,7 +226,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := hashers.NewInplaceLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -152,7 +152,7 @@ func createSomeNodes() []storage.Node {
 }
 
 func createLogNodesForTreeAtSize(ts, rev int64) ([]storage.Node, error) {
-	tree := compact.NewTree(rfc6962.New(crypto.SHA256))
+	tree := compact.NewTree(rfc6962.NewInplace(crypto.SHA256))
 	nodeMap := make(map[string]storage.Node)
 	for l := 0; l < int(ts); l++ {
 		// We're only interested in the side effects of adding leaves - the node updates

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -17,6 +17,7 @@ package testonly
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -119,7 +120,7 @@ func NewMultiFakeNodeReader(readers []FakeNodeReader) *MultiFakeNodeReader {
 // code. To help guard against this we check the tree root hash after each batch has been
 // processed. The supplied batches should be in ascending order of tree revision.
 func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader {
-	tree := compact.NewTree(rfc6962.DefaultHasher)
+	tree := compact.NewTree(rfc6962.NewInplace(crypto.SHA256))
 	readers := make([]FakeNodeReader, 0, len(batches))
 
 	lastBatchRevision := int64(0)

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -244,7 +244,7 @@ func Main(args Options) string {
 	as := memory.NewAdminStorage(ts)
 	tree, tSigner := createTree(as, ls)
 
-	seq := log.NewSequencer(rfc6962.DefaultHasher,
+	seq := log.NewSequencer(rfc6962.NewInplace(crypto.SHA256),
 		clock.System,
 		ls,
 		tSigner,
@@ -299,7 +299,7 @@ func Main(args Options) string {
 		formatter = fullProto
 	}
 
-	hasher, err := hashers.NewLogHasher(trillian.HashStrategy_RFC6962_SHA256)
+	hasher, err := hashers.NewInplaceLogHasher(trillian.HashStrategy_RFC6962_SHA256)
 	if err != nil {
 		glog.Fatalf("Failed to create a log hasher: %v", err)
 	}


### PR DESCRIPTION
Improved version of #1533. This time the API change and caller contract change are explicit and the set of changes is much less intrusive as the old objects remain stateless. Added some docs to existing API.

Apply the new APIs to compact range (via `hash_chainer`) to reduce memory allocation.

The current hasher APIs are constantly allocating slices and copying hashes into them when we often have a chain of hashes like in hash_chainer that can be done in place. The benchmarks with compact merkle tree showed about 25% improvement in time and memory allocation. Some numbers in the description for #1533. I'd expect similar gains for compact range as it uses repeated hashing chains.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
