### PR TITLE
Don't return LeafHash in RunGetLeafByRevisionNoProof

### DIFF
--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -605,10 +605,12 @@ func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trill
 		t.Errorf("len: %v, want %v", got, want)
 	}
 
-	if got, want := getResp.Leaves, leaves; !cmp.Equal(got, want,
+	opts := []cmp.Option{
 		cmp.Comparer(proto.Equal),
-		cmpopts.SortSlices(func(a, b *trillian.MapLeaf) bool { return bytes.Compare(a.Index, b.Index) < 0 })) {
-		t.Errorf("got - want: %v", cmp.Diff(got, want))
+		cmpopts.SortSlices(func(a, b *trillian.MapLeaf) bool { return bytes.Compare(a.Index, b.Index) < 0 }),
+	}
+	if got, want := getResp.Leaves, leaves; !cmp.Equal(got, want, opts...) {
+		t.Errorf("want - got: %v", cmp.Diff(want, got, opts...))
 	}
 }
 

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -605,11 +605,6 @@ func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trill
 		t.Errorf("len: %v, want %v", got, want)
 	}
 
-	// Remove LeafHash because SetLeaves does not supply it.
-	for _, l := range getResp.Leaves {
-		l.LeafHash = nil
-	}
-
 	if got, want := getResp.Leaves, leaves; !cmp.Equal(got, want,
 		cmp.Comparer(proto.Equal),
 		cmpopts.SortSlices(func(a, b *trillian.MapLeaf) bool { return bytes.Compare(a.Index, b.Index) < 0 })) {

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -17,13 +17,13 @@ package maptest
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/golang/glog"
 	"github.com/kylelemons/godebug/pretty"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/trillian"
@@ -55,6 +55,7 @@ var AllTests = TestTable{
 	{"LeafHistory", RunLeafHistory},
 	{"Inclusion", RunInclusion},
 	{"InclusionBatch", RunInclusionBatch},
+	{"RunGetLeafByRevisionNoProof", RunGetLeafByRevisionNoProof},
 }
 
 var (
@@ -581,7 +582,7 @@ func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trill
 		t.Fatalf("newTreeWithHasher(): %v", err)
 	}
 	batchSize := 10
-	numBatches := 2
+	numBatches := 3
 
 	leafMap := writeBatch(ctx, t, tmap, tree, batchSize, numBatches)
 	indexes := make([][]byte, 0, len(leafMap))
@@ -594,13 +595,23 @@ func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trill
 	getResp, err := tmap.GetLeavesByRevisionNoProof(ctx, &trillian.GetMapLeavesByRevisionRequest{
 		MapId:    tree.TreeId,
 		Index:    indexes,
-		Revision: 1,
+		Revision: int64(numBatches),
 	})
 	if err != nil {
 		t.Fatalf("GetLeavesByRevisionNoProof(): %v", err)
 	}
 
+	if got, want := len(getResp.Leaves), len(indexes); got != want {
+		t.Errorf("len: %v, want %v", got, want)
+	}
+
+	// Remove LeafHash because SetLeaves does not supply it.
+	for _, l := range getResp.Leaves {
+		l.LeafHash = nil
+	}
+
 	if got, want := getResp.Leaves, leaves; !cmp.Equal(got, want,
+		cmp.Comparer(proto.Equal),
 		cmpopts.SortSlices(func(a, b *trillian.MapLeaf) bool { return bytes.Compare(a.Index, b.Index) < 0 })) {
 		t.Errorf("got - want: %v", cmp.Diff(got, want))
 	}
@@ -703,7 +714,7 @@ func runMapBatchTest(ctx context.Context, t *testing.T, desc string, tmap trilli
 		for _, incl := range getResp.MapLeafInclusion {
 			index := incl.GetLeaf().GetIndex()
 			leaf := incl.GetLeaf().GetLeafValue()
-			ev, ok := leafMap[hex.EncodeToString(index)]
+			ev, ok := leafMap[string(index)]
 			if !ok {
 				t.Errorf("%s: unexpected key returned: %s", desc, index)
 			}
@@ -723,7 +734,7 @@ func writeBatch(ctx context.Context, t *testing.T, tmap trillian.TrillianMapClie
 	for i := range leafBatch {
 		leafBatch[i] = createBatchLeaves(i, batchSize)
 		for _, l := range leafBatch[i] {
-			leafMap[hex.EncodeToString(l.Index)] = l
+			leafMap[string(l.Index)] = l
 		}
 	}
 

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -180,6 +180,11 @@ func (t *TrillianMapServer) GetLeavesByRevisionNoProof(ctx context.Context, req 
 		return nil, err
 	}
 
+	// Remove LeafHash because SetLeaves does not supply it.
+	for _, l := range leaves {
+		l.LeafHash = nil
+	}
+
 	return &trillian.MapLeaves{Leaves: leaves}, nil
 }
 


### PR DESCRIPTION
Since the Callers of `RunGetLeafByRevisionNoProof` don't rely on `LeafHash`, don't return it. 

This saves on bandwidth and is functionally cleaner. 

This PR also fixes the tests of `RunGetLeafByRevisionNoProof`