### PR TITLE
Add optional CPU and heap profiling to the three main trillian binaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Add Profiling Flags to Binaries
+
+The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`
+binaries now have CPU and heap profiling flags. Profiling is off by default.
+For more details see the
+[Go Blog](https://blog.golang.org/profiling-go-programs).
+
 ### Introduce BatchInclusionProof function
 
 Added a batch version of the Merkle Tree InclusionProof function.

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -196,6 +196,11 @@ func main() {
 		glog.Exitf("Server exited with error: %v", err)
 	}
 
+	if *memProfile != "" {
+		f := mustCreate(*memProfile)
+		pprof.WriteHeapProfile(f)
+	}
+
 	// Give things a few seconds to tidy up
 	glog.Infof("Stopping server, about to exit")
 	time.Sleep(time.Second * 5)


### PR DESCRIPTION
Profiling is off by default.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
