### PR TITLE
Address TODOs by using `kubectl wait`

### DIFF
--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -98,8 +98,6 @@ kubectl apply -f ${DIR}/etcd-role.yaml
 kubectl apply -f ${DIR}/etcd-deployment.yaml
 kubectl apply -f ${DIR}/etcd-service.yaml
 
-# TODO(al): wait for this properly somehow
-sleep 30
-
-# TODO(al): have to wait before doing this?
+# Wait for Custom Resource Definitions (CRD) to be installed before creating Etcd cluster
+kubectl wait --for=condition=Established crd/etcdclusters.etcd.database.coreos.com
 kubectl apply -f ${DIR}/etcd-cluster.yaml


### PR DESCRIPTION
Waits until the etcd-operator CRD is installed before trying to create an EtcdCluster resource. This is faster and more reliable than `sleep 30`.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
