### PR TITLE
Avoid an unnecessary Split() in preload()

### DIFF
--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -110,6 +110,20 @@ func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	}
 }
 
+func TestCacheGetNodesNoWork(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	c := NewSubtreeCache(defaultLogStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
+	// Nothing should be read from storage, fail if it is.
+	_, err := c.GetNodes(nil, func([]storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+		return nil, errors.New("unexpected read")
+	})
+	if err != nil {
+		t.Errorf("GetNodes()=_, %v, want: no error", err)
+	}
+}
+
 func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
The prefix can be used directly from the NodeID path slice, it's only used to create a hash table key. The code already effectively assumes that the prefix is a multiple of 8 bits. For one thing the subtree strata store prefix lengths in terms of bytes not bits.

Not sure how good the tests are for this code. I'll investigate.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
