### PR TITLE
Make namespace configurable in Kubernetes configs

### DIFF
--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -93,10 +93,10 @@ done
 COREACCOUNT=$(gcloud config config-helper --format=json | jq -r '.configuration.properties.core.account')
 kubectl create clusterrolebinding etcd-cluster-admin-binding --clusterrole=cluster-admin --user="${COREACCOUNT}"
 
-kubectl apply -f ${DIR}/etcd-role-binding.yaml
-kubectl apply -f ${DIR}/etcd-role.yaml
-kubectl apply -f ${DIR}/etcd-deployment.yaml
+for f in "etcd-role-binding.yaml" "etcd-role.yaml" "etcd-deployment.yaml" "etcd-service.yaml"; do
+  envsubst < ${DIR}/${f} | kubectl apply --namespace="${NAMESPACE}" -f -
+done
 
 # Wait for Custom Resource Definitions (CRD) to be installed before creating Etcd cluster
 kubectl wait --for=condition=Established crd/etcdclusters.etcd.database.coreos.com
-kubectl apply -f ${DIR}/etcd-cluster.yaml
+envsubst < ${DIR}/etcd-cluster.yaml | kubectl --namespace="${NAMESPACE}" apply -f -

--- a/examples/deployment/kubernetes/deploy.sh
+++ b/examples/deployment/kubernetes/deploy.sh
@@ -56,8 +56,8 @@ done
 
 echo "Updating jobs..."
 # Prepare configmap:
-kubectl delete configmap deploy-config || true
-envsubst < ${CONFIGMAP} | kubectl create -f -
+kubectl delete --namespace="${NAMESPACE}" configmap deploy-config || true
+envsubst < ${CONFIGMAP} | kubectl create --namespace="${NAMESPACE}" -f -
 
 # Launch with kubernetes
 kubeconfigs="trillian-log-deployment.yaml trillian-log-service.yaml trillian-log-signer-deployment.yaml trillian-log-signer-service.yaml"
@@ -66,8 +66,8 @@ if ${RUN_MAP}; then
 fi
 for thing in ${kubeconfigs}; do
   echo ${thing}
-  envsubst < ${DIR}/${thing} | kubectl apply -f -
+  envsubst < ${DIR}/${thing} | kubectl apply --namespace="${NAMESPACE}" -f -
 done
 
-kubectl get all
-kubectl get services
+kubectl get all --namespace="${NAMESPACE}"
+kubectl get services --namespace="${NAMESPACE}"

--- a/examples/deployment/kubernetes/etcd-role-binding.yaml
+++ b/examples/deployment/kubernetes/etcd-role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
+  namespace: ${NAMESPACE}

--- a/examples/deployment/kubernetes/etcd-role.yaml
+++ b/examples/deployment/kubernetes/etcd-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: default
 rules:
 - apiGroups:
   - etcd.database.coreos.com

--- a/examples/deployment/kubernetes/trillian-cloudspanner.yaml
+++ b/examples/deployment/kubernetes/trillian-cloudspanner.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deploy-config
-  namespace: default
 data:
   STORAGE_SYSTEM: cloud_spanner
   STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-spanner/databases/trillian-db

--- a/examples/deployment/kubernetes/trillian-mysql.yaml
+++ b/examples/deployment/kubernetes/trillian-mysql.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deploy-config
-  namespace: default
 data:
   CLOUD_PROJECT: ${PROJECT_ID}
   # Update this with your DB connection string:

--- a/examples/deployment/kubernetes/trillian-opensource-ci-config.sh
+++ b/examples/deployment/kubernetes/trillian-opensource-ci-config.sh
@@ -1,5 +1,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+export NAMESPACE=default
 export PROJECT_ID=trillian-opensource-ci
 export CLUSTER_NAME=trillian-opensource-ci
 export REGION=us-central1

--- a/examples/deployment/kubernetes/trillian-opensource-ci.yaml
+++ b/examples/deployment/kubernetes/trillian-opensource-ci.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deploy-config
-  namespace: default
 data:
   STORAGE_SYSTEM: cloud_spanner
   STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-opensource-ci/databases/trillian-opensource-ci-db


### PR DESCRIPTION
This makes it easier to deploy multiple Trillian instances to the same Kubernetes cluster, e.g. for having multiple CI environments with different storage backends.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
