### PR TITLE
Added interceptor for Map WriteLeaves added in #1655.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,8 @@ run:
 linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 25
+    # TODO(mhutchinson): lower this again after reworking interceptor
+    min-complexity: 26
   depguard:
     list-type: blacklist
     packages:

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -55,12 +55,14 @@ var (
 	contextErrCounter    monitoring.Counter
 	metricsOnce          sync.Once
 	enabledServices      = map[string]bool{
-		"trillian.TrillianLog":   true,
-		"trillian.TrillianMap":   true,
-		"trillian.TrillianAdmin": true,
-		"TrillianLog":            true,
-		"TrillianMap":            true,
-		"TrillianAdmin":          true,
+		"trillian.TrillianLog":      true,
+		"trillian.TrillianMap":      true,
+		"trillian.TrillianMapWrite": true,
+		"trillian.TrillianAdmin":    true,
+		"TrillianLog":               true,
+		"TrillianMap":               true,
+		"TrillianMapWrite":          true,
+		"TrillianAdmin":             true,
 	}
 )
 
@@ -438,6 +440,10 @@ func newRPCInfoForRequest(req interface{}) (*rpcInfo, error) {
 
 	// Map / readwrite
 	case *trillian.SetMapLeavesRequest:
+		info.readonly = false
+		info.treeTypes = []trillian.TreeType{trillian.TreeType_MAP}
+		info.tokens = len(req.GetLeaves())
+	case *trillian.WriteMapLeavesRequest:
 		info.readonly = false
 		info.treeTypes = []trillian.TreeType{trillian.TreeType_MAP}
 		info.tokens = len(req.GetLeaves())

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -372,6 +372,19 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			wantTokens: 5,
 		},
 		{
+			desc:   "batchWriteMapLeavesRequest",
+			method: "/trillian.TrillianMapWrite/WriteLeaves",
+			req: &trillian.WriteMapLeavesRequest{
+				MapId:  mapTree.TreeId,
+				Leaves: []*trillian.MapLeaf{{}, {}, {}, {}, {}},
+			},
+			specs: []quota.Spec{
+				{Group: quota.Tree, Kind: quota.Write, TreeID: mapTree.TreeId},
+				{Group: quota.Global, Kind: quota.Write},
+			},
+			wantTokens: 5,
+		},
+		{
 			desc:   "quotaError",
 			method: "/trillian.TrillianLog/GetLatestSignedLogRoot",
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},


### PR DESCRIPTION
Without this change, quota enforcement for WriteLeaves will not be applied even in environments where quota enforcement is enabled.
