### PR TITLE
Delete LogMetadata.GetUnsequencedCounts()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,8 @@ The `SubtreeCache.GetNodeHash()` method is no longer exported.
 The memory storage provider has been refactored to make it more consistent with
 the other storage providers.
 
+The `LogMetadata.GetUnsequencedCounts()` method has been removed.
+
 ### Maphammer improvements
 
 The maphammer test tool for the experimental Trillian Map has been enhanced.

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -197,11 +197,4 @@ type LogMetadata interface {
 	// GetActiveLogIDs returns a list of the IDs of all the logs that are
 	// configured in storage and are eligible to have entries sequenced.
 	GetActiveLogIDs(ctx context.Context) ([]int64, error)
-
-	// GetUnsequencedCounts returns a map of the number of unsequenced entries
-	// by log ID.
-	//
-	// This call is likely to be VERY expensive and take a long time to complete.
-	// Consider carefully whether you really need to call it!
-	GetUnsequencedCounts(ctx context.Context) (CountByLogID, error)
 }

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -425,18 +425,3 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 func (t *logTreeTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return getActiveLogIDs(t.ts.trees), nil
 }
-
-func (t *readOnlyLogTX) GetUnsequencedCounts(ctx context.Context) (storage.CountByLogID, error) {
-	t.ms.mu.RLock()
-	defer t.ms.mu.RUnlock()
-
-	ret := make(map[int64]int64)
-	for id, tree := range t.ms.trees {
-		tree.RLock()
-		k := unseqKey(id)
-		queue := tree.store.Get(k).(*kv).v.(*list.List)
-		ret[id] = int64(queue.Len())
-		tree.RUnlock()
-	}
-	return ret, nil
-}

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -1155,21 +1155,6 @@ func (mr *MockReadOnlyLogTXMockRecorder) GetActiveLogIDs(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveLogIDs", reflect.TypeOf((*MockReadOnlyLogTX)(nil).GetActiveLogIDs), arg0)
 }
 
-// GetUnsequencedCounts mocks base method
-func (m *MockReadOnlyLogTX) GetUnsequencedCounts(arg0 context.Context) (CountByLogID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnsequencedCounts", arg0)
-	ret0, _ := ret[0].(CountByLogID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnsequencedCounts indicates an expected call of GetUnsequencedCounts
-func (mr *MockReadOnlyLogTXMockRecorder) GetUnsequencedCounts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnsequencedCounts", reflect.TypeOf((*MockReadOnlyLogTX)(nil).GetUnsequencedCounts), arg0)
-}
-
 // Rollback mocks base method
 func (m *MockReadOnlyLogTX) Rollback() error {
 	m.ctrl.T.Helper()

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -50,9 +50,8 @@ const (
 		  AND TreeState IN(?,?)
 		  AND (Deleted IS NULL OR Deleted = 'false')`
 
-	selectSequencedLeafCountSQL   = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
-	selectUnsequencedLeafCountSQL = "SELECT TreeId, COUNT(1) FROM Unsequenced GROUP BY TreeId"
-	selectLatestSignedLogRootSQL  = `SELECT TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature
+	selectSequencedLeafCountSQL  = "SELECT COUNT(*) FROM SequencedLeafData WHERE TreeId=?"
+	selectLatestSignedLogRootSQL = `SELECT TreeHeadTimestamp,TreeSize,RootHash,TreeRevision,RootSignature
 			FROM TreeHead WHERE TreeId=?
 			ORDER BY TreeHeadTimestamp DESC LIMIT 1`
 
@@ -892,31 +891,6 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		ret = append(ret, leaf)
 	}
 
-	return ret, nil
-}
-
-func (t *readOnlyLogTX) GetUnsequencedCounts(ctx context.Context) (storage.CountByLogID, error) {
-	stx, err := t.tx.PrepareContext(ctx, selectUnsequencedLeafCountSQL)
-	if err != nil {
-		glog.Warningf("Failed to prep unsequenced leaf count statement: %v", err)
-		return nil, err
-	}
-	defer stx.Close()
-
-	rows, err := stx.QueryContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	ret := make(map[int64]int64)
-	for rows.Next() {
-		var logID, count int64
-		if err := rows.Scan(&logID, &count); err != nil {
-			return nil, fmt.Errorf("failed to scan row from unsequenced counts: %v", err)
-		}
-		ret[logID] = count
-	}
 	return ret, nil
 }
 


### PR DESCRIPTION
It is unused and the documentation warns against using it.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
