### PR TITLE
skylog: Add Merkle tree build worker

### DIFF
--- a/skylog/core/builder.go
+++ b/skylog/core/builder.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core contains code for a scalable Merkle tree construction.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/trillian/merkle/compact"
+	"github.com/google/trillian/skylog/storage"
+)
+
+// BuildJob is a slice of leaf data hashes spanning a range of a Merkle tree.
+type BuildJob struct {
+	Begin  uint64   // The beginning of the range.
+	Hashes [][]byte // The leaf hashes.
+}
+
+// BuildWorker processes tree building jobs.
+type BuildWorker struct {
+	tw storage.TreeWriter
+	rf *compact.RangeFactory
+}
+
+// NewBuildWorker returns a new BuildWorker for the specified tree.
+func NewBuildWorker(tw storage.TreeWriter, rf *compact.RangeFactory) *BuildWorker {
+	return &BuildWorker{tw: tw, rf: rf}
+}
+
+// Process handles a single build job. It populates the tree storage with the
+// leaf hashes from the slice in the job, and all internal nodes of the tree
+// that can be inferred from them. Returns the compact range of the resulting
+// tree segment.
+func (b *BuildWorker) Process(ctx context.Context, job BuildJob) (*compact.Range, error) {
+	rng := b.rf.NewEmptyRange(job.Begin)
+	if len(job.Hashes) == 0 {
+		return rng, nil
+	}
+	nodes := make([]storage.Node, 0, len(job.Hashes)*2-1)
+	visit := func(id compact.NodeID, hash []byte) {
+		nodes = append(nodes, storage.Node{ID: id, Hash: hash})
+	}
+	for i, hash := range job.Hashes {
+		// Add the leaf node.
+		visit(compact.NewNodeID(0, job.Begin+uint64(i)), hash)
+		// Add the internal tree nodes.
+		if err := rng.Append(hash, visit); err != nil {
+			return nil, fmt.Errorf("appending hash: %v", err)
+		}
+	}
+	if err := b.tw.Write(ctx, nodes); err != nil {
+		return nil, fmt.Errorf("writing tree nodes: %v", err)
+	}
+	return rng, nil
+}

--- a/skylog/core/builder.go
+++ b/skylog/core/builder.go
@@ -25,8 +25,8 @@ import (
 
 // BuildJob is a slice of leaf data hashes spanning a range of a Merkle tree.
 type BuildJob struct {
-	Begin  uint64   // The beginning of the range.
-	Hashes [][]byte // The leaf hashes.
+	RangeStart uint64   // The beginning of the range.
+	Hashes     [][]byte // The leaf hashes.
 }
 
 // BuildWorker processes tree building jobs.
@@ -45,7 +45,7 @@ func NewBuildWorker(tw storage.TreeWriter, rf *compact.RangeFactory) *BuildWorke
 // that can be inferred from them. Returns the compact range of the resulting
 // tree segment.
 func (b *BuildWorker) Process(ctx context.Context, job BuildJob) (*compact.Range, error) {
-	rng := b.rf.NewEmptyRange(job.Begin)
+	rng := b.rf.NewEmptyRange(job.RangeStart)
 	if len(job.Hashes) == 0 {
 		return rng, nil
 	}
@@ -55,7 +55,7 @@ func (b *BuildWorker) Process(ctx context.Context, job BuildJob) (*compact.Range
 	}
 	for i, hash := range job.Hashes {
 		// Add the leaf node.
-		visit(compact.NewNodeID(0, job.Begin+uint64(i)), hash)
+		visit(compact.NewNodeID(0, job.RangeStart+uint64(i)), hash)
 		// Add the internal tree nodes.
 		if err := rng.Append(hash, visit); err != nil {
 			return nil, fmt.Errorf("appending hash: %v", err)

--- a/skylog/core/builder_test.go
+++ b/skylog/core/builder_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/trillian/merkle/compact"
+	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/google/trillian/merkle/testonly"
+	"github.com/google/trillian/skylog/storage"
+)
+
+// TODO(pavelkalinnikov): Use GoMock?
+type mockTreeWriter struct {
+	calls [][]storage.Node
+}
+
+func (t *mockTreeWriter) Write(ctx context.Context, nodes []storage.Node) error {
+	t.calls = append(t.calls, nodes)
+	return nil
+}
+
+func (t *mockTreeWriter) verify(nodes []storage.Node) error {
+	if len(t.calls) == 0 && len(nodes) == 0 {
+		return nil
+	}
+	if got, want := len(t.calls), 1; got != want {
+		return fmt.Errorf("wrong number of calls %d, want %d", got, want)
+	}
+	if got, want := t.calls[0], nodes; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("got nodes: %+v\nwant: %+v", got, want)
+	}
+	return nil
+}
+
+func TestBuildWorker(t *testing.T) {
+	hashes := testonly.NodeHashes()
+	n := len(hashes[0])
+	if got, want := n, 8; got != want {
+		t.Fatalf("got %d leaves, want %d", got, want)
+	}
+	node := func(level uint, index uint64) storage.Node {
+		return storage.Node{ID: compact.NewNodeID(level, index), Hash: hashes[level][index]}
+	}
+	adds := [][]storage.Node{
+		{node(0, 0)},
+		{node(0, 1), node(1, 0)},
+		{node(0, 2)},
+		{node(0, 3), node(1, 1), node(2, 0)},
+		{node(0, 4)},
+		{node(0, 5), node(1, 2)},
+		{node(0, 6)},
+		{node(0, 7), node(1, 3), node(2, 1), node(3, 0)},
+	}
+
+	rf := &compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}
+	var wantAdds []storage.Node
+	for end := 0; end <= n; end++ {
+		// TODO(pavelkalinnikov): Add tests where Begin > 0.
+		t.Run(fmt.Sprintf("0:%d", end), func(t *testing.T) {
+			var tw mockTreeWriter
+			bw := NewBuildWorker(&tw, rf)
+			bj := BuildJob{Begin: 0, Hashes: hashes[0][0:end]}
+			if _, err := bw.Process(context.Background(), bj); err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			if err := tw.verify(wantAdds); err != nil {
+				t.Errorf("verify: %v", err)
+			}
+		})
+		if end < n {
+			wantAdds = append(wantAdds, adds[end]...)
+		}
+	}
+}

--- a/skylog/core/builder_test.go
+++ b/skylog/core/builder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/trillian/skylog/storage"
 )
 
-// TODO(pavelkalinnikov): Use GoMock?
+// TODO(pavelkalinnikov): Use GoMock instead.
 type mockTreeWriter struct {
 	calls [][]storage.Node
 }
@@ -53,7 +53,7 @@ func TestBuildWorker(t *testing.T) {
 	hashes := testonly.NodeHashes()
 	n := len(hashes[0])
 	if got, want := n, 8; got != want {
-		t.Fatalf("got %d leaves, want %d", got, want)
+		t.Fatalf("prerequisite: testonly.NodeHashes() returned %d leaves, want %d", got, want)
 	}
 	node := func(level uint, index uint64) storage.Node {
 		return storage.Node{ID: compact.NewNodeID(level, index), Hash: hashes[level][index]}
@@ -72,11 +72,11 @@ func TestBuildWorker(t *testing.T) {
 	rf := &compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}
 	var wantAdds []storage.Node
 	for end := 0; end <= n; end++ {
-		// TODO(pavelkalinnikov): Add tests where Begin > 0.
+		// TODO(pavelkalinnikov): Add tests where RangeStart > 0.
 		t.Run(fmt.Sprintf("0:%d", end), func(t *testing.T) {
 			var tw mockTreeWriter
 			bw := NewBuildWorker(&tw, rf)
-			bj := BuildJob{Begin: 0, Hashes: hashes[0][0:end]}
+			bj := BuildJob{RangeStart: 0, Hashes: hashes[0][0:end]}
 			if _, err := bw.Process(context.Background(), bj); err != nil {
 				t.Fatalf("Process: %v", err)
 			}


### PR DESCRIPTION
This change introduces `BuildWorker` which is responsible for building lower
levels of the Merkle tree in accordance with leaf hashes that it gets.