### PR TITLE
compact: Simplify getting hashes in NewTreeWithState

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -136,8 +136,8 @@ var (
 	// Nodes that will be loaded when updating the tree of size 21.
 	compactTree21 = []storage.Node{
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 64},
-			Hash:         testonly.MustDecodeBase64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
+			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
+			Hash:         testonly.MustDecodeBase64("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="),
 			NodeRevision: 5,
 		},
 		{
@@ -146,8 +146,8 @@ var (
 			NodeRevision: 5,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
-			Hash:         testonly.MustDecodeBase64("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="),
+			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 64},
+			Hash:         testonly.MustDecodeBase64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
 			NodeRevision: 5,
 		},
 	}

--- a/merkle/compact/tree_test.go
+++ b/merkle/compact/tree_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/bits"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -261,6 +262,31 @@ func TestRootHashForVariousTreeSizes(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestTreeNodes(t *testing.T) {
+	for _, tc := range []struct {
+		size uint64
+		want []NodeID
+	}{
+		{size: 0, want: []NodeID{}},
+		{size: 1, want: []NodeID{{Level: 0, Index: 0}}},
+		{size: 2, want: []NodeID{{Level: 1, Index: 0}}},
+		{size: 3, want: []NodeID{{Level: 1, Index: 0}, {Level: 0, Index: 2}}},
+		{size: 4, want: []NodeID{{Level: 2, Index: 0}}},
+		{size: 5, want: []NodeID{{Level: 2, Index: 0}, {Level: 0, Index: 4}}},
+		{size: 15, want: []NodeID{{Level: 3, Index: 0}, {Level: 2, Index: 2}, {Level: 1, Index: 6}, {Level: 0, Index: 14}}},
+		{size: 100, want: []NodeID{{Level: 6, Index: 0}, {Level: 5, Index: 2}, {Level: 2, Index: 24}}},
+		{size: 513, want: []NodeID{{Level: 9, Index: 0}, {Level: 0, Index: 512}}},
+		{size: uint64(1) << 63, want: []NodeID{{Level: 63, Index: 0}}},
+		{size: (uint64(1) << 63) + (uint64(1) << 57), want: []NodeID{{Level: 63, Index: 0}, {Level: 57, Index: 64}}},
+	} {
+		t.Run(fmt.Sprintf("size:%d", tc.size), func(t *testing.T) {
+			if got, want := TreeNodes(tc.size), tc.want; !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("TreeNodes: got %v, want %v", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This change factors out getting the list of node IDs needed to initialize `compact.Tree`
into a separate exported function.

This eliminates `GetNodesFunc` callback which makes client code simpler, and also
allows a more direct initialization of `compact.Range`.