### PR TITLE
compact.Tree: Compute root hash on demand

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -534,8 +534,12 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 
 	// If the two reference results disagree there's no point in continuing the checks. This is a
 	// "can't happen" situation.
-	if !bytes.Equal(compactTree.CurrentRoot(), merkleTree.CurrentRoot().Hash()) {
-		return nil, fmt.Errorf("different root hash results from merkle tree building: %v and %v", compactTree.CurrentRoot(), merkleTree.CurrentRoot())
+	root, err := compactTree.CurrentRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute compact tree root: %v", err)
+	}
+	if !bytes.Equal(root, merkleTree.CurrentRoot().Hash()) {
+		return nil, fmt.Errorf("different root hash results from merkle tree building: %v and %v", root, merkleTree.CurrentRoot())
 	}
 
 	return merkleTree, nil

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -431,8 +431,12 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 		stageStart = s.timeSource.Now()
 
 		// Create the log root ready for signing
+		root, err := merkleTree.CurrentRoot()
+		if err != nil {
+			return fmt.Errorf("%v: failed to compute new root hash: %v", tree.TreeId, err)
+		}
 		newLogRoot = &types.LogRootV1{
-			RootHash:       merkleTree.CurrentRoot(),
+			RootHash:       root,
 			TimestampNanos: uint64(s.timeSource.Now().UnixNano()),
 			TreeSize:       uint64(merkleTree.Size()),
 			Revision:       uint64(newVersion),

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -32,7 +32,6 @@ import (
 // TODO(pavelkalinnikov): Remove it, use compact.Range instead.
 type Tree struct {
 	hasher hashers.LogHasher
-	root   []byte
 	// The list of "dangling" left-hand nodes, where entry [0] is the leaf.
 	// So: nodes[0] is the hash of a subtree of size 1 = 1<<0, if included.
 	//     nodes[1] is the hash of a subtree of size 2 = 1<<1, if included.
@@ -43,7 +42,7 @@ type Tree struct {
 	// 16 + 4 + 1, so nodes[1] == nodes[3] == nil.
 	//
 	// For a tree whose size is a perfect power of two, only the last
-	// entry in nodes will be set (and it will match root).
+	// entry in nodes will be set (which is also the root hash).
 	nodes [][]byte
 	size  int64
 }
@@ -72,7 +71,6 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 	r := Tree{
 		hasher: hasher,
 		nodes:  make([][]byte, sizeBits),
-		root:   hasher.EmptyRoot(),
 		size:   size,
 	}
 
@@ -94,13 +92,18 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 	for i, id := range ids {
 		r.nodes[id.Level] = hashes[i]
 	}
-	r.recalculateRoot(func(NodeID, []byte) {})
 
-	if !bytes.Equal(r.root, expectedRoot) {
-		glog.Warningf("Corrupt state, expected root %s, got %s", hex.EncodeToString(expectedRoot[:]), hex.EncodeToString(r.root[:]))
-		return nil, fmt.Errorf("root hash mismatch: got %v, expected %v", r.root, expectedRoot)
+	// TODO(pavelkalinnikov): This check should be done externally.
+	root, err := r.CurrentRoot()
+	if err != nil {
+		return nil, err
 	}
-	glog.V(1).Infof("Resuming at size %d, with root: %s", r.size, base64.StdEncoding.EncodeToString(r.root[:]))
+	if !bytes.Equal(root, expectedRoot) {
+		glog.Warningf("Corrupt state, expected root %s, got %s", hex.EncodeToString(expectedRoot[:]), hex.EncodeToString(root))
+		return nil, fmt.Errorf("root hash mismatch: got %v, expected %v", root, expectedRoot)
+	}
+
+	glog.V(1).Infof("Resuming at size %d, with root: %s", r.size, base64.StdEncoding.EncodeToString(root))
 	return &r, nil
 }
 
@@ -108,21 +111,20 @@ func NewTreeWithState(hasher hashers.LogHasher, size int64, getNodesFn GetNodesF
 func NewTree(hasher hashers.LogHasher) *Tree {
 	return &Tree{
 		hasher: hasher,
-		root:   hasher.EmptyRoot(),
 		nodes:  make([][]byte, 0),
 		size:   0,
 	}
 }
 
 // CurrentRoot returns the current root hash.
-func (t *Tree) CurrentRoot() []byte {
-	return t.root
+func (t *Tree) CurrentRoot() ([]byte, error) {
+	return t.calculateRoot(func(NodeID, []byte) {})
 }
 
 // String describes the internal state of the compact Tree.
 func (t *Tree) String() string {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("Tree Nodes @ %d root=%x\n", t.size, t.root))
+	buf.WriteString(fmt.Sprintf("Tree Nodes @ %d\n", t.size))
 	mask := int64(1)
 	numBits := bits.Len64(uint64(t.size))
 	for bit := 0; bit < numBits; bit++ {
@@ -136,18 +138,18 @@ func (t *Tree) String() string {
 	return buf.String()
 }
 
-// recalculateRoot updates the current root hash, and calls visit function for
-// imperfect subtrees along the right border of the tree.
+// calculateRoot computes the current root hash. It calls visit function for
+// imperfect subtrees along the right border of the tree while calculating it.
 //
 // TODO(pavelkalinnikov): Run this only once, after multiple AddLeaf calls.
-func (t *Tree) recalculateRoot(visit VisitFn) error {
+func (t *Tree) calculateRoot(visit VisitFn) ([]byte, error) {
 	if t.size == 0 {
-		return nil
+		return t.hasher.EmptyRoot(), nil
 	}
 
 	index := uint64(t.size)
 
-	var newRoot []byte
+	var hash []byte
 	first := true
 	mask := int64(1)
 	numBits := uint(bits.Len64(uint64(t.size)))
@@ -155,17 +157,16 @@ func (t *Tree) recalculateRoot(visit VisitFn) error {
 		index >>= 1
 		if t.size&mask != 0 {
 			if first {
-				newRoot = t.nodes[bit]
+				hash = t.nodes[bit]
 				first = false
 			} else {
-				newRoot = t.hasher.HashChildren(t.nodes[bit], newRoot)
-				visit(NewNodeID(bit+1, index), newRoot)
+				hash = t.hasher.HashChildren(t.nodes[bit], hash)
+				visit(NewNodeID(bit+1, index), hash)
 			}
 		}
 		mask <<= 1
 	}
-	t.root = newRoot
-	return nil
+	return hash, nil
 }
 
 // AddLeaf calculates the Merkle leaf hash of the given leaf data and appends
@@ -191,8 +192,8 @@ func (t *Tree) AddLeaf(data []byte, visit VisitFn) ([]byte, error) {
 func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) error {
 	defer func() {
 		t.size++
-		// TODO(pavelkalinnikov): Handle recalculateRoot errors.
-		t.recalculateRoot(visit)
+		// TODO(pavelkalinnikov): Handle calculateRoot errors.
+		t.calculateRoot(visit)
 	}()
 
 	assignedSeq := t.size

--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -92,7 +92,11 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 				return fmt.Errorf("got seq of %d, but expected %d", got, expected)
 			}
 		}
-		st.RootHash = cmt.CurrentRoot()
+		root, err := cmt.CurrentRoot()
+		if err != nil {
+			return fmt.Errorf("failed to compute root hash: %v", err)
+		}
+		st.RootHash = root
 
 		// Additional check - after population we should have the same number of internal nodes
 		// as before the subtree was written to storage. Either because they were loaded from

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -292,7 +292,11 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		if err := populateTheThing(&s); err != nil {
 			t.Fatalf("failed populate subtree: %v", err)
 		}
-		if got, expected := s.RootHash, cmt.CurrentRoot(); !bytes.Equal(got, expected) {
+		root, err := cmt.CurrentRoot()
+		if err != nil {
+			t.Fatalf("CurrentRoot: %v", err)
+		}
+		if got, expected := s.RootHash, root; !bytes.Equal(got, expected) {
 			t.Fatalf("Got root %v for tree size %d, expected %v. subtree:\n%#v", got, numLeaves, expected, s.String())
 		}
 

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -139,7 +139,12 @@ func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader 
 		}
 
 		// Sanity check the tree root hash against the one we expect to see.
-		if got, want := tree.CurrentRoot(), batch.ExpectedRoot; !bytes.Equal(got, want) {
+		root, err := tree.CurrentRoot()
+		if err != nil {
+			// TODO(pavelkalinnikov): Use testing.T.Fatalf instead of panic.
+			panic(fmt.Errorf("CurrentRoot: %v", err))
+		}
+		if got, want := root, batch.ExpectedRoot; !bytes.Equal(got, want) {
 			panic(fmt.Errorf("NewMultiFakeNodeReaderFromLeaves() got root: %x, want: %x (%v)", got, want, batch))
 		}
 


### PR DESCRIPTION
This change removes root hash field from `compact.Tree` so it is no longer
necessary to maintain it after each `AddLeafHash` operation. A side effect
of this is that `CurrentRoot` now can return an error. We make sure that
the error is handled in the client code.

This commit prepares us to remove some unnecessary computation when many
`AddLeafHash` calls are done in a row. As a result, ephemeral nodes along the
right border of the tree and the root hash will be computed only once.