### PR TITLE
Fixed error message in crypto verifier.

### DIFF
--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -81,7 +81,7 @@ func Verify(pub crypto.PublicKey, hasher crypto.Hash, data, sig []byte) error {
 		return verifyRSA(pub, digest, sig, hasher, hasher)
 
 	default:
-		return fmt.Errorf("unknown private key type: %T", pub)
+		return fmt.Errorf("unknown public key type: %T", pub)
 	}
 }
 


### PR DESCRIPTION
The error message indicated that the type being checked was a private key, but in reality we are checking a public key.