### PR TITLE
Fix build collision

### DIFF
--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -660,18 +660,18 @@ func RunInclusionBatch(ctx context.Context, t *testing.T, tadmin trillian.Trilli
 }
 
 // RunWriteStress performs stress checks on Trillian Map's SetLeaves call.
-func RunWriteStress(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient) {
-	runWriteStressTest(ctx, t, tadmin, tmap, *stressBatchSize, *stressBatches)
+func RunWriteStress(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient, twrite trillian.TrillianMapWriteClient) {
+	runWriteStressTest(ctx, t, tadmin, tmap, twrite, *stressBatchSize, *stressBatches)
 }
 
 // runWriteStressTest is a helper for RunWriteStress, and TestMapWriteStress.
-func runWriteStressTest(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient, batchSize int, numBatches int) {
+func runWriteStressTest(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient, twrite trillian.TrillianMapWriteClient, batchSize int, numBatches int) {
 	tree, err := newTreeWithHasher(ctx, tadmin, tmap, trillian.HashStrategy_TEST_MAP_HASHER)
 	if err != nil {
 		t.Fatalf("%v: newTreeWithHasher(): %v", trillian.HashStrategy_TEST_MAP_HASHER, err)
 	}
 
-	_ = writeBatch(ctx, t, tmap, tree, batchSize, numBatches)
+	_ = writeBatch(ctx, t, tmap, twrite, tree, batchSize, numBatches)
 }
 
 // runMapBatchTest is a helper for RunInclusionBatch.


### PR DESCRIPTION
Fix a fall out from two colliding PRs.

### Checklist



- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
