### PR TITLE
Run CT Go tests with Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ script:
       ./integration/integration_test.sh
       pushd `go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go`
       chmod +x ./trillian/integration/integration_test.sh
-      ./trillian/integration/integration_test.sh
+      GO111MODULE=on ./trillian/integration/integration_test.sh
       popd
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,8 @@ install:
   - export PATH="$(pwd)/../protoc/bin:$PATH"
   # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
   - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
+  - git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
   - go get ${GOFLAGS} -d -t ./...
-  - go get -d -t github.com/google/certificate-transparency-go/...
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.0
   - go get
       github.com/golang/mock/mockgen


### PR DESCRIPTION
Now that certificate-transprency-go is Go Module enabled, Trillian needs to use it with Go Modules enabled.

certificate-transprency-go temporarily adds a few of Trillian's dependencies while #1400 is pending: 
https://github.com/google/certificate-transparency-go/commit/91518eb820ef28e923d43d77ce8565c0af9d1b3e