### PR TITLE
Fold the MaskLeft operation into Neighbour.

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -402,16 +402,16 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 	}
 }
 
-// Neighbor returns the same node with the bit at PrefixLenBits flipped.
+// Neighbor returns a new copy of a node, applying a LeftMask operation and
+// with the bit at PrefixLenBits in the copy flipped.
 // In terms of a tree traversal, this is the parent node's other child node
 // in the binary tree (often termed sibling node).
-// TODO(Martin2112): This is only used by Siblings() in conjunction with
-// MaskLeft() and could be cleaned up further.
-func (n *NodeID) Neighbor() *NodeID {
-	height := n.PathLenBits() - n.PrefixLenBits
-	bIndex := (n.PathLenBits() - height - 1) / 8
-	n.Path[bIndex] ^= 1 << uint(height%8)
-	return n
+func (n *NodeID) Neighbor(depth int) *NodeID {
+	node := n.MaskLeft(depth)
+	height := node.PathLenBits() - node.PrefixLenBits
+	bIndex := (node.PathLenBits() - height - 1) / 8
+	node.Path[bIndex] ^= 1 << uint(height%8)
+	return node
 }
 
 // Siblings returns the siblings of the given node.
@@ -425,7 +425,7 @@ func (n *NodeID) Siblings() []NodeID {
 	sibs := make([]NodeID, n.PrefixLenBits)
 	for height := range sibs {
 		depth := n.PrefixLenBits - height
-		sibs[height] = *(n.MaskLeft(depth).Neighbor())
+		sibs[height] = *n.Neighbor(depth)
 	}
 	return sibs
 }

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -623,7 +623,7 @@ func TestNeighbour(t *testing.T) {
 		{index: h2b("8000000000000000"), want: h2b("8000000000000001")},
 	} {
 		nID := NewNodeIDFromHash(tc.index)
-		if got, want := nID.Neighbor().Path, tc.want; !bytes.Equal(got, want) {
+		if got, want := nID.Neighbor(nID.PrefixLenBits).Path, tc.want; !bytes.Equal(got, want) {
 			t.Errorf("flipBit(%x): %x, want %x", tc.index, got, want)
 		}
 	}


### PR DESCRIPTION
This means Neighbour no longer mutates the input node. There is no
additional copying as MaskLeft was always previous applied.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
