### PR TITLE
Use []*trillian.MapLeaf consistently

### DIFF
--- a/log/mock_operation.go
+++ b/log/mock_operation.go
@@ -34,6 +34,7 @@ func (m *MockOperation) EXPECT() *MockOperationMockRecorder {
 
 // ExecutePass mocks base method
 func (m *MockOperation) ExecutePass(arg0 context.Context, arg1 int64, arg2 *OperationInfo) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecutePass", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -42,5 +43,6 @@ func (m *MockOperation) ExecutePass(arg0 context.Context, arg1 int64, arg2 *Oper
 
 // ExecutePass indicates an expected call of ExecutePass
 func (mr *MockOperationMockRecorder) ExecutePass(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePass", reflect.TypeOf((*MockOperation)(nil).ExecutePass), arg0, arg1, arg2)
 }

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -216,7 +216,7 @@ func (t *TrillianMapServer) getLeavesByRevision(ctx context.Context, mapID int64
 			return
 		}
 		for i, l := range leaves {
-			leavesByIndex[string(l.Index)] = &leaves[i]
+			leavesByIndex[string(l.Index)] = leaves[i]
 		}
 		if len(indices) != len(leavesByIndex) {
 			glog.V(1).Infof("%v: request had %v indices, %v of these are unique", mapID, len(indices), len(leavesByIndex))

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -302,7 +302,7 @@ func (tx *mapTX) getMapLeaf(ctx context.Context, revision int64, index []byte) (
 // as the corresponding values in indexes.
 // An error will be returned if there is a problem with the underlying
 // storage.
-func (tx *mapTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]trillian.MapLeaf, error) {
+func (tx *mapTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, error) {
 	// c will carry any retrieved MapLeaves.
 	c := make(chan *trillian.MapLeaf, len(indexes))
 	// errc will carry any errors while reading from spanner, although we'll only
@@ -323,14 +323,14 @@ func (tx *mapTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]t
 	}
 
 	// Now wait for the goroutines to do their thing.
-	ret := make([]trillian.MapLeaf, 0, len(indexes))
+	ret := make([]*trillian.MapLeaf, 0, len(indexes))
 	for range indexes {
 		select {
 		case err := <-errc:
 			return nil, err
 		case l := <-c:
 			if l != nil {
-				ret = append(ret, *l)
+				ret = append(ret, l)
 			}
 		}
 	}

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -51,7 +51,7 @@ type ReadOnlyMapTreeTX interface {
 	// The returned array of MapLeaves will only contain entries for which values
 	// exist.  i.e. requesting a set of unknown keys would result in a
 	// zero-length array being returned.
-	Get(ctx context.Context, revision int64, keyHashes [][]byte) ([]trillian.MapLeaf, error)
+	Get(ctx context.Context, revision int64, keyHashes [][]byte) ([]*trillian.MapLeaf, error)
 }
 
 // MapTreeTX is the transactional interface for reading/modifying a Map.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -806,10 +806,10 @@ func (mr *MockMapTreeTXMockRecorder) Commit() *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockMapTreeTX) Get(arg0 context.Context, arg1 int64, arg2 [][]byte) ([]trillian.MapLeaf, error) {
+func (m *MockMapTreeTX) Get(arg0 context.Context, arg1 int64, arg2 [][]byte) ([]*trillian.MapLeaf, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]trillian.MapLeaf)
+	ret0, _ := ret[0].([]*trillian.MapLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1405,10 +1405,10 @@ func (mr *MockReadOnlyMapTreeTXMockRecorder) Commit() *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockReadOnlyMapTreeTX) Get(arg0 context.Context, arg1 int64, arg2 [][]byte) ([]trillian.MapLeaf, error) {
+func (m *MockReadOnlyMapTreeTX) Get(arg0 context.Context, arg1 int64, arg2 [][]byte) ([]*trillian.MapLeaf, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]trillian.MapLeaf)
+	ret0, _ := ret[0].([]*trillian.MapLeaf)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -205,13 +205,13 @@ func (m *mapTreeTX) Set(ctx context.Context, keyHash []byte, value trillian.MapL
 // Get returns a list of map leaves indicated by indexes.
 // If an index is not found, no corresponding entry is returned.
 // Each MapLeaf.Index is overwritten with the index the leaf was found at.
-func (m *mapTreeTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]trillian.MapLeaf, error) {
+func (m *mapTreeTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, error) {
 	m.treeTX.mu.Lock()
 	defer m.treeTX.mu.Unlock()
 
 	// If no indexes are requested, return an empty set.
 	if len(indexes) == 0 {
-		return []trillian.MapLeaf{}, nil
+		return []*trillian.MapLeaf{}, nil
 	}
 	stmt, err := m.ms.getStmt(ctx, selectMapLeafSQL, len(indexes), "?", "?")
 	if err != nil {
@@ -236,7 +236,7 @@ func (m *mapTreeTX) Get(ctx context.Context, revision int64, indexes [][]byte) (
 	}
 	defer rows.Close()
 
-	ret := make([]trillian.MapLeaf, 0, len(indexes))
+	ret := make([]*trillian.MapLeaf, 0, len(indexes))
 	nr := 0
 	er := 0
 	for rows.Next() {
@@ -257,7 +257,7 @@ func (m *mapTreeTX) Get(ctx context.Context, revision int64, indexes [][]byte) (
 			return nil, err
 		}
 		mapLeaf.Index = mapKeyHash
-		ret = append(ret, mapLeaf)
+		ret = append(ret, &mapLeaf)
 		nr++
 	}
 	return ret, nil

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -299,7 +299,7 @@ func TestMapSetGetRoundTrip(t *testing.T) {
 			if got, want := len(readValues), 1; got != want {
 				t.Fatalf("Got %d values, expected %d", got, want)
 			}
-			if got, want := &readValues[0], &mapLeaf; !proto.Equal(got, want) {
+			if got, want := readValues[0], &mapLeaf; !proto.Equal(got, want) {
 				t.Fatalf("Read back %v, but expected %v", got, want)
 			}
 			return nil
@@ -411,7 +411,7 @@ func TestMapSetGetMultipleRevisions(t *testing.T) {
 						if got, want := len(readValues), 1; got != want {
 							t.Fatalf("At i %d got %d values, expected %d", i, got, want)
 						}
-						if got, want := &readValues[0], &tests[expectRev].leaf; !proto.Equal(got, want) {
+						if got, want := readValues[0], &tests[expectRev].leaf; !proto.Equal(got, want) {
 							t.Fatalf("At i %d read back %v, but expected %v", i, got, want)
 						}
 						return nil


### PR DESCRIPTION
Repeated proto fields are slices of pointers.  By using slices of
pointers throught, we can avoid multiple conversions and memcopies.