### PR TITLE
NewEmptyNodeID return *trillian.MapLeaf

### DIFF
--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -387,7 +387,7 @@ func (s SparseMerkleTreeReader) RootAtRevision(ctx context.Context, rev int64) (
 	defer spanEnd()
 
 	rootNodeID := storage.NewEmptyNodeID(256)
-	nodes, err := s.tx.GetMerkleNodes(ctx, rev, []storage.NodeID{rootNodeID})
+	nodes, err := s.tx.GetMerkleNodes(ctx, rev, []storage.NodeID{*rootNodeID})
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (s SparseMerkleTreeReader) RootAtRevision(ctx context.Context, rev int64) (
 		return nil, fmt.Errorf("expected 1 node, but got %d", len(nodes))
 	}
 	// Sanity check the nodeID
-	if !nodes[0].NodeID.Equivalent(rootNodeID) {
+	if !nodes[0].NodeID.Equivalent(*rootNodeID) {
 		return nil, fmt.Errorf("unexpected node returned with ID: %v", nodes[0].NodeID)
 	}
 	// Sanity check the revision

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -113,7 +113,7 @@ func randomBytes(t *testing.T, n int) []byte {
 
 func getRandomRootNode(t *testing.T, rev int64) storage.Node {
 	return storage.Node{
-		NodeID:       storage.NewEmptyNodeID(0),
+		NodeID:       *storage.NewEmptyNodeID(0),
 		Hash:         randomBytes(t, 32),
 		NodeRevision: rev,
 	}
@@ -124,7 +124,7 @@ func getRandomNonRootNode(t *testing.T, rev int64) storage.Node {
 	// Make sure it's not a root node.
 	nodeID.PrefixLenBits = int(1 + randomBytes(t, 1)[0]%254)
 	return storage.Node{
-		NodeID:       nodeID,
+		NodeID:       *nodeID,
 		Hash:         randomBytes(t, 32),
 		NodeRevision: rev,
 	}
@@ -404,7 +404,7 @@ func testSparseTreeFetches(ctx context.Context, t *testing.T, vec sparseTestVect
 		// calculate the set of expected node reads.
 		for _, kv := range vec.kv {
 			keyHash := testonly.HashKey(kv.k)
-			nodeID := storage.NewNodeIDFromHash(keyHash)
+			nodeID := *storage.NewNodeIDFromHash(keyHash)
 			leafNodeIDs = append(leafNodeIDs, nodeID)
 			sibs := nodeID.Siblings()
 

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -478,7 +478,7 @@ func calcAllSiblingsParallel(ctx context.Context, treeDepth int, hkv []merkle.Ha
 		go func(k []byte) {
 			defer wg.Done()
 			nid := storage.NewNodeIDFromHash(k)
-			sibs := (&nid).Siblings()
+			sibs := nid.Siblings()
 			for _, sib := range sibs {
 				sibID := sib.AsKey()
 				sib := sib

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -49,11 +49,11 @@ var h4 = th.HashLeaf([]byte("Hash 4"))
 var h5 = th.HashLeaf([]byte("Hash 5"))
 
 // And the dummy nodes themselves.
-var sn1 = storage.Node{NodeID: storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
-var sn2 = storage.Node{NodeID: storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
-var sn3 = storage.Node{NodeID: storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
-var sn4 = storage.Node{NodeID: storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
-var sn5 = storage.Node{NodeID: storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
+var sn1 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
+var sn2 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
+var sn3 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
+var sn4 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
+var sn5 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 
 func TestRehasher(t *testing.T) {
 	hasher := rfc6962.DefaultHasher

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -63,7 +63,7 @@ func TestSplitNodeID(t *testing.T) {
 		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
 		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
 	} {
-		n := storage.NewNodeIDFromHash(tc.inPath)
+		n := *storage.NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
 		sInfo := c.stratumInfoForNodeID(n)
@@ -89,7 +89,7 @@ func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	m := NewMockNodeStorage(mockCtrl)
 	c := NewSubtreeCache(defaultLogStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
-	nodeID := storage.NewNodeIDFromHash([]byte("1234"))
+	nodeID := *storage.NewNodeIDFromHash([]byte("1234"))
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
 	// NodeID, we should see just one "Get" request for each subtree.
 	si := 0
@@ -119,9 +119,9 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	c := NewSubtreeCache(defaultLogStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
 	nodeIDs := []storage.NodeID{
-		storage.NewNodeIDFromHash([]byte("1234")),
-		storage.NewNodeIDFromHash([]byte("4567")),
-		storage.NewNodeIDFromHash([]byte("89ab")),
+		*storage.NewNodeIDFromHash([]byte("1234")),
+		*storage.NewNodeIDFromHash([]byte("4567")),
+		*storage.NewNodeIDFromHash([]byte("89ab")),
 	}
 
 	// Set up the expected reads:
@@ -172,14 +172,14 @@ func TestCacheFlush(t *testing.T) {
 	c := NewSubtreeCache(defaultMapStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
 	h := "0123456789abcdef0123456789abcdef"
-	nodeID := storage.NewNodeIDFromHash([]byte(h))
+	nodeID := *storage.NewNodeIDFromHash([]byte(h))
 	expectedSetIDs := make(map[string]string)
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
 	// NodeID, we should see just one "Get" request for each subtree.
 	si := -1
 	for b := 0; b < nodeID.PrefixLenBits; b += defaultMapStrata[si] {
 		si++
-		e := storage.NewNodeIDFromHash([]byte(h))
+		e := *storage.NewNodeIDFromHash([]byte(h))
 		//e := nodeID
 		e.PrefixLenBits = b
 		expectedSetIDs[e.String()] = "expected"
@@ -377,7 +377,7 @@ func TestIdempotentWrites(t *testing.T) {
 	m := NewMockNodeStorage(mockCtrl)
 
 	h := "0123456789abcdef0123456789abcdef"
-	nodeID := storage.NewNodeIDFromHash([]byte(h))
+	nodeID := *storage.NewNodeIDFromHash([]byte(h))
 	nodeID.PrefixLenBits = 40
 	subtreeID := nodeID
 	subtreeID.PrefixLenBits = 32
@@ -393,7 +393,7 @@ func TestIdempotentWrites(t *testing.T) {
 	// We should only see a single write attempt
 	m.EXPECT().SetSubtrees(gomock.Any()).Times(1).Do(func(trees []*storagepb.SubtreeProto) {
 		for _, s := range trees {
-			subID := storage.NewNodeIDFromHash(s.Prefix)
+			subID := *storage.NewNodeIDFromHash(s.Prefix)
 			state, ok := expectedSetIDs[subID.String()]
 			if !ok {
 				t.Errorf("Unexpected write to subtree %s", subID.String())

--- a/storage/memory/tree_debug.go
+++ b/storage/memory/tree_debug.go
@@ -38,7 +38,7 @@ func Dump(t *btree.BTree) {
 func DumpSubtrees(ls storage.LogStorage, treeID int64, callback func(string, *storagepb.SubtreeProto)) {
 	m := ls.(*memoryLogStorage)
 	tree := m.trees[treeID]
-	pi := subtreeKey(treeID, 0, storage.NewEmptyNodeID(64))
+	pi := subtreeKey(treeID, 0, *storage.NewEmptyNodeID(64))
 
 	tree.store.AscendGreaterOrEqual(pi, func(bi btree.Item) bool {
 		i := bi.(*kv)

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -220,7 +220,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 		if s.Prefix == nil {
 			panic(fmt.Errorf("nil prefix on %v", s))
 		}
-		k := subtreeKey(t.treeID, t.writeRevision, storage.NewNodeIDFromHash(s.Prefix))
+		k := subtreeKey(t.treeID, t.writeRevision, *storage.NewNodeIDFromHash(s.Prefix))
 		k.(*kv).v = s
 		t.tx.ReplaceOrInsert(k)
 	}

--- a/storage/node.go
+++ b/storage/node.go
@@ -108,8 +108,8 @@ func bytesForBits(numBits int) int {
 }
 
 // NewNodeIDFromHash creates a new NodeID for the given Hash.
-func NewNodeIDFromHash(h []byte) NodeID {
-	return NodeID{
+func NewNodeIDFromHash(h []byte) *NodeID {
+	return &NodeID{
 		Path:          h,
 		PrefixLenBits: len(h) * 8,
 	}
@@ -117,11 +117,11 @@ func NewNodeIDFromHash(h []byte) NodeID {
 
 // NewEmptyNodeID creates a new zero-length NodeID with sufficient underlying
 // capacity to store a maximum of maxLenBits.
-func NewEmptyNodeID(maxLenBits int) NodeID {
+func NewEmptyNodeID(maxLenBits int) *NodeID {
 	if got, want := maxLenBits%8, 0; got != want {
 		panic(fmt.Sprintf("storage: NewEmptyNodeID() maxLenBits mod 8: %v, want %v", got, want))
 	}
-	return NodeID{
+	return &NodeID{
 		Path:          make([]byte, maxLenBits/8),
 		PrefixLenBits: 0,
 	}
@@ -241,7 +241,7 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 	// In the storage model nodes closer to the leaves have longer nodeIDs, so
 	// we "reverse" depth here:
 	r.PrefixLenBits = int(maxPathBits - int(depth))
-	return r, nil
+	return *r, nil
 }
 
 // Bit returns 1 if the zero indexed ith bit from the right (of the whole path

--- a/storage/node_test.go
+++ b/storage/node_test.go
@@ -580,8 +580,8 @@ func TestNodeEquivalentFromHash(t *testing.T) {
 		h1 := mustDecode(tc.str1)
 		h2 := mustDecode(tc.str2)
 
-		n1 := NewNodeIDFromHash(h1)
-		n2 := NewNodeIDFromHash(h2)
+		n1 := *NewNodeIDFromHash(h1)
+		n2 := *NewNodeIDFromHash(h2)
 
 		if n1.Equivalent(n2) != tc.want || n2.Equivalent(n1) != tc.want {
 			t.Errorf("TestNodeIDFromHash mismatch: %v", tc)
@@ -605,7 +605,7 @@ func TestNeighbour(t *testing.T) {
 		{index: h2b("0000000000010000"), want: h2b("0000000000010001")},
 		{index: h2b("8000000000000000"), want: h2b("8000000000000001")},
 	} {
-		nID := NewNodeIDFromHash(tc.index)
+		nID := *NewNodeIDFromHash(tc.index)
 		if got, want := nID.Neighbor(nID.PrefixLenBits).Path, tc.want; !bytes.Equal(got, want) {
 			t.Errorf("flipBit(%x): %x, want %x", tc.index, got, want)
 		}
@@ -669,7 +669,7 @@ func TestString(t *testing.T) {
 		wantKey string
 	}{
 		{
-			n:       NewEmptyNodeID(32),
+			n:       *NewEmptyNodeID(32),
 			want:    "",
 			wantKey: "0:",
 		},
@@ -704,7 +704,7 @@ func TestString(t *testing.T) {
 			wantKey: "16:1234",
 		},
 		{
-			n:       NewNodeIDFromHash([]byte("this is a hash")),
+			n:       *NewNodeIDFromHash([]byte("this is a hash")),
 			want:    "0111010001101000011010010111001100100000011010010111001100100000011000010010000001101000011000010111001101101000",
 			wantKey: "112:7468697320697320612068617368",
 		},


### PR DESCRIPTION
One can't take the address of `&NewEmptyNodeID()`
Meanwhile one can dereference `*NewEmptyNodeID()`


<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).