### PR TITLE
Remove unused Snapshot interface

### DIFF
--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -73,9 +73,6 @@ type MapTreeTX interface {
 type ReadOnlyMapStorage interface {
 	DatabaseChecker
 
-	// Snapshot starts a read-only transaction not tied to any particular tree.
-	Snapshot(ctx context.Context) (ReadOnlyMapTX, error)
-
 	// SnapshotForTree starts a new read-only transaction.
 	// Commit must be called when the caller is finished with the returned object,
 	// and values read through it should only be propagated if Commit returns

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -562,10 +562,12 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 
 func TestReadOnlyMapTX_Rollback(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
+	ctx := context.Background()
 
 	cleanTestDB(DB)
+	activeMap := createInitializedMapForTests(ctx, t, DB)
 	s := NewMapStorage(DB)
-	tx, err := s.Snapshot(context.Background())
+	tx, err := s.SnapshotForTree(ctx, activeMap)
 	if err != nil {
 		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
 	}


### PR DESCRIPTION
The ReadOnlyMapTX.Snapshot API is completely unused.

This PR removes the cruft.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.