### PR TITLE
 Remove NewNodeIDWithPrefix constructor.

### DIFF
--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -143,7 +143,7 @@ func forceWriteRevision(rev int64, tx storage.TreeTX) {
 func createSomeNodes() []storage.Node {
 	r := make([]storage.Node, 4)
 	for i := range r {
-		r[i].NodeID = storage.NewNodeIDWithPrefix(uint64(i), 8, 8, 8)
+		r[i].NodeID = storage.NewNodeIDFromPrefix([]byte{byte(i)}, 0, 8, 8, 8)
 		h := sha256.Sum256([]byte{byte(i)})
 		r[i].Hash = h[:]
 		glog.Infof("Node to store: %v\n", r[i].NodeID)

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -86,10 +86,10 @@ func forceWriteRevision(rev int64, tx storage.TreeTX) {
 func createSomeNodes() []storage.Node {
 	r := make([]storage.Node, 4)
 	for i := range r {
-		r[i].NodeID = storage.NewNodeIDWithPrefix(uint64(i), 8, 8, 8)
+		r[i].NodeID = storage.NewNodeIDFromPrefix([]byte{byte(i)}, 0, 8, 8, 8)
 		h := sha256.Sum256([]byte{byte(i)})
 		r[i].Hash = h[:]
-		glog.Infof("Node to store: %v", r[i].NodeID)
+		glog.Infof("Node to store: %v\n", r[i].NodeID)
 	}
 	return r
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -237,31 +237,6 @@ func (n NodeID) BigInt() *big.Int {
 	return new(big.Int).SetBytes(n.Path)
 }
 
-// NewNodeIDWithPrefix creates a new NodeID of nodeIDLen bits with the prefixLen MSBs set to prefix.
-// NewNodeIDWithPrefix places the lower prefixLenBits of prefix in the most significant bits of path.
-// Path will have enough bytes to hold maxLenBits
-//
-func NewNodeIDWithPrefix(prefix uint64, prefixLenBits, nodeIDLenBits, maxLenBits int) NodeID {
-	if got, want := nodeIDLenBits%8, 0; got != want {
-		panic(fmt.Sprintf("nodeIDLenBits mod 8: %v, want %v", got, want))
-	}
-	maxLenBytes := bytesForBits(maxLenBits)
-	p := NodeID{
-		Path:          make([]byte, maxLenBytes),
-		PrefixLenBits: nodeIDLenBits,
-	}
-
-	bit := maxLenBits - prefixLenBits
-	for i := 0; i < prefixLenBits; i++ {
-		if prefix&1 != 0 {
-			p.SetBit(bit, 1)
-		}
-		bit++
-		prefix >>= 1
-	}
-	return p
-}
-
 // NewNodeIDForTreeCoords creates a new NodeID for a Tree node with a specified depth and
 // index.
 // This method is used exclusively by the Log, and, since the Log model grows upwards from the
@@ -290,17 +265,6 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 	// we "reverse" depth here:
 	r.PrefixLenBits = int(maxPathBits - int(depth))
 	return r, nil
-}
-
-// SetBit sets the ith bit to true if b is non-zero, and false otherwise.
-// Note that the bit index 0 is the right most valid bit in the path.
-func (n *NodeID) SetBit(i int, b uint) {
-	bIndex := (n.PathLenBits() - i - 1) / 8
-	if b == 0 {
-		n.Path[bIndex] &= ^(1 << uint(i%8))
-	} else {
-		n.Path[bIndex] |= (1 << uint(i%8))
-	}
 }
 
 // Bit returns 1 if the zero indexed ith bit from the right (of the whole path

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"testing"
 
 	"github.com/google/trillian/testonly"
@@ -71,23 +70,6 @@ func TestNewEmptyNodeIDPanic(t *testing.T) {
 				}
 			}()
 			_ = NewEmptyNodeID(b)
-		})
-	}
-}
-
-func TestNodeIDWithPrefixPanic(t *testing.T) {
-	for b := 0; b < 64; b++ {
-		t.Run(fmt.Sprintf("%dbits", b), func(t *testing.T) {
-			// It should panic if nodeIDLenBits is not a multiple of 8.
-			want := b%8 != 0
-			// Unfortunately we have to test for panics.
-			defer func() {
-				got := recover()
-				if (got != nil && !want) || (got == nil && want) {
-					t.Errorf("Incorrect panic behaviour got: %v, want: %v", got, want)
-				}
-			}()
-			_ = NewNodeIDWithPrefix(0x12345, 32, b, 64)
 		})
 	}
 }
@@ -397,27 +379,6 @@ func TestNewNodeIDFromPrefix(t *testing.T) {
 	}
 }
 
-func TestNewNodeIDWithPrefix(t *testing.T) {
-	for _, tc := range []struct {
-		input    uint64
-		inputLen int
-		pathLen  int
-		maxLen   int
-		want     []byte
-	}{
-		{input: h26("00"), inputLen: 0, pathLen: 0, maxLen: 64, want: h2b("0000000000000000")},
-		{input: h26("12345678"), inputLen: 32, pathLen: 32, maxLen: 64, want: h2b("1234567800000000")},
-		// top 15 bits of 0x345678 are: 0101 0110 0111 1000
-		{input: h26("345678"), inputLen: 15, pathLen: 16, maxLen: 24, want: h2b("acf000")},
-	} {
-		n := NewNodeIDWithPrefix(tc.input, tc.inputLen, tc.pathLen, tc.maxLen)
-		if got, want := n.Path, tc.want; !bytes.Equal(got, want) {
-			t.Errorf("NewNodeIDWithPrefix(%x, %v, %v, %v).Path: %x, want %x",
-				tc.input, tc.inputLen, tc.pathLen, tc.maxLen, got, want)
-		}
-	}
-}
-
 func TestNewNodeIDForTreeCoords(t *testing.T) {
 	for _, v := range []struct {
 		height     int64
@@ -491,8 +452,8 @@ func TestEquivalentTreeCoords(t *testing.T) {
 
 func TestEquivalentTrailingBits(t *testing.T) {
 	// Set up node IDs with 56 significant bits and length 64.
-	n1 := NewNodeIDWithPrefix(h26("12345678"), 56, 56, 64)
-	n2 := NewNodeIDWithPrefix(h26("12345678"), 56, 56, 64)
+	n1 := NewNodeIDFromPrefix(h2b("00112233445566"), 0, 0, 8, 64)
+	n2 := NewNodeIDFromPrefix(h2b("00112233445566"), 0, 0, 8, 64)
 	// Whatever we do to the last byte of the path shouldn't affect their
 	// equivalence.
 	for b := 0; b < 256; b++ {
@@ -575,37 +536,6 @@ func TestNodeEquivalentFromHash(t *testing.T) {
 	}
 }
 
-func TestSetBit(t *testing.T) {
-	for _, tc := range []struct {
-		n    NodeID
-		i    int
-		b    uint
-		want []byte
-	}{
-		{
-			n: NewNodeIDWithPrefix(h26("00"), 0, 64, 64),
-			i: 27, b: 1,
-			want: h2b("0000000008000000"),
-		},
-		{
-			n: NewNodeIDWithPrefix(h26("00"), 0, 56, 64),
-			i: 0, b: 1,
-			want: h2b("0000000000000001"),
-		},
-		{
-			n: NewNodeIDWithPrefix(h26("00"), 0, 64, 64),
-			i: 27, b: 0,
-			want: h2b("0000000000000000"),
-		},
-	} {
-		n := tc.n
-		n.SetBit(tc.i, tc.b)
-		if got, want := n.Path, tc.want; !bytes.Equal(got, want) {
-			t.Errorf("%x.SetBit(%v,%v): %v, want %v", tc.n.Path, tc.i, tc.b, got, want)
-		}
-	}
-}
-
 func TestNeighbour(t *testing.T) {
 	for _, tc := range []struct {
 		index []byte
@@ -636,19 +566,19 @@ func TestBit(t *testing.T) {
 	}{
 		{
 			// Every 3rd bit is 1.
-			n:    NewNodeIDWithPrefix(h26("9249"), 16, 16, 16),
+			n:    NewNodeIDFromPrefix(h2b("9249"), 16, 0, 8, 16),
 			want: "1001001001001001",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("0055"), 16, 16, 24),
+			n:    NewNodeIDFromPrefix(h2b("0055"), 16, 0, 16, 24),
 			want: "000000000101010100000000",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("f2"), 8, 0, 24),
+			n:    NewNodeIDFromPrefix(h2b("f2"), 8, 0, 0, 24),
 			want: "111100100000000000000000",
 		},
 		{
-			n:    NewNodeIDWithPrefix(h26("01"), 1, 8, 24),
+			n:    NewNodeIDFromPrefix(h2b("80"), 1, 0, 8, 24),
 			want: "100000000000000000000000",
 		},
 	} {
@@ -662,7 +592,7 @@ func TestBit(t *testing.T) {
 }
 
 func TestBitPanics(t *testing.T) {
-	n := NewNodeIDWithPrefix(95, 8, 8, 8)
+	n := NewNodeIDFromPrefix(h2b("64"), 0, 0, 8, 8)
 	for b := 0; b < 64; b++ {
 		t.Run(fmt.Sprintf("%dbits", b), func(t *testing.T) {
 			// Testing anything larger than the 7th bit should fail.
@@ -691,32 +621,32 @@ func TestString(t *testing.T) {
 			wantKey: "0:",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("345678"), 24, 32, 32),
+			n:       NewNodeIDFromPrefix(h2b("34567800"), 0, 0, 32, 32),
 			want:    "00110100010101100111100000000000",
 			wantKey: "32:34567800",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("12345678"), 32, 32, 64),
+			n:       NewNodeIDFromPrefix(h2b("12345678"), 0, 0, 32, 32),
 			want:    "00010010001101000101011001111000",
 			wantKey: "32:12345678",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("345678"), 15, 16, 24),
+			n:       NewNodeIDFromPrefix(h2b("acf0"), 0, 0, 16, 16),
 			want:    fmt.Sprintf("%016b", (0x345678<<1)&0xfffd),
 			wantKey: "16:acf0",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("1234"), 15, 16, 16),
+			n:       NewNodeIDFromPrefix(h2b("2468"), 0, 0, 16, 16),
 			want:    "0010010001101000",
 			wantKey: "16:2468",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("f2"), 8, 8, 24),
+			n:       NewNodeIDFromPrefix(h2b("f2"), 0, 0, 8, 8),
 			want:    "11110010",
 			wantKey: "8:f2",
 		},
 		{
-			n:       NewNodeIDWithPrefix(h26("1234"), 16, 16, 16),
+			n:       NewNodeIDFromPrefix(h2b("1234"), 0, 0, 16, 16),
 			want:    "0001001000110100",
 			wantKey: "16:1234",
 		},
@@ -742,16 +672,16 @@ func TestString(t *testing.T) {
 
 func TestSiblings(t *testing.T) {
 	for _, tc := range []struct {
-		input    uint64
+		prefix   []byte
+		index    int64
 		inputLen int
-		pathLen  int
 		maxLen   int
 		want     []string
 	}{
 		{
-			input:    h26("abe4"),
+			prefix:   h2b("abe4"),
+			index:    0,
 			inputLen: 16,
-			pathLen:  16,
 			maxLen:   16,
 			want: []string{"1010101111100101",
 				"101010111110011",
@@ -771,7 +701,7 @@ func TestSiblings(t *testing.T) {
 				"0"},
 		},
 	} {
-		n := NewNodeIDWithPrefix(tc.input, tc.inputLen, tc.pathLen, tc.maxLen)
+		n := NewNodeIDFromPrefix(tc.prefix, 0, tc.index, tc.inputLen, tc.maxLen)
 		sibs := n.Siblings()
 		if got, want := len(sibs), len(tc.want); got != want {
 			t.Errorf("Got %d siblings, want %d", got, want)
@@ -788,57 +718,51 @@ func TestSiblings(t *testing.T) {
 
 func TestNodeEquivalent(t *testing.T) {
 	l := 16
-	na := NewNodeIDWithPrefix(h26("1234"), l, l, l)
+	na := NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l)
 	for _, tc := range []struct {
 		n1, n2 NodeID
 		want   bool
 	}{
 		{
-			// Self is Equal
+			// Self is Equal.
 			n1:   na,
 			n2:   na,
 			want: true,
 		},
 		{
-			// Equal
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
+			// Equal (different instances).
+			n1:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
 			want: true,
 		},
 		{
-			// Different PrefixLen
-			n1:   NewNodeIDWithPrefix(h26("123f"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("123f"), l-1, l, l),
+			// Different Index.
+			n1:   NewNodeIDFromPrefix(h2b("123f"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("123f"), 1, int64(l), l, l),
 			want: false,
 		},
 		{
-			// Different IDLen
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("1234"), l, l+8, l+8),
+			// Different Prefix.
+			n1:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("5432"), 0, int64(l), l, l),
 			want: false,
 		},
 		{
-			// Different Prefix
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("5432"), l, l, l),
+			// Different Prefix 2.
+			n1:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("1235"), 0, int64(l), l, l),
 			want: false,
 		},
 		{
-			// Different Prefix 2
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("1235"), l, l, l),
+			// Different Prefix 3.
+			n1:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("2234"), 0, int64(l), l, l),
 			want: false,
 		},
 		{
-			// Different Prefix 3
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("2234"), l, l, l),
-			want: false,
-		},
-		{
-			// Different max len, but that's ok because the prefixes are identical
-			n1:   NewNodeIDWithPrefix(h26("1234"), l, l, l),
-			n2:   NewNodeIDWithPrefix(h26("1234"), l, l, l*2),
+			// Different max len, but that's ok because the prefixes are identical.
+			n1:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l),
+			n2:   NewNodeIDFromPrefix(h2b("1234"), 0, int64(l), l, l+8),
 			want: true,
 		},
 	} {
@@ -867,15 +791,6 @@ func TestCoordString(t *testing.T) {
 			}
 		}
 	}
-}
-
-// h26 converts a hex string into an uint64.
-func h26(h string) uint64 {
-	i, err := strconv.ParseUint(h, 16, 64)
-	if err != nil {
-		panic(err)
-	}
-	return i
 }
 
 func mustDecode(h string) []byte {


### PR DESCRIPTION
This only appears to be used by tests. Replace with another prefix constructor in tests. Also remove `SetBit` from `NodeID` as this seems to be the only user of it.

Continuing the plan to remove arbitrary bit twiddling from these objects. 

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
