### PR TITLE
Make trace spans more readable

### DIFF
--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const traceSpanRoot = "github.com/google/trillian/monitoring.RPCStatsInterceptor"
+const traceSpanRoot = "/trillian/mon/"
 
 // RPCStatsInterceptor provides a gRPC interceptor that records statistics about the RPCs passing through it.
 type RPCStatsInterceptor struct {

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -41,7 +41,7 @@ const (
 	insufficientTokensReason = "insufficient_tokens"
 	getTreeStage             = "get_tree"
 	getTokensStage           = "get_tokens"
-	traceSpanRoot            = "github/com/google/trillian/server/interceptor"
+	traceSpanRoot            = "/trillian/server/int"
 )
 
 var (

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -158,7 +158,8 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}, method
 		return ctx, nil
 	}
 
-	ctx, spanEnd := spanFor(ctx, "Before")
+	// Don't want the Before to contain the action, so don't overwrite the ctx.
+	_, spanEnd := spanFor(ctx, "Before")
 	defer spanEnd()
 	info, err := newRPCInfo(req)
 	if err != nil {

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -38,7 +38,7 @@ import (
 // Pass this as a fixed value to proof calculations. It's used as the max depth of the tree
 const (
 	proofMaxBitLen = 64
-	traceSpanRoot  = "github.com/google/trillian/server"
+	traceSpanRoot  = "/trillian"
 )
 
 var (

--- a/storage/admin_helpers.go
+++ b/storage/admin_helpers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/trillian/monitoring"
 )
 
-const traceSpanRoot = "github.com/google/trillian/storage"
+const traceSpanRoot = "/trillian/storage"
 
 // GetTree reads a tree from storage using a snapshot transaction.
 // It's a convenience wrapper around RunInAdminSnapshot and AdminReader's GetTree.

--- a/trees/trees.go
+++ b/trees/trees.go
@@ -33,7 +33,7 @@ import (
 	tcrypto "github.com/google/trillian/crypto"
 )
 
-const traceSpanRoot = "github.com/google/trillian/trees"
+const traceSpanRoot = "/trillian/trees"
 
 type treeKey struct{}
 


### PR DESCRIPTION
Reduce the length of text in the trace spans, and stop the interceptor.Before span being considered a parent.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
