### PR TITLE
Add GOFLAGS environment variable to Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,9 @@ inclusion proof queries.
 
 ### Deployments
 
+The Trillian Docker images now accept GOFLAGS and GO111MODULE arguments
+and set them as environment variables inside the Docker container.
+
 The [db\_server Docker image](examples/deployment/docker/db_server/Dockerfile)
 is now based on
 [the MySQL 5.7 image from the Google Cloud Marketplace](https://console.cloud.google.com/marketplace/details/google/mysql5),

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -4,6 +4,7 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
 ARG GO111MODULE=auto
 ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_log_server ./scripts/licenses

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -4,6 +4,7 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
 ARG GO111MODULE=auto
 ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_log_signer ./scripts/licenses

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -4,6 +4,7 @@ ADD . /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
 ARG GO111MODULE=auto
 ENV GO111MODULE=$GO111MODULE
 RUN go get ./server/trillian_map_server ./scripts/licenses


### PR DESCRIPTION
The $GOFLAGS variable was being passed as an argument, but not being propagated to an environment variable inside the Docker container.
