### PR TITLE
sequencer: Clean up compact Tree updates

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -170,17 +170,15 @@ func (s Sequencer) buildMerkleTreeFromStorageAtRoot(ctx context.Context, root *t
 }
 
 func (s Sequencer) buildNodesFromNodeMap(nodeMap map[compact.NodeID][]byte, newVersion int64) ([]storage.Node, error) {
-	targetNodes := make([]storage.Node, len(nodeMap))
-	i := 0
+	nodes := make([]storage.Node, 0, len(nodeMap))
 	for id, hash := range nodeMap {
 		nodeID, err := storage.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)
 		if err != nil {
 			return nil, err
 		}
-		targetNodes[i] = storage.Node{NodeID: nodeID, Hash: hash, NodeRevision: newVersion}
-		i++
+		nodes = append(nodes, storage.Node{NodeID: nodeID, Hash: hash, NodeRevision: newVersion})
 	}
-	return targetNodes, nil
+	return nodes, nil
 }
 
 func (s Sequencer) prepareLeaves(leaves []*trillian.LogLeaf, begin int64, label string) error {


### PR DESCRIPTION
This change cleans up compact Tree update code:
- Timestamps / merge delay computation is factored out into a separate function.
- Node ID computation and hashmap updating is deduplicated.
- Use compact node IDs as hashmap keys.

The last one also saves some time/memory because we stop converting NodeID to string.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
