### PR TITLE
Pass context to storeSubtrees()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Not yet released; provisionally v2.0.0 (may change).
 
+### Storage Commit takes context.Context
+
+To support passing a context down to `NodeStorage.SetLeaves`, and remove various `context.TODO()`s, 
+the following functions have been modified to accept a `context.Context` parameter:
+
+- `storage/cache.NodeStorage.SetLeaves`
+- `storage/cache.SetSubtreesFunc`
+- `storage/cache.SubtreeCache.Flush`
+- `storage.ReadonlyLogTX.Commit`
+
 ### Go Module Support
 
 Go Module support has been enabled. Please use GO111MODULE=on to build Trillian.

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -156,7 +156,7 @@ func (o *OperationManager) getActiveLogIDs(ctx context.Context) ([]int64, error)
 		return nil, fmt.Errorf("failed to get active logIDs: %v", err)
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("failed to commit: %v", err)
 	}
 	return logIDs, nil

--- a/log/operation_manager_test.go
+++ b/log/operation_manager_test.go
@@ -98,7 +98,7 @@ func TestOperationManagerCommitFails(t *testing.T) {
 
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).Return([]int64{}, nil)
-	mockTx.EXPECT().Commit().Return(errors.New("commit"))
+	mockTx.EXPECT().Commit(gomock.Any()).Return(errors.New("commit"))
 	mockTx.EXPECT().Close().Return(nil)
 	fakeStorage := storage.NewMockLogStorage(ctrl)
 	fakeStorage.EXPECT().Snapshot(gomock.Any()).Return(mockTx, nil)
@@ -145,7 +145,7 @@ func setupLogIDs(ctrl *gomock.Controller, logNames map[int64]string) (*storage.M
 	fakeStorage := storage.NewMockLogStorage(ctrl)
 	mockTx := storage.NewMockReadOnlyLogTX(ctrl)
 	mockTx.EXPECT().GetActiveLogIDs(gomock.Any()).AnyTimes().Return(ids, nil)
-	mockTx.EXPECT().Commit().AnyTimes().Return(nil)
+	mockTx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	mockTx.EXPECT().Close().AnyTimes().Return(nil)
 	fakeStorage.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(mockTx, nil)
 

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -101,7 +101,7 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, fixedGoSigner, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*testSignedRoot0, nil)
@@ -160,7 +160,7 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*testSignedRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
 			mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil),
-			mockTx.EXPECT().Commit().Return(nil),
+			mockTx.EXPECT().Commit(gomock.Any()).Return(nil),
 			mockTx.EXPECT().Close().Return(nil),
 		)
 
@@ -234,7 +234,7 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 
 	// Set up enough mockery to be able to sequence. We don't test all the error paths
 	// through sequencer as other tests cover this
-	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(int64(testRoot0.Revision+1), nil)
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{testLeaf0}, nil)
@@ -276,7 +276,7 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 	keys.RegisterHandler(fakeKeyProtoHandler(keyProto.Message, fixedGoSigner, nil))
 	defer keys.UnregisterHandler(keyProto.Message)
 
-	mockTx.EXPECT().Commit().Return(nil)
+	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
 	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*testSignedRoot0, nil)

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -292,9 +292,9 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	if params.shouldCommit {
 		if !params.commitFails {
-			mockTx.EXPECT().Commit().Return(nil)
+			mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 		} else {
-			mockTx.EXPECT().Commit().Return(params.commitError)
+			mockTx.EXPECT().Commit(gomock.Any()).Return(params.commitError)
 		}
 	}
 	// Close is always called, regardless of explicit commits
@@ -779,7 +779,7 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 			logTX.EXPECT().UpdateSequencedLeaves(any, any).AnyTimes().Return(nil)
 			logTX.EXPECT().SetMerkleNodes(any, any).AnyTimes().Return(nil)
 			logTX.EXPECT().StoreSignedLogRoot(any, any).AnyTimes().Return(nil)
-			logTX.EXPECT().Commit().Return(nil)
+			logTX.EXPECT().Commit(gomock.Any()).Return(nil)
 			logTX.EXPECT().Close().Return(nil)
 			logStorage := &stestonly.FakeLogStorage{TX: logTX}
 

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -138,7 +138,7 @@ func TestRootAtRevision(t *testing.T) {
 
 	r, tx := getSparseMerkleTreeReaderWithMockTX(mockCtrl, 100)
 	node := getRandomRootNode(t, 14)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(23), rootNodeMatcher{}).Return([]storage.Node{node}, nil)
 	root, err := r.RootAtRevision(ctx, 23)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestRootAtUnknownRevision(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	r, tx := getSparseMerkleTreeReaderWithMockTX(mockCtrl, 100)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(23), rootNodeMatcher{}).Return([]storage.Node{}, nil)
 	_, err := r.RootAtRevision(ctx, 23)
 	if err != ErrNoSuchRevision {
@@ -172,7 +172,7 @@ func TestRootAtRevisionHasMultipleRoots(t *testing.T) {
 
 	r, tx := getSparseMerkleTreeReaderWithMockTX(mockCtrl, 100)
 	n1, n2 := getRandomRootNode(t, 14), getRandomRootNode(t, 15)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(23), rootNodeMatcher{}).Return([]storage.Node{n1, n2}, nil)
 	_, err := r.RootAtRevision(ctx, 23)
 	if err == nil || err == ErrNoSuchRevision {
@@ -191,7 +191,7 @@ func TestRootAtRevisionCatchesFutureRevision(t *testing.T) {
 	// Sanity checking in RootAtRevision should catch this node being incorrectly
 	// returned by the storage layer.
 	n1 := getRandomRootNode(t, rev+1)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(rev), rootNodeMatcher{}).Return([]storage.Node{n1}, nil)
 	_, err := r.RootAtRevision(ctx, rev)
 	if err == nil || err == ErrNoSuchRevision {
@@ -225,7 +225,7 @@ func TestInclusionProofForNullEntryInEmptyTree(t *testing.T) {
 
 	const rev = 100
 	r, tx := getSparseMerkleTreeReaderWithMockTX(mockCtrl, rev)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(rev), gomock.Any()).Return([]storage.Node{}, nil)
 	const key = "SomeArbitraryKey"
 	proof, err := r.InclusionProof(ctx, rev, testonly.HashKey(key))
@@ -253,7 +253,7 @@ func TestBatchInclusionProofForNullEntriesInEmptyTrees(t *testing.T) {
 
 	const rev = 100
 	r, tx := getSparseMerkleTreeReaderWithMockTX(mockCtrl, rev)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(rev), gomock.Any()).Return([]storage.Node{}, nil)
 	key := testonly.HashKey("SomeArbitraryKey")
 	key2 := testonly.HashKey("SomeOtherArbitraryKey")
@@ -320,7 +320,7 @@ func testSparseTreeCalculatedRoot(ctx context.Context, t *testing.T, vec sparseT
 	const rev = 100
 	w, tx := getSparseMerkleTreeWriterWithMockTX(ctx, mockCtrl, treeID, rev)
 
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().Close().AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(rev), gomock.Any()).AnyTimes().Return([]storage.Node{}, nil)
 	tx.EXPECT().SetMerkleNodes(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
@@ -391,7 +391,7 @@ func testSparseTreeFetches(ctx context.Context, t *testing.T, vec sparseTestVect
 
 	const rev = 100
 	w, tx := getSparseMerkleTreeWriterWithMockTX(ctx, mockCtrl, treeID, rev)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().Close().AnyTimes().Return(nil)
 
 	reads := make(map[string]string)
@@ -571,7 +571,7 @@ func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
 	w, tx := getSparseMerkleTreeWriterWithMockTX(ctx, mockCtrl, treeID, rev)
 
 	tx.EXPECT().Close().AnyTimes().Return(nil)
-	tx.EXPECT().Commit().AnyTimes().Return(nil)
+	tx.EXPECT().Commit(gomock.Any()).AnyTimes().Return(nil)
 	tx.EXPECT().GetMerkleNodes(gomock.Any(), int64(rev), gomock.Any()).AnyTimes().Return([]storage.Node{}, nil)
 	tx.EXPECT().SetMerkleNodes(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -250,7 +250,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 	}
 	t.recordIndexPercent(req.LeafIndex, root.TreeSize)
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -314,7 +314,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 		t.recordIndexPercent(leaf.LeafIndex, root.TreeSize)
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 	if len(proofs) < 1 {
@@ -371,7 +371,7 @@ func (t *TrillianLogRPCServer) GetConsistencyProof(ctx context.Context, req *tri
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -680,7 +680,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 		r.Leaf = leaves[0]
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -688,7 +688,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 }
 
 func (t *TrillianLogRPCServer) commitAndLog(ctx context.Context, logID int64, tx storage.ReadOnlyLogTreeTX, op string) error {
-	err := tx.Commit()
+	err := tx.Commit(ctx)
 	if err != nil {
 		glog.Warningf("%v: Commit failed for %v: %v", logID, op, err)
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -175,7 +175,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
-				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
+				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &leaf0Request,
@@ -188,7 +188,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, errors.New("SLR"))
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
 			},
@@ -202,7 +202,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*corruptLogRoot, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
 			},
@@ -216,7 +216,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0}).Return([]*trillian.LogLeaf{leaf1}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
 			},
@@ -233,7 +233,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{0, 3}).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 				tx.EXPECT().IsOpen().AnyTimes().Return(false)
 			},
@@ -378,14 +378,14 @@ func TestGetLeavesByRange(t *testing.T) {
 							mockTX.EXPECT().GetLeavesByRange(gomock.Any(), test.start, test.count).Return(nil, test.getErr)
 						} else {
 							mockTX.EXPECT().GetLeavesByRange(gomock.Any(), test.start, test.count).Return(test.want, nil)
-							mockTX.EXPECT().Commit().Return(nil)
+							mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 						}
 					}
 					mockTX.EXPECT().Close().Return(nil)
 				}
 			} else {
 				if test.txErr != nil {
-					mockTX.EXPECT().Commit().Return(nil)
+					mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 				}
 			}
 		}
@@ -634,7 +634,7 @@ func TestGetLatestSignedLogRoot(t *testing.T) {
 			mockTX.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(test.storageRoot, test.rootErr)
 		}
 		if !test.noCommit {
-			mockTX.EXPECT().Commit().Return(test.commitErr)
+			mockTX.EXPECT().Commit(gomock.Any()).Return(test.commitErr)
 		}
 		if !test.noClose {
 			mockTX.EXPECT().Close().Return(nil)
@@ -725,7 +725,7 @@ func TestGetLeavesByHash(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
+				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getByHashRequest1,
@@ -774,7 +774,7 @@ func TestGetLeavesByHash(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1, leafHash3}, false).Return([]*trillian.LogLeaf{leaf1, leaf3}, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req: &getByHashRequest1,
@@ -917,7 +917,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(nil, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
+				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -1011,7 +1011,7 @@ func TestGetProofByHash(t *testing.T) {
 				{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 				{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 				{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil).AnyTimes()
-			mockTX.EXPECT().Commit().Return(nil)
+			mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 			mockTX.EXPECT().Close().Return(nil)
 
 			registry := extension.Registry{
@@ -1149,7 +1149,7 @@ func TestGetProofByIndex(t *testing.T) {
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
-				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
+				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1190,7 +1190,7 @@ func TestGetProofByIndex(t *testing.T) {
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req: &getInclusionProofByIndexRequest7,
@@ -1318,7 +1318,7 @@ func TestGetEntryAndProof(t *testing.T) {
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
-				tx.EXPECT().Commit().Return(errors.New("COMMIT"))
+				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getEntryAndProofRequest7,
@@ -1378,7 +1378,7 @@ func TestGetEntryAndProof(t *testing.T) {
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req: &getEntryAndProofRequest7,
@@ -1401,7 +1401,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(*signedRoot1, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req: &getEntryAndProofRequest17_11,
@@ -1421,7 +1421,7 @@ func TestGetEntryAndProof(t *testing.T) {
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
 				tx.EXPECT().GetLeavesByIndex(gomock.Any(), []int64{2}).Return([]*trillian.LogLeaf{leaf1}, nil)
-				tx.EXPECT().Commit().Return(nil)
+				tx.EXPECT().Commit(gomock.Any()).Return(nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req: &getEntryAndProofRequest17_2,
@@ -1521,7 +1521,7 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	fakeStorage.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(mockTX, nil)
 
 	mockTX.EXPECT().GetSequencedLeafCount(gomock.Any()).Return(int64(268), nil)
-	mockTX.EXPECT().Commit().Return(nil)
+	mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTX.EXPECT().Close().Return(nil)
 
 	registry := extension.Registry{
@@ -1670,7 +1670,7 @@ func TestGetConsistencyProof(t *testing.T) {
 				mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, test.nodeIDs).Return(test.nodes, test.getNodesErr)
 			}
 			if !test.noCommit {
-				mockTX.EXPECT().Commit().Return(test.commitErr)
+				mockTX.EXPECT().Commit(gomock.Any()).Return(test.commitErr)
 			}
 			mockTX.EXPECT().Close().Return(nil)
 
@@ -2094,7 +2094,7 @@ func TestInitLog(t *testing.T) {
 			}
 			if tc.wantInit && !tc.signFail {
 				if tc.storeErr == nil {
-					mockTX.EXPECT().Commit().Return(nil)
+					mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 				}
 				mockTX.EXPECT().StoreSignedLogRoot(gomock.Any(), gomock.Any()).Return(tc.storeErr)
 			}
@@ -2172,7 +2172,7 @@ func (p *parameterizedTest) executeCommitFailsTest(t *testing.T, logID int64) {
 	}
 	if p.mode != noTX {
 		p.prepareTX(mockTX)
-		mockTX.EXPECT().Commit().Return(errors.New("bang"))
+		mockTX.EXPECT().Commit(gomock.Any()).Return(errors.New("bang"))
 		mockTX.EXPECT().Close().Return(errors.New("bang"))
 		mockTX.EXPECT().IsOpen().AnyTimes().Return(false)
 	}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -297,7 +297,7 @@ func (t *TrillianMapServer) getLeavesByRevision(ctx context.Context, mapID int64
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("could not commit db transaction: %v", err)
 	}
 
@@ -544,7 +544,7 @@ func (t *TrillianMapServer) GetSignedMapRoot(ctx context.Context, req *trillian.
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		glog.Warningf("%v: Commit failed for GetSignedMapRoot: %v", req.MapId, err)
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func (t *TrillianMapServer) GetSignedMapRootByRevision(ctx context.Context, req 
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		glog.Warningf("%v: Commit failed for GetSignedMapRootByRevision: %v", req.MapId, err)
 		return nil, err
 	}

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -94,7 +94,7 @@ func TestInitMap(t *testing.T) {
 			mockTX.EXPECT().IsOpen().AnyTimes().Return(false)
 			mockTX.EXPECT().Close().Return(nil)
 			if tc.wantInit {
-				mockTX.EXPECT().Commit().Return(nil)
+				mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 				mockTX.EXPECT().StoreSignedMapRoot(gomock.Any(), gomock.Any())
 			}
 
@@ -200,7 +200,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 			if test.snapShErr == nil {
 				mockTX.EXPECT().LatestSignedMapRoot(gomock.Any()).Return(test.mapRoot, test.lsmrErr)
 				if test.lsmrErr == nil {
-					mockTX.EXPECT().Commit().Return(nil)
+					mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 				}
 				mockTX.EXPECT().IsOpen().AnyTimes().Return(false)
 			}
@@ -308,7 +308,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 				if test.snapShErr == nil {
 					mockTX.EXPECT().GetSignedMapRoot(gomock.Any(), test.req.Revision).Return(test.mapRoot, test.lsmrErr)
 					if test.lsmrErr == nil {
-						mockTX.EXPECT().Commit().Return(nil)
+						mockTX.EXPECT().Commit(gomock.Any()).Return(nil)
 					}
 					mockTX.EXPECT().Close().Return(nil)
 					mockTX.EXPECT().IsOpen().AnyTimes().Return(false)

--- a/storage/cache/gen.go
+++ b/storage/cache/gen.go
@@ -18,6 +18,8 @@ package cache
 //go:generate mockgen -self_package github.com/google/trillian/storage/cache -package cache -imports github.com/google/trillian/storage/storagepb -destination mock_node_storage.go github.com/google/trillian/storage/cache NodeStorage
 
 import (
+	"context"
+
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
 )
@@ -25,5 +27,5 @@ import (
 // NodeStorage provides an interface for storing and retrieving subtrees.
 type NodeStorage interface {
 	GetSubtree(n storage.NodeID) (*storagepb.SubtreeProto, error)
-	SetSubtrees(s []*storagepb.SubtreeProto) error
+	SetSubtrees(ctx context.Context, s []*storagepb.SubtreeProto) error
 }

--- a/storage/cache/mock_node_storage.go
+++ b/storage/cache/mock_node_storage.go
@@ -5,6 +5,7 @@
 package cache
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	storage "github.com/google/trillian/storage"
 	storagepb "github.com/google/trillian/storage/storagepb"
@@ -50,15 +51,15 @@ func (mr *MockNodeStorageMockRecorder) GetSubtree(arg0 interface{}) *gomock.Call
 }
 
 // SetSubtrees mocks base method
-func (m *MockNodeStorage) SetSubtrees(arg0 []*storagepb.SubtreeProto) error {
+func (m *MockNodeStorage) SetSubtrees(arg0 context.Context, arg1 []*storagepb.SubtreeProto) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetSubtrees", arg0)
+	ret := m.ctrl.Call(m, "SetSubtrees", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetSubtrees indicates an expected call of SetSubtrees
-func (mr *MockNodeStorageMockRecorder) SetSubtrees(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeStorageMockRecorder) SetSubtrees(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubtrees", reflect.TypeOf((*MockNodeStorage)(nil).SetSubtrees), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubtrees", reflect.TypeOf((*MockNodeStorage)(nil).SetSubtrees), arg0, arg1)
 }

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -36,7 +37,7 @@ type GetSubtreeFunc func(id storage.NodeID) (*storagepb.SubtreeProto, error)
 type GetSubtreesFunc func(ids []storage.NodeID) ([]*storagepb.SubtreeProto, error)
 
 // SetSubtreesFunc describes a function which can store a collection of Subtrees into storage.
-type SetSubtreesFunc func(s []*storagepb.SubtreeProto) error
+type SetSubtreesFunc func(ctx context.Context, s []*storagepb.SubtreeProto) error
 
 // stratumInfo represents a single stratum across the tree.
 // It it used inside the SubtreeCache to determine which Subtree prefix should
@@ -416,7 +417,7 @@ func (s *SubtreeCache) SetNodeHash(id storage.NodeID, h []byte, getSubtree GetSu
 }
 
 // Flush causes the cache to write all dirty Subtrees back to storage.
-func (s *SubtreeCache) Flush(setSubtrees SetSubtreesFunc) error {
+func (s *SubtreeCache) Flush(ctx context.Context, setSubtrees SetSubtreesFunc) error {
 	glog.V(1).Info("cache: Flush")
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -444,7 +445,7 @@ func (s *SubtreeCache) Flush(setSubtrees SetSubtreesFunc) error {
 	if len(treesToWrite) == 0 {
 		return nil
 	}
-	err := setSubtrees(treesToWrite)
+	err := setSubtrees(ctx, treesToWrite)
 	glog.V(1).Infof("cache: Flush done %v", err)
 	return err
 }

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -166,7 +166,7 @@ func (ls *logStorage) ReadWriteTransaction(ctx context.Context, tree *trillian.T
 		if err := f(ctx, tx); err != nil {
 			return err
 		}
-		return tx.flushSubtrees()
+		return tx.flushSubtrees(ctx)
 	})
 	return err
 }

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -124,7 +124,7 @@ func (ms *mapStorage) ReadWriteTransaction(ctx context.Context, tree *trillian.T
 		if err := f(ctx, tx); err != nil {
 			return err
 		}
-		if err := tx.flushSubtrees(); err != nil {
+		if err := tx.flushSubtrees(ctx); err != nil {
 			glog.Errorf("failed to tx.flushSubtrees(): %v", err)
 			return err
 		}

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -28,7 +28,7 @@ type ReadOnlyLogTX interface {
 
 	// Commit ensures the data read by the TX is consistent in the database. Only after Commit the
 	// data read should be regarded as valid.
-	Commit() error
+	Commit(context.Context) error
 
 	// Rollback discards the read-only TX.
 	Rollback() error

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -128,7 +128,7 @@ func (m *memoryLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX,
 	return &readOnlyLogTX{m.TreeStorage}, nil
 }
 
-func (t *readOnlyLogTX) Commit(_ context.Context) error {
+func (t *readOnlyLogTX) Commit(context.Context) error {
 	return nil
 }
 

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -128,7 +128,7 @@ func (m *memoryLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX,
 	return &readOnlyLogTX{m.TreeStorage}, nil
 }
 
-func (t *readOnlyLogTX) Commit() error {
+func (t *readOnlyLogTX) Commit(_ context.Context) error {
 	return nil
 }
 
@@ -194,7 +194,7 @@ func (m *memoryLogStorage) ReadWriteTransaction(ctx context.Context, tree *trill
 	if err := f(ctx, tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(ctx)
 }
 
 func (m *memoryLogStorage) AddSequencedLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, timestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
@@ -225,7 +225,7 @@ func (m *memoryLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree,
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -252,12 +252,12 @@ func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []storage.Node) error
 	return nil
 }
 
-func (t *treeTX) Commit() error {
+func (t *treeTX) Commit(ctx context.Context) error {
 	defer t.unlock()
 
 	if t.writeRevision > -1 {
-		if err := t.subtreeCache.Flush(func(st []*storagepb.SubtreeProto) error {
-			return t.storeSubtrees(context.TODO(), st)
+		if err := t.subtreeCache.Flush(ctx, func(ctx context.Context, st []*storagepb.SubtreeProto) error {
+			return t.storeSubtrees(ctx, st)
 		}); err != nil {
 			glog.Warningf("TX commit flush error: %v", err)
 			return err

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -440,17 +440,17 @@ func (mr *MockLogTreeTXMockRecorder) Close() *gomock.Call {
 }
 
 // Commit mocks base method
-func (m *MockLogTreeTX) Commit() error {
+func (m *MockLogTreeTX) Commit(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit")
+	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit
-func (mr *MockLogTreeTXMockRecorder) Commit() *gomock.Call {
+func (mr *MockLogTreeTXMockRecorder) Commit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockLogTreeTX)(nil).Commit))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockLogTreeTX)(nil).Commit), arg0)
 }
 
 // DequeueLeaves mocks base method
@@ -777,17 +777,17 @@ func (mr *MockMapTreeTXMockRecorder) Close() *gomock.Call {
 }
 
 // Commit mocks base method
-func (m *MockMapTreeTX) Commit() error {
+func (m *MockMapTreeTX) Commit(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit")
+	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit
-func (mr *MockMapTreeTXMockRecorder) Commit() *gomock.Call {
+func (mr *MockMapTreeTXMockRecorder) Commit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockMapTreeTX)(nil).Commit))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockMapTreeTX)(nil).Commit), arg0)
 }
 
 // Get mocks base method
@@ -1112,17 +1112,17 @@ func (mr *MockReadOnlyLogTXMockRecorder) Close() *gomock.Call {
 }
 
 // Commit mocks base method
-func (m *MockReadOnlyLogTX) Commit() error {
+func (m *MockReadOnlyLogTX) Commit(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit")
+	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit
-func (mr *MockReadOnlyLogTXMockRecorder) Commit() *gomock.Call {
+func (mr *MockReadOnlyLogTXMockRecorder) Commit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyLogTX)(nil).Commit))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyLogTX)(nil).Commit), arg0)
 }
 
 // GetActiveLogIDs mocks base method
@@ -1192,17 +1192,17 @@ func (mr *MockReadOnlyLogTreeTXMockRecorder) Close() *gomock.Call {
 }
 
 // Commit mocks base method
-func (m *MockReadOnlyLogTreeTX) Commit() error {
+func (m *MockReadOnlyLogTreeTX) Commit(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit")
+	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit
-func (mr *MockReadOnlyLogTreeTXMockRecorder) Commit() *gomock.Call {
+func (mr *MockReadOnlyLogTreeTXMockRecorder) Commit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).Commit))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).Commit), arg0)
 }
 
 // GetLeavesByHash mocks base method
@@ -1376,17 +1376,17 @@ func (mr *MockReadOnlyMapTreeTXMockRecorder) Close() *gomock.Call {
 }
 
 // Commit mocks base method
-func (m *MockReadOnlyMapTreeTX) Commit() error {
+func (m *MockReadOnlyMapTreeTX) Commit(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit")
+	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Commit indicates an expected call of Commit
-func (mr *MockReadOnlyMapTreeTXMockRecorder) Commit() *gomock.Call {
+func (mr *MockReadOnlyMapTreeTXMockRecorder) Commit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyMapTreeTX)(nil).Commit))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockReadOnlyMapTreeTX)(nil).Commit), arg0)
 }
 
 // Get mocks base method

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -187,7 +187,7 @@ func (m *mySQLLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, 
 	return &readOnlyLogTX{m, &sync.Mutex{}, tx}, nil
 }
 
-func (t *readOnlyLogTX) Commit(_ context.Context) error {
+func (t *readOnlyLogTX) Commit(context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -187,7 +187,7 @@ func (m *mySQLLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, 
 	return &readOnlyLogTX{m, &sync.Mutex{}, tx}, nil
 }
 
-func (t *readOnlyLogTX) Commit() error {
+func (t *readOnlyLogTX) Commit(_ context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -279,7 +279,7 @@ func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, tree *trilli
 	if err := f(ctx, tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(ctx)
 }
 
 func (m *mySQLLogStorage) AddSequencedLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, timestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
@@ -297,7 +297,7 @@ func (m *mySQLLogStorage) AddSequencedLeaves(ctx context.Context, tree *trillian
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -327,7 +327,7 @@ func (m *mySQLLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, 
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -200,7 +200,7 @@ func TestSnapshot(t *testing.T) {
 			if err != nil {
 				t.Errorf("LatestSignedLogRoot() returned err = %v", err)
 			}
-			if err := tx.Commit(); err != nil {
+			if err := tx.Commit(ctx); err != nil {
 				t.Errorf("Commit() returned err = %v", err)
 			}
 		})
@@ -1047,7 +1047,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	if err != storage.ErrTreeNeedsInit {
 		t.Fatalf("SnapshotForTree gave %v, want %v", err, storage.ErrTreeNeedsInit)
 	}
-	commit(tx, t)
+	commit(ctx, tx, t)
 }
 
 func TestLatestSignedLogRoot(t *testing.T) {
@@ -1222,7 +1222,7 @@ func TestGetActiveLogIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActiveLogIDs() returns err = %v", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Commit() returned err = %v", err)
 	}
 
@@ -1249,7 +1249,7 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActiveLogIDs() = (_, %v), want = (_, nil)", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Commit() = %v, want = nil", err)
 	}
 
@@ -1403,12 +1403,12 @@ func runLogTX(s storage.LogStorage, tree *trillian.Tree, t *testing.T, f storage
 }
 
 type committableTX interface {
-	Commit() error
+	Commit(ctx context.Context) error
 }
 
-func commit(tx committableTX, t *testing.T) {
+func commit(ctx context.Context, tx committableTX, t *testing.T) {
 	t.Helper()
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Failed to commit tx: %v", err)
 	}
 }

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -139,7 +139,7 @@ func (m *mySQLMapStorage) ReadWriteTransaction(ctx context.Context, tree *trilli
 	if err := f(ctx, tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(ctx)
 }
 
 type mapTreeTX struct {

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -111,7 +111,7 @@ func TestMapSnapshot(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if err := tx.Commit(); err != nil {
+			if err := tx.Commit(ctx); err != nil {
 				t.Errorf("Commit()=_,%v; want _,nil", err)
 			}
 		})

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -376,13 +376,13 @@ func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []storage.Node) error
 	return nil
 }
 
-func (t *treeTX) Commit() error {
+func (t *treeTX) Commit(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if t.writeRevision > -1 {
-		if err := t.subtreeCache.Flush(func(st []*storagepb.SubtreeProto) error {
-			return t.storeSubtrees(context.TODO(), st)
+		if err := t.subtreeCache.Flush(ctx, func(ctx context.Context, st []*storagepb.SubtreeProto) error {
+			return t.storeSubtrees(ctx, st)
 		}); err != nil {
 			glog.Warningf("TX commit flush error: %v", err)
 			return err

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -216,7 +216,7 @@ func (m *postgresLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogT
 	return &readOnlyLogTX{m, tx}, nil
 }
 
-func (t *readOnlyLogTX) Commit() error {
+func (t *readOnlyLogTX) Commit(_ context.Context) error {
 	return t.tx.Commit()
 }
 
@@ -298,7 +298,7 @@ func (m *postgresLogStorage) ReadWriteTransaction(ctx context.Context, tree *tri
 	if err := f(ctx, tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(ctx)
 }
 
 func (m *postgresLogStorage) AddSequencedLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, timestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {
@@ -310,7 +310,7 @@ func (m *postgresLogStorage) AddSequencedLeaves(ctx context.Context, tree *trill
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -334,7 +334,7 @@ func (m *postgresLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tre
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -216,7 +216,7 @@ func (m *postgresLogStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogT
 	return &readOnlyLogTX{m, tx}, nil
 }
 
-func (t *readOnlyLogTX) Commit(_ context.Context) error {
+func (t *readOnlyLogTX) Commit(context.Context) error {
 	return t.tx.Commit()
 }
 

--- a/storage/postgres/log_storage_test.go
+++ b/storage/postgres/log_storage_test.go
@@ -196,7 +196,7 @@ func TestSnapshot(t *testing.T) {
 			if err != nil {
 				t.Errorf("LatestSignedLogRoot() returned err = %v", err)
 			}
-			if err := tx.Commit(); err != nil {
+			if err := tx.Commit(ctx); err != nil {
 				t.Errorf("Commit() returned err = %v", err)
 			}
 		})
@@ -969,7 +969,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 	if err != storage.ErrTreeNeedsInit {
 		t.Fatalf("SnapshotForTree gave %v, want %v", err, storage.ErrTreeNeedsInit)
 	}
-	commit(tx, t)
+	commit(ctx, tx, t)
 }
 
 func TestLatestSignedLogRoot(t *testing.T) {
@@ -1144,7 +1144,7 @@ func TestGetActiveLogIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActiveLogIDs() returns err = %v", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Commit() returned err = %v", err)
 	}
 
@@ -1171,7 +1171,7 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActiveLogIDs() = (_, %v), want = (_, nil)", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Commit() = %v, want = nil", err)
 	}
 
@@ -1325,12 +1325,12 @@ func runLogTX(s storage.LogStorage, tree *trillian.Tree, t *testing.T, f storage
 }
 
 type committableTX interface {
-	Commit() error
+	Commit(ctx context.Context) error
 }
 
-func commit(tx committableTX, t *testing.T) {
+func commit(ctx context.Context, tx committableTX, t *testing.T) {
 	t.Helper()
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		t.Errorf("Failed to commit tx: %v", err)
 	}
 }

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -366,10 +366,10 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 	return nil
 }
 
-func (t *treeTX) Commit() error {
+func (t *treeTX) Commit(ctx context.Context) error {
 	if t.writeRevision > -1 {
-		if err := t.subtreeCache.Flush(func(st []*storagepb.SubtreeProto) error {
-			return t.storeSubtrees(context.TODO(), st)
+		if err := t.subtreeCache.Flush(ctx, func(ctx context.Context, st []*storagepb.SubtreeProto) error {
+			return t.storeSubtrees(ctx, st)
 		}); err != nil {
 			glog.Warningf("TX commit flush error: %v", err)
 			return err

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -32,7 +32,7 @@ func RunOnLogTX(tx storage.LogTreeTX) func(ctx context.Context, treeID int64, f 
 		if err := f(ctx, tx); err != nil {
 			return err
 		}
-		return tx.Commit()
+		return tx.Commit(ctx)
 	}
 }
 
@@ -43,7 +43,7 @@ func RunOnMapTX(tx storage.MapTreeTX) func(ctx context.Context, treeID int64, f 
 		if err := f(ctx, tx); err != nil {
 			return err
 		}
-		return tx.Commit()
+		return tx.Commit(ctx)
 	}
 }
 

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -476,7 +476,7 @@ func traverseTreeStorage(ctx context.Context, ls storage.LogStorage, tree *trill
 
 func dumpLeaves(ctx context.Context, ls storage.LogStorage, tree *trillian.Tree, ts int) string {
 	out := new(bytes.Buffer)
-	tx, err := ls.SnapshotForTree(context.TODO(), tree)
+	tx, err := ls.SnapshotForTree(ctx, tree)
 	if err != nil {
 		glog.Fatalf("SnapshotForTree: %v", err)
 	}
@@ -487,7 +487,7 @@ func dumpLeaves(ctx context.Context, ls storage.LogStorage, tree *trillian.Tree,
 	}()
 
 	for l := int64(0); l < int64(ts); l++ {
-		leaves, err := tx.GetLeavesByIndex(context.TODO(), []int64{l})
+		leaves, err := tx.GetLeavesByIndex(ctx, []int64{l})
 		if err != nil {
 			glog.Fatalf("GetLeavesByIndex for index %d got: %v", l, err)
 		}

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -34,7 +34,7 @@ type ReadOnlyTreeTX interface {
 	ReadRevision(ctx context.Context) (int64, error)
 
 	// Commit attempts to commit any reads performed under this transaction.
-	Commit() error
+	Commit(context.Context) error
 
 	// Rollback aborts this transaction.
 	Rollback() error


### PR DESCRIPTION
Commit() calls subtreeCache.Flush which calls storeSubtrees which
requires a context:

```
-                       return t.storeSubtrees(context.TODO(), st)
+                       return t.storeSubtrees(ctx, st)
```