### PR TITLE
License tool includes the target Go package in its output

### DIFF
--- a/scripts/licenses/licenses/library_test.go
+++ b/scripts/licenses/licenses/library_test.go
@@ -34,6 +34,7 @@ func TestLibaries(t *testing.T) {
 			desc:       "Detects direct dependency",
 			importPath: "github.com/google/trillian/scripts/licenses/licenses/testdata/direct",
 			wantLibs: []string{
+				"github.com/google/trillian/scripts/licenses/licenses/testdata/direct",
 				"github.com/google/trillian/scripts/licenses/licenses/testdata/indirect",
 			},
 		},
@@ -41,6 +42,7 @@ func TestLibaries(t *testing.T) {
 			desc:       "Detects transitive dependency",
 			importPath: "github.com/google/trillian/scripts/licenses/licenses/testdata",
 			wantLibs: []string{
+				"github.com/google/trillian/scripts/licenses/licenses/testdata",
 				"github.com/google/trillian/scripts/licenses/licenses/testdata/direct",
 				"github.com/google/trillian/scripts/licenses/licenses/testdata/indirect",
 			},


### PR DESCRIPTION
Previously, `licenses.Libraries()` would not return a `Library` for the root Go package (e.g. with `github.com/google/trillian/server/trilian_log_server` as an argument, it wouldn't return a `Library` called "github.com/google/trillian"), or for any packages that were part of that Library. This changes its behaviour to do so. This is an improvement because command output will now be comprehensive - it will include all license information, including the license that covers the root package (i.e. not just dependencies).

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
