### PR TITLE
Just one copy of bytes from big.Int in NewNodeIDFromBigInt

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -173,15 +173,17 @@ func NewNodeIDFromBigInt(depth int, index *big.Int, totalDepth int) NodeID {
 		panic(fmt.Sprintf("storage NewNodeFromBitInt(): totalDepth mod 8: %v, want %v", got, want))
 	}
 
+	// TODO(al): We _could_ use Bits() and avoid the extra copy/alloc.
+	b := index.Bytes()
 	// Put index in the LSB bits of path.
 	path := make([]byte, totalDepth/8)
-	unusedHighBytes := len(path) - len(index.Bytes())
-	copy(path[unusedHighBytes:], index.Bytes())
+	unusedHighBytes := len(path) - len(b)
+	copy(path[unusedHighBytes:], b)
 
 	// TODO(gdbelvin): consider masking off insignificant bits past depth.
 	if glog.V(5) {
 		glog.Infof("NewNodeIDFromBigInt(%v, %x, %v): %v, %x",
-			depth, index.Bytes(), totalDepth, depth, path)
+			depth, b, totalDepth, depth, path)
 	}
 
 	return NodeID{


### PR DESCRIPTION
`big.Int.Bytes()` makes a new copy of the underlying data, so we shouldn't call it 3 times in the same function!

Might be worth investigating whether calling `Bits()` instead, and doing the conversion ourselves into `path` is worth the saving of one more copy...

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
