### PR TITLE
compact: Report ephemeral nodes through visitor

### DIFF
--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -118,10 +118,13 @@ func (r *Range) AppendRange(other *Range, visitor VisitFn) error {
 	return r.appendImpl(other.end, other.hashes[0], other.hashes[1:], visitor)
 }
 
-// GetRootHash returns the root hash of the Merkle tree represented by
-// this compact range. Requires the range to start at index 0. If the
-// range is empty, returns nil.
-func (r *Range) GetRootHash() ([]byte, error) {
+// GetRootHash returns the root hash of the Merkle tree represented by this
+// compact range. Requires the range to start at index 0. If the range is
+// empty, returns nil.
+//
+// If visitor is not nil, it is called with all "ephemeral" nodes (i.e. the
+// ones rooting imperfect subtrees) along the right border of the tree.
+func (r *Range) GetRootHash(visitor VisitFn) ([]byte, error) {
 	if r.begin != 0 {
 		return nil, fmt.Errorf("begin=%d, want 0", r.begin)
 	}
@@ -130,8 +133,17 @@ func (r *Range) GetRootHash() ([]byte, error) {
 		return nil, nil
 	}
 	hash := r.hashes[ln-1]
-	for i := ln - 2; i >= 0; i-- {
+	// All non-perfect subtree hashes along the right border of the tree
+	// correspond to the parents of all perfect subtree nodes except the lowest
+	// one (therefore the loop skips it).
+	for i, size := ln-2, r.end; i >= 0; i-- {
 		hash = r.f.Hash(r.hashes[i], hash)
+		if visitor != nil {
+			size &= size - 1                              // Delete the previous node.
+			level := uint(bits.TrailingZeros64(size)) + 1 // Compute the parent level.
+			index := size >> level                        // And its horizontal index.
+			visitor(level, index, hash)
+		}
 	}
 	return hash, nil
 }

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -380,20 +380,60 @@ func TestGetRootHash(t *testing.T) {
 }
 
 func TestGetRootHashGolden(t *testing.T) {
+	type node struct {
+		level uint
+		index uint64
+		hash  string
+	}
+
 	// TODO(pavelkalinnikov): Values are copied from tree_test. Commonize them.
 	for _, tc := range []struct {
-		size     int
-		wantRoot string
+		size      int
+		wantRoot  string
+		wantNodes []node
 	}{
-		{size: 10, wantRoot: "VjWMPSYNtCuCNlF/RLnQy6HcwSk6CIipfxm+hettA+4="},
+		{
+			size:      10,
+			wantRoot:  "VjWMPSYNtCuCNlF/RLnQy6HcwSk6CIipfxm+hettA+4=",
+			wantNodes: []node{{4, 0, "VjWMPSYNtCuCNlF/RLnQy6HcwSk6CIipfxm+hettA+4="}},
+		},
 		{size: 15, wantRoot: "j4SulYmocFuxdeyp12xXCIgK6PekBcxzAIj4zbQzNEI="},
-		{size: 16, wantRoot: "c+4Uc6BCMOZf/v3NZK1kqTUJe+bBoFtOhP+P3SayKRE="},
-		{size: 100, wantRoot: "dUh9hYH88p0CMoHkdr1wC2szbhcLAXOejWpINIooKUY="},
-		{size: 255, wantRoot: "SmdsuKUqiod3RX2jyF2M6JnbdE4QuTwwipfAowI4/i0="},
-		{size: 256, wantRoot: "qFI0t/tZ1MdOYgyPpPzHFiZVw86koScXy9q3FU5casA="},
-		{size: 1000, wantRoot: "RXrgb8xHd55Y48FbfotJwCbV82Kx22LZfEbmBGAvwlQ="},
+		{size: 16, wantRoot: "c+4Uc6BCMOZf/v3NZK1kqTUJe+bBoFtOhP+P3SayKRE=", wantNodes: []node{}},
+		{
+			size:     100,
+			wantRoot: "dUh9hYH88p0CMoHkdr1wC2szbhcLAXOejWpINIooKUY=",
+			wantNodes: []node{
+				{6, 1, "/K5I3bQ6Wz/beVi9IFKizZ073WqI8kGqstdkbmMcTXI="},
+				{7, 0, "dUh9hYH88p0CMoHkdr1wC2szbhcLAXOejWpINIooKUY="},
+			},
+		},
+		{
+			size:     255,
+			wantRoot: "SmdsuKUqiod3RX2jyF2M6JnbdE4QuTwwipfAowI4/i0=",
+			wantNodes: []node{
+				{2, 63, "EphrHrAU2E+H65CW1o2SwiJVA1dNragVhsMsOkyBdZ4="},
+				{3, 31, "fwen9eGNKOdGYC7L1GSwMKBlyjIIZBlsKVkmPGtsZEY="},
+				{4, 15, "Iq5blg5fdl93qbEUzBBEiGMoP7zyzbwf14JuB5YBidM="},
+				{5, 7, "D6s+gn79wNsgmdvBv0fVIYCougsU+PUSdtLGrWGmyO4="},
+				{6, 3, "swSuozoE2E7iTV9cnNGcnjbLEeDq+5ep2hRJuI0pTtI="},
+				{7, 1, "xv1RcZ3JpQusUjlsGQzsV9kWuITo3aLNpEsKymbFhak="},
+				{8, 0, "SmdsuKUqiod3RX2jyF2M6JnbdE4QuTwwipfAowI4/i0="},
+			},
+		},
+		{size: 256, wantRoot: "qFI0t/tZ1MdOYgyPpPzHFiZVw86koScXy9q3FU5casA=", wantNodes: []node{}},
+		{
+			size:     1000,
+			wantRoot: "RXrgb8xHd55Y48FbfotJwCbV82Kx22LZfEbmBGAvwlQ=",
+			wantNodes: []node{
+				{6, 15, "CBbiN/le+CpZNxEmCVIgfQSl/ZTapYxUOsdKTkiVjtc="},
+				{7, 7, "npfCeOdllUJZLLRbvEkxlwY7enS6pRlChKVTJjHcevI="},
+				{8, 3, "5MVDHIWhLErkcLgceSnxZWOTG04QlhIkm3aUEOQLpWw="},
+				{9, 1, "6EoN2SheMl5oA3qymXw1Ltcp1ku/INU+rBqEe2+jIjI="},
+				{10, 0, "RXrgb8xHd55Y48FbfotJwCbV82Kx22LZfEbmBGAvwlQ="},
+			},
+		},
 		{size: 4095, wantRoot: "cWRFdQhPcjn9WyBXE/r1f04ejxIm5lvg40DEpRBVS0w="},
-		{size: 4096, wantRoot: "6uU/phfHg1n/GksYT6TO9aN8EauMCCJRl3dIK0HDs2M="},
+		{size: 4096, wantRoot: "6uU/phfHg1n/GksYT6TO9aN8EauMCCJRl3dIK0HDs2M=", wantNodes: []node{}},
 		{size: 10000, wantRoot: "VZcav65F9haHVRk3wre2axFoBXRNeUh/1d9d5FQfxIg="},
 		{size: 65535, wantRoot: "iPuVYJhP6SEE4gUFp8qbafd2rYv9YTCDYqAxCj8HdLM="},
 	} {
@@ -409,12 +449,20 @@ func TestGetRootHashGolden(t *testing.T) {
 					t.Fatalf("Append(%d): %v", i, err)
 				}
 			}
-			hash, err := rng.GetRootHash(nil)
+			visited := make([]node, 0, len(tc.wantNodes))
+			hash, err := rng.GetRootHash(func(level uint, index uint64, hash []byte) {
+				visited = append(visited, node{level: level, index: index, hash: base64.StdEncoding.EncodeToString(hash)})
+			})
 			if err != nil {
 				t.Fatalf("GetRootHash: %v", err)
 			}
 			if got, want := base64.StdEncoding.EncodeToString(hash), tc.wantRoot; got != want {
 				t.Errorf("root hash mismatch: got %q, want %q", got, want)
+			}
+			if tc.wantNodes != nil {
+				if !reflect.DeepEqual(visited, tc.wantNodes) {
+					t.Errorf("visited:\n%v\nwant:\n%v", visited, tc.wantNodes)
+				}
 			}
 		})
 	}

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -362,7 +362,7 @@ func TestGetRootHash(t *testing.T) {
 			for i := uint64(0); i < size; i++ {
 				rng.Append(tree.leaf(i), nil)
 			}
-			root, err := rng.GetRootHash()
+			root, err := rng.GetRootHash(nil)
 			if err != nil {
 				t.Fatalf("GetRootHash: %v", err)
 			}
@@ -374,7 +374,7 @@ func TestGetRootHash(t *testing.T) {
 
 	// Should accept only [0, N) ranges.
 	rng := factory.NewEmptyRange(10)
-	if _, err := rng.GetRootHash(); err == nil {
+	if _, err := rng.GetRootHash(nil); err == nil {
 		t.Error("GetRootHash succeeded unexpectedly")
 	}
 }
@@ -409,7 +409,7 @@ func TestGetRootHashGolden(t *testing.T) {
 					t.Fatalf("Append(%d): %v", i, err)
 				}
 			}
-			hash, err := rng.GetRootHash()
+			hash, err := rng.GetRootHash(nil)
 			if err != nil {
 				t.Fatalf("GetRootHash: %v", err)
 			}


### PR DESCRIPTION
This change extends `GetRootHash` method with an optional visitor function which allows enumerating all "ephemeral" non-power-of-2 nodes of the tree.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
