### PR TITLE
skylog: Fix unsupported types in schema and code

### DIFF
--- a/skylog/storage/cloudspanner/schema.sdl
+++ b/skylog/storage/cloudspanner/schema.sdl
@@ -3,7 +3,7 @@
 -- order to maximize writing parallelism.
 CREATE TABLE TreeNodes (
   TreeID   INT64 NOT NULL,
-  ShardID  INT32 NOT NULL,
-  NodeID   UINT64 NOT NULL,
+  ShardID  INT64 NOT NULL,
+  NodeID   INT64 NOT NULL,
   NodeHash BYTES(32) NOT NULL,
 ) PRIMARY KEY (TreeID, ShardID, NodeID);

--- a/skylog/storage/cloudspanner/tree.go
+++ b/skylog/storage/cloudspanner/tree.go
@@ -97,15 +97,15 @@ func (t *TreeStorage) Write(ctx context.Context, nodes []storage.Node) error {
 // TODO(pavelkalinnikov): Store the parameters in per-tree metadata.
 type TreeOpts struct {
 	ShardLevels uint // Between 1 and 65.
-	LeafShards  int32
+	LeafShards  int64
 }
 
-func (o TreeOpts) shardID(id compact.NodeID) int32 {
+func (o TreeOpts) shardID(id compact.NodeID) int64 {
 	if id.Level >= o.ShardLevels {
 		return o.LeafShards
 	}
 	offset := id.Index >> (o.ShardLevels - id.Level - 1)
-	return int32(offset % uint64(o.LeafShards))
+	return int64(offset) % o.LeafShards
 }
 
 // packNodeID encodes the ID of the node into a single integer. The numbering
@@ -121,6 +121,6 @@ func (o TreeOpts) shardID(id compact.NodeID) int32 {
 //   Level  0:  (2^63) ... (2^64 - 1)
 //
 // TODO(pavelkalinnikov): Check bounds.
-func packNodeID(id compact.NodeID) uint64 {
-	return uint64(1)<<(63-id.Level) | id.Index
+func packNodeID(id compact.NodeID) int64 {
+	return int64(1)<<(63-id.Level) | int64(id.Index)
 }

--- a/skylog/storage/cloudspanner/tree_test.go
+++ b/skylog/storage/cloudspanner/tree_test.go
@@ -28,7 +28,7 @@ func TestTreeOpts(t *testing.T) {
 	for _, tc := range []struct {
 		opts TreeOpts
 		id   compact.NodeID
-		want int32
+		want int64
 	}{
 		{opts: opts, id: compact.NewNodeID(0, 0), want: 0},
 		{opts: opts, id: compact.NewNodeID(0, 1), want: 0},
@@ -73,7 +73,7 @@ func TestPackNodeID(t *testing.T) {
 		{id: compact.NewNodeID(0, (1<<63)-1), want: 0xFFFFFFFFFFFFFFFF},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc.id), func(t *testing.T) {
-			if got, want := packNodeID(tc.id), tc.want; got != want {
+			if got, want := packNodeID(tc.id), int64(tc.want); got != want {
 				t.Fatalf("packNodeID: got %d, want %d", got, want)
 			}
 		})


### PR DESCRIPTION
Use signed 64-bit integer type, the only one supported in Cloud Spanner.