### PR TITLE
compact.Tree: Factor out root verification method

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -527,16 +527,11 @@ func buildMemoryMerkleTree(leafMap map[int64]*trillian.LogLeaf, params TestParam
 		merkleTree.AddLeaf(leafMap[l].LeafValue)
 	}
 
-	// If the two reference results disagree there's no point in continuing the checks. This is a
-	// "can't happen" situation.
-	root, err := compactTree.CurrentRoot()
-	if err != nil {
-		return nil, fmt.Errorf("failed to compute compact tree root: %v", err)
+	// If the two reference results disagree there's no point in continuing the
+	// checks. This is a "can't happen" situation.
+	if err := compactTree.VerifyRoot(merkleTree.CurrentRoot().Hash()); err != nil {
+		return nil, fmt.Errorf("failed to verify root hash: %v", err)
 	}
-	if !bytes.Equal(root, merkleTree.CurrentRoot().Hash()) {
-		return nil, fmt.Errorf("different root hash results from merkle tree building: %v and %v", root, merkleTree.CurrentRoot())
-	}
-
 	return merkleTree, nil
 }
 

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -161,7 +161,13 @@ func (s Sequencer) buildMerkleTreeFromStorageAtRoot(ctx context.Context, root *t
 		hashes[i] = node.Hash
 	}
 
-	return compact.NewTreeWithState(s.hasher, int64(root.TreeSize), hashes, root.RootHash)
+	mt, err := compact.NewTreeWithState(s.hasher, int64(root.TreeSize), hashes)
+	if err != nil {
+		return nil, err
+	} else if err := mt.VerifyRoot(root.RootHash); err != nil {
+		return nil, err
+	}
+	return mt, nil
 }
 
 func (s Sequencer) buildNodesFromNodeMap(nodeMap map[compact.NodeID][]byte, newVersion int64) ([]storage.Node, error) {


### PR DESCRIPTION
This change makes root verification in `compact.Tree` optional,
by factoring it out from the constructor.