### PR TITLE
Workaround for single-tx-mode map performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`
 binaries now have CPU and heap profiling flags. Profiling is off by default.
 For more details see the
 [Go Blog](https://blog.golang.org/profiling-go-programs).
+### Map performance tweaks
+
+The map mode has had some performance tweaks added:
+* A workaround for locking issues which affect the map when it's used in
+  single-transaction mode.
 
 ### Introduce BatchInclusionProof function
 

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -68,12 +68,11 @@ var (
 	configFile = flag.String("config", "", "Config file containing flags, file contents can be overridden by command line flags")
 
 	useSingleTransaction = flag.Bool("single_transaction", false, "Experimental: use a single transaction when updating the map")
+	largePreload         = flag.Bool("large_preload_fix", false, "Experimental: work-around locking performance issues when using useSingleTransaction mode")
 
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
-
-	largePreload = flag.Bool("large_preload_fix", true, "Experimental: work-around locking performance issues when using useSingleTransaction mode")
 )
 
 func main() {

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -72,6 +72,8 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
+
+	largePreload = flag.Bool("large_preload_fix", true, "Experimental: work-around locking performance issues when using useSingleTransaction mode")
 )
 
 func main() {
@@ -150,6 +152,7 @@ func main() {
 			mapServer := server.NewTrillianMapServer(registry,
 				server.TrillianMapServerOptions{
 					UseSingleTransaction: *useSingleTransaction,
+					UseLargePreload:      *largePreload,
 				})
 			if err := mapServer.IsHealthy(); err != nil {
 				return err


### PR DESCRIPTION
Adds a workaround for performance hit when using the map in single transaction mode.

When using the map in this mode, the various map builder go routines experience massive lock contention because they share a single underlying subtreeCache.  This workaround preloads the entire set of nodes we know the set of builders will want and so reduce the time spent with locks held in the cache.

### Checklist

- [ X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
