### PR TITLE
Shim MapWrite.WriteLeaves

### DIFF
--- a/integration/map.go
+++ b/integration/map.go
@@ -101,15 +101,15 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 
 	fmt.Printf("%d: ================ Revision 1 ==================\n", mi.id)
 	// Add a single leaf (key0=>value0) for revision 1.
-	fmt.Printf("%d: Set map[key0]=%q\n", mi.id, value0)
+	fmt.Printf("%d: Write map[key0]=%q\n", mi.id, value0)
 	leaves := []*trillian.MapLeaf{{Index: key0, LeafValue: value0}}
-	setRsp, err := mi.cl.SetLeaves(ctx, &trillian.SetMapLeavesRequest{MapId: mi.id, Leaves: leaves})
+	writeRsp, err := mi.cl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: leaves})
 	if err != nil {
-		return fmt.Errorf("failed to set-map-leaves: %v", err)
+		return fmt.Errorf("failed to write-map-leaves: %v", err)
 	}
 	mi.contents = mi.contents.UpdatedWith(1, leaves)
 
-	root1, err := mi.checkMapRoot(setRsp.MapRoot)
+	root1, err := mi.checkMapRoot(write.MapRoot)
 	if err != nil {
 		return fmt.Errorf("checks on SMR 1 failed: %v", err)
 	}
@@ -123,15 +123,15 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 
 	fmt.Printf("%d: ================ Revision 2 ==================\n", mi.id)
 	// Remove the single leaf by setting it to have empty contents, creating revision 2.
-	fmt.Printf("%d: Set map[key0]=''\n", mi.id)
+	fmt.Printf("%d: Write map[key0]=''\n", mi.id)
 	emptyLeaves := []*trillian.MapLeaf{{Index: key0, LeafValue: []byte{}}}
-	setRsp, err = mi.cl.SetLeaves(ctx, &trillian.SetMapLeavesRequest{MapId: mi.id, Leaves: emptyLeaves, Metadata: []byte("metadata-2")})
+	setRsp, err = mi.cl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: emptyLeaves, Metadata: []byte("metadata-2")})
 	if err != nil {
-		return fmt.Errorf("failed to set-map-leaves: %v", err)
+		return fmt.Errorf("failed to write-map-leaves: %v", err)
 	}
 	mi.contents = mi.contents.UpdatedWith(2, emptyLeaves)
 
-	root2, err := mi.checkMapRoot(setRsp.MapRoot)
+	root2, err := mi.checkMapRoot(writeRsp.MapRoot)
 	if err != nil {
 		return fmt.Errorf("checks on SMR 2 failed: %v", err)
 	}
@@ -156,21 +156,21 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 	}
 
 	fmt.Printf("%d: ================ Revision 3 ==================\n", mi.id)
-	// Set two leaves in one go to make revision 3.
-	fmt.Printf("%d: Set map[key0]=%q\n", mi.id, value1)
-	fmt.Printf("%d: Set map[key1]=%q\n", mi.id, value2)
+	// Write two leaves in one go to make revision 3.
+	fmt.Printf("%d: Write map[key0]=%q\n", mi.id, value1)
+	fmt.Printf("%d: Write map[key1]=%q\n", mi.id, value2)
 
 	newLeaves := []*trillian.MapLeaf{
 		{Index: key0, LeafValue: value1},
 		{Index: key1, LeafValue: value2},
 	}
-	setRsp, err = mi.cl.SetLeaves(ctx, &trillian.SetMapLeavesRequest{MapId: mi.id, Leaves: newLeaves, Metadata: []byte("metadata-3")})
+	writeRsp, err = mi.cl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: newLeaves, Metadata: []byte("metadata-3")})
 	if err != nil {
-		return fmt.Errorf("failed to set-map-leaves: %v", err)
+		return fmt.Errorf("failed to write-map-leaves: %v", err)
 	}
 	mi.contents = mi.contents.UpdatedWith(3, newLeaves)
 
-	root3, err := mi.checkMapRoot(setRsp.MapRoot)
+	root3, err := mi.checkMapRoot(writeRsp.MapRoot)
 	if err != nil {
 		return fmt.Errorf("checks on SMR 3 failed: %v", err)
 	}
@@ -202,8 +202,8 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 	}
 
 	fmt.Printf("%d: ============== Invalid Requests ================\n", mi.id)
-	if _, err := mi.cl.SetLeaves(ctx, &trillian.SetMapLeavesRequest{MapId: mi.id + 1, Leaves: newLeaves}); err == nil {
-		return errors.New("succeeded in set-map-leaves for wrong MapId")
+	if _, err := mi.cl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id + 1, Leaves: newLeaves}); err == nil {
+		return errors.New("succeeded in write-map-leaves for wrong MapId")
 	}
 	if _, err := mi.cl.GetLeaves(ctx, &trillian.GetMapLeavesRequest{MapId: mi.id + 1, Index: [][]byte{key0}}); err == nil {
 		return errors.New("succeeded in get-map-leaves for wrong MapId")

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -32,6 +32,12 @@ import (
 
 const mapID1 = int64(1)
 
+// Assert that the RPC server implements the two Map API surfaces.
+var (
+	_ trillian.TrillianMapServer = &TrillianMapServer{}
+	_ trillian.TrillianMapWrite  = &TrillianMapServer{}
+)
+
 func TestIsHealthy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Implements the new `MapWrite` API in terms of the old methods.
- Switches the map integration test to use the new `WriteLeaves` method.
- Adds a compile-time assert that the `MapRPCServer` satisfies both RPC API surfaces.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
