### PR TITLE
skylog: Add Cloud Spanner tree storage implementation

### DIFF
--- a/skylog/storage/cloudspanner/schema.sdl
+++ b/skylog/storage/cloudspanner/schema.sdl
@@ -1,9 +1,9 @@
 -- TreeNodes stores Merkle tree nodes. The nodes are sharded according to
--- ShardId, which is computed based on the tree shape and write pattern, in
+-- ShardID, which is computed based on the tree shape and write pattern, in
 -- order to maximize writing parallelism.
 CREATE TABLE TreeNodes (
-  TreeId       INT64 NOT NULL,
-  ShardId      INT32 NOT NULL,
-  NodeId       UINT64 NOT NULL,
+  TreeID       INT64 NOT NULL,
+  ShardID      INT32 NOT NULL,
+  NodeID       UINT64 NOT NULL,
   SubtreeHash  BYTES(32) NOT NULL,
-) PRIMARY KEY (TreeId, ShardId, NodeId);
+) PRIMARY KEY (TreeID, ShardID, NodeID);

--- a/skylog/storage/cloudspanner/schema.sdl
+++ b/skylog/storage/cloudspanner/schema.sdl
@@ -1,0 +1,9 @@
+-- TreeNodes stores Merkle tree nodes. The nodes are sharded according to
+-- ShardId, which is computed based on the tree shape and write pattern, in
+-- order to maximize writing parallelism.
+CREATE TABLE TreeNodes (
+  TreeId       INT64 NOT NULL,
+  ShardId      INT32 NOT NULL,
+  NodeId       UINT64 NOT NULL,
+  SubtreeHash  BYTES(32) NOT NULL,
+) PRIMARY KEY (TreeId, ShardId, NodeId);

--- a/skylog/storage/cloudspanner/schema.sdl
+++ b/skylog/storage/cloudspanner/schema.sdl
@@ -2,8 +2,8 @@
 -- ShardID, which is computed based on the tree shape and write pattern, in
 -- order to maximize writing parallelism.
 CREATE TABLE TreeNodes (
-  TreeID       INT64 NOT NULL,
-  ShardID      INT32 NOT NULL,
-  NodeID       UINT64 NOT NULL,
-  SubtreeHash  BYTES(32) NOT NULL,
+  TreeID   INT64 NOT NULL,
+  ShardID  INT32 NOT NULL,
+  NodeID   UINT64 NOT NULL,
+  NodeHash BYTES(32) NOT NULL,
 ) PRIMARY KEY (TreeID, ShardID, NodeID);

--- a/skylog/storage/cloudspanner/tree.go
+++ b/skylog/storage/cloudspanner/tree.go
@@ -120,7 +120,7 @@ func (o TreeOpts) shardID(id compact.NodeID) int32 {
 //     ...       ...   ...   ...
 //   Level  0:  (2^63) ... (2^64 - 1)
 //
+// TODO(pavelkalinnikov): Check bounds.
 func packNodeID(id compact.NodeID) uint64 {
-	// TODO(pavelkalinnikov): Check bounds.
 	return uint64(1)<<(63-id.Level) | id.Index
 }

--- a/skylog/storage/cloudspanner/tree.go
+++ b/skylog/storage/cloudspanner/tree.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package cloudspanner provides implementation of the Skylog storage API in
 // Cloud Spanner.
 package cloudspanner

--- a/skylog/storage/cloudspanner/tree.go
+++ b/skylog/storage/cloudspanner/tree.go
@@ -108,7 +108,18 @@ func (o TreeOpts) shardID(id compact.NodeID) int32 {
 	return int32(offset % uint64(o.LeafShards))
 }
 
-// packNodeID encodes the ID of the node into a single integer.
+// packNodeID encodes the ID of the node into a single integer. The numbering
+// scheme assumes that we have a tree of up to 63 levels, i.e. 2^63 leaves, as
+// on the diagram below:
+//
+//   Level 63:          1
+//                     / \
+//   Level 62:        2   3
+//                   / \ / \
+//   Level 61:      4  5 6  7
+//     ...       ...   ...   ...
+//   Level  0:  (2^63) ... (2^64 - 1)
+//
 func packNodeID(id compact.NodeID) uint64 {
 	// TODO(pavelkalinnikov): Check bounds.
 	return uint64(1)<<(63-id.Level) | id.Index

--- a/skylog/storage/cloudspanner/tree_test.go
+++ b/skylog/storage/cloudspanner/tree_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudspanner
 
 import (

--- a/skylog/storage/cloudspanner/tree_test.go
+++ b/skylog/storage/cloudspanner/tree_test.go
@@ -67,8 +67,8 @@ func TestPackNodeID(t *testing.T) {
 		{id: compact.NewNodeID(60, 5), want: 13},
 		{id: compact.NewNodeID(32, 0), want: 2147483648},
 		{id: compact.NewNodeID(32, 1<<30), want: 3221225472},
-		{id: compact.NewNodeID(0, 0), want: 9223372036854775808},
-		{id: compact.NewNodeID(0, 1<<30), want: 9223372037928517632},
+		{id: compact.NewNodeID(0, 0), want: 1 << 63},
+		{id: compact.NewNodeID(0, 1<<30), want: 1<<63 + 1<<30},
 		{id: compact.NewNodeID(0, (1<<63)-1), want: 0xFFFFFFFFFFFFFFFF},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc.id), func(t *testing.T) {

--- a/skylog/storage/cloudspanner/tree_test.go
+++ b/skylog/storage/cloudspanner/tree_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	_ "github.com/golang/glog"
 	"github.com/google/trillian/merkle/compact"
 )
 

--- a/skylog/storage/cloudspanner/tree_test.go
+++ b/skylog/storage/cloudspanner/tree_test.go
@@ -1,0 +1,66 @@
+package cloudspanner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/trillian/merkle/compact"
+)
+
+func TestTreeOpts(t *testing.T) {
+	opts := TreeOpts{ShardLevels: 2, LeafShards: 3}
+	opts2 := TreeOpts{ShardLevels: 1, LeafShards: 2}
+	for _, tc := range []struct {
+		opts TreeOpts
+		id   compact.NodeID
+		want int32
+	}{
+		{opts: opts, id: compact.NewNodeID(0, 0), want: 0},
+		{opts: opts, id: compact.NewNodeID(0, 1), want: 0},
+		{opts: opts, id: compact.NewNodeID(0, 2), want: 1},
+		{opts: opts, id: compact.NewNodeID(0, 3), want: 1},
+		{opts: opts, id: compact.NewNodeID(0, 4), want: 2},
+		{opts: opts, id: compact.NewNodeID(0, 5), want: 2},
+		{opts: opts, id: compact.NewNodeID(0, 6), want: 0},
+		{opts: opts, id: compact.NewNodeID(0, 7), want: 0},
+		{opts: opts, id: compact.NewNodeID(0, 8), want: 1},
+		{opts: opts, id: compact.NewNodeID(1, 0), want: 0},
+		{opts: opts, id: compact.NewNodeID(1, 1), want: 1},
+		{opts: opts, id: compact.NewNodeID(1, 2), want: 2},
+		{opts: opts, id: compact.NewNodeID(1, 3), want: 0},
+		{opts: opts, id: compact.NewNodeID(1, 4), want: 1},
+		{opts: opts, id: compact.NewNodeID(2, 0), want: 3},
+		{opts: opts2, id: compact.NewNodeID(0, 10), want: 0},
+		{opts: opts2, id: compact.NewNodeID(0, 15), want: 1},
+		{opts: opts2, id: compact.NewNodeID(10, 20), want: 2},
+	} {
+		t.Run(fmt.Sprintf("%+v:%+v", tc.opts, tc.id), func(t *testing.T) {
+			if got, want := tc.opts.shardID(tc.id), tc.want; got != want {
+				t.Fatalf("shardID=%d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestPackNodeID(t *testing.T) {
+	for _, tc := range []struct {
+		id   compact.NodeID
+		want uint64
+	}{
+		{id: compact.NewNodeID(63, 0), want: 1},
+		{id: compact.NewNodeID(62, 0), want: 2},
+		{id: compact.NewNodeID(62, 1), want: 3},
+		{id: compact.NewNodeID(60, 5), want: 13},
+		{id: compact.NewNodeID(32, 0), want: 2147483648},
+		{id: compact.NewNodeID(32, 1<<30), want: 3221225472},
+		{id: compact.NewNodeID(0, 0), want: 9223372036854775808},
+		{id: compact.NewNodeID(0, 1<<30), want: 9223372037928517632},
+		{id: compact.NewNodeID(0, (1<<63)-1), want: 0xFFFFFFFFFFFFFFFF},
+	} {
+		t.Run(fmt.Sprintf("%+v", tc.id), func(t *testing.T) {
+			if got, want := packNodeID(tc.id), tc.want; got != want {
+				t.Fatalf("packNodeID: got %d, want %d", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change introduces Skylog tree storage implementation in Cloud Spanner.
Data in the nodes table is sharded in a way that allows massive parallelism if
nodes arrive "mostly" sequentially.