### PR TITLE
CODEOWNERS: only apply to top-level API protos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Default
-*.proto                    @Martin2112 @AlCutter
+/*.proto                    @Martin2112 @AlCutter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,5 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Default
-/*.proto                    @Martin2112 @AlCutter
+/*.proto                         @Martin2112 @AlCutter
+/storage/storagepb/storage.proto @Martin2112 @AlCutter


### PR DESCRIPTION
Commit d0c1b7b7f05e ("Create CODEOWNERS file (#1520)") added
ownership to .proto files, but it applies to all .proto files
across the repo.

Instead, just apply to the top-level API definitions.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
