### PR TITLE
Take advantage of Go Modules in Docker images

### DIFF
--- a/examples/deployment/docker-compose.yml
+++ b/examples/deployment/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       dockerfile: examples/deployment/docker/log_server/Dockerfile
       args:
         - GOFLAGS
-        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -36,7 +35,6 @@ services:
       dockerfile: examples/deployment/docker/log_signer/Dockerfile
       args:
         - GOFLAGS
-        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -56,7 +54,6 @@ services:
       dockerfile: examples/deployment/docker/map_server/Dockerfile
       args:
         - GOFLAGS
-        - GO111MODULE
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,15 +1,24 @@
 FROM golang:1.11 as build
 
-ADD . /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/trillian
+WORKDIR /trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 ENV GO111MODULE=on
 
+# Download dependencies first - this should be cacheable.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now add the local Trillian repo, which typically isn't cacheable.
+COPY . .
+
+# Build the server and licensing tool.
 RUN go get ./server/trillian_log_server ./scripts/licenses
+# Run the licensing tool and save licenses, copyright notices, etc.
 RUN licenses save ./server/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 
+# Make a minimal image.
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_log_server /

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ARG GO111MODULE=auto
-ENV GO111MODULE=$GO111MODULE
+ENV GO111MODULE=on
+
 RUN go get ./server/trillian_log_server ./scripts/licenses
 RUN licenses save ./server/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,15 +1,24 @@
 FROM golang:1.11 as build
 
-ADD . /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/trillian
+WORKDIR /trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 ENV GO111MODULE=on
 
+# Download dependencies first - this should be cacheable.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now add the local Trillian repo, which typically isn't cacheable.
+COPY . .
+
+# Build the signer and licensing tool.
 RUN go get ./server/trillian_log_signer ./scripts/licenses
+# Run the licensing tool and save licenses, copyright notices, etc.
 RUN licenses save ./server/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 
+# Make a minimal image.
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_log_signer /

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ARG GO111MODULE=auto
-ENV GO111MODULE=$GO111MODULE
+ENV GO111MODULE=on
+
 RUN go get ./server/trillian_log_signer ./scripts/licenses
 RUN licenses save ./server/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -1,15 +1,24 @@
 FROM golang:1.11 as build
 
-ADD . /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/trillian
+WORKDIR /trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 ENV GO111MODULE=on
 
+# Download dependencies first - this should be cacheable.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now add the local Trillian repo, which typically isn't cacheable.
+COPY . .
+
+# Build the server and licensing tool.
 RUN go get ./server/trillian_map_server ./scripts/licenses
+# Run the licensing tool and save licenses, copyright notices, etc.
 RUN licenses save ./server/trillian_map_server --save_path /THIRD_PARTY_NOTICES
 
+# Make a minimal image.
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/trillian_map_server /

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /go/src/github.com/google/trillian
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ARG GO111MODULE=auto
-ENV GO111MODULE=$GO111MODULE
+ENV GO111MODULE=on
+
 RUN go get ./server/trillian_map_server ./scripts/licenses
 RUN licenses save ./server/trillian_map_server --save_path /THIRD_PARTY_NOTICES
 


### PR DESCRIPTION
Force `$GO111MODULE=on`, since we don't support non-Modules builds, and fetch Trillian's dependencies before adding it to the image, as this improves cacheability of layers and therefore speeds up image builds.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
