### PR TITLE
Storage test helpers accept storage interfaces

### DIFF
--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -146,7 +146,7 @@ func TestSnapshot(t *testing.T) {
 	s := NewLogStorage(DB, nil)
 
 	frozenLog := mustCreateTree(ctx, t, as, testonly.LogTree)
-	createFakeSignedLogRoot(ctx, t, s, frozenLog, 0)
+	mustSignAndStoreLogRoot(ctx, t, s, frozenLog, 0)
 	if _, err := storage.UpdateTree(ctx, as, frozenLog.TreeId, func(tree *trillian.Tree) {
 		tree.TreeState = trillian.TreeState_FROZEN
 	}); err != nil {
@@ -154,7 +154,7 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	activeLog := mustCreateTree(ctx, t, as, testonly.LogTree)
-	createFakeSignedLogRoot(ctx, t, s, activeLog, 0)
+	mustSignAndStoreLogRoot(ctx, t, s, activeLog, 0)
 	mapTreeID := mustCreateTree(ctx, t, as, testonly.MapTree).TreeId
 
 	tests := []struct {
@@ -214,7 +214,7 @@ func TestReadWriteTransaction(t *testing.T) {
 	as := NewAdminStorage(DB)
 	s := NewLogStorage(DB, nil)
 	activeLog := mustCreateTree(ctx, t, as, testonly.LogTree)
-	createFakeSignedLogRoot(ctx, t, s, activeLog, 0)
+	mustSignAndStoreLogRoot(ctx, t, s, activeLog, 0)
 
 	tests := []struct {
 		desc        string
@@ -874,7 +874,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	s := NewLogStorage(DB, nil)
 
 	// The leaf indices are checked against the tree size so we need a root.
-	createFakeSignedLogRoot(ctx, t, s, tree, uint64(sequenceNumber+1))
+	mustSignAndStoreLogRoot(ctx, t, s, tree, uint64(sequenceNumber+1))
 
 	data := []byte("some data")
 	data2 := []byte("some other data")
@@ -979,7 +979,7 @@ func testGetLeavesByRangeImpl(t *testing.T, create *trillian.Tree, tests []getLe
 	s := NewLogStorage(DB, nil)
 
 	// Note: GetLeavesByRange loads the root internally to get the tree size.
-	createFakeSignedLogRoot(ctx, t, s, tree, 14)
+	mustSignAndStoreLogRoot(ctx, t, s, tree, 14)
 
 	// Create leaves [0]..[19] but drop leaf [5] and set the tree size to 14.
 	for i := int64(0); i < 20; i++ {

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -145,7 +145,7 @@ func TestSnapshot(t *testing.T) {
 	as := NewAdminStorage(DB)
 	s := NewLogStorage(DB, nil)
 
-	frozenLog := createTree(ctx, t, as, testonly.LogTree)
+	frozenLog := mustCreateTree(ctx, t, as, testonly.LogTree)
 	createFakeSignedLogRoot(ctx, t, s, frozenLog, 0)
 	if _, err := storage.UpdateTree(ctx, as, frozenLog.TreeId, func(tree *trillian.Tree) {
 		tree.TreeState = trillian.TreeState_FROZEN
@@ -153,9 +153,9 @@ func TestSnapshot(t *testing.T) {
 		t.Fatalf("Error updating frozen tree: %v", err)
 	}
 
-	activeLog := createTree(ctx, t, as, testonly.LogTree)
+	activeLog := mustCreateTree(ctx, t, as, testonly.LogTree)
 	createFakeSignedLogRoot(ctx, t, s, activeLog, 0)
-	mapTreeID := createTree(ctx, t, as, testonly.MapTree).TreeId
+	mapTreeID := mustCreateTree(ctx, t, as, testonly.MapTree).TreeId
 
 	tests := []struct {
 		desc    string
@@ -213,7 +213,7 @@ func TestReadWriteTransaction(t *testing.T) {
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
 	s := NewLogStorage(DB, nil)
-	activeLog := createTree(ctx, t, as, testonly.LogTree)
+	activeLog := mustCreateTree(ctx, t, as, testonly.LogTree)
 	createFakeSignedLogRoot(ctx, t, s, activeLog, 0)
 
 	tests := []struct {
@@ -273,7 +273,7 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 	count := 15
 	leaves := createTestLeaves(int64(count), 10)
@@ -340,7 +340,7 @@ func TestQueueLeaves(t *testing.T) {
 
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
@@ -381,7 +381,7 @@ type addSequencedLeavesTest struct {
 func initAddSequencedLeavesTest(ctx context.Context, t *testing.T) addSequencedLeavesTest {
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.PreorderedLogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.PreorderedLogTree)
 	s := NewLogStorage(DB, nil)
 	return addSequencedLeavesTest{t, s, tree}
 }
@@ -467,7 +467,7 @@ func TestDequeueLeavesNoneQueued(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
@@ -486,7 +486,7 @@ func TestDequeueLeaves(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	{
@@ -533,7 +533,7 @@ func TestDequeueLeavesHaveQueueTimestamp(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	{
@@ -566,7 +566,7 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	leavesToDequeue1 := 3
@@ -640,7 +640,7 @@ func TestDequeueLeavesGuardInterval(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	{
@@ -685,7 +685,7 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	batchSize := 2
@@ -749,7 +749,7 @@ func TestGetLeavesByHashNotPresent(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
@@ -771,7 +771,7 @@ func TestGetLeavesByHash(t *testing.T) {
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	data := []byte("some data")
@@ -797,7 +797,7 @@ func TestGetLeafDataByIdentityHash(t *testing.T) {
 	// Create fake leaf as if it had been sequenced
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 	data := []byte("some data")
 	leaf := createFakeLeaf(ctx, DB, tree.TreeId, dummyRawHash, dummyHash, data, someExtraData, sequenceNumber, t)
@@ -870,7 +870,7 @@ func TestGetLeavesByIndex(t *testing.T) {
 	// Create fake leaf as if it had been sequenced, read it back and check contents
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	// The leaf indices are checked against the tree size so we need a root.
@@ -975,7 +975,7 @@ func testGetLeavesByRangeImpl(t *testing.T, create *trillian.Tree, tests []getLe
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, create)
+	tree := mustCreateTree(ctx, t, as, create)
 	s := NewLogStorage(DB, nil)
 
 	// Note: GetLeavesByRange loads the root internally to get the tree size.
@@ -1061,7 +1061,7 @@ func TestLatestSignedRootNoneWritten(t *testing.T) {
 
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	tx, err := s.SnapshotForTree(ctx, tree)
@@ -1075,7 +1075,7 @@ func TestLatestSignedLogRoot(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	signer := tcrypto.NewSigner(tree.TreeId, ttestonly.NewSignerWithFixedSig(nil, []byte("notempty")), crypto.SHA256)
@@ -1114,7 +1114,7 @@ func TestDuplicateSignedLogRoot(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	signer := tcrypto.NewSigner(tree.TreeId, ttestonly.NewSignerWithFixedSig(nil, []byte("notempty")), crypto.SHA256)
@@ -1145,7 +1145,7 @@ func TestLogRootUpdate(t *testing.T) {
 	// Write two roots for a log and make sure the one with the newest timestamp supersedes
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, testonly.LogTree)
+	tree := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	signer := tcrypto.NewSigner(tree.TreeId, ttestonly.NewSignerWithFixedSig(nil, []byte("notempty")), crypto.SHA256)
@@ -1309,8 +1309,8 @@ func TestGetSequencedLeafCount(t *testing.T) {
 	// We'll create leaves for two different trees
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	log1 := createTree(ctx, t, as, testonly.LogTree)
-	log2 := createTree(ctx, t, as, testonly.LogTree)
+	log1 := mustCreateTree(ctx, t, as, testonly.LogTree)
+	log2 := mustCreateTree(ctx, t, as, testonly.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	{

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -45,11 +45,21 @@ func MustSignMapRoot(root *types.MapRootV1) *trillian.SignedMapRoot {
 	return r
 }
 
-func TestMapSnapshot(t *testing.T) {
+func TestMySQLMapStorage_CheckDatabaseAccessible(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
-	ctx := context.Background()
 
 	cleanTestDB(DB)
+	s := NewMapStorage(DB)
+	if err := s.CheckDatabaseAccessible(context.Background()); err != nil {
+		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
+	}
+}
+
+func TestMapSnapshot(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
+
+	cleanTestDB(DB)
+	ctx := context.Background()
 	as := NewAdminStorage(DB)
 	s := NewMapStorage(DB)
 	frozenMap := createInitializedMapForTests(ctx, t, s, as)

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -53,7 +53,7 @@ func TestMapSnapshot(t *testing.T) {
 	as := NewAdminStorage(DB)
 	s := NewMapStorage(DB)
 	frozenMap := createInitializedMapForTests(ctx, t, s, as)
-	updateTree(DB, frozenMap.TreeId, func(tree *trillian.Tree) {
+	storage.UpdateTree(ctx, as, frozenMap.TreeId, func(tree *trillian.Tree) {
 		tree.TreeState = trillian.TreeState_FROZEN
 	})
 

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -68,7 +68,7 @@ func TestMapSnapshot(t *testing.T) {
 	})
 
 	activeMap := createInitializedMapForTests(ctx, t, s, as)
-	logID := createTree(ctx, t, as, storageto.LogTree).TreeId
+	logID := mustCreateTree(ctx, t, as, storageto.LogTree).TreeId
 
 	tests := []struct {
 		desc    string
@@ -431,7 +431,7 @@ func TestGetSignedMapRootNotExist(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, storageto.MapTree) // Uninitialized: no revision 0 MapRoot exists.
+	tree := mustCreateTree(ctx, t, as, storageto.MapTree) // Uninitialized: no revision 0 MapRoot exists.
 	s := NewMapStorage(DB)
 
 	err := s.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.MapTreeTX) error {
@@ -595,7 +595,7 @@ func runMapTX(ctx context.Context, s storage.MapStorage, tree *trillian.Tree, t 
 
 func createInitializedMapForTests(ctx context.Context, t *testing.T, s storage.MapStorage, as storage.AdminStorage) *trillian.Tree {
 	t.Helper()
-	tree := createTree(ctx, t, as, storageto.MapTree)
+	tree := mustCreateTree(ctx, t, as, storageto.MapTree)
 
 	signer := tcrypto.NewSigner(tree.TreeId, testonly.NewSignerWithFixedSig(nil, []byte("sig")), crypto.SHA256)
 	err := s.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.MapTreeTX) error {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -244,7 +244,7 @@ func cleanTestDB(db *sql.DB) {
 	}
 }
 
-func createFakeSignedLogRoot(ctx context.Context, t *testing.T, l storage.LogStorage, tree *trillian.Tree, treeSize uint64) {
+func mustSignAndStoreLogRoot(ctx context.Context, t *testing.T, l storage.LogStorage, tree *trillian.Tree, treeSize uint64) {
 	t.Helper()
 	signer := tcrypto.NewSigner(0, testonly.NewSignerWithFixedSig(nil, []byte("notnil")), crypto.SHA256)
 

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -244,11 +244,9 @@ func cleanTestDB(db *sql.DB) {
 	}
 }
 
-func createFakeSignedLogRoot(db *sql.DB, tree *trillian.Tree, treeSize uint64) {
+func createFakeSignedLogRoot(ctx context.Context, t *testing.T, l storage.LogStorage, tree *trillian.Tree, treeSize uint64) {
 	signer := tcrypto.NewSigner(0, testonly.NewSignerWithFixedSig(nil, []byte("notnil")), crypto.SHA256)
 
-	ctx := context.Background()
-	l := NewLogStorage(db, nil)
 	err := l.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 		root, err := signer.SignLogRoot(&types.LogRootV1{TreeSize: treeSize, RootHash: []byte{0}})
 		if err != nil {
@@ -260,7 +258,7 @@ func createFakeSignedLogRoot(db *sql.DB, tree *trillian.Tree, treeSize uint64) {
 		return nil
 	})
 	if err != nil {
-		panic(fmt.Sprintf("ReadWriteTransaction() = %v", err))
+		t.Fatalf("ReadWriteTransaction() = %v", err)
 	}
 }
 
@@ -272,13 +270,6 @@ func createTree(ctx context.Context, t *testing.T, s storage.AdminStorage, tree 
 		t.Fatalf("storage.CreateTree(): %v", err)
 	}
 	return tree
-}
-
-// updateTree updates the specified tree using AdminStorage.
-func updateTree(db *sql.DB, treeID int64, updateFn func(*trillian.Tree)) (*trillian.Tree, error) {
-	ctx := context.Background()
-	s := NewAdminStorage(db)
-	return storage.UpdateTree(ctx, s, treeID, updateFn)
 }
 
 // DB is the database used for tests. It's initialized and closed by TestMain().

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -42,7 +42,7 @@ func TestNodeRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, storageto.LogTree)
+	tree := mustCreateTree(ctx, t, as, storageto.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	const writeRevision = int64(100)
@@ -87,7 +87,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 	ctx := context.Background()
 	cleanTestDB(DB)
 	as := NewAdminStorage(DB)
-	tree := createTree(ctx, t, as, storageto.LogTree)
+	tree := mustCreateTree(ctx, t, as, storageto.LogTree)
 	s := NewLogStorage(DB, nil)
 
 	const writeRevision = int64(100)
@@ -245,6 +245,7 @@ func cleanTestDB(db *sql.DB) {
 }
 
 func createFakeSignedLogRoot(ctx context.Context, t *testing.T, l storage.LogStorage, tree *trillian.Tree, treeSize uint64) {
+	t.Helper()
 	signer := tcrypto.NewSigner(0, testonly.NewSignerWithFixedSig(nil, []byte("notnil")), crypto.SHA256)
 
 	err := l.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
@@ -262,8 +263,8 @@ func createFakeSignedLogRoot(ctx context.Context, t *testing.T, l storage.LogSto
 	}
 }
 
-// createTree creates the specified tree using AdminStorage.
-func createTree(ctx context.Context, t *testing.T, s storage.AdminStorage, tree *trillian.Tree) *trillian.Tree {
+// mustCreateTree creates the specified tree using AdminStorage.
+func mustCreateTree(ctx context.Context, t *testing.T, s storage.AdminStorage, tree *trillian.Tree) *trillian.Tree {
 	t.Helper()
 	tree, err := storage.CreateTree(ctx, s, tree)
 	if err != nil {


### PR DESCRIPTION
By passing storage.{Log,Map,Admin}Storage to test helpers, we can abstract away the specifics of the storage implementation from its tests.