### PR TITLE
Correct use of pathspec magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ script:
       # because protoc is not deterministic when generating file descriptors.
       # Skip go.mod and go.sum because testing may add indirect dependencies that would be trimmed by 'go mod tidy'
       echo "Checking that generated files are the same as checked-in versions."
-      git diff --exit-code -- ':!*.pb.go' ':!*_string.go' '!go.*'
+      git diff --exit-code -- ':!*.pb.go' ':!*_string.go' ':!go.*'
     fi
   - |
       if [[ "${WITH_ETCD}" == "true" ]]; then


### PR DESCRIPTION
git pathspec uses `:` followed by magic words to modify the behavior of matches:
https://git-scm.com/docs/gitglossary#def_pathspec
https://kgrz.io/git-intro-to-pathspec.html


<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).