### PR TITLE
licenses tool: Parse flags that use "flag" package

### DIFF
--- a/scripts/licenses/main.go
+++ b/scripts/licenses/main.go
@@ -46,6 +46,7 @@ func init() {
 }
 
 func main() {
+	flag.Parse()
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	if err := parseGoBuildFlags(rootCmd.PersistentFlags()); err != nil {
 		glog.Error(err)


### PR DESCRIPTION
It appears that Cobra will not automatically parse these flags, as it does with those declared via its own API. This avoids warnings from the glog package about logging before flag parsing.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
