### PR TITLE
Use Skeema to manage MySQL schema changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ install:
       github.com/golang/protobuf/protoc-gen-go
       github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
       github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+      github.com/skeema/skeema
       github.com/uber/prototool/cmd/prototool
       golang.org/x/tools/cmd/stringer
   # install vendored etcd binary

--- a/scripts/lintdb.sh
+++ b/scripts/lintdb.sh
@@ -4,7 +4,7 @@
 #
 # This tool lints and diffs the local copy of an SQL schema file against the
 # version stored in the specified branch ("master" by default). If linting
-# detects a problem or the diff identifies a backwards-incompatble change,
+# detects a problem or the diff identifies a backwards-incompatible change,
 # the tool will exit with a non-zero exit code.
 
 die() {

--- a/scripts/lintdb.sh
+++ b/scripts/lintdb.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Usage: lintdb.sh [branch] [SQL file]
+#
+# This tool lints and diffs the local copy of an SQL schema file against the
+# version stored in the specified branch ("master" by default). If linting
+# detects a problem or the diff identifies a backwards-incompatble change,
+# the tool will exit with a non-zero exit code.
+
+die() {
+  echo $@ > /dev/stderr
+  exit 1
+}
+
+schema_stashed=false
+
+# Saves the given directory by stashing it if it contains uncommitted changes.
+# Will automatically restore those changes on exit.
+save_schema() {
+  local schema_dir=${1:?Usage: save_schema <schema dir>}
+  local output=$(git diff-index --exit-code HEAD -- ${schema_dir} 2>&1)
+  case $? in
+    0)
+      # No uncommitted changes to database schema
+      return 0
+      ;;
+    1)
+      # Uncommitted changes to database schema - stash them
+      git stash push --quiet -- ${schema_dir} ||
+        die "Failed to stash ${schema_dir}"
+      schema_stashed=true
+      trap "restore_schema ${schema_dir}" EXIT
+      ;;
+    *)
+      # Error occurred
+      echo ${output}
+      return 1
+      ;;
+  esac
+}
+
+# Restores the given directory from the current branch.
+# If save_schema() stashed uncommitted changes, these will be restored.
+restore_schema() {
+  local schema_dir=${1:?Usage: restore_schema <schema dir>}
+
+  # Restore the schema from this branch. It is necessary to reset $schema_dir
+  # before checking it out, because the checkout will have added it to the index
+  # (resetting it undoes this, allowing the checkout to succeed).
+  git reset -q ${schema_dir} && git checkout -- ${schema_dir} ||
+    die "Failed to checkout ${schema_dir}"
+
+  if ${schema_stashed}; then
+    git stash pop --quiet ||
+      die "Failed to restore ${schema_dir} from Git stash"
+    schema_stashed=false
+  fi
+}
+
+configure_skeema() {
+  local skeema_file=${1:?Usage: configure_skeema <schema dir>}/.skeema
+  cat << EOF >> ${skeema_file} || die "Failed to configure Skeema"
+
+[${diff_schema}]
+host=127.0.0.1
+port=3306
+schema=${diff_schema}
+new-schemas=false
+EOF
+}
+
+main() {
+  local schema_dir=${1:-storage/mysql/schema}
+  local diff_branch=${2:-master}
+
+  git diff --quiet ${diff_branch} -- ${schema_dir}
+  case $? in
+    0)
+      # No changes made to database schema
+      return 0
+      ;;
+    1)
+      # Changes made - diff them.
+      ;;
+    *)
+      # Error occurred
+      return 1
+      ;;
+  esac
+
+  local diff_hash=$(git rev-parse --short ${diff_branch})
+  local diff_schema="trillian_${diff_hash}"
+
+  echo "Creating ${diff_schema} database based on schema from ${diff_branch}..."
+
+  # Save the current schema, then checkout the version from $diff_branch.
+  save_schema "${schema_dir}" || die "Failed to save ${schema_dir}"
+  git checkout ${diff_branch} -- ${schema_dir} ||
+    die "Failed to checkout ${schema_dir} from ${diff_branch}"
+
+  # Get Skeema to create a database from the checked out schema.
+  configure_skeema ${schema_dir} || die "Failed to configure Skeema"
+  (cd ${schema_dir} && skeema push ${diff_schema}) ||
+    die "Failed to create database from ${schema_dir} in ${diff_branch} branch"
+
+  echo "Diffing current schema against ${diff_schema}..."
+
+  # Restore the schema to its original state.
+  restore_schema ${schema_dir} || die "Failed to restore ${schema_dir}"
+
+  # Have to reconfigure Skeema because restore_schema() will have erased
+  # changes made by the last call to configure_skeema().
+  configure_skeema ${schema_dir} || die "Failed to reconfigure Skeema"
+  # Lint and diff the original schema against the version from $diff_branch.
+  (cd ${schema_dir} && skeema lint ${diff_schema}) || die "${schema_dir} failed lint check"
+  (cd ${schema_dir} && skeema diff ${diff_schema})
+  # An exit code > 1 means an error occurred or an incompatible change was
+  # detected in the schema. 0 means no diff, 1 means diff.
+  if [[ $? > 1 ]]; then
+    die
+  fi
+}
+
+main "$@"

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -124,9 +124,7 @@ main() {
     echo 'checking license headers'
     ./scripts/check_license.sh ${go_srcs}
     echo 'checking database schema'
-    # TODO(RJPercival): Lint against version of schema in master branch,
-    # to detect backwards-incompatible changes.
-    (cd storage/mysql/schema && skeema lint dev)
+    ./scripts/lintdb.sh master
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -114,6 +114,8 @@ main() {
       'have you installed github.com/golangci/golangci-lint?' || exit 1
     check_cmd prototool \
       'have you installed github.com/uber/prototool/cmd/prototool?' || exit 1
+    check_cmd skeema \
+      'have you installed github.com/skeema/skeema?' || exit 1
 
     echo 'running golangci-lint'
     golangci-lint run
@@ -121,6 +123,10 @@ main() {
     prototool lint
     echo 'checking license headers'
     ./scripts/check_license.sh ${go_srcs}
+    echo 'checking database schema'
+    # TODO(RJPercival): Lint against version of schema in master branch,
+    # to detect backwards-incompatible changes.
+    (cd storage/mysql/schema && skeema lint dev)
   fi
 
   if [[ "${run_generate}" -eq 1 ]]; then

--- a/storage/mysql/schema/.skeema
+++ b/storage/mysql/schema/.skeema
@@ -1,0 +1,9 @@
+default-character-set=utf8mb4
+default-collation=utf8mb4_general_ci
+schema=trillian
+
+[dev]
+host=127.0.0.1
+port=3306
+schema=test
+new-schemas=false

--- a/storage/mysql/schema/storage.sql
+++ b/storage/mysql/schema/storage.sql
@@ -6,62 +6,58 @@
 
 -- Tree parameters should not be changed after creation. Doing so can
 -- render the data in the tree unusable or inconsistent.
-CREATE TABLE IF NOT EXISTS Trees(
-  TreeId                BIGINT NOT NULL,
-  TreeState             ENUM('ACTIVE', 'FROZEN', 'DRAINING') NOT NULL,
-  TreeType              ENUM('LOG', 'MAP', 'PREORDERED_LOG') NOT NULL,
-  HashStrategy          ENUM('RFC6962_SHA256', 'TEST_MAP_HASHER', 'OBJECT_RFC6962_SHA256', 'CONIKS_SHA512_256', 'CONIKS_SHA256') NOT NULL,
-  HashAlgorithm         ENUM('SHA256') NOT NULL,
-  SignatureAlgorithm    ENUM('ECDSA', 'RSA') NOT NULL,
-  DisplayName           VARCHAR(20),
-  Description           VARCHAR(200),
-  CreateTimeMillis      BIGINT NOT NULL,
-  UpdateTimeMillis      BIGINT NOT NULL,
-  MaxRootDurationMillis BIGINT NOT NULL,
-  PrivateKey            MEDIUMBLOB NOT NULL,
-  PublicKey             MEDIUMBLOB NOT NULL,
-  Deleted               BOOLEAN,
-  DeleteTimeMillis      BIGINT,
-  PRIMARY KEY(TreeId)
-);
+CREATE TABLE `Trees` (
+  `TreeId` bigint(20) NOT NULL,
+  `TreeState` enum('ACTIVE','FROZEN','DRAINING') NOT NULL,
+  `TreeType` enum('LOG','MAP','PREORDERED_LOG') NOT NULL,
+  `HashStrategy` enum('RFC6962_SHA256','TEST_MAP_HASHER','OBJECT_RFC6962_SHA256','CONIKS_SHA512_256','CONIKS_SHA256') NOT NULL,
+  `HashAlgorithm` enum('SHA256') NOT NULL,
+  `SignatureAlgorithm` enum('ECDSA','RSA') NOT NULL,
+  `DisplayName` varchar(20) DEFAULT NULL,
+  `Description` varchar(200) DEFAULT NULL,
+  `CreateTimeMillis` bigint(20) NOT NULL,
+  `UpdateTimeMillis` bigint(20) NOT NULL,
+  `MaxRootDurationMillis` bigint(20) NOT NULL,
+  `PrivateKey` mediumblob NOT NULL,
+  `PublicKey` mediumblob NOT NULL,
+  `Deleted` tinyint(1) DEFAULT NULL,
+  `DeleteTimeMillis` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`TreeId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- This table contains tree parameters that can be changed at runtime such as for
 -- administrative purposes.
-CREATE TABLE IF NOT EXISTS TreeControl(
-  TreeId                  BIGINT NOT NULL,
-  SigningEnabled          BOOLEAN NOT NULL,
-  SequencingEnabled       BOOLEAN NOT NULL,
-  SequenceIntervalSeconds INTEGER NOT NULL,
-  PRIMARY KEY(TreeId),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
+CREATE TABLE `TreeControl` (
+  `TreeId` bigint(20) NOT NULL,
+  `SigningEnabled` tinyint(1) NOT NULL,
+  `SequencingEnabled` tinyint(1) NOT NULL,
+  `SequenceIntervalSeconds` int(11) NOT NULL,
+  PRIMARY KEY (`TreeId`),
+  CONSTRAINT `TreeControl_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS Subtree(
-  TreeId               BIGINT NOT NULL,
-  SubtreeId            VARBINARY(255) NOT NULL,
-  Nodes                MEDIUMBLOB NOT NULL,
-  SubtreeRevision      INTEGER NOT NULL,
-  -- Key columns must be in ASC order in order to benefit from group-by/min-max
-  -- optimization in MySQL.
-  PRIMARY KEY(TreeId, SubtreeId, SubtreeRevision),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
+CREATE TABLE `Subtree` (
+  `TreeId` bigint(20) NOT NULL,
+  `SubtreeId` varbinary(255) NOT NULL,
+  `Nodes` mediumblob NOT NULL,
+  `SubtreeRevision` int(11) NOT NULL,
+  PRIMARY KEY (`TreeId`,`SubtreeId`,`SubtreeRevision`) COMMENT 'Key columns must be in ASC order in order to benefit from group-by/min-max optimization in MySQL.',
+  CONSTRAINT `Subtree_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- The TreeRevisionIdx is used to enforce that there is only one STH at any
 -- tree revision
-CREATE TABLE IF NOT EXISTS TreeHead(
-  TreeId               BIGINT NOT NULL,
-  TreeHeadTimestamp    BIGINT,
-  TreeSize             BIGINT,
-  RootHash             VARBINARY(255) NOT NULL,
-  RootSignature        VARBINARY(1024) NOT NULL,
-  TreeRevision         BIGINT,
-  PRIMARY KEY(TreeId, TreeHeadTimestamp),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
-
-CREATE UNIQUE INDEX TreeHeadRevisionIdx
-  ON TreeHead(TreeId, TreeRevision);
+CREATE TABLE `TreeHead` (
+  `TreeId` bigint(20) NOT NULL,
+  `TreeHeadTimestamp` bigint(20) NOT NULL,
+  `TreeSize` bigint(20) DEFAULT NULL,
+  `RootHash` varbinary(255) NOT NULL,
+  `RootSignature` varbinary(1024) NOT NULL,
+  `TreeRevision` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`TreeId`,`TreeHeadTimestamp`),
+  UNIQUE KEY `TreeHeadRevisionIdx` (`TreeId`,`TreeRevision`),
+  CONSTRAINT `TreeHead_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ---------------------------------------------
 -- Log specific stuff here
@@ -73,23 +69,15 @@ CREATE UNIQUE INDEX TreeHeadRevisionIdx
 
 -- A leaf that has not been sequenced has a row in this table. If duplicate leaves
 -- are allowed they will all reference this row.
-CREATE TABLE IF NOT EXISTS LeafData(
-  TreeId               BIGINT NOT NULL,
-  -- This is a personality specific has of some subset of the leaf data.
-  -- It's only purpose is to allow Trillian to identify duplicate entries in
-  -- the context of the personality.
-  LeafIdentityHash     VARBINARY(255) NOT NULL,
-  -- This is the data stored in the leaf for example in CT it contains a DER encoded
-  -- X.509 certificate but is application dependent
-  LeafValue            LONGBLOB NOT NULL,
-  -- This is extra data that the application can associate with the leaf should it wish to.
-  -- This data is not included in signing and hashing.
-  ExtraData            LONGBLOB,
-  -- The timestamp from when this leaf data was first queued for inclusion.
-  QueueTimestampNanos  BIGINT NOT NULL,
-  PRIMARY KEY(TreeId, LeafIdentityHash),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
+CREATE TABLE `LeafData` (
+  `TreeId` bigint(20) NOT NULL,
+  `LeafIdentityHash` varbinary(255) NOT NULL COMMENT 'This is a personality specific hash of some subset of the leaf data. It''s only purpose is to allow Trillian to identify duplicate entries in the context of the personality.',
+  `LeafValue` longblob NOT NULL COMMENT 'This is the data stored in the leaf for example in CT it contains a DER encoded X.509 certificate but is application dependent.',
+  `ExtraData` longblob COMMENT 'This is extra data that the application can associate with the leaf should it wish to. This data is not included in signing and hashing.',
+  `QueueTimestampNanos` bigint(20) NOT NULL COMMENT 'The timestamp from when this leaf data was first queued for inclusion.',
+  PRIMARY KEY (`TreeId`,`LeafIdentityHash`),
+  CONSTRAINT `LeafData_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- When a leaf is sequenced a row is added to this table. If logs allow duplicates then
 -- multiple rows will exist with different sequence numbers. The signed timestamp
@@ -97,73 +85,55 @@ CREATE TABLE IF NOT EXISTS LeafData(
 -- on the log parameters and we can't insert into this table until we have the sequence number
 -- which is not available at the time we queue the entry. We need both hashes because the
 -- LeafData table is keyed by the raw data hash.
-CREATE TABLE IF NOT EXISTS SequencedLeafData(
-  TreeId               BIGINT NOT NULL,
-  SequenceNumber       BIGINT UNSIGNED NOT NULL,
-  -- This is a personality specific has of some subset of the leaf data.
-  -- It's only purpose is to allow Trillian to identify duplicate entries in
-  -- the context of the personality.
-  LeafIdentityHash     VARBINARY(255) NOT NULL,
-  -- This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for
-  -- CT this hash will include the leaf prefix byte as well as the leaf data.
-  MerkleLeafHash       VARBINARY(255) NOT NULL,
-  IntegrateTimestampNanos BIGINT NOT NULL,
-  PRIMARY KEY(TreeId, SequenceNumber),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE,
-  FOREIGN KEY(TreeId, LeafIdentityHash) REFERENCES LeafData(TreeId, LeafIdentityHash) ON DELETE CASCADE
-);
+CREATE TABLE `SequencedLeafData` (
+  `TreeId` bigint(20) NOT NULL,
+  `SequenceNumber` bigint(20) unsigned NOT NULL,
+  `LeafIdentityHash` varbinary(255) NOT NULL COMMENT 'This is a personality specific has of some subset of the leaf data. It''s only purpose is to allow Trillian to identify duplicate entries in the context of the personality.',
+  `MerkleLeafHash` varbinary(255) NOT NULL COMMENT 'This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for CT this hash will include the leaf prefix byte as well as the leaf data.',
+  `IntegrateTimestampNanos` bigint(20) NOT NULL,
+  PRIMARY KEY (`TreeId`,`SequenceNumber`),
+  KEY `TreeId` (`TreeId`,`LeafIdentityHash`),
+  KEY `SequencedLeafMerkleIdx` (`TreeId`,`MerkleLeafHash`),
+  CONSTRAINT `SequencedLeafData_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE,
+  CONSTRAINT `SequencedLeafData_ibfk_2` FOREIGN KEY (`TreeId`, `LeafIdentityHash`) REFERENCES `LeafData` (`TreeId`, `LeafIdentityHash`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
-CREATE INDEX SequencedLeafMerkleIdx
-  ON SequencedLeafData(TreeId, MerkleLeafHash);
-
-CREATE TABLE IF NOT EXISTS Unsequenced(
-  TreeId               BIGINT NOT NULL,
-  -- The bucket field is to allow the use of time based ring bucketed schemes if desired. If
-  -- unused this should be set to zero for all entries.
-  Bucket               INTEGER NOT NULL,
-  -- This is a personality specific hash of some subset of the leaf data.
-  -- It's only purpose is to allow Trillian to identify duplicate entries in
-  -- the context of the personality.
-  LeafIdentityHash     VARBINARY(255) NOT NULL,
-  -- This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for
-  -- CT this hash will include the leaf prefix byte as well as the leaf data.
-  MerkleLeafHash       VARBINARY(255) NOT NULL,
-  QueueTimestampNanos  BIGINT NOT NULL,
-  -- This is a SHA256 hash of the TreeID, LeafIdentityHash and QueueTimestampNanos. It is used
-  -- for batched deletes from the table when trillian_log_server and trillian_log_signer are
-  -- built with the batched_queue tag.
-  QueueID VARBINARY(32) DEFAULT NULL UNIQUE,
-  PRIMARY KEY (TreeId, Bucket, QueueTimestampNanos, LeafIdentityHash)
-);
+CREATE TABLE `Unsequenced` (
+  `TreeId` bigint(20) NOT NULL,
+  `Bucket` int(11) NOT NULL COMMENT 'The bucket field is to allow the use of time based ring bucketed schemes if desired. If unused this should be set to zero for all entries.',
+  `LeafIdentityHash` varbinary(255) NOT NULL COMMENT 'This is a personality specific hash of some subset of the leaf data. It''s only purpose is to allow Trillian to identify duplicate entries in the context of the personality.',
+  `MerkleLeafHash` varbinary(255) NOT NULL COMMENT 'This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for CT this hash will include the leaf prefix byte as well as the leaf data.',
+  `QueueTimestampNanos` bigint(20) NOT NULL,
+  `QueueID` varbinary(32) DEFAULT NULL COMMENT 'This is a SHA256 hash of the TreeID, LeafIdentityHash and QueueTimestampNanos. It is used for batched deletes from the table when trillian_log_server and trillian_log_signer are built with the batched_queue tag.',
+  PRIMARY KEY (`TreeId`,`Bucket`,`QueueTimestampNanos`,`LeafIdentityHash`),
+  UNIQUE KEY `QueueID` (`QueueID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 -- ---------------------------------------------
 -- Map specific stuff here
 -- ---------------------------------------------
 
-CREATE TABLE IF NOT EXISTS MapLeaf(
-  TreeId                BIGINT NOT NULL,
-  KeyHash               VARBINARY(255) NOT NULL,
-  -- MapRevision is stored negated to invert ordering in the primary key index
-  -- st. more recent revisions come first.
-  MapRevision           BIGINT NOT NULL,
-  LeafValue             LONGBLOB NOT NULL,
-  PRIMARY KEY(TreeId, KeyHash, MapRevision),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
+CREATE TABLE `MapLeaf` (
+  `TreeId` bigint(20) NOT NULL,
+  `KeyHash` varbinary(255) NOT NULL,
+  `MapRevision` bigint(20) NOT NULL COMMENT 'MapRevision is stored negated to invert ordering in the primary key index st. more recent revisions come first.',
+  `LeafValue` longblob NOT NULL,
+  PRIMARY KEY (`TreeId`,`KeyHash`,`MapRevision`),
+  CONSTRAINT `MapLeaf_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE IF NOT EXISTS MapHead(
-  TreeId               BIGINT NOT NULL,
-  MapHeadTimestamp     BIGINT,
-  RootHash             VARBINARY(255) NOT NULL,
-  MapRevision          BIGINT,
-  RootSignature        VARBINARY(1024) NOT NULL,
-  MapperData           MEDIUMBLOB,
-  PRIMARY KEY(TreeId, MapHeadTimestamp),
-  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
-);
+CREATE TABLE `MapHead` (
+  `TreeId` bigint(20) NOT NULL,
+  `MapHeadTimestamp` bigint(20) NOT NULL,
+  `RootHash` varbinary(255) NOT NULL,
+  `MapRevision` bigint(20) DEFAULT NULL,
+  `RootSignature` varbinary(1024) NOT NULL,
+  `MapperData` mediumblob,
+  PRIMARY KEY (`TreeId`,`MapHeadTimestamp`),
+  UNIQUE KEY `MapHeadRevisionIdx` (`TreeId`,`MapRevision`),
+  CONSTRAINT `MapHead_ibfk_1` FOREIGN KEY (`TreeId`) REFERENCES `Trees` (`TreeId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE UNIQUE INDEX MapHeadRevisionIdx
-  ON MapHead(TreeId, MapRevision);


### PR DESCRIPTION
Use [Skeema](https://www.skeema.io/) to manage our MySQL schema changes. It will enforce a canonical style on our schema (via `skeema lint`) and ensure that no backwards-incompatible changes are made. It simplifies application of schema changes by simply requiring the user to execute `skeema add-environment` (to configure it with the address of their database) and `skeema push`. In a future change, I intend to add a sidecar to our Kubernetes configs to allow it to automatically update the database schema.

I had to manually replace `CREATE [UNIQUE] INDEX` statements with `[UNIQUE] KEY` options within the `CREATE TABLE` statements, because Skeema doesn't support the former.

I've had to move comments out of the `CREATE TABLE` statements and place them before the statement instead. This is because `Skeema` rewrites those statements when linting and would remove the comments. I experimented with recording those comments as column documentation using the `COMMENT` option, which is compatible with Skeema, but it would have the undesirable side effect of causing Skeema to drop and then recreate indexes to which we add comments, which would be rather expensive on large tables. Therefore, I haven't done this (see cb80c279c72f469d1450e19b5337963314c3740b if you're interested).

Skeema deletes the `IF NOT EXISTS` part of the `CREATE TABLE` statements because it doesn't support them. This should be fine if we switch to using Skeema, because it handles this functionality (creating or altering tables as necessary).

Contributes to #1297. 

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.