### PR TITLE
Switch some low-level logging in hashing related code to 'if' guards

### DIFF
--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -70,7 +70,9 @@ func (m *hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 	binary.Write(buf, binary.BigEndian, uint32(depth))
 	h.Write(buf.Bytes())
 	r := h.Sum(nil)
-	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	if glog.V(5) {
+		glog.Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	}
 	return r
 }
 
@@ -87,7 +89,9 @@ func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, erro
 	buf.Write(leaf)
 	h.Write(buf.Bytes())
 	p := h.Sum(nil)
-	glog.V(5).Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
+	if glog.V(5) {
+		glog.Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
+	}
 	return p, nil
 }
 
@@ -100,7 +104,9 @@ func (m *hasher) HashChildren(l, r []byte) []byte {
 	buf.Write(r)
 	h.Write(buf.Bytes())
 	p := h.Sum(nil)
-	glog.V(5).Infof("HashChildren(%x, %x): %x", l, r, p)
+	if glog.V(5) {
+		glog.Infof("HashChildren(%x, %x): %x", l, r, p)
+	}
 	return p
 }
 

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -65,7 +65,9 @@ func (m *MapHasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 		panic(fmt.Sprintf("HashEmpty(%v) out of bounds", height))
 	}
 	depth := m.BitLen() - height
-	glog.V(5).Infof("HashEmpty(%x, %d): %x", index, depth, m.nullHashes[height])
+	if glog.V(5) {
+		glog.Infof("HashEmpty(%x, %d): %x", index, depth, m.nullHashes[height])
+	}
 	return m.nullHashes[height]
 }
 
@@ -76,7 +78,9 @@ func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, e
 	h.Write([]byte{leafHashPrefix})
 	h.Write(leaf)
 	r := h.Sum(nil)
-	glog.V(5).Infof("HashLeaf(%x): %x", index, r)
+	if glog.V(5) {
+		glog.Infof("HashLeaf(%x): %x", index, r)
+	}
 	return r, nil
 }
 
@@ -88,7 +92,9 @@ func (m *MapHasher) HashChildren(l, r []byte) []byte {
 	h.Write(l)
 	h.Write(r)
 	p := h.Sum(nil)
-	glog.V(5).Infof("HashChildren(%x, %x): %x", l, r, p)
+	if glog.V(5) {
+		glog.Infof("HashChildren(%x, %x): %x", l, r, p)
+	}
 	return p
 }
 

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -258,8 +258,10 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 		root, err = hs2.HStar2Nodes(s.prefix, s.subtreeDepth, leaves,
 			func(depth int, index *big.Int) ([]byte, error) {
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
-				glog.V(4).Infof("buildSubtree.get(%x, %d) nid: %x, %v",
-					index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits)
+				if glog.V(4) {
+					glog.Infof("buildSubtree.get(%x, %d) nid: %x, %v",
+						index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits)
+				}
 				nodes, err := tx.GetMerkleNodes(hsCtx, s.treeRevision, []storage.NodeID{nodeID})
 				if err != nil {
 					return nil, err
@@ -282,8 +284,10 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 					return nil
 				}
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
-				glog.V(4).Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
-					index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits, h)
+				if glog.V(4) {
+					glog.Infof("buildSubtree.set(%x, %v) nid: %x, %v : %x",
+						index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits, h)
+				}
 				nodesToStore = append(nodesToStore,
 					storage.Node{
 						NodeID:       nodeID,
@@ -449,8 +453,10 @@ func (s SparseMerkleTreeReader) BatchInclusionProof(ctx context.Context, rev int
 	_, postprocessSpanEnd := spanFor(ctx, "binc.postprocess")
 	nodeMap := make(map[string]*storage.Node)
 	for i, n := range nodes {
-		glog.V(2).Infof("   %x, %d: %x", n.NodeID.Path, len(n.NodeID.AsKey()), n.Hash)
-		nodeMap[n.NodeID.AsKey()] = &nodes[i]
+		if glog.V(2) {
+			glog.Infof("   %x, %d: %x", n.NodeID.Path, len(n.NodeID.AsKey()), n.Hash)
+			nodeMap[n.NodeID.AsKey()] = &nodes[i]
+		}
 	}
 
 	r := map[string]([][]byte){}

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -455,8 +455,8 @@ func (s SparseMerkleTreeReader) BatchInclusionProof(ctx context.Context, rev int
 	for i, n := range nodes {
 		if glog.V(2) {
 			glog.Infof("   %x, %d: %x", n.NodeID.Path, len(n.NodeID.AsKey()), n.Hash)
-			nodeMap[n.NodeID.AsKey()] = &nodes[i]
 		}
+		nodeMap[n.NodeID.AsKey()] = &nodes[i]
 	}
 
 	r := map[string]([][]byte){}

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -284,11 +284,15 @@ func (s *SubtreeCache) GetNodes(ids []storage.NodeID, getSubtrees GetSubtreesFun
 
 // getNodeHash returns a single node hash from the cache.
 func (s *SubtreeCache) getNodeHash(id storage.NodeID, getSubtree GetSubtreeFunc) ([]byte, error) {
-	glog.V(3).Infof("cache: getNodeHash(path=%x, prefixLen=%d) {", id.Path, id.PrefixLenBits)
+	if glog.V(3) {
+		glog.Infof("cache: getNodeHash(path=%x, prefixLen=%d) {", id.Path, id.PrefixLenBits)
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	data, err := s.getNodeHashUnderLock(id, getSubtree)
-	glog.V(3).Infof("cache: getNodeHash(path=%x, prefixLen=%d) => %x, %v }", id.Path, id.PrefixLenBits, data, err)
+	if glog.V(3) {
+		glog.Infof("cache: getNodeHash(path=%x, prefixLen=%d) => %x, %v }", id.Path, id.PrefixLenBits, data, err)
+	}
 	return data, err
 }
 
@@ -352,7 +356,9 @@ func (s *SubtreeCache) getNodeHashUnderLock(id storage.NodeID, getSubtree GetSub
 
 // SetNodeHash sets a node hash in the cache.
 func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSubtreeFunc) error {
-	glog.V(3).Infof("cache: SetNodeHash(%x, %d)=%x", id.Path, id.PrefixLenBits, h)
+	if glog.V(3) {
+		glog.Infof("cache: SetNodeHash(%x, %d)=%x", id.Path, id.PrefixLenBits, h)
+	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	px, sx := s.splitNodeID(id)
@@ -444,7 +450,9 @@ func (s *SubtreeCache) Flush(setSubtrees SetSubtreesFunc) error {
 
 func (s *SubtreeCache) newEmptySubtree(id storage.NodeID, px []byte) *storagepb.SubtreeProto {
 	sInfo := s.stratumInfoForPrefixLength(id.PrefixLenBits)
-	glog.V(2).Infof("Creating new empty subtree for %x, with depth %d", px, sInfo.depth)
+	if glog.V(2) {
+		glog.Infof("Creating new empty subtree for %x, with depth %d", px, sInfo.depth)
+	}
 	// storage didn't have one for us, so we'll store an empty proto here
 	// incase we try to update it later on (we won't flush it back to
 	// storage unless it's been written to.)

--- a/storage/types.go
+++ b/storage/types.go
@@ -179,8 +179,10 @@ func NewNodeIDFromBigInt(depth int, index *big.Int, totalDepth int) NodeID {
 	copy(path[unusedHighBytes:], index.Bytes())
 
 	// TODO(gdbelvin): consider masking off insignificant bits past depth.
-	glog.V(5).Infof("NewNodeIDFromBigInt(%v, %x, %v): %v, %x",
-		depth, index.Bytes(), totalDepth, depth, path)
+	if glog.V(5) {
+		glog.Infof("NewNodeIDFromBigInt(%v, %x, %v): %v, %x",
+			depth, index.Bytes(), totalDepth, depth, path)
+	}
 
 	return NodeID{
 		Path:          path,


### PR DESCRIPTION
Didn't expect much gain as the arguments involved don't require complex evaluation. However the CONIKS hasher turned out faster by ~10% using this.

Results were repeatable across multiple runs.

Before:

BenchmarkHStar2Root-12    	     200	  47001010 ns/op
BenchmarkHStar2Root-12    	     200	  46416230 ns/op
BenchmarkHStar2Root-12    	     200	  47124380 ns/op

After:

BenchmarkHStar2Root-12    	     200	  41636550 ns/op
BenchmarkHStar2Root-12    	     200	  41859620 ns/op
BenchmarkHStar2Root-12    	     200	  42533060 ns/op

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
