### PR TITLE
Guard verbose logging in merkle path code

### DIFF
--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -156,7 +156,9 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 		sibling := node ^ 1
 		if sibling < lastNode {
 			// The sibling is not the last node of the level in the snapshot tree
-			glog.V(vvLevel).Infof("Not last: S:%d L:%d", sibling, level)
+			if glog.V(vvLevel) {
+				glog.Infof("Not last: S:%d L:%d", sibling, level)
+			}
 			n, err := storage.NewNodeIDForTreeCoords(int64(level), sibling, maxBitLen)
 			if err != nil {
 				return nil, err
@@ -166,7 +168,9 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 			// The sibling is the last node of the level in the snapshot tree.
 			// We might need to recompute a previous hash value here. This can only occur on the
 			// rightmost tree nodes because this is the only area of the tree that is not fully populated.
-			glog.V(vvLevel).Infof("Last: S:%d L:%d", sibling, level)
+			if glog.V(vvLevel) {
+				glog.Infof("Last: S:%d L:%d", sibling, level)
+			}
 
 			if snapshot == treeSize {
 				// No recomputation required as we're using the tree in its current state
@@ -193,7 +197,9 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 				proof = append(proof, rehashFetches...)
 			}
 		} else {
-			glog.V(vvLevel).Infof("Nonexistent: S:%d L:%d", sibling, level)
+			if glog.V(vvLevel) {
+				glog.Infof("Nonexistent: S:%d L:%d", sibling, level)
+			}
 		}
 
 		// Sibling > lastNode so does not exist, move up
@@ -237,35 +243,47 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 	for (lastNode & 1) != 0 {
 		if nodeLevel == level {
 			// Then we want a copy of the node at this level
-			glog.V(vvLevel).Infof("copying l:%d ln:%d", level, lastNode)
+			if glog.V(vvLevel) {
+				glog.Infof("copying l:%d ln:%d", level, lastNode)
+			}
 			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
 			if err != nil {
 				return nil, err
 			}
 
-			glog.V(vvLevel).Infof("copy node at %s", nodeID.CoordString())
+			if glog.V(vvLevel) {
+				glog.Infof("copy node at %s", nodeID.CoordString())
+			}
 			return append(fetches, NodeFetch{Rehash: false, NodeID: nodeID}), nil
 		}
 
 		// Left sibling and parent exist at this snapshot and don't need to be rehashed
-		glog.V(vvLevel).Infof("move up ln:%d level:%d", lastNode, level)
+		if glog.V(vvLevel) {
+			glog.Infof("move up ln:%d level:%d", lastNode, level)
+		}
 		lastNode >>= 1
 		lastNodeAtLevel >>= 1
 		level++
 	}
 
-	glog.V(vvLevel).Infof("done ln:%d level:%d", lastNode, level)
+	if glog.V(vvLevel) {
+		glog.Infof("done ln:%d level:%d", lastNode, level)
+	}
 
 	// lastNode is now the index of a left sibling with no right sibling. This is where the
 	// rehashing starts
 	savedNodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
-	glog.V(vvLevel).Infof("root for recompute is: %s", savedNodeID.CoordString())
+	if glog.V(vvLevel) {
+		glog.Infof("root for recompute is: %s", savedNodeID.CoordString())
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	if nodeLevel == level {
-		glog.V(vvLevel).Info("emit root (1)")
+		if glog.V(vvLevel) {
+			glog.Info("emit root (1)")
+		}
 		return append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID}), nil
 	}
 
@@ -277,7 +295,9 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 	// the appropriate point because we don't immediately know whether it's part of the
 	// rehashing.
 	for lastNode != 0 {
-		glog.V(vvLevel).Infof("in loop level:%d ln:%d lnal:%d", level, lastNode, lastNodeAtLevel)
+		if glog.V(vvLevel) {
+			glog.Infof("in loop level:%d ln:%d lnal:%d", level, lastNode, lastNodeAtLevel)
+		}
 
 		if (lastNode & 1) != 0 {
 			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, (lastNode-1)^1, maxBitlen)
@@ -286,12 +306,16 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 			}
 
 			if !rehash && !subRootEmitted {
-				glog.V(vvLevel).Info("emit root (2)")
+				if glog.V(vvLevel) {
+					glog.Info("emit root (2)")
+				}
 				fetches = append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID})
 				subRootEmitted = true
 			}
 
-			glog.V(vvLevel).Infof("rehash with %s", nodeID.CoordString())
+			if glog.V(vvLevel) {
+				glog.Infof("rehash with %s", nodeID.CoordString())
+			}
 			fetches = append(fetches, NodeFetch{Rehash: true, NodeID: nodeID})
 			rehash = true
 		}
@@ -301,18 +325,24 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 		level++
 
 		if nodeLevel == level && !subRootEmitted {
-			glog.V(vvLevel).Info("emit root (3)")
+			if glog.V(vvLevel) {
+				glog.Info("emit root (3)")
+			}
 			return append(fetches, NodeFetch{Rehash: rehash, NodeID: savedNodeID}), nil
 		}
 
 		// Exit early if we've gone far enough up the tree to hit the level we're recomputing
 		if level == nodeLevel {
-			glog.V(vvLevel).Infof("returning fetches early: %v", fetches)
+			if glog.V(vvLevel) {
+				glog.Infof("returning fetches early: %v", fetches)
+			}
 			return fetches, nil
 		}
 	}
 
-	glog.V(vvLevel).Infof("returning fetches: %v", fetches)
+	if glog.V(vvLevel) {
+		glog.Infof("returning fetches: %v", fetches)
+	}
 	return fetches, nil
 }
 
@@ -409,7 +439,9 @@ func skipMissingLevels(snapshot, lastNode int64, level int, node int64) (int, in
 		level--
 		sibling *= 2
 		lastNode = (snapshot - 1) >> uint(level)
-		glog.V(vvLevel).Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
+		if glog.V(vvLevel) {
+			glog.Infof("Move down: S:%d L:%d LN:%d", sibling, level, lastNode)
+		}
 	}
 
 	return level, sibling

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -251,9 +251,6 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 				return nil, err
 			}
 
-			if glog.V(vvLevel) {
-				glog.Infof("copy node at %s", nodeID.CoordString())
-			}
 			return append(fetches, NodeFetch{Rehash: false, NodeID: nodeID}), nil
 		}
 
@@ -273,17 +270,11 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 	// lastNode is now the index of a left sibling with no right sibling. This is where the
 	// rehashing starts
 	savedNodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
-	if glog.V(vvLevel) {
-		glog.Infof("root for recompute is: %s", savedNodeID.CoordString())
-	}
 	if err != nil {
 		return nil, err
 	}
 
 	if nodeLevel == level {
-		if glog.V(vvLevel) {
-			glog.Info("emit root (1)")
-		}
 		return append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID}), nil
 	}
 
@@ -306,9 +297,6 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 			}
 
 			if !rehash && !subRootEmitted {
-				if glog.V(vvLevel) {
-					glog.Info("emit root (2)")
-				}
 				fetches = append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID})
 				subRootEmitted = true
 			}
@@ -325,9 +313,6 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 		level++
 
 		if nodeLevel == level && !subRootEmitted {
-			if glog.V(vvLevel) {
-				glog.Info("emit root (3)")
-			}
 			return append(fetches, NodeFetch{Rehash: rehash, NodeID: savedNodeID}), nil
 		}
 


### PR DESCRIPTION
Add guards to verbose logging in `merkle_path.go` as it will see a lot of use for calculating proofs and is normally turned off.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
