### PR TITLE
compact: Remove leaf index from method signatures

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -524,7 +524,7 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.
 	for l := params.StartLeaf; l < params.LeafCount; l++ {
-		if _, _, err := compactTree.AddLeaf(leafMap[l].LeafValue, func(compact.NodeID, []byte) {}); err != nil {
+		if _, err := compactTree.AddLeaf(leafMap[l].LeafValue, func(compact.NodeID, []byte) {}); err != nil {
 			return nil, err
 		}
 		if _, _, err := merkleTree.AddLeaf(leafMap[l].LeafValue); err != nil {

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -169,7 +169,7 @@ func (t *Tree) recalculateRoot(visit VisitFn) error {
 }
 
 // AddLeaf calculates the Merkle leaf hash of the given leaf data and appends
-// it to the tree. Returns Merkle hash of the new leaf.
+// it to the tree. Returns the Merkle hash of the new leaf.
 //
 // visit is a callback which will be called multiple times with the coordinates
 // of the Merkle tree nodes whose hash should be updated.

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -74,7 +74,7 @@ func TestAddingLeaves(t *testing.T) {
 			idx := 0
 			for _, br := range tc.breaks {
 				for ; idx < br; idx++ {
-					if _, _, err := tree.AddLeaf(inputs[idx], func(NodeID, []byte) {}); err != nil {
+					if _, err := tree.AddLeaf(inputs[idx], func(NodeID, []byte) {}); err != nil {
 						t.Fatalf("AddLeaf: %v", err)
 					}
 					if err := checkUnusedNodesInvariant(tree); err != nil {
@@ -170,7 +170,8 @@ func TestCompactVsFullTree(t *testing.T) {
 			t.Errorf("AddLeaf(): %v", err)
 		}
 
-		cSeq, cHash, err := cmt.AddLeaf(newLeaf, func(id NodeID, hash []byte) {
+		cSeq := cmt.Size()
+		cHash, err := cmt.AddLeaf(newLeaf, func(id NodeID, hash []byte) {
 			nodes[id] = hash
 		})
 		if err != nil {
@@ -196,12 +197,12 @@ func TestCompactVsFullTree(t *testing.T) {
 	cmt := NewTree(rfc6962.DefaultHasher)
 	for i := int64(0); i < imt.LeafCount(); i++ {
 		newLeaf := []byte(fmt.Sprintf("Leaf %d", i))
-		seq, _, err := cmt.AddLeaf(newLeaf, func(NodeID, []byte) {})
+		_, err := cmt.AddLeaf(newLeaf, func(NodeID, []byte) {})
 		if err != nil {
 			t.Fatalf("AddLeaf(%d)=_,_,%v, want _,_,nil", i, err)
 		}
-		if seq != i {
-			t.Fatalf("AddLeaf(%d)=%d, want %d", i, seq, i)
+		if got, want := cmt.Size(), i+1; got != want {
+			t.Fatalf("new size=%d, want %d", got, want)
 		}
 	}
 	if a, b := imt.CurrentRoot().Hash(), cmt.CurrentRoot(); !bytes.Equal(a, b) {

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -170,13 +170,13 @@ func TestCompactVsFullTree(t *testing.T) {
 			t.Errorf("AddLeaf(): %v", err)
 		}
 
-		cSeq := cmt.Size()
 		cHash, err := cmt.AddLeaf(newLeaf, func(id NodeID, hash []byte) {
 			nodes[id] = hash
 		})
 		if err != nil {
 			t.Fatalf("mt update failed: %v", err)
 		}
+		cSeq := cmt.Size() - 1 // The index of the last inserted leaf.
 
 		// In-Memory tree is 1-based for sequence numbers, since it's based on the original CT C++ impl.
 		if got, want := iSeq, i+1; got != want {
@@ -202,7 +202,7 @@ func TestCompactVsFullTree(t *testing.T) {
 			t.Fatalf("AddLeaf(%d)=_,_,%v, want _,_,nil", i, err)
 		}
 		if got, want := cmt.Size(), i+1; got != want {
-			t.Fatalf("new size=%d, want %d", got, want)
+			t.Fatalf("new tree size=%d, want %d", got, want)
 		}
 	}
 	if a, b := imt.CurrentRoot().Hash(), cmt.CurrentRoot(); !bytes.Equal(a, b) {

--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -68,7 +68,8 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 			if h == nil {
 				return fmt.Errorf("unexpectedly got nil for subtree leaf suffix %s", sfx)
 			}
-			seq, err := cmt.AddLeafHash(h, func(id compact.NodeID, h []byte) {
+			seq := cmt.Size()
+			if err := cmt.AddLeafHash(h, func(id compact.NodeID, h []byte) {
 				if id.Level == logStrataDepth && id.Index == 0 {
 					// no space for the root in the node cache
 					return
@@ -84,8 +85,7 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 					sfxKey := sfx.String()
 					st.InternalNodes[sfxKey] = h
 				}
-			})
-			if err != nil {
+			}); err != nil {
 				return err
 			}
 			if got, expected := seq, leafIndex; got != expected {

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -267,15 +267,14 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		if err != nil {
 			t.Fatalf("HashLeaf(%v): %v", leaf, err)
 		}
-		_, err = cmt.AddLeafHash(leafHash, func(id compact.NodeID, h []byte) {
+		if err := cmt.AddLeafHash(leafHash, func(id compact.NodeID, h []byte) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
 				_, sfx := c.splitNodeID(n)
 				cmtStorage.InternalNodes[sfx.String()] = h
 			}
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatalf("merkle tree update failed: %v", err)
 		}
 

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -156,7 +156,7 @@ func createLogNodesForTreeAtSize(t *testing.T, ts, rev int64) ([]storage.Node, e
 	nodeMap := make(map[compact.NodeID][]byte)
 	for l := 0; l < int(ts); l++ {
 		// We're only interested in the side effects of adding leaves - the node updates
-		if _, _, err := tree.AddLeaf([]byte(fmt.Sprintf("Leaf %d", l)), func(id compact.NodeID, hash []byte) {
+		if _, err := tree.AddLeaf([]byte(fmt.Sprintf("Leaf %d", l)), func(id compact.NodeID, hash []byte) {
 			nodeMap[id] = hash
 		}); err != nil {
 			return nil, err


### PR DESCRIPTION
This change removes leaf index from `AddLeaf` and `AddLeafHash` returned
values, as the same information can be obtained using the `Size` method.