### PR TITLE
Require Docker tests to pass for Travis build to succeed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: DOCKER_TESTS=true
 
 services:
   - docker


### PR DESCRIPTION
The Docker tests are slightly faster than the integration tests, so
they don't slow down the overall build.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
