### PR TITLE
MapHasher: Do not return error from HashLeaf

### DIFF
--- a/integration/map.go
+++ b/integration/map.go
@@ -301,10 +301,7 @@ func (mi *MapInfo) checkSingleLeafResponse(rsp *trillian.GetMapLeavesResponse, k
 	if got := rsp.MapLeafInclusion[0].Leaf.Index; !bytes.Equal(got, key) {
 		return fmt.Errorf("unexpected leaf key %x from get-map-leaves", got)
 	}
-	wantHash, err := mi.verifier.Hasher.HashLeaf(mi.id, key, want)
-	if err != nil {
-		return fmt.Errorf("failed to hash leaf %x=>%x: %v", key, want, err)
-	}
+	wantHash := mi.verifier.Hasher.HashLeaf(mi.id, key, want)
 	// The hash for an empty leaf may be nil or wantHash.
 	if got := rsp.MapLeafInclusion[0].Leaf.LeafHash; !bytes.Equal(got, wantHash) && (len(want) != 0 || len(got) != 0) {
 		return fmt.Errorf("unexpected leaf hash %x from get-map-leaves, want %x", got, wantHash)

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -117,10 +117,7 @@ func verifyGetMapLeavesResponse(mapVerifier *client.MapVerifier, getResp *trilli
 		index := incl.GetLeaf().GetIndex()
 		leafHash := incl.GetLeaf().GetLeafHash()
 
-		wantLeafHash, err := mapVerifier.Hasher.HashLeaf(mapVerifier.MapID, index, value)
-		if err != nil {
-			return err
-		}
+		wantLeafHash := mapVerifier.Hasher.HashLeaf(mapVerifier.MapID, index, value)
 		if !bytes.Equal(leafHash, wantLeafHash) {
 			if len(value) == 0 {
 				// The leaf value is empty; if this is because it has never been set then its

--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -78,7 +78,7 @@ func (m *hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 
 // HashLeaf calculate the merkle tree leaf value:
 // H(Identifier || treeID || depth || index || dataHash)
-func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error) {
+func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
 	depth := m.BitLen()
 	buf := bytes.NewBuffer(make([]byte, 0, 32+len(leaf)))
 	h := m.New()
@@ -92,7 +92,7 @@ func (m *hasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, erro
 	if glog.V(5) {
 		glog.Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
 	}
-	return p, nil
+	return p
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.

--- a/merkle/coniks/coniks_test.go
+++ b/merkle/coniks/coniks_test.go
@@ -90,11 +90,7 @@ func TestHashLeaf(t *testing.T) {
 		// Test vector from Key Transparency
 		{0, h2b("1111111111111111111111111111111111111111111111111111111111111111"), []byte("leaf"), h2b("87f51e6ceb5a46947fedbd1de543482fb72f7459055d853a841566ef8e43c4a2")},
 	} {
-		leafHash, err := Default.HashLeaf(tc.treeID, tc.index, tc.leaf)
-		if err != nil {
-			t.Errorf("HashLeaf(): %v", err)
-			continue
-		}
+		leafHash := Default.HashLeaf(tc.treeID, tc.index, tc.leaf)
 		if got, want := leafHash, tc.want; !bytes.Equal(got, want) {
 			t.Errorf("HashLeaf(%v, %s, %s): %x, want %x", tc.treeID, tc.index, tc.leaf, got, want)
 		}

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -45,7 +45,7 @@ type MapHasher interface {
 	// can be different between:
 	//  - a leaf that is unset
 	//  - a leaf that has been explicitly set, including set to []byte{}.
-	HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error)
+	HashLeaf(treeID int64, index []byte, leaf []byte) []byte
 	// HashChildren computes interior nodes, when at least one of the child
 	// subtrees is non-empty.
 	HashChildren(l, r []byte) []byte

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -53,7 +53,7 @@ var simpleTestVector = []struct {
 
 // createHStar2Leaves returns a []HStar2LeafHash formed by the mapping of index, value ...
 // createHStar2Leaves panics if len(iv) is odd. Duplicate i/v pairs get over written.
-func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) ([]*HStar2LeafHash, error) {
+func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) []*HStar2LeafHash {
 	if len(iv)%2 != 0 {
 		panic(fmt.Sprintf("merkle: createHstar2Leaves got odd number of iv pairs: %v", len(iv)))
 	}
@@ -64,10 +64,7 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) ([
 			index = b
 			continue
 		}
-		leafHash, err := hasher.HashLeaf(treeID, index, b)
-		if err != nil {
-			return nil, err
-		}
+		leafHash := hasher.HashLeaf(treeID, index, b)
 		m[fmt.Sprintf("%x", index)] = &HStar2LeafHash{
 			Index:    new(big.Int).SetBytes(index),
 			LeafHash: leafHash,
@@ -78,7 +75,7 @@ func createHStar2Leaves(treeID int64, hasher hashers.MapHasher, iv ...[]byte) ([
 	for _, v := range m {
 		r = append(r, v)
 	}
-	return r, nil
+	return r
 }
 
 func TestHStar2SimpleDataSetKAT(t *testing.T) {
@@ -87,10 +84,7 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 	iv := [][]byte{}
 	for i, x := range simpleTestVector {
 		iv = append(iv, x.index, x.value)
-		values, err := createHStar2Leaves(treeID, maphasher.Default, iv...)
-		if err != nil {
-			t.Fatalf("createHStar2Leaves(): %v", err)
-		}
+		values := createHStar2Leaves(treeID, maphasher.Default, iv...)
 		root, err := s.HStar2Root(s.hasher.BitLen(), values)
 		if err != nil {
 			t.Errorf("Failed to calculate root at iteration %d: %v", i, err)
@@ -112,10 +106,7 @@ func TestHStar2GetSet(t *testing.T) {
 
 	for i, x := range simpleTestVector {
 		s := NewHStar2(treeID, hasher)
-		values, err := createHStar2Leaves(treeID, hasher, x.index, x.value)
-		if err != nil {
-			t.Fatalf("createHStar2Leaves(): %v", err)
-		}
+		values := createHStar2Leaves(treeID, hasher, x.index, x.value)
 		// ensure we're going incrementally, one leaf at a time.
 		if len(values) != 1 {
 			t.Fatalf("Should only have 1 leaf per run, got %d", len(values))
@@ -178,10 +169,7 @@ func TestHStar2OffsetRootKAT(t *testing.T) {
 		// TODO(al): improve rootsForTrimmedKeys to use a map and remove this
 		// requirement.
 		for size := 24; size < 256; size += 8 {
-			leaves, err := createHStar2Leaves(treeID, maphasher.Default, iv...)
-			if err != nil {
-				t.Fatalf("createHStar2Leaves(): %v", err)
-			}
+			leaves := createHStar2Leaves(treeID, maphasher.Default, iv...)
 			intermediates := rootsForTrimmedKeys(t, size, leaves)
 
 			root, err := s.HStar2Nodes(nil, size, intermediates, nil, nil)

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -43,10 +43,7 @@ func VerifyMapInclusionProof(treeID int64, leaf *trillian.MapLeaf, expectedRoot 
 		}
 	}
 
-	leafHash, err := h.HashLeaf(treeID, leaf.Index, leaf.LeafValue)
-	if err != nil {
-		return fmt.Errorf("HashLeaf(): %v", err)
-	}
+	leafHash := h.HashLeaf(treeID, leaf.Index, leaf.LeafValue)
 	if len(leaf.LeafValue) == 0 && len(leaf.LeafHash) == 0 {
 		// This is an empty value that has never been set, and so has a LeafHash of nil
 		// (indicating that the effective hash value is h.HashEmpty(index, 0)).

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -73,7 +73,7 @@ func (m *MapHasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 
 // HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
 // The hashed structure is leafHashPrefix||leaf.
-func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, error) {
+func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
 	h := m.New()
 	h.Write([]byte{leafHashPrefix})
 	h.Write(leaf)
@@ -81,7 +81,7 @@ func (m *MapHasher) HashLeaf(treeID int64, index []byte, leaf []byte) ([]byte, e
 	if glog.V(5) {
 		glog.Infof("HashLeaf(%x): %x", index, r)
 	}
-	return r, nil
+	return r
 }
 
 // HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
@@ -112,13 +112,7 @@ func (m *MapHasher) initNullHashes() {
 	// There are Size()*8 edges, and Size()*8 + 1 nodes in the tree.
 	nodes := m.Size()*8 + 1
 	r := make([][]byte, nodes)
-	h, err := m.HashLeaf(0, nil, nil)
-	if err != nil {
-		// This panic should be impossible to trigger.
-		// MapHasher.HashLeaf never returns an error.
-		panic(fmt.Sprintf("HashLeaf(): %v", err))
-	}
-	r[0] = h
+	r[0] = m.HashLeaf(0, nil, nil)
 	for i := 1; i < nodes; i++ {
 		r[i] = m.HashChildren(r[i-1], r[i-1])
 	}

--- a/merkle/maphasher/maphasher_test.go
+++ b/merkle/maphasher/maphasher_test.go
@@ -54,11 +54,7 @@ func TestHashLeaf(t *testing.T) {
 		{[]byte{0x01}, []byte("foo"), h2b("1d2039fa7971f4bf01a1c20cb2a3fe7af46865ca9cd9b840c2063df8fec4ff75")},
 	}
 	for _, test := range tests {
-		got, err := Default.HashLeaf(6962, test.index, test.value)
-		if err != nil {
-			t.Errorf("HashLeaf(%x)=_,%v; want _,nil", test.value, err)
-			continue
-		}
+		got := Default.HashLeaf(6962, test.index, test.value)
 		if !bytes.Equal(got, test.want) {
 			t.Errorf("HashLeaf(%x)=%x; want %x", test.value, got, test.want)
 		}
@@ -68,10 +64,7 @@ func TestHashLeaf(t *testing.T) {
 // Compares the old HStar2 empty branch algorithm to the new.
 func TestHStar2Equivalence(t *testing.T) {
 	m := New(crypto.SHA256)
-	leafHash, err := m.HashLeaf(treeID, nil, []byte(""))
-	if err != nil {
-		t.Fatalf("HashLeaf(): %v", err)
-	}
+	leafHash := m.HashLeaf(treeID, nil, []byte(""))
 	star := hstar{
 		hasher:          m,
 		hStarEmptyCache: [][]byte{leafHash},

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -330,10 +330,7 @@ func testSparseTreeCalculatedRootWithWriter(ctx context.Context, t *testing.T, _
 	var leaves []HashKeyValue
 	for _, kv := range vec.kv {
 		index := testonly.HashKey(kv.k)
-		leafHash, err := w.hasher.HashLeaf(treeID, index, []byte(kv.v))
-		if err != nil {
-			t.Fatalf("HashLeaf(): %v", err)
-		}
+		leafHash := w.hasher.HashLeaf(treeID, index, []byte(kv.v))
 		leaves = append(leaves, HashKeyValue{
 			HashedKey:   index,
 			HashedValue: leafHash,
@@ -582,10 +579,7 @@ func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 		h := make([]HashKeyValue, batchSize)
 		for y := 0; y < batchSize; y++ {
 			index := testonly.HashKey(fmt.Sprintf("key-%d-%d", x, y))
-			leafHash, err := w.hasher.HashLeaf(treeID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
-			if err != nil {
-				t.Fatalf("HashLeaf(): %v", err)
-			}
+			leafHash := w.hasher.HashLeaf(treeID, index, []byte(fmt.Sprintf("value-%d-%d", x, y)))
 			h[y].HashedKey = index
 			h[y].HashedValue = leafHash
 		}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -315,11 +315,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 			if err := checkIndexSize(l.Index, hasher); err != nil {
 				return err
 			}
-			leafHash, err := hasher.HashLeaf(mapID, l.Index, l.LeafValue)
-			if err != nil {
-				return fmt.Errorf("HashLeaf(): %v", err)
-			}
-			l.LeafHash = leafHash
+			l.LeafHash = hasher.HashLeaf(mapID, l.Index, l.LeafValue)
 
 			if err = tx.Set(ctx, l.Index, *l); err != nil {
 				return err

--- a/testonly/mapcontents.go
+++ b/testonly/mapcontents.go
@@ -177,11 +177,7 @@ func (m *MapContents) RootHash(treeID int64, hasher hashers.MapHasher) ([]byte, 
 	for k, v := range m.data {
 		prefixKey := bitString{bitLen: curBitLen}
 		copy(prefixKey.data[:], k[:])
-		var err error
-		curHashes[prefixKey], err = hasher.HashLeaf(treeID, k[:], []byte(v))
-		if err != nil {
-			return nil, err
-		}
+		curHashes[prefixKey] = hasher.HashLeaf(treeID, k[:], []byte(v))
 	}
 
 	for curBitLen > 0 {


### PR DESCRIPTION
Hashes to hashes and errors to errors.