### PR TITLE
Pass `trillian.SignedMapRoot` by reference

### DIFF
--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -221,13 +221,13 @@ func (t *TrillianMapServer) getLeavesByRevision(ctx context.Context, mapID int64
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch the latest SignedMapRoot: %v", err)
 		}
-		root = &r
+		root = r
 	} else {
 		r, err := tx.GetSignedMapRoot(ctx, revision)
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch SignedMapRoot %v: %v", revision, err)
 		}
-		root = &r
+		root = r
 	}
 
 	var mapRoot types.MapRootV1
@@ -549,9 +549,7 @@ func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.
 		return nil, err
 	}
 
-	return &trillian.GetSignedMapRootResponse{
-		MapRoot: &r,
-	}, nil
+	return &trillian.GetSignedMapRootResponse{MapRoot: r}, nil
 }
 
 // GetSignedMapRootByRevision implements the GetSignedMapRootByRevision RPC
@@ -582,9 +580,7 @@ func (t *TrillianMapServer) GetSignedMapRootByRevision(ctx context.Context, req 
 		return nil, err
 	}
 
-	return &trillian.GetSignedMapRootResponse{
-		MapRoot: &r,
-	}, nil
+	return &trillian.GetSignedMapRootResponse{MapRoot: r}, nil
 }
 
 func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, opts trees.GetOpts) (*trillian.Tree, hashers.MapHasher, error) {

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -408,7 +408,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		}
 
 		// TODO(al): need an smtWriter.Rollback() or similar I think.
-		return tx.StoreSignedMapRoot(ctx, *newRoot)
+		return tx.StoreSignedMapRoot(ctx, newRoot)
 	})
 	if err != nil {
 		return nil, err
@@ -635,7 +635,7 @@ func (t *TrillianMapServer) InitMap(ctx context.Context, req *trillian.InitMapRe
 			return fmt.Errorf("makeSignedMapRoot(): %v", err)
 		}
 
-		return tx.StoreSignedMapRoot(ctx, *rev0Root)
+		return tx.StoreSignedMapRoot(ctx, rev0Root)
 	})
 	if err != nil {
 		return nil, err

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -186,7 +186,7 @@ func (tx *mapTX) LatestSignedMapRoot(ctx context.Context) (*trillian.SignedMapRo
 // StoreSignedMapRoot stores the provided root.
 // This method will return an error if the caller attempts to store more than
 // one root per map for a given map revision.
-func (tx *mapTX) StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error {
+func (tx *mapTX) StoreSignedMapRoot(ctx context.Context, root *trillian.SignedMapRoot) error {
 	stx, ok := tx.stx.(*spanner.ReadWriteTransaction)
 	if !ok {
 		return ErrWrongTXType

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -64,7 +64,7 @@ type MapTreeTX interface {
 	TreeWriter
 
 	// StoreSignedMapRoot stores root.
-	StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error
+	StoreSignedMapRoot(ctx context.Context, root *trillian.SignedMapRoot) error
 	// Set sets key to leaf
 	Set(ctx context.Context, keyHash []byte, value *trillian.MapLeaf) error
 }

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -41,9 +41,9 @@ type ReadOnlyMapTreeTX interface {
 
 	// GetSignedMapRoot returns the SignedMapRoot associated with the
 	// specified revision.
-	GetSignedMapRoot(ctx context.Context, revision int64) (trillian.SignedMapRoot, error)
+	GetSignedMapRoot(ctx context.Context, revision int64) (*trillian.SignedMapRoot, error)
 	// LatestSignedMapRoot returns the most recently created SignedMapRoot.
-	LatestSignedMapRoot(ctx context.Context) (trillian.SignedMapRoot, error)
+	LatestSignedMapRoot(ctx context.Context) (*trillian.SignedMapRoot, error)
 
 	// Get retrieves the values associated with the keyHashes, if any, at the
 	// specified revision.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -821,10 +821,10 @@ func (mr *MockMapTreeTXMockRecorder) GetMerkleNodes(arg0, arg1, arg2 interface{}
 }
 
 // GetSignedMapRoot mocks base method
-func (m *MockMapTreeTX) GetSignedMapRoot(arg0 context.Context, arg1 int64) (trillian.SignedMapRoot, error) {
+func (m *MockMapTreeTX) GetSignedMapRoot(arg0 context.Context, arg1 int64) (*trillian.SignedMapRoot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSignedMapRoot", arg0, arg1)
-	ret0, _ := ret[0].(trillian.SignedMapRoot)
+	ret0, _ := ret[0].(*trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -850,10 +850,10 @@ func (mr *MockMapTreeTXMockRecorder) IsOpen() *gomock.Call {
 }
 
 // LatestSignedMapRoot mocks base method
-func (m *MockMapTreeTX) LatestSignedMapRoot(arg0 context.Context) (trillian.SignedMapRoot, error) {
+func (m *MockMapTreeTX) LatestSignedMapRoot(arg0 context.Context) (*trillian.SignedMapRoot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LatestSignedMapRoot", arg0)
-	ret0, _ := ret[0].(trillian.SignedMapRoot)
+	ret0, _ := ret[0].(*trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1420,10 +1420,10 @@ func (mr *MockReadOnlyMapTreeTXMockRecorder) GetMerkleNodes(arg0, arg1, arg2 int
 }
 
 // GetSignedMapRoot mocks base method
-func (m *MockReadOnlyMapTreeTX) GetSignedMapRoot(arg0 context.Context, arg1 int64) (trillian.SignedMapRoot, error) {
+func (m *MockReadOnlyMapTreeTX) GetSignedMapRoot(arg0 context.Context, arg1 int64) (*trillian.SignedMapRoot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSignedMapRoot", arg0, arg1)
-	ret0, _ := ret[0].(trillian.SignedMapRoot)
+	ret0, _ := ret[0].(*trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1449,10 +1449,10 @@ func (mr *MockReadOnlyMapTreeTXMockRecorder) IsOpen() *gomock.Call {
 }
 
 // LatestSignedMapRoot mocks base method
-func (m *MockReadOnlyMapTreeTX) LatestSignedMapRoot(arg0 context.Context) (trillian.SignedMapRoot, error) {
+func (m *MockReadOnlyMapTreeTX) LatestSignedMapRoot(arg0 context.Context) (*trillian.SignedMapRoot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LatestSignedMapRoot", arg0)
-	ret0, _ := ret[0].(trillian.SignedMapRoot)
+	ret0, _ := ret[0].(*trillian.SignedMapRoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -922,7 +922,7 @@ func (mr *MockMapTreeTXMockRecorder) SetMerkleNodes(arg0, arg1 interface{}) *gom
 }
 
 // StoreSignedMapRoot mocks base method
-func (m *MockMapTreeTX) StoreSignedMapRoot(arg0 context.Context, arg1 trillian.SignedMapRoot) error {
+func (m *MockMapTreeTX) StoreSignedMapRoot(arg0 context.Context, arg1 *trillian.SignedMapRoot) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreSignedMapRoot", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -334,7 +334,7 @@ func (m *mapTreeTX) signedMapRoot(timestamp, mapRevision int64, rootHash, rootSi
 	}, nil
 }
 
-func (m *mapTreeTX) StoreSignedMapRoot(ctx context.Context, root trillian.SignedMapRoot) error {
+func (m *mapTreeTX) StoreSignedMapRoot(ctx context.Context, root *trillian.SignedMapRoot) error {
 	m.treeTX.mu.Lock()
 	defer m.treeTX.mu.Unlock()
 

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -264,7 +264,7 @@ func unmarshalMapLeaf(marshaledLeaf, mapKeyHash []byte) (*trillian.MapLeaf, erro
 	return &mapLeaf, nil
 }
 
-func (m *mapTreeTX) GetSignedMapRoot(ctx context.Context, revision int64) (trillian.SignedMapRoot, error) {
+func (m *mapTreeTX) GetSignedMapRoot(ctx context.Context, revision int64) (*trillian.SignedMapRoot, error) {
 	m.treeTX.mu.Lock()
 	defer m.treeTX.mu.Unlock()
 
@@ -274,7 +274,7 @@ func (m *mapTreeTX) GetSignedMapRoot(ctx context.Context, revision int64) (trill
 
 	stmt, err := m.tx.PrepareContext(ctx, selectGetSignedMapRootSQL)
 	if err != nil {
-		return trillian.SignedMapRoot{}, err
+		return nil, err
 	}
 	defer stmt.Close()
 
@@ -282,15 +282,15 @@ func (m *mapTreeTX) GetSignedMapRoot(ctx context.Context, revision int64) (trill
 		&timestamp, &rootHash, &mapRevision, &rootSignatureBytes, &mapperMetaBytes)
 	if err != nil {
 		if revision == 0 {
-			return trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit
+			return nil, storage.ErrTreeNeedsInit
 		}
-		return trillian.SignedMapRoot{}, err
+		return nil, err
 	}
 	m.readRevision = mapRevision
 	return m.signedMapRoot(timestamp, mapRevision, rootHash, rootSignatureBytes, mapperMetaBytes)
 }
 
-func (m *mapTreeTX) LatestSignedMapRoot(ctx context.Context) (trillian.SignedMapRoot, error) {
+func (m *mapTreeTX) LatestSignedMapRoot(ctx context.Context) (*trillian.SignedMapRoot, error) {
 	m.treeTX.mu.Lock()
 	defer m.treeTX.mu.Unlock()
 
@@ -300,7 +300,7 @@ func (m *mapTreeTX) LatestSignedMapRoot(ctx context.Context) (trillian.SignedMap
 
 	stmt, err := m.tx.PrepareContext(ctx, selectLatestSignedMapRootSQL)
 	if err != nil {
-		return trillian.SignedMapRoot{}, err
+		return nil, err
 	}
 	defer stmt.Close()
 
@@ -309,15 +309,15 @@ func (m *mapTreeTX) LatestSignedMapRoot(ctx context.Context) (trillian.SignedMap
 
 	// It's possible there are no roots for this tree yet
 	if err == sql.ErrNoRows {
-		return trillian.SignedMapRoot{}, storage.ErrTreeNeedsInit
+		return nil, storage.ErrTreeNeedsInit
 	} else if err != nil {
-		return trillian.SignedMapRoot{}, err
+		return nil, err
 	}
 	m.readRevision = mapRevision
 	return m.signedMapRoot(timestamp, mapRevision, rootHash, rootSignatureBytes, mapperMetaBytes)
 }
 
-func (m *mapTreeTX) signedMapRoot(timestamp, mapRevision int64, rootHash, rootSignature, mapperMeta []byte) (trillian.SignedMapRoot, error) {
+func (m *mapTreeTX) signedMapRoot(timestamp, mapRevision int64, rootHash, rootSignature, mapperMeta []byte) (*trillian.SignedMapRoot, error) {
 	mapRoot, err := (&types.MapRootV1{
 		RootHash:       rootHash,
 		TimestampNanos: uint64(timestamp),
@@ -325,10 +325,10 @@ func (m *mapTreeTX) signedMapRoot(timestamp, mapRevision int64, rootHash, rootSi
 		Metadata:       mapperMeta,
 	}).MarshalBinary()
 	if err != nil {
-		return trillian.SignedMapRoot{}, err
+		return nil, err
 	}
 
-	return trillian.SignedMapRoot{
+	return &trillian.SignedMapRoot{
 		MapRoot:   mapRoot,
 		Signature: rootSignature,
 	}, nil

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -493,7 +493,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to get back new map root: %v", err)
 			}
-			if !proto.Equal(root, &root2) {
+			if !proto.Equal(root, root2) {
 				t.Fatalf("Getting root round trip failed: <%#v> and: <%#v>", root, root2)
 			}
 			return nil
@@ -527,7 +527,7 @@ func TestLatestSignedMapRoot(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to read back new map root: %v", err)
 			}
-			if !proto.Equal(root, &root2) {
+			if !proto.Equal(root, root2) {
 				t.Fatalf("Root round trip failed: <%#v> and: <%#v>", root, root2)
 			}
 			return nil

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -236,7 +236,7 @@ func TestMapRootUpdate(t *testing.T) {
 	} {
 		func() {
 			runMapTX(ctx, s, tree, t, func(ctx context.Context, tx storage.MapTreeTX) error {
-				if err := tx.StoreSignedMapRoot(ctx, *tc.root); err != nil {
+				if err := tx.StoreSignedMapRoot(ctx, tc.root); err != nil {
 					t.Fatalf("%v: Failed to store signed map root: %v", tc.desc, err)
 				}
 				return nil
@@ -481,7 +481,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 	})
 	runMapTX(ctx, s, tree, t, func(ctx context.Context, tx storage.MapTreeTX) error {
-		if err := tx.StoreSignedMapRoot(ctx, *root); err != nil {
+		if err := tx.StoreSignedMapRoot(ctx, root); err != nil {
 			t.Fatalf("Failed to store signed root: %v", err)
 		}
 		return nil
@@ -515,7 +515,7 @@ func TestLatestSignedMapRoot(t *testing.T) {
 		RootHash:       []byte(dummyHash),
 	})
 	runMapTX(ctx, s, tree, t, func(ctx context.Context, tx storage.MapTreeTX) error {
-		if err := tx.StoreSignedMapRoot(ctx, *root); err != nil {
+		if err := tx.StoreSignedMapRoot(ctx, root); err != nil {
 			t.Fatalf("Failed to store signed root: %v", err)
 		}
 		return nil
@@ -549,11 +549,11 @@ func TestDuplicateSignedMapRoot(t *testing.T) {
 			Revision:       5,
 			RootHash:       []byte(dummyHash),
 		})
-		if err := tx.StoreSignedMapRoot(ctx, *root); err != nil {
+		if err := tx.StoreSignedMapRoot(ctx, root); err != nil {
 			t.Fatalf("Failed to store signed map root: %v", err)
 		}
 		// Shouldn't be able to do it again
-		if err := tx.StoreSignedMapRoot(ctx, *root); err == nil {
+		if err := tx.StoreSignedMapRoot(ctx, root); err == nil {
 			t.Fatal("Allowed duplicate signed map root")
 		}
 		return nil
@@ -596,7 +596,7 @@ func createInitializedMapForTests(ctx context.Context, t *testing.T, db *sql.DB)
 			Revision: 0,
 		})
 
-		if err := tx.StoreSignedMapRoot(ctx, *initialRoot); err != nil {
+		if err := tx.StoreSignedMapRoot(ctx, initialRoot); err != nil {
 			t.Fatalf("Failed to StoreSignedMapRoot: %v", err)
 		}
 		return nil


### PR DESCRIPTION
Modify the storage layer to accept and return `*trillian.SignedMapRoot`
Passing by reference is the only supported method of passing protobufs. 

- StoreSignedMapRoot
- LatestSignedMapRoot
- GetSignedMapRoot
