### PR TITLE
Propagate Log Update Failures in AddSequencedLeaves

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -316,7 +316,7 @@ func (c *LogClient) AddSequencedLeaves(ctx context.Context, dataByIndex map[int6
 	})
 	for _, leaf := range resp.GetResults() {
 		if stat := leaf.GetStatus().GetCode(); stat != int32(codes.OK) && stat != int32(codes.AlreadyExists) {
-			return fmt.Errorf("unexpected fail status in AddSequencedLeaves: %+v", leaf)
+			return status.Errorf(s.Code(), "unexpected fail status in AddSequencedLeaves: %+v, err: %v", leaf, s.Message())
 		}
 	}
 	return err

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -315,7 +315,7 @@ func (c *LogClient) AddSequencedLeaves(ctx context.Context, dataByIndex map[int6
 		Leaves: leaves,
 	})
 	for _, leaf := range resp.GetResults() {
-		if stat := leaf.GetStatus().GetCode(); stat != int32(codes.OK) && stat != int32(codes.AlreadyExists) {
+		if s := status.FromProto(leaf.GetStatus()); s.Code() != codes.OK && s.Code() != codes.AlreadyExists {
 			return status.Errorf(s.Code(), "unexpected fail status in AddSequencedLeaves: %+v, err: %v", leaf, s.Message())
 		}
 	}

--- a/client/log_client.go
+++ b/client/log_client.go
@@ -315,11 +315,8 @@ func (c *LogClient) AddSequencedLeaves(ctx context.Context, dataByIndex map[int6
 		Leaves: leaves,
 	})
 	for _, leaf := range resp.GetResults() {
-		if stat := leaf.GetStatus().GetCode(); stat != codes.OK {
-			glog.Warningf("Got a non-OK status for a sequenced leaf: %+v", leaf)
-			if stat != codes.AlreadyExists {
-				return fmt.Errorf("unexpected fail status in AddSequencedLeaves: %+v", leaf)
-			}
+		if stat := leaf.GetStatus().GetCode(); stat != int32(codes.OK) && stat != int32(codes.AlreadyExists) {
+			return fmt.Errorf("unexpected fail status in AddSequencedLeaves: %+v", leaf)
 		}
 	}
 	return err


### PR DESCRIPTION
AddSequencedLeaves in the log client previously did not evaluate the response proto. Adding some fail case checking and logging.
