### PR TITLE
Rename TreeNodes to RangeNodesForPrefix

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -141,7 +141,7 @@ func (s Sequencer) initCompactRangeFromStorage(ctx context.Context, root *types.
 		return fact.NewEmptyRange(0), nil
 	}
 
-	ids := compact.TreeNodes(root.TreeSize)
+	ids := compact.RangeNodesForPrefix(root.TreeSize)
 	storIDs := make([]storage.NodeID, len(ids))
 	for i, id := range ids {
 		nodeID, err := storage.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)

--- a/merkle/compact/nodes.go
+++ b/merkle/compact/nodes.go
@@ -37,10 +37,9 @@ func NewNodeID(level uint, index uint64) NodeID {
 	return NodeID{Level: level, Index: index}
 }
 
-// TreeNodes returns the list of node IDs that comprise a compact tree, in the
-// same order they are used in compact.Tree and compact.Range, i.e. ordered
-// from upper to lower levels.
-func TreeNodes(size uint64) []NodeID {
+// RangeNodesForPrefix returns the list of node IDs that comprise the [0, size)
+// compact range. Nodes are ordered from upper to lower levels.
+func RangeNodesForPrefix(size uint64) []NodeID {
 	ids := make([]NodeID, 0, bits.OnesCount64(size))
 	// Iterate over perfect subtrees along the right border of the tree. Those
 	// correspond to the bits of the tree size that are set to one.

--- a/merkle/compact/nodes_test.go
+++ b/merkle/compact/nodes_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestTreeNodes(t *testing.T) {
+func TestRangeNodesForPrefix(t *testing.T) {
 	for _, tc := range []struct {
 		size uint64
 		want []NodeID
@@ -38,8 +38,8 @@ func TestTreeNodes(t *testing.T) {
 		{size: (uint64(1) << 63) + (uint64(1) << 57), want: []NodeID{{Level: 63, Index: 0}, {Level: 57, Index: 64}}},
 	} {
 		t.Run(fmt.Sprintf("size:%d", tc.size), func(t *testing.T) {
-			if got, want := TreeNodes(tc.size), tc.want; !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("TreeNodes: got %v, want %v", got, want)
+			if got, want := RangeNodesForPrefix(tc.size), tc.want; !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("RangeNodesForPrefix: got %v, want %v", got, want)
 			}
 		})
 	}

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -366,7 +366,7 @@ func TestNewRangeWithStorage(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("%d: Append: %v", i, err)
 		}
-		hashes := getHashes(TreeNodes(i + 1))
+		hashes := getHashes(RangeNodesForPrefix(i + 1))
 		var err error
 		if cr, err = factory.NewRange(0, i+1, hashes); err != nil {
 			t.Fatalf("%d: NewRange: %v", i+1, err)


### PR DESCRIPTION
This change renames `TreeNodes` function to `RangeNodesForPrefix`, as
the `compact.Tree` has been deleted, and we need a more accurate name
with respect to `compact.Range`.