### PR TITLE
Make MaskLeft of NodeID return an explicit copy.

### DIFF
--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -70,7 +70,7 @@ func VerifyMapInclusionProof(treeID int64, leaf *trillian.MapLeaf, expectedRoot 
 		// for the branch that we are on before combining it with the neighbor.
 		if len(runningHash) == 0 && len(pElement) != 0 {
 			depth := nID.PrefixLenBits - height
-			emptyBranch := nID.Copy().MaskLeft(depth)
+			emptyBranch := nID.MaskLeft(depth)
 			runningHash = h.HashEmpty(treeID, emptyBranch.Path, height)
 		}
 
@@ -86,7 +86,7 @@ func VerifyMapInclusionProof(treeID int64, leaf *trillian.MapLeaf, expectedRoot 
 	}
 	if len(runningHash) == 0 {
 		depth := 0
-		emptyBranch := nID.Copy().MaskLeft(depth)
+		emptyBranch := nID.MaskLeft(depth)
 		runningHash = h.HashEmpty(treeID, emptyBranch.Path, h.BitLen())
 	}
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -349,7 +349,7 @@ func (n *NodeID) FlipRightBit(i int) *NodeID {
 // is 0. leftmask is only used to mask the last byte.
 var leftmask = [8]byte{0xFF, 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE}
 
-// MaskLeft returns NodeID with only the left n bits set
+// MaskLeft returns a new copy of NodeID with only the left n bits set.
 func (n *NodeID) MaskLeft(depth int) *NodeID {
 	r := make([]byte, len(n.Path))
 	if depth > 0 {
@@ -359,11 +359,14 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 		// Mask off unwanted bits in the last byte.
 		r[depthBytes-1] = r[depthBytes-1] & leftmask[depth%8]
 	}
+	b := n.PrefixLenBits
 	if depth < n.PrefixLenBits {
-		n.PrefixLenBits = depth
+		b = depth
 	}
-	n.Path = r
-	return n
+	return &NodeID{
+		PrefixLenBits: b,
+		Path:          r,
+	}
 }
 
 // Neighbor returns the same node with the bit at PrefixLenBits flipped.
@@ -385,7 +388,7 @@ func (n *NodeID) Siblings() []NodeID {
 	sibs := make([]NodeID, n.PrefixLenBits)
 	for height := range sibs {
 		depth := n.PrefixLenBits - height
-		sibs[height] = *(n.Copy().MaskLeft(depth).Neighbor())
+		sibs[height] = *(n.MaskLeft(depth).Neighbor())
 	}
 	return sibs
 }


### PR DESCRIPTION
Currently we're copying everything twice as we do `n.Copy().MaskLeft()` everywhere.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
