### PR TITLE
Implementation of Map Write API that delegates to legacy methods.

### DIFF
--- a/integration/map_integration_test.go
+++ b/integration/map_integration_test.go
@@ -44,7 +44,7 @@ func TestInProcessMapIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create log: %v", err)
 	}
-	info, err := integration.New(env.Map, tree)
+	info, err := integration.New(env.Map, env.Write, tree)
 	if err != nil {
 		t.Fatalf("Failed to create MapInfo for test: %v", err)
 	}

--- a/integration/maptest/map_test.go
+++ b/integration/maptest/map_test.go
@@ -51,7 +51,7 @@ func TestMapIntegration(t *testing.T) {
 
 	for _, test := range AllTests {
 		t.Run(test.Name, func(t *testing.T) {
-			test.Fn(ctx, t, env.Admin, env.Map)
+			test.Fn(ctx, t, env.Admin, env.Map, env.Write)
 		})
 	}
 }

--- a/server/map_write_rpc_server.go
+++ b/server/map_write_rpc_server.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
+	"github.com/google/trillian/crypto/keys/der"
+	"github.com/google/trillian/extension"
+	"github.com/google/trillian/trees"
+)
+
+// TrillianMapWriteServer implements the Write RPC API
+type TrillianMapWriteServer struct {
+	mapServer *TrillianMapServer
+	registry  extension.Registry
+}
+
+// NewTrillianMapWriteServer creates a new RPC server for map writes
+func NewTrillianMapWriteServer(registry extension.Registry, mapServer *TrillianMapServer) *TrillianMapWriteServer {
+	return &TrillianMapWriteServer{mapServer: mapServer, registry: registry}
+}
+
+// GetLeavesByRevision implements the GetLeavesByRevision write RPC method.
+func (t *TrillianMapWriteServer) GetLeavesByRevision(ctx context.Context, req *trillian.GetMapLeavesByRevisionRequest) (*trillian.MapLeaves, error) {
+	return t.mapServer.GetLeavesByRevisionNoProof(ctx, req)
+}
+
+// WriteLeaves implements the WriteLeaves write RPC method.
+func (t *TrillianMapWriteServer) WriteLeaves(ctx context.Context, req *trillian.WriteMapLeavesRequest) (*trillian.WriteMapLeavesResponse, error) {
+	tree, err := trees.GetTree(ctx, t.registry.AdminStorage, req.MapId, optsMapWrite)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := der.UnmarshalPublicKey(tree.PublicKey.GetDer())
+	if err != nil {
+		return nil, err
+	}
+	hash, err := trees.Hash(tree)
+	if err != nil {
+		return nil, err
+	}
+
+	setLeavesReq := trillian.SetMapLeavesRequest{
+		MapId:    req.MapId,
+		Leaves:   req.Leaves,
+		Metadata: req.Metadata,
+		Revision: req.ExpectRevision}
+
+	resp, err := t.mapServer.SetLeaves(ctx, &setLeavesReq)
+	if err != nil {
+		return nil, err
+	}
+	root, err := tcrypto.VerifySignedMapRoot(pub, hash, resp.MapRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &trillian.WriteMapLeavesResponse{Revision: int64(root.Revision)}, nil
+}
+
+// IsHealthy returns nil if the server is healthy, error otherwise.
+func (t *TrillianMapWriteServer) IsHealthy() error {
+	return t.mapServer.IsHealthy()
+}

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -160,6 +160,16 @@ func main() {
 				return err
 			}
 			trillian.RegisterTrillianMapServer(s, mapServer)
+
+			if !*useSingleTransaction {
+				glog.Warning("Write API not recommended without single_transaction enabled")
+			}
+			writeServer := server.NewTrillianMapWriteServer(registry, mapServer)
+			if err := writeServer.IsHealthy(); err != nil {
+				return err
+			}
+			trillian.RegisterTrillianMapWriteServer(s, writeServer)
+
 			if *server.QuotaSystem == server.QuotaEtcd {
 				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
 			}

--- a/testonly/integration/mapenv.go
+++ b/testonly/integration/mapenv.go
@@ -49,6 +49,7 @@ type MapEnv struct {
 
 	// Trillian API clients.
 	Map   trillian.TrillianMapClient
+	Write trillian.TrillianMapWriteClient
 	Admin trillian.TrillianAdminClient
 }
 
@@ -62,6 +63,7 @@ func NewMapEnvFromConn(addr string) (*MapEnv, error) {
 	return &MapEnv{
 		clientConn: cc,
 		Map:        trillian.NewTrillianMapClient(cc),
+		Write:      trillian.NewTrillianMapWriteClient(cc),
 		Admin:      trillian.NewTrillianAdminClient(cc),
 	}, nil
 }
@@ -116,7 +118,9 @@ func NewMapEnvWithRegistry(registry extension.Registry, singleTX bool) (*MapEnv,
 		)),
 	)
 	mapServer := server.NewTrillianMapServer(registry, server.TrillianMapServerOptions{UseSingleTransaction: singleTX})
+	writeServer := server.NewTrillianMapWriteServer(registry, mapServer)
 	trillian.RegisterTrillianMapServer(grpcServer, mapServer)
+	trillian.RegisterTrillianMapWriteServer(grpcServer, writeServer)
 	trillian.RegisterTrillianAdminServer(grpcServer, admin.New(registry, nil /* allowedTreeTypes */))
 	go grpcServer.Serve(lis)
 
@@ -133,6 +137,7 @@ func NewMapEnvWithRegistry(registry extension.Registry, singleTX bool) (*MapEnv,
 		grpcServer: grpcServer,
 		clientConn: cc,
 		Map:        trillian.NewTrillianMapClient(cc),
+		Write:      trillian.NewTrillianMapWriteClient(cc),
 		Admin:      trillian.NewTrillianAdminClient(cc),
 	}, nil
 }


### PR DESCRIPTION
The write API would preferably only be enabled if the single transaction mode is enabled, however forcing this would require splitting the integration tests to allow testing the write API in an optional way. This overhead seems more likely to introduce errors than temporarily supporting the multi-transaction writes in the Write API.

Future work in this area will move the implementation of the write methods into the write server, which will allow synthesis & publishing of the Merkle Tree to be performed asynchronously from the key/value write operations.

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
