### PR TITLE
Postgres tests should not fail if a Postgres server is not available

### DIFF
--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -290,6 +290,5 @@ func TestMain(m *testing.M) {
 	DB = openTestDBOrDie()
 	defer DB.Close()
 	cleanTestDB(DB)
-	ec := m.Run()
-	os.Exit(ec)
+	os.Exit(m.Run())
 }

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -38,6 +38,5 @@ func TestMain(m *testing.M) {
 	defer cancel()
 	db = testdb.NewTrillianDBOrDie(ctx)
 	defer db.Close()
-	ec := m.Run()
-	os.Exit(ec)
+	os.Exit(m.Run())
 }

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -30,16 +30,14 @@ var db *sql.DB
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	ec := 0
-	defer func() { os.Exit(ec) }()
 	if !testdb.PGAvailable() {
 		glog.Errorf("PG not available, skipping all PG storage tests")
-		ec = 1
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*30))
 	defer cancel()
 	db = testdb.NewTrillianDBOrDie(ctx)
 	defer db.Close()
-	ec = m.Run()
+	ec := m.Run()
+	os.Exit(ec)
 }


### PR DESCRIPTION
The MySQL tests pass if a MySQL server is not installed, and the Postgres tests should behave similarly. Ideally, both sets of tests would mark themselves as skipped using `t.Skip()`, but that would require more extensive changes.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
