### PR TITLE
Add methods for individually getting at prefix/suffix of NodeID

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -158,7 +158,8 @@ func (s *SubtreeCache) preload(ids []storage.NodeID, getSubtrees GetSubtreesFunc
 	want := make(map[string]*storage.NodeID)
 	for _, id := range ids {
 		id := id
-		px, _ := s.splitNodeID(id)
+		sInfo := s.stratumInfoForPrefixLength(id.PrefixLenBits - 1)
+		px := id.Prefix(sInfo.prefixBytes)
 		pxKey := string(px)
 		// TODO(al): fix for non-uniform strata
 		id.PrefixLenBits = len(px) * depthQuantum

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -66,7 +66,8 @@ func TestSplitNodeID(t *testing.T) {
 		n := storage.NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
-		p, s := c.splitNodeID(n)
+		sInfo := c.stratumInfoForNodeID(n)
+		p, s := n.Split(sInfo.prefixBytes, sInfo.depth)
 		if got, want := p, tc.outPrefix; !bytes.Equal(got, want) {
 			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
 			continue
@@ -269,7 +270,8 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
-				_, sfx := c.splitNodeID(n)
+				sInfo := c.stratumInfoForNodeID(n)
+				sfx := n.Suffix(sInfo.prefixBytes, sInfo.depth)
 				cmtStorage.InternalNodes[sfx.String()] = hash
 			}
 		}

--- a/storage/types.go
+++ b/storage/types.go
@@ -469,7 +469,7 @@ func (n *NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
 	return NewSuffix(byte(b), sfxPath)
 }
 
-// Prefix returns a NodeID's prefix.
+// Prefix returns a copy of NodeID's prefix.
 // This is the same value that would be returned from Split, but without the
 // overhead of calulating the suffix too.
 func (n *NodeID) Prefix(prefixBytes int) []byte {
@@ -493,6 +493,7 @@ func (n *NodeID) PrefixAsKey(prefixBytes int) string {
 }
 
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
+// The returned prefix is a copy of the underlying bytes.
 func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	if n.PrefixLenBits == 0 {
 		return []byte{}, EmptySuffix

--- a/storage/types.go
+++ b/storage/types.go
@@ -469,6 +469,29 @@ func (n *NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
 	return NewSuffix(byte(b), sfxPath)
 }
 
+// Prefix returns a NodeID's prefix.
+// This is the same value that would be returned from Split, but without the
+// overhead of calulating the suffix too.
+func (n *NodeID) Prefix(prefixBytes int) []byte {
+	if n.PrefixLenBits == 0 {
+		return []byte{}
+	}
+	a := make([]byte, prefixBytes)
+	copy(a, n.Path[:prefixBytes])
+
+	return a
+}
+
+// PrefixAsKey returns a NodeID's prefix in a format suitable for use as a map key.
+// This is the same value that would be returned from Split, but without the
+// overhead of calulating the suffix too.
+func (n *NodeID) PrefixAsKey(prefixBytes int) string {
+	if n.PrefixLenBits == 0 {
+		return ""
+	}
+	return string(n.Path[:prefixBytes])
+}
+
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
 func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	if n.PrefixLenBits == 0 {
@@ -477,7 +500,7 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	a := make([]byte, prefixBytes)
 	copy(a, n.Path[:prefixBytes])
 
-	return a, n.Suffix(prefixBytes, suffixBits)
+	return n.Prefix(prefixBytes), n.Suffix(prefixBytes, suffixBits)
 }
 
 // Equivalent return true iff the other represents the same path prefix as this NodeID.


### PR DESCRIPTION
This PR adds finer-grained accessors for getting at Prefix and Suffix parts of a given NodeID, rather than forcing the caller to pay the overhead cost of calling `Split` if only one of the parts is required.

It also provides a `PrefixAsKey` method as a means to avoid a double allocation.

### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
