### PR TITLE
Use Kaniko cache to accelerate Docker builds in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,41 +15,45 @@ steps:
   - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
   waitFor:
   - pull_mysql
-- id: build_db_server
+- id: push_mysql
   name: gcr.io/cloud-builders/docker
   args:
-  - build
-  - --file=examples/deployment/docker/db_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-  - .
+  - push
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
   waitFor:
   - tag_mysql
-- id: build_log_server
-  name: gcr.io/cloud-builders/docker
+- id: build_db_server
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/db_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-ttl=24h
+  waitFor:
+  - push_mysql
+- id: build_log_server
+  name: gcr.io/kaniko-project/executor
+  args:
+  - --dockerfile=examples/deployment/docker/log_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_signer/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/map_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/map_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 images:
 - gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,8 +51,4 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --cache=true
   waitFor: ["-"]
-images:
-- gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,6 @@ steps:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
   - --cache=true
-  - --cache-ttl=24h
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -37,7 +36,6 @@ steps:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -45,7 +43,6 @@ steps:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -53,7 +50,6 @@ steps:
   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 images:
 - gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -95,8 +95,4 @@ steps:
   - envsubst_kubernetes_configs
   - push_log_server
   - push_log_signer
-images:
-- gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-- gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -32,7 +32,6 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/db_server:latest
   - --cache=true
-  - --cache-ttl=24h
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -42,7 +41,6 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/log_server:latest
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -51,7 +49,6 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/log_signer:latest
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -60,7 +57,6 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/map_server:latest
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_envsubst
   name: gcr.io/cloud-builders/docker

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -26,79 +26,42 @@ steps:
   waitFor:
   - tag_mysql
 - id: build_db_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/db_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-  - --cache-from=gcr.io/${PROJECT_ID}/db_server:latest
-  - .
+  - --dockerfile=examples/deployment/docker/db_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
+  - --destination=gcr.io/${PROJECT_ID}/db_server:latest
+  - --cache=true
+  - --cache-ttl=24h
   waitFor:
   - push_mysql
 - id: build_log_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-  - --cache-from=gcr.io/${PROJECT_ID}/log_server:latest
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/log_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
+  - --destination=gcr.io/${PROJECT_ID}/log_server:latest
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_signer/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-  - --cache-from=gcr.io/${PROJECT_ID}/log_signer:latest
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
+  - --destination=gcr.io/${PROJECT_ID}/log_signer:latest
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/map_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
-  - --cache-from=gcr.io/${PROJECT_ID}/map_server:latest
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/map_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+  - --destination=gcr.io/${PROJECT_ID}/map_server:latest
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
-- id: push_log_server
-  name: gcr.io/cloud-builders/docker
-  args:
-  - push
-  - gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-  waitFor:
-  - build_log_server
-- id: push_log_signer
-  name: gcr.io/cloud-builders/docker
-  args:
-  - push
-  - gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-  waitFor:
-  - build_log_signer
-- id: tag_latest_log_server
-  name: gcr.io/cloud-builders/gcloud
-  args:
-  - container
-  - images
-  - add-tag
-  - gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-  - gcr.io/${PROJECT_ID}/log_server:latest
-  waitFor:
-  - push_log_server
-- id: tag_latest_log_signer
-  name: gcr.io/cloud-builders/gcloud
-  args:
-  - container
-  - images
-  - add-tag
-  - gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-  - gcr.io/${PROJECT_ID}/log_signer:latest
-  waitFor:
-  - push_log_signer
 - id: build_envsubst
   name: gcr.io/cloud-builders/docker
   args:

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -23,40 +23,37 @@ steps:
   waitFor:
   - tag_mysql
 - id: build_db_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/db_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/db_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor:
   - push_mysql
 - id: build_log_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/log_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/log_signer/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
-  - --build-arg=GO111MODULE=on
-  - .
+  - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/kaniko-project/executor
   args:
-  - build
-  - --file=examples/deployment/docker/map_server/Dockerfile
-  - --tag=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
-  - .
+  - --dockerfile=examples/deployment/docker/map_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
+  - --cache=true
+  - --cache-ttl=24h
   waitFor: ["-"]
 images:
 - gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -51,8 +51,4 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
   - --cache=true
   waitFor: ["-"]
-images:
-- gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
-- gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
-- gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
-- gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
+

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -28,7 +28,6 @@ steps:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
   - --cache=true
-  - --cache-ttl=24h
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -37,7 +36,6 @@ steps:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -45,7 +43,6 @@ steps:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -53,7 +50,6 @@ steps:
   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
   - --cache=true
-  - --cache-ttl=24h
   waitFor: ["-"]
 images:
 - gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}


### PR DESCRIPTION
As suggested on https://cloud.google.com/cloud-build/docs/speeding-up-builds. Saves about 5 minutes when building the Docker images from cache, bringing the total build time down from 17 minutes to 12 minutes.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
