### PR TITLE
Add missing calls to StorageProvider.Close()

### DIFF
--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -106,6 +106,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}
+	defer sp.Close()
 
 	client, err := etcd.NewClientFromString(*server.EtcdServers)
 	if err != nil {

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -102,6 +102,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}
+	defer sp.Close()
 
 	client, err := etcd.NewClientFromString(*server.EtcdServers)
 	if err != nil {


### PR DESCRIPTION
trillian_log_signer defers a call to `StorageProvider.Close()`, but neither trillian_log_server nor trillian_map_server do. This PR fixes that inconsistency. Note that this deferred function won't actually execute if any of the `glog.Exit()` calls happen.

https://github.com/google/trillian/blob/c25d9d042b3a454b13c9e8fc14bdf10e36b48ac0/server/trillian_log_signer/main.go#L99-L103

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
