### PR TITLE
skylog: Get tree sharding info from BuildJob

### DIFF
--- a/skylog/storage/gcp/cloudfunc/go.mod
+++ b/skylog/storage/gcp/cloudfunc/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/go-toolsmith/pkgload v1.0.0 // indirect
 	github.com/go-toolsmith/typep v1.0.0 // indirect
 	github.com/golang/protobuf v1.3.2-0.20190517061210-b285ee9cfc6c
-	github.com/google/trillian v1.2.2-0.20190619133759-4511faac1a5c
+	github.com/google/trillian v1.2.2-0.20190621140556-9386836a076e
 	github.com/grpc-ecosystem/grpc-gateway v1.9.2 // indirect
 )

--- a/skylog/storage/gcp/cloudfunc/go.sum
+++ b/skylog/storage/gcp/cloudfunc/go.sum
@@ -189,8 +189,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/monologue v0.0.0-20190606152607-4b11a32b5934/go.mod h1:6NTfaQoUpg5QmPsCUWLR3ig33FHrKXhTtWzF0DVdmuk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/trillian v1.2.2-0.20190612132142-05461f4df60a/go.mod h1:YPmUVn5NGwgnDUgqlVyFGMTgaWlnSvH7W5p+NdOG8UA=
-github.com/google/trillian v1.2.2-0.20190619133759-4511faac1a5c h1:vyexAq39KDshelZLvg0si5DykhtTFd/+RwsmOkMovQo=
-github.com/google/trillian v1.2.2-0.20190619133759-4511faac1a5c/go.mod h1:Z8gTwl38CCQjwQQ/RkrxUhfvSV+jkyyyAlzJ7AnUvhk=
+github.com/google/trillian v1.2.2-0.20190621140556-9386836a076e h1:NUNKk3Fo1x85LDTKjf3CWNTXyDmeTpOcuRRLCF8hp0Q=
+github.com/google/trillian v1.2.2-0.20190621140556-9386836a076e/go.mod h1:fAG44/F5EOVrCrTWDXAUkhTQsMMqZ4tmnY/JbYz1FaY=
 github.com/google/trillian-examples v0.0.0-20190603134952-4e75ba15216c/go.mod h1:WgL3XZ3pA8/9cm7yxqWrZE6iZkESB2ItGxy5Fo6k2lk=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/skylog/storage/gcp/cloudfunc/worker.go
+++ b/skylog/storage/gcp/cloudfunc/worker.go
@@ -87,7 +87,7 @@ func treeOpts(job *pb.BuildJob) (cs.TreeOpts, error) {
 	if ts == nil {
 		return cs.TreeOpts{}, errors.New("missing tree sharding info")
 	} else if ts.Levels <= 0 || ts.Shards <= 0 {
-		return cs.TreeOpts{}, errors.New("invalid tree sharding info")
+		return cs.TreeOpts{}, fmt.Errorf("invalid tree sharding: %s", proto.CompactTextString(ts))
 	}
 	return cs.TreeOpts{ShardLevels: uint(ts.Levels), LeafShards: int64(ts.Shards)}, nil
 }


### PR DESCRIPTION
The worker Cloud Function now takes sharding info from the passed-in event.