### PR TITLE
log_subtree_cache: Factor out visitor callback

### DIFF
--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -58,6 +58,23 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 		if st.InternalNodes == nil || len(st.Leaves) == maxLeaves {
 			st.InternalNodes = make(map[string][]byte)
 		}
+		store := func(id compact.NodeID, hash []byte) {
+			if id.Level == logStrataDepth && id.Index == 0 {
+				// no space for the root in the node cache
+				return
+			}
+
+			// Don't put leaves into the internal map and only update if we're rebuilding internal
+			// nodes. If the subtree was saved with internal nodes then we don't touch the map.
+			if id.Level > 0 && len(st.Leaves) == maxLeaves {
+				subDepth := logStrataDepth - int(id.Level)
+				// TODO(Martin2112): See if we can possibly avoid the expense hiding inside NewNodeIDFromPrefix.
+				nodeID := storage.NewNodeIDFromPrefix(st.Prefix, subDepth, int64(id.Index), logStrataDepth, maxLogDepth)
+				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+				sfxKey := sfx.String()
+				st.InternalNodes[sfxKey] = hash
+			}
+		}
 
 		// We need to update the subtree root hash regardless of whether it's fully populated
 		for leafIndex := int64(0); leafIndex < int64(len(st.Leaves)); leafIndex++ {
@@ -68,28 +85,11 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 			if h == nil {
 				return fmt.Errorf("unexpectedly got nil for subtree leaf suffix %s", sfx)
 			}
-			seq := cmt.Size()
-			if err := cmt.AddLeafHash(h, func(id compact.NodeID, h []byte) {
-				if id.Level == logStrataDepth && id.Index == 0 {
-					// no space for the root in the node cache
-					return
-				}
-
-				// Don't put leaves into the internal map and only update if we're rebuilding internal
-				// nodes. If the subtree was saved with internal nodes then we don't touch the map.
-				if id.Level > 0 && len(st.Leaves) == maxLeaves {
-					subDepth := logStrataDepth - int(id.Level)
-					// TODO(Martin2112): See if we can possibly avoid the expense hiding inside NewNodeIDFromPrefix.
-					nodeID := storage.NewNodeIDFromPrefix(st.Prefix, subDepth, int64(id.Index), logStrataDepth, maxLogDepth)
-					_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
-					sfxKey := sfx.String()
-					st.InternalNodes[sfxKey] = h
-				}
-			}); err != nil {
-				return err
+			if size, expected := cmt.Size(), leafIndex; size != expected {
+				return fmt.Errorf("got size of %d, but expected %d", size, expected)
 			}
-			if got, expected := seq, leafIndex; got != expected {
-				return fmt.Errorf("got seq of %d, but expected %d", got, expected)
+			if err := cmt.AddLeafHash(h, store); err != nil {
+				return err
 			}
 		}
 		root, err := cmt.CurrentRoot()

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -267,14 +267,15 @@ func TestRepopulateLogSubtree(t *testing.T) {
 		if err != nil {
 			t.Fatalf("HashLeaf(%v): %v", leaf, err)
 		}
-		if err := cmt.AddLeafHash(leafHash, func(id compact.NodeID, h []byte) {
+		store := func(id compact.NodeID, hash []byte) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
 				_, sfx := c.splitNodeID(n)
-				cmtStorage.InternalNodes[sfx.String()] = h
+				cmtStorage.InternalNodes[sfx.String()] = hash
 			}
-		}); err != nil {
+		}
+		if err := cmt.AddLeafHash(leafHash, store); err != nil {
 			t.Fatalf("merkle tree update failed: %v", err)
 		}
 


### PR DESCRIPTION
This change prepares the visitor callback in log subtree cache to be
used multiple times when `AddLeafHash` of `compact.Tree` is replaced by a
method no longer reporting ephemeral nodes. Besides, it reduces
indentation/nesting in the code.