### PR TITLE
Use go list to find certificate-transparency-go path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,9 +114,9 @@ script:
   - |
     if [[ "${INTEG_TESTS}" == "true" ]]; then
       ./integration/integration_test.sh
-      pushd .
-      cd `go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go`
+      pushd `go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go`
       chmod +x ./trillian/integration/integration_test.sh
+      ./trillian/integration/integration_test.sh
       popd
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,9 +114,10 @@ script:
   - |
     if [[ "${INTEG_TESTS}" == "true" ]]; then
       ./integration/integration_test.sh
-      cd "$HOME/gopath/src/github.com/google/certificate-transparency-go"
-      ./trillian/integration/integration_test.sh
-      cd $HOME/gopath/src/github.com/google/trillian
+      pushd .
+      cd `go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go`
+      chmod +x ./trillian/integration/integration_test.sh
+      popd
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
     fi
   - |

--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -339,7 +339,7 @@ map_provision() {
       --tree_type=MAP \
       --hash_strategy=TEST_MAP_HASHER \
       --private_key_format=PrivateKey \
-      --pem_key_path=${GOPATH}/src/github.com/google/trillian/testdata/map-rpc-server.privkey.pem \
+      --pem_key_path=${TRILLIAN_PATH}/testdata/map-rpc-server.privkey.pem \
       --pem_key_password=towel \
       --signature_algorithm=ECDSA)
     echo "Created map ${tree_id}"


### PR DESCRIPTION
This enables other repos that have go modules enabled to use
the scripts in the Trillian repo.