### PR TITLE
Do preload nodeID calculations in parallel

### DIFF
--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/trillian/types"
 
 	"github.com/golang/glog"
-	"go.opencensus.io/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -319,6 +319,13 @@ func doPreload(ctx context.Context, tx storage.MapTreeTX, treeDepth int, hkv []m
 	if err != nil {
 		return err
 	}
+
+	nids := calcAllSiblingsParallel(ctx, treeDepth, hkv)
+	_, err = tx.GetMerkleNodes(ctx, readRev, nids)
+	return err
+}
+
+func calcAllSiblingsParallel(ctx context.Context, treeDepth int, hkv []merkle.HashKeyValue) []storage.NodeID {
 	nidSet := make(map[string]bool)
 	type nodeAndID struct {
 		id   string
@@ -358,8 +365,7 @@ func doPreload(ctx context.Context, tx storage.MapTreeTX, treeDepth int, hkv []m
 
 	<-done
 
-	_, err = tx.GetMerkleNodes(ctx, readRev, nids)
-	return err
+	return nids
 }
 
 func (t *TrillianMapServer) makeSignedMapRoot(ctx context.Context, tree *trillian.Tree, smrTs time.Time,

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -341,7 +341,7 @@ func calcAllSiblingsParallel(ctx context.Context, treeDepth int, hkv []merkle.Ha
 			nid := storage.NewNodeIDFromHash(k)
 			sibs := (&nid).Siblings()
 			for _, sib := range sibs {
-				sibID := sib.String()
+				sibID := sib.AsKey()
 				sib := sib
 				c <- nodeAndID{sibID, sib}
 			}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -37,8 +37,6 @@ import (
 const (
 	// Used internally by GetLeaves.
 	mostRecentRevision = -1
-
-	traceSpanRoot = "github.com/google/trillian/server/map_rpc_server"
 )
 
 var (
@@ -326,8 +324,8 @@ func doPreload(ctx context.Context, tx storage.MapTreeTX, hkv []merkle.HashKeyVa
 
 	for _, i := range hkv {
 		wg.Add(1)
-		go func() {
-			nid := storage.NewNodeIDFromHash(i.HashedKey)
+		go func(k []byte) {
+			nid := storage.NewNodeIDFromHash(k)
 			sibs := (&nid).Siblings()
 			for _, sib := range sibs {
 				sibID := sib.String()
@@ -335,7 +333,7 @@ func doPreload(ctx context.Context, tx storage.MapTreeTX, hkv []merkle.HashKeyVa
 				c <- nodeAndID{sibID, sib}
 			}
 			wg.Done()
-		}()
+		}(i.HashedKey)
 	}
 
 	done := make(chan bool)

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/trillian/types"
 
 	"github.com/golang/glog"
+	"go.opencensus.io/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -37,6 +38,8 @@ import (
 const (
 	// Used internally by GetLeaves.
 	mostRecentRevision = -1
+
+	traceSpanRoot = "github.com/google/trillian/server/map_rpc_server"
 )
 
 var (
@@ -214,6 +217,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 
 	ctx, span := spanFor(ctx, "SetLeaves")
 	defer span.End()
+
 	mapID := req.MapId
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, optsMapWrite)
 	if err != nil {
@@ -306,6 +310,9 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 }
 
 func doPreload(ctx context.Context, tx storage.MapTreeTX, hkv []merkle.HashKeyValue) error {
+	ctx, span := spanFor(ctx, "doPreload")
+	defer span.End()
+
 	readRev, err := tx.ReadRevision(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Do nodeID calculations for set leaves preload concurrently.

For large batches there is a lot of time spent creating NodeID strings here, so do the work concurrently.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
