### PR TITLE
Raise lint timeout from 5 to 8 minutes.

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -115,7 +115,7 @@ main() {
       'have you installed github.com/uber/prototool/cmd/prototool?' || exit 1
 
     echo 'running golangci-lint'
-    golangci-lint run --deadline=5m
+    golangci-lint run --deadline=8m
     echo 'running prototool lint'
     prototool lint
     echo 'checking license headers'


### PR DESCRIPTION
Out of 3 trials it takes 6:15 +/- 1s on my machine. Giving 8 minutes because other machines likely have fewer and/or slower cores.

Longer term, it would be great if golangci-lint could be made faster. This feels like too long for linting a codebase of this size.