### PR TITLE
Convert directly from Int.Bits() to NodeID

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -170,7 +170,7 @@ func NewNodeIDFromPrefix(prefix []byte, depth int, index int64, subDepth, totalD
 // depth indicates the number of bits from the most significant bit to treat as part of the path.
 func newNodeIDFromBigIntOld(depth int, index *big.Int, totalDepth int) NodeID {
 	if got, want := totalDepth%8, 0; got != want || got < want {
-		panic(fmt.Sprintf("storage NewNodeFromBitInt(): totalDepth mod 8: %v, want %v", got, want))
+		panic(fmt.Sprintf("storage NewNodeFromBitIntOld(): totalDepth mod 8: %v, want %v", got, want))
 	}
 
 	// TODO(al): We _could_ use Bits() and avoid the extra copy/alloc.
@@ -182,7 +182,7 @@ func newNodeIDFromBigIntOld(depth int, index *big.Int, totalDepth int) NodeID {
 
 	// TODO(gdbelvin): consider masking off insignificant bits past depth.
 	if glog.V(5) {
-		glog.Infof("NewNodeIDFromBigInt(%v, %x, %v): %v, %x",
+		glog.Infof("NewNodeIDFromBigIntOld(%v, %x, %v): %v, %x",
 			depth, b, totalDepth, depth, path)
 	}
 
@@ -193,17 +193,17 @@ func newNodeIDFromBigIntOld(depth int, index *big.Int, totalDepth int) NodeID {
 }
 
 func NewNodeIDFromBigInt(depth int, index *big.Int, totalDepth int) NodeID {
-	if got, want := totalDepth%8, 0; got != want || got < want {
+	if got, want := totalDepth%8, 0; got != want {
 		panic(fmt.Sprintf("storage NewNodeFromBitInt(): totalDepth mod 8: %v, want %v", got, want))
 	}
 
 	if totalDepth == 0 {
-		panic("totalDepth must not be zero")
+		panic("storage NewNodeFromBitInt(): totalDepth must not be zero")
 	}
 
 	// Put index in the LSB bits of path.
 	// This code more-or-less pinched from nat.go in the golang math/big package:
-	_S := bits.UintSize / 8
+	const _S = bits.UintSize / 8
 	path := make([]byte, totalDepth/8)
 
 	iBits := index.Bits()

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -185,7 +185,7 @@ func TestNewNodeIDFromBigInt(t *testing.T) {
 		// We should be able to get the same big.Int back. This is used in
 		// the HStar2 implementation so should be tested.
 		if got, want := n.BigInt(), tc.index; want.Cmp(got) != 0 {
-			t.Errorf("NewNodeIDFromBigInt(%v, %x, %v): got: %v, want: %v",
+			t.Errorf("NewNodeIDFromBigInt(%v, %x, %v):got:\n%v, want:\n%v",
 				tc.depth, tc.index.Bytes(), tc.totalDepth, got, want)
 		}
 	}
@@ -201,7 +201,7 @@ func TestNewNodeIDFromBigIntPanic(t *testing.T) {
 			defer func() {
 				got := recover()
 				if (got != nil && !want) || (got == nil && want) {
-					t.Errorf("Incorrect panic behaviour got: %v, want: %v", got, want)
+					t.Errorf("Incorrect panic behaviour (b=%d) got: %v, want: %v", b, got, want)
 				}
 			}()
 			_ = NewNodeIDFromBigInt(12, big.NewInt(234), b)
@@ -891,4 +891,19 @@ func BenchmarkSuffix(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = n.Suffix(10, 176)
 	}
+}
+
+func runBenchmarkNewNodeIDFromBigInt(b *testing.B, f func(int, *big.Int, int) NodeID) {
+	b.Helper()
+	for i := 0; i < b.N; i++ {
+		_ = f(256, new(big.Int).SetBytes(h2b("00")), 256)
+	}
+}
+
+func BenchmarkNewNodeIDFromBigIntOld(b *testing.B) {
+	runBenchmarkNewNodeIDFromBigInt(b, newNodeIDFromBigIntOld)
+}
+
+func BenchmarkNewNodeIDFromBigIntNew(b *testing.B) {
+	runBenchmarkNewNodeIDFromBigInt(b, NewNodeIDFromBigInt)
 }


### PR DESCRIPTION
Wall-clock equivalent, but allocates half the amount of memory.

### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
