### PR TITLE
Remove FlipRightBit and fold into Neighbor func.

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -377,13 +377,6 @@ func (n *NodeID) Copy() *NodeID {
 	}
 }
 
-// FlipRightBit flips the ith bit from LSB
-func (n *NodeID) FlipRightBit(i int) *NodeID {
-	bIndex := (n.PathLenBits() - i - 1) / 8
-	n.Path[bIndex] ^= 1 << uint(i%8)
-	return n
-}
-
 // leftmask contains bitmasks indexed such that the left x bits are set. It is
 // indexed by byte position from 0-7 0 is special cased to 0xFF since 8 mod 8
 // is 0. leftmask is only used to mask the last byte.
@@ -412,9 +405,13 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 // Neighbor returns the same node with the bit at PrefixLenBits flipped.
 // In terms of a tree traversal, this is the parent node's other child node
 // in the binary tree (often termed sibling node).
+// TODO(Martin2112): This is only used by Siblings() in conjunction with
+// MaskLeft() and could be cleaned up further.
 func (n *NodeID) Neighbor() *NodeID {
 	height := n.PathLenBits() - n.PrefixLenBits
-	return n.FlipRightBit(height)
+	bIndex := (n.PathLenBits() - height - 1) / 8
+	n.Path[bIndex] ^= 1 << uint(height%8)
+	return n
 }
 
 // Siblings returns the siblings of the given node.

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -574,27 +574,25 @@ func TestSetBit(t *testing.T) {
 	}
 }
 
-func TestFlipRightBit(t *testing.T) {
+func TestNeighbour(t *testing.T) {
 	for _, tc := range []struct {
 		index []byte
-		i     int
 		want  []byte
 	}{
-		{index: h2b("00"), i: 0, want: h2b("01")},
-		{index: h2b("00"), i: 7, want: h2b("80")},
-		{index: h2b("000b"), i: 0, want: h2b("000a")},
-		{index: h2b("000b"), i: 1, want: h2b("0009")},
-		{index: h2b("000b"), i: 2, want: h2b("000f")},
-		{index: h2b("000b"), i: 3, want: h2b("0003")},
-		{index: h2b("0001"), i: 0, want: h2b("0000")},
-		{index: h2b("8000"), i: 15, want: h2b("0000")},
-		{index: h2b("0000000000000001"), i: 0, want: h2b("0000000000000000")},
-		{index: h2b("0000000000010000"), i: 16, want: h2b("0000000000000000")},
-		{index: h2b("8000000000000000"), i: 63, want: h2b("0000000000000000")},
+		{index: h2b("00"), want: h2b("01")},
+		{index: h2b("000b"), want: h2b("000a")},
+		{index: h2b("000c"), want: h2b("000d")},
+		{index: h2b("000d"), want: h2b("000c")},
+		{index: h2b("0009"), want: h2b("0008")},
+		{index: h2b("0001"), want: h2b("0000")},
+		{index: h2b("8000"), want: h2b("8001")},
+		{index: h2b("0000000000000001"), want: h2b("0000000000000000")},
+		{index: h2b("0000000000010000"), want: h2b("0000000000010001")},
+		{index: h2b("8000000000000000"), want: h2b("8000000000000001")},
 	} {
 		nID := NewNodeIDFromHash(tc.index)
-		if got, want := nID.FlipRightBit(tc.i).Path, tc.want; !bytes.Equal(got, want) {
-			t.Errorf("flipBit(%x, %d): %x, want %x", tc.index, tc.i, got, want)
+		if got, want := nID.Neighbor().Path, tc.want; !bytes.Equal(got, want) {
+			t.Errorf("flipBit(%x): %x, want %x", tc.index, got, want)
 		}
 	}
 }
@@ -867,13 +865,6 @@ func BenchmarkAsKey(b *testing.B) {
 	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
 	for i := 0; i < b.N; i++ {
 		_ = nID.AsKey()
-	}
-}
-
-func BenchmarkFlipRightBit(b *testing.B) {
-	nID := NewNodeIDFromHash(h2b("000102030405060708090A0B0C0D0E0F10111213"))
-	for i := 0; i < b.N; i++ {
-		nID.FlipRightBit(27)
 	}
 }
 


### PR DESCRIPTION
Reduces the number of mutators for NodeID by one. Continuing to try to rationalize this API.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
