### PR TITLE
Run CT Go tests with Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ script:
       ./integration/integration_test.sh
       pushd `go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go`
       chmod +x ./trillian/integration/integration_test.sh
-      ./trillian/integration/integration_test.sh
+      GO111MODULE=on ./trillian/integration/integration_test.sh
       popd
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
     fi


### PR DESCRIPTION
Now that certificate-transprency-go is Go Module enabled, Trillian needs to use it with Go Modules enabled.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).