### PR TITLE
Couple of changes to make NodeIDs more frugal.

### DIFF
--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -69,7 +69,7 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 				subDepth := logStrataDepth - int(id.Level)
 				// TODO(Martin2112): See if we can possibly avoid the expense hiding inside NewNodeIDFromPrefix.
 				nodeID := storage.NewNodeIDFromPrefix(st.Prefix, subDepth, int64(id.Index), logStrataDepth, maxLogDepth)
-				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+				sfx := nodeID.Suffix(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.String()
 				st.InternalNodes[sfxKey] = hash
 			}
@@ -81,7 +81,7 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 		// We need to update the subtree root hash regardless of whether it's fully populated
 		for leafIndex := int64(0); leafIndex < int64(len(st.Leaves)); leafIndex++ {
 			nodeID := storage.NewNodeIDFromPrefix(st.Prefix, logStrataDepth, leafIndex, logStrataDepth, maxLogDepth)
-			_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+			sfx := nodeID.Suffix(len(st.Prefix), int(st.Depth))
 			sfxKey := sfx.String()
 			h := st.Leaves[sfxKey]
 			if h == nil {

--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -63,7 +63,7 @@ func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.Pop
 					return nil
 				}
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, hasher.BitLen())
-				_, sfx := nodeID.Split(len(st.Prefix), int(st.Depth))
+				sfx := nodeID.Suffix(len(st.Prefix), int(st.Depth))
 				sfxKey := sfx.String()
 				if glog.V(4) {
 					b, err := base64.StdEncoding.DecodeString(sfxKey)

--- a/storage/suffix.go
+++ b/storage/suffix.go
@@ -68,7 +68,7 @@ func NewSuffix(bits byte, path []byte) *Suffix {
 	r = append(r, path...)
 	s := base64.StdEncoding.EncodeToString(r)
 
-	return &Suffix{bits: bits, path: append(make([]byte, 0, len(path)), path...), asString: s}
+	return &Suffix{bits: bits, path: r[1:], asString: s}
 }
 
 // Bits returns the number of significant bits in the Suffix path.

--- a/storage/suffix_test.go
+++ b/storage/suffix_test.go
@@ -77,7 +77,7 @@ func TestSplitParseSuffixRoundtrip(t *testing.T) {
 		{h2b("12345678"), 253, h2b("fd")},
 	} {
 		nodeID := NewNodeIDFromPrefix(tc.prefix, logStrataDepth, tc.leafIndex, logStrataDepth, maxLogDepth)
-		_, sfx := nodeID.Split(len(tc.prefix), logStrataDepth)
+		sfx := nodeID.Suffix(len(tc.prefix), logStrataDepth)
 		sfxKey := sfx.String()
 
 		sfxP, err := ParseSuffix(sfxKey)
@@ -88,7 +88,7 @@ func TestSplitParseSuffixRoundtrip(t *testing.T) {
 		if got, want := sfx.Bits(), sfxP.Bits(); got != want {
 			t.Errorf("ParseSuffix(%s).Bits: %v, want %v", sfxKey, got, want)
 		}
-		// This is the roundtrip test that the parsed value matches the Split().
+		// This is the roundtrip test that the parsed value matches the Suffix().
 		if got, want := sfx.Path(), sfxP.Path(); !bytes.Equal(got, want) {
 			t.Errorf("ParseSuffix(%s).Path: %x, want %x", sfxKey, got, want)
 		}
@@ -100,7 +100,7 @@ func TestSplitParseSuffixRoundtrip(t *testing.T) {
 	}
 }
 
-// TestSuffixKeyEquals ensures that NodeID.Split produces the same output as makeSuffixKey for the Log's use cases.
+// TestSuffixKeyEquals ensures that NodeID.Suffix produces the same output as makeSuffixKey for the Log's use cases.
 func TestSuffixKeyEquals(t *testing.T) {
 	for _, tc := range []struct {
 		prefix    []byte
@@ -128,7 +128,7 @@ func TestSuffixKeyEquals(t *testing.T) {
 		}
 
 		nodeID := NewNodeIDFromPrefix(tc.prefix, logStrataDepth, tc.leafIndex, logStrataDepth, maxLogDepth)
-		_, sfxB := nodeID.Split(len(tc.prefix), logStrataDepth)
+		sfxB := nodeID.Suffix(len(tc.prefix), logStrataDepth)
 		sfxBKey := sfxB.String()
 		sfxBBytes, err := base64.StdEncoding.DecodeString(sfxBKey)
 		if err != nil {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -876,3 +876,12 @@ func BenchmarkFlipRightBit(b *testing.B) {
 		nID.FlipRightBit(27)
 	}
 }
+
+func BenchmarkSplit(b *testing.B) {
+	n := NewNodeIDFromHash(h2b("0000000000000000000000000000000000000000000000000000000000000001"))
+	n.PrefixLenBits = 256
+	for i := 0; i < b.N; i++ {
+
+		_, _ = n.Split(10, 176)
+	}
+}

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -881,7 +881,14 @@ func BenchmarkSplit(b *testing.B) {
 	n := NewNodeIDFromHash(h2b("0000000000000000000000000000000000000000000000000000000000000001"))
 	n.PrefixLenBits = 256
 	for i := 0; i < b.N; i++ {
-
 		_, _ = n.Split(10, 176)
+	}
+}
+
+func BenchmarkSuffix(b *testing.B) {
+	n := NewNodeIDFromHash(h2b("0000000000000000000000000000000000000000000000000000000000000001"))
+	n.PrefixLenBits = 256
+	for i := 0; i < b.N; i++ {
+		_ = n.Suffix(10, 176)
 	}
 }


### PR DESCRIPTION
This change causes less memory to be allocated when manipulating NodeIDs:
 -  Introduces `NodeID.Suffix()` to be used rather than `NodeID.Split()`when only the suffix is required, saves ~30% memory compared to `Split`,
 - `storage.NewSuffix()` now allocates ~90% less memory, and is 15% faster

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
