### PR TITLE
compact.Tree: Allow nil visitor and add benchmarks

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -524,7 +524,7 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 
 	// We use the leafMap as we need to use the same order for the memory tree to get the same hash.
 	for l := params.StartLeaf; l < params.LeafCount; l++ {
-		if _, err := compactTree.AddLeaf(leafMap[l].LeafValue, func(compact.NodeID, []byte) {}); err != nil {
+		if _, err := compactTree.AddLeaf(leafMap[l].LeafValue, nil); err != nil {
 			return nil, err
 		}
 		if _, _, err := merkleTree.AddLeaf(leafMap[l].LeafValue); err != nil {

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -118,7 +118,7 @@ func NewTree(hasher hashers.LogHasher) *Tree {
 
 // CurrentRoot returns the current root hash.
 func (t *Tree) CurrentRoot() ([]byte, error) {
-	return t.calculateRoot(func(NodeID, []byte) {})
+	return t.calculateRoot(nil)
 }
 
 // String describes the internal state of the compact Tree.

--- a/merkle/compact/tree.go
+++ b/merkle/compact/tree.go
@@ -161,7 +161,9 @@ func (t *Tree) calculateRoot(visit VisitFn) ([]byte, error) {
 				first = false
 			} else {
 				hash = t.hasher.HashChildren(t.nodes[bit], hash)
-				visit(NewNodeID(bit+1, index), hash)
+				if visit != nil {
+					visit(NewNodeID(bit+1, index), hash)
+				}
 			}
 		}
 		mask <<= 1
@@ -172,8 +174,8 @@ func (t *Tree) calculateRoot(visit VisitFn) ([]byte, error) {
 // AddLeaf calculates the Merkle leaf hash of the given leaf data and appends
 // it to the tree. Returns the Merkle hash of the new leaf.
 //
-// visit is a callback which will be called multiple times with the coordinates
-// of the Merkle tree nodes whose hash should be updated.
+// visit is a callback which will be called, if not nil, multiple times with
+// the coordinates of the Merkle tree nodes whose hash should be updated.
 //
 // If returns an error then the Tree is no longer usable.
 func (t *Tree) AddLeaf(data []byte, visit VisitFn) ([]byte, error) {
@@ -189,8 +191,8 @@ func (t *Tree) AddLeaf(data []byte, visit VisitFn) ([]byte, error) {
 
 // AddLeafHash appends the specified Merkle leaf hash to the tree.
 //
-// visit is a callback which will be called multiple times with the coordinates
-// of the Merkle tree nodes whose hash should be updated.
+// visit is a callback which will be called, if not nil, multiple times with
+// the coordinates of the Merkle tree nodes whose hash should be updated.
 //
 // If returns an error then the Tree is no longer usable.
 func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) (res error) {
@@ -207,7 +209,9 @@ func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) (res error) {
 	assignedSeq := t.size
 	index := uint64(assignedSeq)
 
-	visit(NewNodeID(0, index), leafHash)
+	if visit != nil {
+		visit(NewNodeID(0, index), leafHash)
+	}
 
 	if t.size == 0 {
 		// new tree
@@ -225,7 +229,7 @@ func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) (res error) {
 			// Just store the running hash here; we're done.
 			t.nodes[bit] = hash
 			// Don't re-write the leaf hash node (we've done it above already)
-			if bit > 0 {
+			if bit > 0 && visit != nil {
 				// Store the (non-leaf) hash node
 				visit(NewNodeID(bit, index), hash)
 			}
@@ -234,7 +238,9 @@ func (t *Tree) AddLeafHash(leafHash []byte, visit VisitFn) (res error) {
 		// The bit is set so we have a node at that position in the nodes list so hash it with our running hash:
 		hash = t.hasher.HashChildren(t.nodes[bit], hash)
 		// Store the resulting parent hash.
-		visit(NewNodeID(bit+1, index), hash)
+		if visit != nil {
+			visit(NewNodeID(bit+1, index), hash)
+		}
 		// Now, clear this position in the nodes list as the hash it formerly contained will be propagated upwards.
 		t.nodes[bit] = nil
 		// Figure out if we're done:

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -283,3 +283,7 @@ func benchmarkAddLeafHash(b *testing.B, visit VisitFn) {
 func BenchmarkAddLeafHash(b *testing.B) {
 	benchmarkAddLeafHash(b, func(NodeID, []byte) {})
 }
+
+func BenchmarkAddLeafHashNoVisitor(b *testing.B) {
+	benchmarkAddLeafHash(b, nil)
+}

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -266,3 +266,20 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 		}
 	}
 }
+
+func benchmarkAddLeafHash(b *testing.B, visit VisitFn) {
+	const size = 1024
+	for n := 0; n < b.N; n++ {
+		tree := NewTree(rfc6962.DefaultHasher)
+		for i := 0; i < size; i++ {
+			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
+			if _, err := tree.AddLeaf(l, visit); err != nil {
+				b.Fatalf("AddLeaf: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkAddLeafHash(b *testing.B) {
+	benchmarkAddLeafHash(b, func(NodeID, []byte) {})
+}

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -83,7 +83,7 @@ func TestAddingLeaves(t *testing.T) {
 			idx := 0
 			for _, br := range tc.breaks {
 				for ; idx < br; idx++ {
-					if _, err := tree.AddLeaf(inputs[idx], func(NodeID, []byte) {}); err != nil {
+					if _, err := tree.AddLeaf(inputs[idx], nil); err != nil {
 						t.Fatalf("AddLeaf: %v", err)
 					}
 					if err := checkUnusedNodesInvariant(tree); err != nil {
@@ -206,7 +206,7 @@ func TestCompactVsFullTree(t *testing.T) {
 	cmt := NewTree(rfc6962.DefaultHasher)
 	for i := int64(0); i < imt.LeafCount(); i++ {
 		newLeaf := []byte(fmt.Sprintf("Leaf %d", i))
-		_, err := cmt.AddLeaf(newLeaf, func(NodeID, []byte) {})
+		_, err := cmt.AddLeaf(newLeaf, nil)
 		if err != nil {
 			t.Fatalf("AddLeaf(%d)=_,_,%v, want _,_,nil", i, err)
 		}
@@ -244,7 +244,7 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 		tree := NewTree(rfc6962.DefaultHasher)
 		for i := int64(0); i < test.size; i++ {
 			l := []byte{byte(i & 0xff), byte((i >> 8) & 0xff)}
-			tree.AddLeaf(l, func(NodeID, []byte) {})
+			tree.AddLeaf(l, nil)
 		}
 		if gotRoot := mustGetRoot(t, tree); !bytes.Equal(gotRoot, test.wantRoot) {
 			t.Errorf("Test (treesize=%v) got root %v, want %v", test.size, b64e(gotRoot), b64e(test.wantRoot))


### PR DESCRIPTION
This change allows passing nil `visit` function into `AddLeaf` methods,
which makes the code more readable in various places.

Benchmarks don't show significant differences in performance.
Before:
`BenchmarkAddLeafHash-12    	     200	   9425994 ns/op` (varies between 8.8 - 9.6 ms)
After:
`BenchmarkAddLeafHash-12    	     200	   9065164 ns/op` (varies between 8.8 - 9.7 ms)
`BenchmarkAddLeafHashNoVisitor-12    	     200	   9155518 ns/op` (varies between 8.8 - 9.2 ms, slightly faster than the non-nil version)

The benchmarks will also be handy in measuring impact of other
`compact.Tree` optimizations.