### PR TITLE
Improve FlipRightBit by doing it directly.

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -339,7 +339,8 @@ func (n *NodeID) Copy() *NodeID {
 
 // FlipRightBit flips the ith bit from LSB
 func (n *NodeID) FlipRightBit(i int) *NodeID {
-	n.SetBit(i, n.Bit(i)^1)
+	bIndex := (n.PathLenBits() - i - 1) / 8
+	n.Path[bIndex] ^= 1 << uint(i%8)
 	return n
 }
 
@@ -370,8 +371,7 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 // in the binary tree (often termed sibling node).
 func (n *NodeID) Neighbor() *NodeID {
 	height := n.PathLenBits() - n.PrefixLenBits
-	n.FlipRightBit(height)
-	return n
+	return n.FlipRightBit(height)
 }
 
 // Siblings returns the siblings of the given node.

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -574,7 +574,7 @@ func TestSetBit(t *testing.T) {
 	}
 }
 
-func TestFlipBit(t *testing.T) {
+func TestFlipRightBit(t *testing.T) {
 	for _, tc := range []struct {
 		index []byte
 		i     int
@@ -867,5 +867,12 @@ func BenchmarkAsKey(b *testing.B) {
 	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
 	for i := 0; i < b.N; i++ {
 		_ = nID.AsKey()
+	}
+}
+
+func BenchmarkFlipRightBit(b *testing.B) {
+	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
+	for i := 0; i < b.N; i++ {
+		nID.FlipRightBit(27)
 	}
 }


### PR DESCRIPTION
Seems roughly 6x faster, called for every level in the tree via `Siblings() -> Neighbour()` in the sparse Merkle code.

```
BenchmarkFlipRightBit-12    	200000000	         9.19 ns/op
BenchmarkFlipRightBit-12    	2000000000	         1.62 ns/op
```

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
