### PR TITLE
compact.Tree: Change semantic of adding leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,11 @@ The CompactMerkleTree has been moved from `github.com/google/trillian/merkle` to
 A new powerful data structure named Compact Range has been added to the same
 package. It is a generalization of the previous compact Merkle tree structure.
 
+`AddLeaf*` methods of `compact.Tree` have been replaced with the corresponding
+`AppendLeaf*` methods, which do not report hashes of ephemeral nodes along the
+right border of the Merkle tree. The `CalculateRoot` method should be used in
+conjunction with appends if the caller needs to get those hashes.
+
 ### Storage API changes
 
 The internal storage API is modified so that the ReadOnlyTreeTX.ReadRevision and

--- a/integration/log.go
+++ b/integration/log.go
@@ -521,7 +521,7 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.
 	for l := params.StartLeaf; l < params.LeafCount; l++ {
-		if _, err := compactTree.AddLeaf(leafMap[l].LeafValue, nil); err != nil {
+		if _, err := compactTree.AppendLeaf(leafMap[l].LeafValue, nil); err != nil {
 			return nil, err
 		}
 		merkleTree.AddLeaf(leafMap[l].LeafValue)

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -224,9 +224,13 @@ func (s Sequencer) updateCompactTree(mt *compact.Tree, leaves []*trillian.LogLea
 		if size := mt.Size(); size != idx {
 			return nil, fmt.Errorf("leaf index mismatch: got %d, want %d", idx, size)
 		}
-		if err := mt.AddLeafHash(leaf.MerkleLeafHash, store); err != nil {
+		if err := mt.AppendLeafHash(leaf.MerkleLeafHash, store); err != nil {
 			return nil, err
 		}
+	}
+	// TODO(pavelkalinnikov): Reuse the returned root hash in IntegrateBatch.
+	if _, err := mt.CalculateRoot(store); err != nil {
+		return nil, err
 	}
 
 	return nodeMap, nil

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -33,6 +33,11 @@ var (
 	factory      = &RangeFactory{Hash: hashChildren}
 )
 
+// leafData returns test leaf data that depends on the passed in leaf index.
+func leafData(index uint64) []byte {
+	return []byte(fmt.Sprintf("data: %d", index))
+}
+
 // treeNode represents a Merkle tree node which roots a full binary subtree.
 type treeNode struct {
 	hash   []byte // The Merkle hash of the subtree.
@@ -63,7 +68,7 @@ func newTree(t *testing.T, size uint64) (*tree, VisitFn) {
 	}
 	// Compute leaf hashes.
 	for i := uint64(0); i < size; i++ {
-		nodes[0][i].hash = hashLeaf([]byte(fmt.Sprintf("data: %d", i)))
+		nodes[0][i].hash = hashLeaf(leafData(i))
 	}
 	// Compute internal node hashes.
 	for lvl := 1; lvl < levels; lvl++ {

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -187,21 +187,6 @@ func (t *Tree) AppendLeaf(data []byte, visit VisitFn) ([]byte, error) {
 	return h, nil
 }
 
-// AddLeaf is the same as AppendLeaf, except it also visits "ephemeral"
-// non-perfect-subtree node hashes along the right border of the tree.
-//
-// TODO(pavelkalinnikov): Deprecated, remove it.
-func (t *Tree) AddLeaf(data []byte, visit VisitFn) ([]byte, error) {
-	hash, err := t.AppendLeaf(data, visit)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := t.CalculateRoot(visit); err != nil {
-		return nil, err
-	}
-	return hash, nil
-}
-
 // AppendLeafHash appends the specified Merkle leaf hash to the tree.
 //
 // visit is a callback which will be called, if not nil, multiple times with
@@ -267,18 +252,6 @@ func (t *Tree) AppendLeafHash(leafHash []byte, visit VisitFn) error {
 	// We should never get here, because that'd mean we had a running hash which
 	// we've not stored somewhere.
 	return fmt.Errorf("AddLeaf failed running hash not cleared: h: %v seq: %d", leafHash, assignedSeq)
-}
-
-// AddLeafHash is the same as AppendLeafHash, except it also visits "ephemeral"
-// non-perfect-subtree node hashes along the right border of the tree.
-//
-// TODO(pavelkalinnikov): Deprecated, remove it.
-func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) error {
-	if err := t.AppendLeafHash(leafHash, visit); err != nil {
-		return err
-	}
-	_, err := t.CalculateRoot(visit)
-	return err
 }
 
 // Size returns the current size of the tree.

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -140,8 +140,6 @@ func (t *Tree) String() string {
 
 // CalculateRoot computes the current root hash. It calls visit function for
 // imperfect subtrees along the right border of the tree while calculating it.
-//
-// TODO(pavelkalinnikov): Run this only once, after multiple AddLeaf calls.
 func (t *Tree) CalculateRoot(visit VisitFn) ([]byte, error) {
 	if t.size == 0 {
 		return t.hasher.EmptyRoot(), nil

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -118,7 +118,7 @@ func NewTree(hasher hashers.LogHasher) *Tree {
 
 // CurrentRoot returns the current root hash.
 func (t *Tree) CurrentRoot() ([]byte, error) {
-	return t.calculateRoot(nil)
+	return t.CalculateRoot(nil)
 }
 
 // String describes the internal state of the compact Tree.
@@ -138,11 +138,11 @@ func (t *Tree) String() string {
 	return buf.String()
 }
 
-// calculateRoot computes the current root hash. It calls visit function for
+// CalculateRoot computes the current root hash. It calls visit function for
 // imperfect subtrees along the right border of the tree while calculating it.
 //
 // TODO(pavelkalinnikov): Run this only once, after multiple AddLeaf calls.
-func (t *Tree) calculateRoot(visit VisitFn) ([]byte, error) {
+func (t *Tree) CalculateRoot(visit VisitFn) ([]byte, error) {
 	if t.size == 0 {
 		return t.hasher.EmptyRoot(), nil
 	}
@@ -196,7 +196,7 @@ func (t *Tree) AddLeaf(data []byte, visit VisitFn) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := t.calculateRoot(visit); err != nil {
+	if _, err := t.CalculateRoot(visit); err != nil {
 		return nil, err
 	}
 	return hash, nil
@@ -277,7 +277,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) error {
 	if err := t.AppendLeafHash(leafHash, visit); err != nil {
 		return err
 	}
-	_, err := t.calculateRoot(visit)
+	_, err := t.CalculateRoot(visit)
 	return err
 }
 

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -110,6 +110,26 @@ func TestAddingLeaves(t *testing.T) {
 	}
 }
 
+func TestAppendLeaf(t *testing.T) {
+	for _, size := range []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 177, 765} {
+		t.Run(fmt.Sprintf("size:%d", size), func(t *testing.T) {
+			tree, visit := newTree(t, size)
+			mt := NewTree(rfc6962.DefaultHasher)
+			for i := uint64(0); i < size; i++ {
+				hash, err := mt.AppendLeaf(leafData(i), visit)
+				if err != nil {
+					t.Fatalf("AppendLeaf(%d): %v", i, err)
+				}
+				if want := tree.leaf(i); !bytes.Equal(hash, want) {
+					t.Fatalf("Leaf hash mismatch: got %x, want %x", hash, want)
+				}
+			}
+			// Note: The passed in Range is not valid, it is a hack.
+			tree.verifyAllVisited(t, &Range{begin: 0, end: size})
+		})
+	}
+}
+
 func failingGetNodesFunc(_ []NodeID) ([][]byte, error) {
 	return nil, errors.New("bang")
 }

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -284,6 +284,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 }
 
 func benchmarkAppendLeaf(b *testing.B, visit VisitFn) {
+	b.Helper()
 	const size = 1024
 	for n := 0; n < b.N; n++ {
 		tree := NewTree(rfc6962.DefaultHasher)

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -293,6 +293,9 @@ func benchmarkAppendLeaf(b *testing.B, visit VisitFn) {
 				b.Fatalf("AppendLeaf: %v", err)
 			}
 		}
+		if _, err := tree.CalculateRoot(visit); err != nil {
+			b.Fatalf("CalculateRoot: %v", err)
+		}
 	}
 }
 

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -83,8 +83,8 @@ func TestAddingLeaves(t *testing.T) {
 			idx := 0
 			for _, br := range tc.breaks {
 				for ; idx < br; idx++ {
-					if _, err := tree.AddLeaf(inputs[idx], nil); err != nil {
-						t.Fatalf("AddLeaf: %v", err)
+					if _, err := tree.AppendLeaf(inputs[idx], nil); err != nil {
+						t.Fatalf("AppendLeaf: %v", err)
 					}
 					if err := checkUnusedNodesInvariant(tree); err != nil {
 						t.Fatalf("UnusedNodesInvariant check failed: %v", err)
@@ -195,7 +195,7 @@ func TestCompactVsFullTree(t *testing.T) {
 		newLeaf := []byte(fmt.Sprintf("Leaf %d", i))
 
 		iSeq, iHash := imt.AddLeaf(newLeaf)
-		cHash, err := cmt.AddLeaf(newLeaf, func(id NodeID, hash []byte) {
+		cHash, err := cmt.AppendLeaf(newLeaf, func(id NodeID, hash []byte) {
 			nodes[id] = hash
 		})
 		if err != nil {
@@ -222,9 +222,9 @@ func TestCompactVsFullTree(t *testing.T) {
 	cmt := NewTree(rfc6962.DefaultHasher)
 	for i := int64(0); i < imt.LeafCount(); i++ {
 		newLeaf := []byte(fmt.Sprintf("Leaf %d", i))
-		_, err := cmt.AddLeaf(newLeaf, nil)
+		_, err := cmt.AppendLeaf(newLeaf, nil)
 		if err != nil {
-			t.Fatalf("AddLeaf(%d)=_,_,%v, want _,_,nil", i, err)
+			t.Fatalf("AppendLeaf(%d)=_,_,%v, want _,_,nil", i, err)
 		}
 		if got, want := cmt.Size(), i+1; got != want {
 			t.Fatalf("new tree size=%d, want %d", got, want)
@@ -260,7 +260,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 		tree := NewTree(rfc6962.DefaultHasher)
 		for i := int64(0); i < test.size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
-			tree.AddLeaf(l, nil)
+			tree.AppendLeaf(l, nil)
 		}
 		if gotRoot := mustGetRoot(t, tree); !bytes.Equal(gotRoot, test.wantRoot) {
 			t.Errorf("Test (treesize=%v) got root %v, want %v", test.size, b64e(gotRoot), b64e(test.wantRoot))
@@ -283,23 +283,23 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 	}
 }
 
-func benchmarkAddLeafHash(b *testing.B, visit VisitFn) {
+func benchmarkAppendLeaf(b *testing.B, visit VisitFn) {
 	const size = 1024
 	for n := 0; n < b.N; n++ {
 		tree := NewTree(rfc6962.DefaultHasher)
 		for i := 0; i < size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
-			if _, err := tree.AddLeaf(l, visit); err != nil {
-				b.Fatalf("AddLeaf: %v", err)
+			if _, err := tree.AppendLeaf(l, visit); err != nil {
+				b.Fatalf("AppendLeaf: %v", err)
 			}
 		}
 	}
 }
 
-func BenchmarkAddLeafHash(b *testing.B) {
-	benchmarkAddLeafHash(b, func(NodeID, []byte) {})
+func BenchmarkAppendLeaf(b *testing.B) {
+	benchmarkAppendLeaf(b, func(NodeID, []byte) {})
 }
 
-func BenchmarkAddLeafHashNoVisitor(b *testing.B) {
-	benchmarkAddLeafHash(b, nil)
+func BenchmarkAppendLeafNoVisitor(b *testing.B) {
+	benchmarkAppendLeaf(b, nil)
 }

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -154,13 +154,16 @@ func createSomeNodes() []storage.Node {
 func createLogNodesForTreeAtSize(t *testing.T, ts, rev int64) ([]storage.Node, error) {
 	tree := compact.NewTree(rfc6962.New(crypto.SHA256))
 	nodeMap := make(map[compact.NodeID][]byte)
+	store := func(id compact.NodeID, hash []byte) { nodeMap[id] = hash }
 	for l := 0; l < int(ts); l++ {
-		// We're only interested in the side effects of adding leaves - the node updates
-		if _, err := tree.AddLeaf([]byte(fmt.Sprintf("Leaf %d", l)), func(id compact.NodeID, hash []byte) {
-			nodeMap[id] = hash
-		}); err != nil {
+		// Only interested in side effects of AppendLeaf - the node updates.
+		if _, err := tree.AppendLeaf([]byte(fmt.Sprintf("Leaf %d", l)), store); err != nil {
 			return nil, err
 		}
+	}
+	// Store the ephemeral nodes as well.
+	if _, err := tree.CalculateRoot(store); err != nil {
+		return nil, err
 	}
 
 	// Unroll the map, which has deduped the updates for us and retained the latest


### PR DESCRIPTION
This change introduces a family of `AppendLeaf` methods in `compact.Tree`,
and removes the old `AddLeaf` methods.

The new `AppendLeaf` methods are equivalent to `AddLeaf` methods, but they
do not report ephemeral nodes along the right border of the Merkle tree.
We don't simply reuse the old method names because the semantic is changed.

Benefits of `AppendLeaf` over `AddLeaf` methods are:
- They are more aligned with `compact.Range` semantic.
- If called multiple times, `AddLeaf` wastes CPU on computing ephemeral
  hashes that will be overridden by subsequent calls. Instead, ephemeral
  nodes can be computed lazily in the end, after all `AppendLeaf`-s. The
  time complexity of doing N appends reduces from `O(N log N)` to `O(N)`.

### Benchmarks
#### Before:
```
BenchmarkAddLeafHash-12             	     200	   9189829 ns/op
BenchmarkAddLeafHashNoVisitor-12    	     200	   9259209 ns/op
```
#### After:
```
BenchmarkAppendLeaf-12             	     500	   2770825 ns/op
BenchmarkAppendLeafNoVisitor-12    	     500	   2967951 ns/op
```

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
