### PR TITLE
Cloud Build should use latest images as cache when building new images

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -30,6 +30,7 @@ steps:
   - build
   - --file=examples/deployment/docker/db_server/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
+  - --cache-from=gcr.io/${PROJECT_ID}/db_server:latest
   - .
   waitFor:
   - push_mysql
@@ -39,6 +40,7 @@ steps:
   - build
   - --file=examples/deployment/docker/log_server/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
+  - --cache-from=gcr.io/${PROJECT_ID}/log_server:latest
   - .
   waitFor: ["-"]
 - id: build_log_signer
@@ -47,6 +49,7 @@ steps:
   - build
   - --file=examples/deployment/docker/log_signer/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
+  - --cache-from=gcr.io/${PROJECT_ID}/log_signer:latest
   - .
   waitFor: ["-"]
 - id: build_map_server
@@ -55,6 +58,7 @@ steps:
   - build
   - --file=examples/deployment/docker/map_server/Dockerfile
   - --tag=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+  - --cache-from=gcr.io/${PROJECT_ID}/map_server:latest
   - .
   waitFor: ["-"]
 - id: push_log_server


### PR DESCRIPTION
This will accelerate builds when some layers haven't changed or the image has already been built. It is recommended by [the Cloud Build docs](https://cloud.google.com/cloud-build/docs/speeding-up-builds#using_a_cached_docker_image).

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
