### PR TITLE
Faster version of NodeID.String() for use by sparse_merkle_tree

### DIFF
--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -408,7 +408,7 @@ func (s SparseMerkleTreeReader) BatchInclusionProof(ctx context.Context, rev int
 		sibs := nid.Siblings()
 		indexToSibs[string(index)] = sibs
 		for _, sib := range sibs {
-			if sibID := sib.String(); !includedNodes[sibID] {
+			if sibID := sib.AsKey(); !includedNodes[sibID] {
 				includedNodes[sibID] = true
 				allSibs = append(allSibs, sib)
 			}
@@ -420,8 +420,8 @@ func (s SparseMerkleTreeReader) BatchInclusionProof(ctx context.Context, rev int
 	}
 	nodeMap := make(map[string]*storage.Node)
 	for i, n := range nodes {
-		glog.V(2).Infof("   %x, %d: %x", n.NodeID.Path, len(n.NodeID.String()), n.Hash)
-		nodeMap[n.NodeID.String()] = &nodes[i]
+		glog.V(2).Infof("   %x, %d: %x", n.NodeID.Path, len(n.NodeID.AsKey()), n.Hash)
+		nodeMap[n.NodeID.AsKey()] = &nodes[i]
 	}
 
 	r := map[string]([][]byte){}
@@ -433,7 +433,7 @@ func (s SparseMerkleTreeReader) BatchInclusionProof(ctx context.Context, rev int
 		// For each proof element:
 		for i := range ri {
 			proofID := sibs[i]
-			pNode := nodeMap[proofID.String()]
+			pNode := nodeMap[proofID.AsKey()]
 			if pNode == nil {
 				// No node for this level from storage, so use the nil hash.
 				continue

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -651,40 +651,61 @@ func TestBitPanics(t *testing.T) {
 
 func TestString(t *testing.T) {
 	for i, tc := range []struct {
-		n    NodeID
-		want string
+		n       NodeID
+		want    string
+		wantKey string
 	}{
 		{
-			n:    NewEmptyNodeID(32),
-			want: "",
+			n:       NewEmptyNodeID(32),
+			want:    "",
+			wantKey: "0:",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("345678"), 24, 32, 32),
-			want: "00110100010101100111100000000000",
+			n:       NewNodeIDWithPrefix(h26("345678"), 24, 32, 32),
+			want:    "00110100010101100111100000000000",
+			wantKey: "32:34567800",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("12345678"), 32, 32, 64),
-			want: "00010010001101000101011001111000",
+			n:       NewNodeIDWithPrefix(h26("12345678"), 32, 32, 64),
+			want:    "00010010001101000101011001111000",
+			wantKey: "32:12345678",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("345678"), 15, 16, 24),
-			want: fmt.Sprintf("%016b", (0x345678<<1)&0xfffd),
+			n:       NewNodeIDWithPrefix(h26("345678"), 15, 16, 24),
+			want:    fmt.Sprintf("%016b", (0x345678<<1)&0xfffd),
+			wantKey: "16:acf0",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("1234"), 15, 16, 16),
-			want: "0010010001101000",
+			n:       NewNodeIDWithPrefix(h26("1234"), 15, 16, 16),
+			want:    "0010010001101000",
+			wantKey: "16:2468",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("f2"), 8, 8, 24),
-			want: "11110010",
+			n:       NewNodeIDWithPrefix(h26("f2"), 8, 8, 24),
+			want:    "11110010",
+			wantKey: "8:f2",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("1234"), 16, 16, 16),
-			want: "0001001000110100",
+			n:       NewNodeIDWithPrefix(h26("1234"), 16, 16, 16),
+			want:    "0001001000110100",
+			wantKey: "16:1234",
+		},
+		{
+			n:       NewNodeIDFromHash([]byte("this is a hash")),
+			want:    "0111010001101000011010010111001100100000011010010111001100100000011000010010000001101000011000010111001101101000",
+			wantKey: "112:7468697320697320612068617368",
+		},
+		{
+			n:       NewNodeIDFromBigInt(5, big.NewInt(20), 16),
+			want:    "00000",
+			wantKey: "5:00",
 		},
 	} {
 		if got, want := tc.n.String(), tc.want; got != want {
 			t.Errorf("%v: String():  %v,  want '%v'", i, got, want)
+		}
+		if got, want := tc.n.AsKey(), tc.wantKey; got != want {
+			t.Errorf("%v: AsKey():  %v,  want '%v'", i, got, want)
 		}
 	}
 }
@@ -833,4 +854,18 @@ func mustDecode(h string) []byte {
 		panic(err)
 	}
 	return b
+}
+
+func BenchmarkString(b *testing.B) {
+	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
+	for i := 0; i < b.N; i++ {
+		nID.String()
+	}
+}
+
+func BenchmarkAsKey(b *testing.B) {
+	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
+	for i := 0; i < b.N; i++ {
+		nID.AsKey()
+	}
 }

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -859,13 +859,13 @@ func mustDecode(h string) []byte {
 func BenchmarkString(b *testing.B) {
 	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
 	for i := 0; i < b.N; i++ {
-		nID.String()
+		_ = nID.String()
 	}
 }
 
 func BenchmarkAsKey(b *testing.B) {
 	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
 	for i := 0; i < b.N; i++ {
-		nID.AsKey()
+		_ = nID.AsKey()
 	}
 }


### PR DESCRIPTION
For use in mapkeys etc. Add it to the sparse_merkle_tree code where it's
used in proofs. Profiling showed this using over 3% of CPU time in a
maphammer run. This version is 10x faster.

```
BenchmarkString-12    	 1000000	      2989 ns/op
BenchmarkAsKey-12     	 5000000	       307 ns/op
```

The Log sequencer does a similar thing but I've left that alone for now
so this change only affects the map.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
