### PR TITLE
sequencer: Remove redundant hashmap update

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -227,8 +227,6 @@ func (s Sequencer) updateCompactTree(mt *compact.Tree, leaves []*trillian.LogLea
 		if err := mt.AddLeafHash(leaf.MerkleLeafHash, store); err != nil {
 			return nil, err
 		}
-		// Store leaf hash in the Merkle tree too.
-		store(compact.NewNodeID(0, uint64(idx)), leaf.MerkleLeafHash)
 	}
 
 	return nodeMap, nil


### PR DESCRIPTION
The `AddLeafHash` method of `compact.Tree` already sends the leaf hash
through the visitor function, so there is no need to duplicate that.