### PR TITLE
Add tracing abstraction, and opencensus impl

### DIFF
--- a/monitoring/opencensus/trace.go
+++ b/monitoring/opencensus/trace.go
@@ -15,6 +15,7 @@
 package opencensus
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -90,4 +91,12 @@ func applyConfig(percent int) error {
 		trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(float64(percent) / 100.0)})
 	}
 	return nil
+}
+
+// StartSpan starts a new tracing span.
+// The returned context should be used for all child calls within the span, and
+// the returned func should be called to close the span.
+func StartSpan(ctx context.Context, name string) (context.Context, func()) {
+	ctx, span := trace.StartSpan(ctx, name)
+	return ctx, span.End
 }

--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/trillian/util/clock"
-	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
 )
 
@@ -74,8 +73,8 @@ func (r *RPCStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 
 		// This interceptor wraps the request handler so we should track the
 		// additional latency it imposes.
-		ctx, span := trace.StartSpan(ctx, traceSpanRoot)
-		defer span.End()
+		ctx, spanEnd := StartSpan(ctx, traceSpanRoot)
+		defer spanEnd()
 
 		// Increase the request count for the method and start the clock
 		r.ReqCount.Inc(labels...)

--- a/monitoring/trace.go
+++ b/monitoring/trace.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitoring
 
 import (

--- a/monitoring/trace.go
+++ b/monitoring/trace.go
@@ -24,6 +24,3 @@ import (
 // The default implementation of this method is a no-op; insert a real tracing span
 // implementation by setting this global variable to the relevant function at start of day.
 var StartSpan = func(ctx context.Context, msg string) (context.Context, func()) { return ctx, func() {} }
-
-// StartSpanFunc is the signature of a function which starts new tracing spans.
-type StartSpanFunc func(ctx context.Context, name string) (context.Context, func())

--- a/monitoring/trace.go
+++ b/monitoring/trace.go
@@ -1,0 +1,29 @@
+package monitoring
+
+import (
+	"context"
+	"sync"
+)
+
+// StartSpan is the global entry point for Trillian code to create new tracing spans.
+var (
+	once      sync.Once
+	startSpan StartSpanFunc = func(ctx context.Context, _ string) (context.Context, func()) { return ctx, func() {} }
+)
+
+// SetStartSpanFunc allows the tracing span implementation to be set.
+// This function will set the global tracing function to the one supplied by
+// the first caller, future calls to this function will have no effect.
+func SetStartSpanFunc(s StartSpanFunc) {
+	once.Do(func() {
+		startSpan = s
+	})
+}
+
+// StartSpan starts a new tracing span.
+func StartSpan(ctx context.Context, name string) (context.Context, func()) {
+	return startSpan(ctx, name)
+}
+
+// StartSpanFunc is the signature of a function which starts new tracing spans.
+type StartSpanFunc func(ctx context.Context, name string) (context.Context, func())

--- a/monitoring/trace.go
+++ b/monitoring/trace.go
@@ -16,28 +16,14 @@ package monitoring
 
 import (
 	"context"
-	"sync"
 )
 
-// StartSpan is the global entry point for Trillian code to create new tracing spans.
-var (
-	once      sync.Once
-	startSpan StartSpanFunc = func(ctx context.Context, _ string) (context.Context, func()) { return ctx, func() {} }
-)
-
-// SetStartSpanFunc allows the tracing span implementation to be set.
-// This function will set the global tracing function to the one supplied by
-// the first caller, future calls to this function will have no effect.
-func SetStartSpanFunc(s StartSpanFunc) {
-	once.Do(func() {
-		startSpan = s
-	})
-}
-
-// StartSpan starts a new tracing span.
-func StartSpan(ctx context.Context, name string) (context.Context, func()) {
-	return startSpan(ctx, name)
-}
+// StartSpan starts a new tracing span using the given message.
+// The returned context should be used for all child calls within the span, and
+// the returned func should be called to close the span.
+// The default implementation of this method is a no-op; insert a real tracing span
+// implementation by setting this global variable to the relevant function at start of day.
+var StartSpan = func(ctx context.Context, msg string) (context.Context, func()) { return ctx, func() {} }
 
 // StartSpanFunc is the signature of a function which starts new tracing spans.
 type StartSpanFunc func(ctx context.Context, name string) (context.Context, func())

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -811,8 +811,7 @@ func (t *TrillianLogRPCServer) recordIndexPercent(leafIndex int64, treeSize uint
 }
 
 func spanFor(ctx context.Context, name string) (context.Context, func()) {
-	ctx, spanEnd := monitoring.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
-	return ctx, spanEnd
+	return monitoring.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
 }
 
 func (t *TrillianLogRPCServer) snapshotForTree(ctx context.Context, tree *trillian.Tree, method string) (storage.ReadOnlyLogTreeTX, error) {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/trillian/trees"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
-	"go.opencensus.io/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -81,15 +80,15 @@ func NewTrillianLogRPCServer(registry extension.Registry, timeSource clock.TimeS
 
 // IsHealthy returns nil if the server is healthy, error otherwise.
 func (t *TrillianLogRPCServer) IsHealthy() error {
-	ctx, span := spanFor(context.Background(), "IsHealthy")
-	defer span.End()
+	ctx, spanEnd := spanFor(context.Background(), "IsHealthy")
+	defer spanEnd()
 	return t.registry.LogStorage.CheckDatabaseAccessible(ctx)
 }
 
 // QueueLeaf submits one leaf to the queue.
 func (t *TrillianLogRPCServer) QueueLeaf(ctx context.Context, req *trillian.QueueLeafRequest) (*trillian.QueueLeafResponse, error) {
-	ctx, span := spanFor(ctx, "QueueLeaf")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "QueueLeaf")
+	defer spanEnd()
 	if err := validateLogLeaf(req.Leaf, "QueueLeafRequest.Leaf"); err != nil {
 		return nil, err
 	}
@@ -127,8 +126,8 @@ func hashLeaves(leaves []*trillian.LogLeaf, hasher hashers.LogHasher) error {
 
 // QueueLeaves submits a batch of leaves to the log for later integration into the underlying tree.
 func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.QueueLeavesRequest) (*trillian.QueueLeavesResponse, error) {
-	ctx, span := spanFor(ctx, "QueueLeaves")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "QueueLeaves")
+	defer spanEnd()
 	if err := validateLogLeaves(req.Leaves, "QueueLeavesRequest"); err != nil {
 		return nil, err
 	}
@@ -162,8 +161,8 @@ func (t *TrillianLogRPCServer) QueueLeaves(ctx context.Context, req *trillian.Qu
 
 // AddSequencedLeaf submits one sequenced leaf to the storage.
 func (t *TrillianLogRPCServer) AddSequencedLeaf(ctx context.Context, req *trillian.AddSequencedLeafRequest) (*trillian.AddSequencedLeafResponse, error) {
-	ctx, span := spanFor(ctx, "AddSequencedLeaf")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "AddSequencedLeaf")
+	defer spanEnd()
 	if err := validateLogLeaf(req.Leaf, "AddSequencedLeafRequest.Leaf"); err != nil {
 		return nil, err
 	}
@@ -188,8 +187,8 @@ func (t *TrillianLogRPCServer) AddSequencedLeaf(ctx context.Context, req *trilli
 // AddSequencedLeaves submits a batch of sequenced leaves to a pre-ordered log
 // for later integration into its underlying tree.
 func (t *TrillianLogRPCServer) AddSequencedLeaves(ctx context.Context, req *trillian.AddSequencedLeavesRequest) (*trillian.AddSequencedLeavesResponse, error) {
-	ctx, span := spanFor(ctx, "AddSequencedLeaves")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "AddSequencedLeaves")
+	defer spanEnd()
 	if err := validateAddSequencedLeavesRequest(req); err != nil {
 		return nil, err
 	}
@@ -218,8 +217,8 @@ func (t *TrillianLogRPCServer) AddSequencedLeaves(ctx context.Context, req *tril
 // GetInclusionProof obtains the proof of inclusion in the tree for a leaf that has been sequenced.
 // Similar to the get proof by hash handler but one less step as we don't need to look up the index
 func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trillian.GetInclusionProofRequest) (*trillian.GetInclusionProofResponse, error) {
-	ctx, span := spanFor(ctx, "GetInclusionProof")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetInclusionProof")
+	defer spanEnd()
 	if err := validateGetInclusionProofRequest(req); err != nil {
 		return nil, err
 	}
@@ -272,8 +271,8 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 // GetInclusionProofByHash obtains proofs of inclusion by leaf hash. Because some logs can
 // contain duplicate hashes it is possible for multiple proofs to be returned.
 func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req *trillian.GetInclusionProofByHashRequest) (*trillian.GetInclusionProofByHashResponse, error) {
-	ctx, span := spanFor(ctx, "GetInclusionProofByHash")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetInclusionProofByHash")
+	defer spanEnd()
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, req.LogId, optsLogRead)
 	if err != nil {
@@ -343,8 +342,8 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 // other and that the later tree includes all the entries of the prior one. For more details
 // see the example trees in RFC 6962.
 func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *trillian.GetConsistencyProofRequest) (*trillian.GetConsistencyProofResponse, error) {
-	ctx, span := spanFor(ctx, "GetConsistencyProof")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetConsistencyProof")
+	defer spanEnd()
 	if err := validateGetConsistencyProofRequest(req); err != nil {
 		return nil, err
 	}
@@ -393,8 +392,8 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 // GetLatestSignedLogRoot obtains the latest published tree root for the Merkle Tree that
 // underlies the log.
 func (t *TrillianLogRPCServer) GetLatestSignedLogRoot(ctx context.Context, req *trillian.GetLatestSignedLogRootRequest) (*trillian.GetLatestSignedLogRootResponse, error) {
-	ctx, span := spanFor(ctx, "GetLatestSignedLogRoot")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLatestSignedLogRoot")
+	defer spanEnd()
 	tree, hasher, err := t.getTreeAndHasher(ctx, req.LogId, optsLogRead)
 	if err != nil {
 		return nil, err
@@ -469,8 +468,8 @@ func tryGetConsistencyProof(ctx context.Context, firstTreeSize, secondTreeSize, 
 // GetSequencedLeafCount returns the number of leaves that have been integrated into the Merkle
 // Tree. This can be zero for a log containing no entries.
 func (t *TrillianLogRPCServer) GetSequencedLeafCount(ctx context.Context, req *trillian.GetSequencedLeafCountRequest) (*trillian.GetSequencedLeafCountResponse, error) {
-	ctx, span := spanFor(ctx, "GetSequencedLeafCount")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetSequencedLeafCount")
+	defer spanEnd()
 	tree, ctx, err := t.getTreeAndContext(ctx, req.LogId, optsLogRead)
 	if err != nil {
 		return nil, err
@@ -498,8 +497,8 @@ func (t *TrillianLogRPCServer) GetSequencedLeafCount(ctx context.Context, req *t
 // TODO: Validate indices against published tree size in case we implement write sharding that
 // can get ahead of this point. Not currently clear what component should own this state.
 func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trillian.GetLeavesByIndexRequest) (*trillian.GetLeavesByIndexResponse, error) {
-	ctx, span := spanFor(ctx, "GetLeavesByIndex")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLeavesByIndex")
+	defer spanEnd()
 	if err := validateGetLeavesByIndexRequest(req); err != nil {
 		return nil, err
 	}
@@ -539,8 +538,8 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 // This only fetches sequenced leaves; leaves that have been queued but not yet integrated
 // are not visible.
 func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trillian.GetLeavesByRangeRequest) (*trillian.GetLeavesByRangeResponse, error) {
-	ctx, span := spanFor(ctx, "GetLeavesByRange")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLeavesByRange")
+	defer spanEnd()
 	if err := validateGetLeavesByRangeRequest(req); err != nil {
 		return nil, err
 	}
@@ -585,8 +584,8 @@ func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trilli
 // to fetch leaves that have been queued but not yet integrated. Logs may accept duplicate
 // entries so this may return more results than the number of hashes in the request.
 func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillian.GetLeavesByHashRequest) (*trillian.GetLeavesByHashResponse, error) {
-	ctx, span := spanFor(ctx, "GetLeavesByHash")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLeavesByHash")
+	defer spanEnd()
 
 	tree, hasher, err := t.getTreeAndHasher(ctx, req.LogId, optsLogRead)
 	if err != nil {
@@ -630,8 +629,8 @@ func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillia
 // GetEntryAndProof returns both a Merkle Leaf entry and an inclusion proof for a given index
 // and tree size.
 func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trillian.GetEntryAndProofRequest) (*trillian.GetEntryAndProofResponse, error) {
-	ctx, span := spanFor(ctx, "GetEntryAndProof")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetEntryAndProof")
+	defer spanEnd()
 	if err := validateGetEntryAndProofRequest(req); err != nil {
 		return nil, err
 	}
@@ -752,8 +751,8 @@ func (t *TrillianLogRPCServer) getTreeAndContext(ctx context.Context, treeID int
 // InitLog initialises a freshly created Log by creating the first STH with
 // size 0.
 func (t *TrillianLogRPCServer) InitLog(ctx context.Context, req *trillian.InitLogRequest) (*trillian.InitLogResponse, error) {
-	ctx, span := spanFor(ctx, "InitLog")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "InitLog")
+	defer spanEnd()
 	logID := req.LogId
 	tree, hasher, err := t.getTreeAndHasher(ctx, logID, optsLogInit)
 	if err != nil {
@@ -811,8 +810,9 @@ func (t *TrillianLogRPCServer) recordIndexPercent(leafIndex int64, treeSize uint
 	}
 }
 
-func spanFor(ctx context.Context, name string) (context.Context, *trace.Span) {
-	return trace.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
+func spanFor(ctx context.Context, name string) (context.Context, func()) {
+	ctx, spanEnd := monitoring.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
+	return ctx, spanEnd
 }
 
 func (t *TrillianLogRPCServer) snapshotForTree(ctx context.Context, tree *trillian.Tree, method string) (storage.ReadOnlyLogTreeTX, error) {

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -76,8 +76,8 @@ func NewTrillianMapServer(registry extension.Registry, opts TrillianMapServerOpt
 
 // IsHealthy returns nil if the server is healthy, error otherwise.
 func (t *TrillianMapServer) IsHealthy() error {
-	ctx, span := spanFor(context.Background(), "IsHealthy")
-	defer span.End()
+	ctx, spanEnd := spanFor(context.Background(), "IsHealthy")
+	defer spanEnd()
 	return t.registry.MapStorage.CheckDatabaseAccessible(ctx)
 }
 
@@ -85,15 +85,15 @@ func (t *TrillianMapServer) IsHealthy() error {
 // return an inclusion proof to either the leaf, or nil if the leaf does not
 // exist.
 func (t *TrillianMapServer) GetLeaves(ctx context.Context, req *trillian.GetMapLeavesRequest) (*trillian.GetMapLeavesResponse, error) {
-	ctx, span := spanFor(ctx, "GetLeaves")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLeaves")
+	defer spanEnd()
 	return t.getLeavesByRevision(ctx, req.MapId, req.Index, mostRecentRevision)
 }
 
 // GetLeavesByRevision implements the GetLeavesByRevision RPC method.
 func (t *TrillianMapServer) GetLeavesByRevision(ctx context.Context, req *trillian.GetMapLeavesByRevisionRequest) (*trillian.GetMapLeavesResponse, error) {
-	ctx, span := spanFor(ctx, "GetLeavesByRevision")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetLeavesByRevision")
+	defer spanEnd()
 	if req.Revision < 0 {
 		return nil, fmt.Errorf("map revision %d must be >= 0", req.Revision)
 	}
@@ -247,8 +247,8 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		seen[k] = true
 	}
 
-	ctx, span := spanFor(ctx, "SetLeaves")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "SetLeaves")
+	defer spanEnd()
 
 	mapID := req.MapId
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, optsMapWrite)
@@ -347,8 +347,8 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 // sparse Merkle tree code is used with a single transaction (and therefore
 // a single subtreeCache too).
 func doPreload(ctx context.Context, tx storage.MapTreeTX, treeDepth int, hkv []merkle.HashKeyValue) error {
-	ctx, span := spanFor(ctx, "doPreload")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "doPreload")
+	defer spanEnd()
 
 	readRev, err := tx.ReadRevision(ctx)
 	if err != nil {
@@ -423,8 +423,8 @@ func (t *TrillianMapServer) makeSignedMapRoot(ctx context.Context, tree *trillia
 
 // GetSignedMapRoot implements the GetSignedMapRoot RPC method.
 func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.GetSignedMapRootRequest) (*trillian.GetSignedMapRootResponse, error) {
-	ctx, span := spanFor(ctx, "GetSignedMapRoot")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetSignedMapRoot")
+	defer spanEnd()
 	tree, ctx, err := t.getTreeAndContext(ctx, req.MapId, optsMapRead)
 	if err != nil {
 		return nil, err
@@ -453,8 +453,8 @@ func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.
 // GetSignedMapRootByRevision implements the GetSignedMapRootByRevision RPC
 // method.
 func (t *TrillianMapServer) GetSignedMapRootByRevision(ctx context.Context, req *trillian.GetSignedMapRootByRevisionRequest) (*trillian.GetSignedMapRootResponse, error) {
-	ctx, span := spanFor(ctx, "GetSignedMapRootByRevision")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetSignedMapRootByRevision")
+	defer spanEnd()
 	if req.Revision < 0 {
 		return nil, fmt.Errorf("map revision %d must be >= 0", req.Revision)
 	}
@@ -505,8 +505,8 @@ func (t *TrillianMapServer) getTreeAndContext(ctx context.Context, treeID int64,
 
 // InitMap implements the RPC Method of the same name.
 func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRequest) (*trillian.InitMapResponse, error) {
-	ctx, span := spanFor(ctx, "InitMap")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "InitMap")
+	defer spanEnd()
 	mapID := req.MapId
 	tree, hasher, err := t.getTreeAndHasher(ctx, mapID, optsMapInit)
 	if err != nil {

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -30,8 +30,8 @@ import (
 // revisions. This code only relies on the NodeReader interface so can be tested without
 // a complete storage implementation.
 func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hashers.LogHasher, treeRevision, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (trillian.Proof, error) {
-	ctx, span := spanFor(ctx, "fetchNodesAndBuildProof")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "fetchNodesAndBuildProof")
+	defer spanEnd()
 	proofNodes, err := fetchNodes(ctx, tx, treeRevision, proofNodeFetches)
 	if err != nil {
 		return trillian.Proof{}, err
@@ -103,8 +103,8 @@ func (r *rehasher) rehashedProof(leafIndex int64) (trillian.Proof, error) {
 // fetchNodes extracts the NodeIDs from a list of NodeFetch structs and passes them
 // to storage, returning the result after some additional validation checks.
 func fetchNodes(ctx context.Context, tx storage.NodeReader, treeRevision int64, fetches []merkle.NodeFetch) ([]storage.Node, error) {
-	ctx, span := spanFor(ctx, "fetchNodes")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "fetchNodes")
+	defer spanEnd()
 	proofNodeIDs := make([]storage.NodeID, 0, len(fetches))
 
 	for _, fetch := range fetches {

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/quota/etcd/quotaapi"
@@ -90,6 +91,7 @@ func main() {
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}
+	monitoring.SetStartSpanFunc(opencensus.StartSpan)
 
 	if *tracing {
 		opts, err := opencensus.EnableRPCServerTracing(*tracingProjectID, *tracingPercent)

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}
-	monitoring.SetStartSpanFunc(opencensus.StartSpan)
+	monitoring.StartSpan = opencensus.StartSpan
 
 	if *tracing {
 		opts, err := opencensus.EnableRPCServerTracing(*tracingProjectID, *tracingPercent)

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/google/trillian/cmd"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/log"
+	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/util"
@@ -92,6 +94,7 @@ func main() {
 	glog.Info("**** Log Signer Starting ****")
 
 	mf := prometheus.MetricFactory{}
+	monitoring.SetStartSpanFunc(opencensus.StartSpan)
 
 	sp, err := server.NewStorageProviderFromFlags(mf)
 	if err != nil {

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -94,7 +94,7 @@ func main() {
 	glog.Info("**** Log Signer Starting ****")
 
 	mf := prometheus.MetricFactory{}
-	monitoring.SetStartSpanFunc(opencensus.StartSpan)
+	monitoring.StartSpan = opencensus.StartSpan
 
 	sp, err := server.NewStorageProviderFromFlags(mf)
 	if err != nil {

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/quota/etcd/quotaapi"
@@ -86,7 +87,7 @@ func main() {
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}
-	monitoring.SetNewSpanFunc(opencensus.NewSpanFunc)
+	monitoring.SetStartSpanFunc(opencensus.StartSpan)
 
 	if *tracing {
 		opts, err := opencensus.EnableRPCServerTracing(*tracingProjectID, *tracingPercent)

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}
-	monitoring.SetStartSpanFunc(opencensus.StartSpan)
+	monitoring.StartSpan = opencensus.StartSpan
 
 	if *tracing {
 		opts, err := opencensus.EnableRPCServerTracing(*tracingProjectID, *tracingPercent)

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -86,6 +86,7 @@ func main() {
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}
+	monitoring.SetNewSpanFunc(opencensus.NewSpanFunc)
 
 	if *tracing {
 		opts, err := opencensus.EnableRPCServerTracing(*tracingProjectID, *tracingPercent)

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/trillian"
-	"go.opencensus.io/trace"
+	"github.com/google/trillian/monitoring"
 )
 
 const traceSpanRoot = "github.com/google/trillian/storage"
@@ -28,8 +28,8 @@ const traceSpanRoot = "github.com/google/trillian/storage"
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.
 // See RunInAdminSnapshot if you need to perform more than one action per transaction.
 func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "GetTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "GetTree")
+	defer spanEnd()
 	var tree *trillian.Tree
 	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) error {
 		var err error
@@ -43,8 +43,8 @@ func GetTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.T
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's ListTrees.
 // See RunInAdminSnapshot if you need to perform more than one action per transaction.
 func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "ListTrees")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "ListTrees")
+	defer spanEnd()
 	var resp []*trillian.Tree
 	err := RunInAdminSnapshot(ctx, admin, func(tx ReadOnlyAdminTX) error {
 		var err error
@@ -58,8 +58,8 @@ func ListTrees(ctx context.Context, admin AdminStorage, includeDeleted bool) ([]
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's CreateTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "CreateTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "CreateTree")
+	defer spanEnd()
 	var createdTree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		var err error
@@ -73,8 +73,8 @@ func CreateTree(ctx context.Context, admin AdminStorage, tree *trillian.Tree) (*
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UpdateTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*trillian.Tree)) (*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "UpdateTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "UpdateTree")
+	defer spanEnd()
 	var updatedTree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		var err error
@@ -88,8 +88,8 @@ func UpdateTree(ctx context.Context, admin AdminStorage, treeID int64, fn func(*
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's SoftDeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "SoftDeleteTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "SoftDeleteTree")
+	defer spanEnd()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		var err error
@@ -103,8 +103,8 @@ func SoftDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*tri
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's HardDeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error {
-	ctx, span := spanFor(ctx, "HardDeleteTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "HardDeleteTree")
+	defer spanEnd()
 	return admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		return tx.HardDeleteTree(ctx, treeID)
 	})
@@ -114,8 +114,8 @@ func HardDeleteTree(ctx context.Context, admin AdminStorage, treeID int64) error
 // It's a convenience wrapper around ReadWriteTransaction and AdminWriter's UndeleteTree.
 // See ReadWriteTransaction if you need to perform more than one action per transaction.
 func UndeleteTree(ctx context.Context, admin AdminStorage, treeID int64) (*trillian.Tree, error) {
-	ctx, span := spanFor(ctx, "UndeleteTree")
-	defer span.End()
+	ctx, spanEnd := spanFor(ctx, "UndeleteTree")
+	defer spanEnd()
 	var tree *trillian.Tree
 	err := admin.ReadWriteTransaction(ctx, func(ctx context.Context, tx AdminTX) error {
 		var err error
@@ -138,6 +138,6 @@ func RunInAdminSnapshot(ctx context.Context, admin AdminStorage, fn func(tx Read
 	return tx.Commit()
 }
 
-func spanFor(ctx context.Context, name string) (context.Context, *trace.Span) {
-	return trace.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
+func spanFor(ctx context.Context, name string) (context.Context, func()) {
+	return monitoring.StartSpan(ctx, fmt.Sprintf("%s.%s", traceSpanRoot, name))
 }


### PR DESCRIPTION
Adds a very simple tracing abstraction, an opencensus implementation, and switches to using it.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
