### PR TITLE
Limit MySQL connections during tests

### DIFF
--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -35,6 +35,7 @@ import (
 var (
 	trillianSQL   = testonly.RelativeToPackage("../mysql/storage.sql")
 	dataSourceURI = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "The MySQL uri to use when running tests")
+	mysqlMaxConns = flag.Int("test_mysql_max_conns", 100, "Maximum number of connections to open to the MySQL server used when running tests")
 )
 
 // MySQLAvailable indicates whether a default MySQL database is available.
@@ -72,6 +73,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxOpenConns(*mysqlMaxConns)
 
 	return db, db.Ping()
 }


### PR DESCRIPTION
The hammer test can exceed MySQL's default limit on connections (150), resulting in it failing. To make this test reliably pass without requiring all developers to modify their MySQL server configuration, limit the number of connections that any test can make to 100 (leaving some spare in case other processes are also accessing the MySQL server).

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
