### PR TITLE
Export GO111MODULE Variable in Docker Builds

### DIFF
--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       dockerfile: examples/deployment/docker/log_server/Dockerfile
       args:
         - GOFLAGS
+        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -35,6 +36,7 @@ services:
       dockerfile: examples/deployment/docker/log_signer/Dockerfile
       args:
         - GOFLAGS
+        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -54,6 +56,7 @@ services:
       dockerfile: examples/deployment/docker/map_server/Dockerfile
       args:
         - GOFLAGS
+        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -4,6 +4,8 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ARG GO111MODULE=auto
+ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_log_server ./scripts/licenses
 RUN licenses save ./server/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -4,6 +4,8 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ARG GO111MODULE=auto
+ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_log_signer ./scripts/licenses
 RUN licenses save ./server/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -4,6 +4,8 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ARG GO111MODULE=auto
+ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_map_server ./scripts/licenses
 RUN licenses save ./server/trillian_map_server --save_path /THIRD_PARTY_NOTICES
 


### PR DESCRIPTION
Allow the docker images to be built with modules off (by default) or on if GO111MODULE=on is passed as an argument.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).