### PR TITLE
Fix cases where trillian.Tree protos were being incorrectly passed by value.

### DIFF
--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/testonly/integration"
@@ -181,8 +182,8 @@ func TestVerifyInclusionAtIndex(t *testing.T) {
 
 func TestWaitForInclusion(t *testing.T) {
 	ctx := context.Background()
-	tree := *stestonly.LogTree
-	env, client := clientEnvForTest(ctx, t, &tree)
+	tree := proto.Clone(stestonly.LogTree).(*trillian.Tree)
+	env, client := clientEnvForTest(ctx, t, tree)
 	tree.TreeId = client.LogID
 	defer env.Close()
 
@@ -199,7 +200,7 @@ func TestWaitForInclusion(t *testing.T) {
 			client: &MutatingLogClient{TrillianLogClient: env.Log, mutateInclusionProof: true}, wantErr: true},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			client, err := NewFromTree(test.client, &tree, types.LogRootV1{})
+			client, err := NewFromTree(test.client, tree, types.LogRootV1{})
 			if err != nil {
 				t.Fatalf("NewFromTree(): %v", err)
 			}
@@ -259,8 +260,8 @@ func TestUpdateRoot(t *testing.T) {
 
 func TestUpdateRootSkew(t *testing.T) {
 	ctx := context.Background()
-	tree := *stestonly.LogTree
-	env, client := clientEnvForTest(ctx, t, &tree)
+	tree := proto.Clone(stestonly.LogTree).(*trillian.Tree)
+	env, client := clientEnvForTest(ctx, t, tree)
 	tree.TreeId = client.LogID
 	defer env.Close()
 
@@ -285,7 +286,7 @@ func TestUpdateRootSkew(t *testing.T) {
 
 	// Now force a bad request.
 	badRawClient := &MutatingLogClient{TrillianLogClient: env.Log, mutateRootSize: true}
-	badClient, err := NewFromTree(badRawClient, &tree, *root)
+	badClient, err := NewFromTree(badRawClient, tree, *root)
 	if err != nil {
 		t.Fatalf("failed to create mutating client: %v", err)
 	}

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/storage/testonly"
@@ -48,7 +49,7 @@ func TestNewMapVerifier(t *testing.T) {
 		wantErr bool
 	}{
 		{desc: "success", tree: tree},
-		{desc: "nil PublicKey", tree: func() *trillian.Tree { t := *tree; t.PublicKey = nil; return &t }(), wantErr: true},
+		{desc: "nil PublicKey", tree: func() *trillian.Tree { t := proto.Clone(tree).(*trillian.Tree); t.PublicKey = nil; return t }(), wantErr: true},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			if _, err := NewMapClientFromTree(env.Map, tc.tree); (err != nil) != tc.wantErr {

--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -64,7 +64,7 @@ func mustMarshalAny(p proto.Message) *any.Any {
 }
 
 func TestCreateTree(t *testing.T) {
-	nonDefaultTree := *defaultTree
+	nonDefaultTree := proto.Clone(defaultTree).(*trillian.Tree)
 	nonDefaultTree.TreeType = trillian.TreeType_MAP
 	nonDefaultTree.SignatureAlgorithm = sigpb.DigitallySigned_RSA
 	nonDefaultTree.DisplayName = "Llamas Map"
@@ -84,7 +84,7 @@ func TestCreateTree(t *testing.T) {
 				*displayName = nonDefaultTree.DisplayName
 				*description = nonDefaultTree.Description
 			},
-			wantTree: &nonDefaultTree,
+			wantTree: nonDefaultTree,
 		},
 		{
 			desc: "mandatoryOptsNotSet",
@@ -132,7 +132,7 @@ func TestCreateTree(t *testing.T) {
 				nonDefaultTree.TreeType = trillian.TreeType_MAP
 				*treeType = nonDefaultTree.TreeType.String()
 			},
-			wantTree: &nonDefaultTree,
+			wantTree: nonDefaultTree,
 			initErr:  status.Errorf(codes.Unavailable, "map init failed"),
 			wantErr:  true,
 		},

--- a/cmd/createtree/pem_test.go
+++ b/cmd/createtree/pem_test.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
@@ -26,7 +28,7 @@ import (
 func TestWithPEMKeyFile(t *testing.T) {
 	pemPath, pemPassword := "../../testdata/log-rpc-server.privkey.pem", "towel"
 
-	wantTree := *defaultTree
+	wantTree := proto.Clone(defaultTree).(*trillian.Tree)
 	wantTree.PrivateKey = mustMarshalAny(&keyspb.PEMKeyFile{
 		Path:     pemPath,
 		Password: pemPassword,
@@ -60,7 +62,7 @@ func TestWithPEMKeyFile(t *testing.T) {
 				*pemKeyPath = pemPath
 				*pemKeyPass = pemPassword
 			},
-			wantTree: &wantTree,
+			wantTree: wantTree,
 		},
 	})
 }
@@ -78,7 +80,7 @@ func TestWithPrivateKey(t *testing.T) {
 		t.Fatalf("Error marshaling test private key to DER: %v", err)
 	}
 
-	wantTree := *defaultTree
+	wantTree := proto.Clone(defaultTree).(*trillian.Tree)
 	wantTree.PrivateKey = mustMarshalAny(&keyspb.PrivateKey{
 		Der: keyDER,
 	})
@@ -111,7 +113,7 @@ func TestWithPrivateKey(t *testing.T) {
 				*pemKeyPath = pemPath
 				*pemKeyPass = pemPassword
 			},
-			wantTree: &wantTree,
+			wantTree: wantTree,
 		},
 	})
 }

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/server/interceptor"
 	"github.com/google/trillian/storage"
@@ -123,7 +124,7 @@ func TestAdminServer_CreateTree(t *testing.T) {
 			t.Errorf("%v: GetTree() = (_, %v), want = (_, nil)", test.desc, err)
 			continue
 		}
-		if diff := pretty.Compare(storedTree, createdTree); diff != "" {
+		if diff := cmp.Diff(storedTree, createdTree, cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%v: post-CreateTree diff (-stored +created):\n%v", test.desc, diff)
 		}
 	}
@@ -321,7 +322,7 @@ func TestAdminServer_ListTrees(t *testing.T) {
 
 		got := resp.Tree
 		sortByTreeID(got)
-		if diff := pretty.Compare(got, createdTrees); diff != "" {
+		if diff := cmp.Diff(got, createdTrees, cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%v: post-ListTrees diff:\n%v", test.desc, diff)
 		}
 

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -138,7 +138,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 	}
 	defer ts.closeAll()
 
-	baseTree := *testonly.LogTree
+	baseTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 
 	// successTree specifies changes in all rw fields
 	successTree := &trillian.Tree{
@@ -148,7 +148,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 	}
 	successMask := &field_mask.FieldMask{Paths: []string{"tree_state", "display_name", "description"}}
 
-	successWant := baseTree
+	successWant := proto.Clone(baseTree).(*trillian.Tree)
 	successWant.TreeState = successTree.TreeState
 	successWant.DisplayName = successTree.DisplayName
 	successWant.Description = successTree.Description
@@ -162,8 +162,8 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 	}{
 		{
 			desc:       "success",
-			createTree: &baseTree,
-			wantTree:   &successWant,
+			createTree: baseTree,
+			wantTree:   successWant,
 			req:        &trillian.UpdateTreeRequest{Tree: successTree, UpdateMask: successMask},
 		},
 		{
@@ -176,7 +176,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 		},
 		{
 			desc:       "readonlyField",
-			createTree: &baseTree,
+			createTree: baseTree,
 			req: &trillian.UpdateTreeRequest{
 				Tree:       successTree,
 				UpdateMask: &field_mask.FieldMask{Paths: []string{"tree_type"}},
@@ -185,7 +185,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 		},
 		{
 			desc:       "invalidUpdate",
-			createTree: &baseTree,
+			createTree: baseTree,
 			req: &trillian.UpdateTreeRequest{
 				Tree:       &trillian.Tree{}, // tree_state = UNKNOWN_TREE_STATE
 				UpdateMask: &field_mask.FieldMask{Paths: []string{"tree_state"}},
@@ -225,12 +225,12 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 		}
 
 		// Copy storage-generated fields to the expected tree
-		want := *test.wantTree
+		want := proto.Clone(test.wantTree).(*trillian.Tree)
 		want.TreeId = tree.TreeId
 		want.CreateTime = tree.CreateTime
 		want.UpdateTime = tree.UpdateTime
-		if !proto.Equal(tree, &want) {
-			diff := pretty.Compare(tree, &want)
+		if !proto.Equal(tree, want) {
+			diff := pretty.Compare(tree, want)
 			t.Errorf("%v: post-UpdateTree diff:\n%v", test.desc, diff)
 		}
 	}

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -264,7 +264,7 @@ func TestServer_GetTree(t *testing.T) {
 		if test.getErr {
 			tx.EXPECT().GetTree(gomock.Any(), storedTree.TreeId).Return(nil, errors.New("GetTree failed"))
 		} else {
-			tx.EXPECT().GetTree(gomock.Any(), storedTree.TreeId).Return(&storedTree, nil)
+			tx.EXPECT().GetTree(gomock.Any(), storedTree.TreeId).Return(storedTree, nil)
 		}
 		wantErr := test.getErr || test.commitErr
 

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -501,7 +501,7 @@ func TestServer_CreateTree(t *testing.T) {
 					newTree.TreeId = 12345
 					newTree.CreateTime = nowPB
 					newTree.UpdateTime = nowPB
-				}).Return(&newTree, test.createErr)
+				}).Return(newTree, test.createErr)
 			}
 
 			// Copy test.req so that any changes CreateTree makes don't affect the original, which may be shared between tests.

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -553,7 +553,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			admin := storage.NewMockAdminStorage(ctrl)
 			adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 			admin.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(adminTX, nil)
-			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(&logTree, nil)
+			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(logTree, nil)
 			adminTX.EXPECT().Close().AnyTimes().Return(nil)
 			adminTX.EXPECT().Commit().AnyTimes().Return(nil)
 			putTokensCh := make(chan bool, 1)
@@ -663,7 +663,7 @@ func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
 			admin := storage.NewMockAdminStorage(ctrl)
 			adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 			admin.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(adminTX, nil)
-			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(&logTree, nil)
+			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(logTree, nil)
 			adminTX.EXPECT().Close().AnyTimes().Return(nil)
 			adminTX.EXPECT().Commit().AnyTimes().Return(nil)
 

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -405,9 +405,9 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			admin := storage.NewMockAdminStorage(ctrl)
 			adminTX := storage.NewMockReadOnlyAdminTX(ctrl)
 			admin.EXPECT().Snapshot(gomock.Any()).AnyTimes().Return(adminTX, nil)
-			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(&logTree, nil)
-			adminTX.EXPECT().GetTree(gomock.Any(), mapTree.TreeId).AnyTimes().Return(&mapTree, nil)
-			adminTX.EXPECT().GetTree(gomock.Any(), preorderedTree.TreeId).AnyTimes().Return(&preorderedTree, nil)
+			adminTX.EXPECT().GetTree(gomock.Any(), logTree.TreeId).AnyTimes().Return(logTree, nil)
+			adminTX.EXPECT().GetTree(gomock.Any(), mapTree.TreeId).AnyTimes().Return(mapTree, nil)
+			adminTX.EXPECT().GetTree(gomock.Any(), preorderedTree.TreeId).AnyTimes().Return(preorderedTree, nil)
 			adminTX.EXPECT().Close().AnyTimes().Return(nil)
 			adminTX.EXPECT().Commit().AnyTimes().Return(nil)
 

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -192,13 +192,13 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 
 func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 
-	logTree := *testonly.LogTree
+	logTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	logTree.TreeId = 10
 
-	mapTree := *testonly.MapTree
+	mapTree := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	mapTree.TreeId = 11
 
-	preorderedTree := *testonly.PreorderedLogTree
+	preorderedTree := proto.Clone(testonly.PreorderedLogTree).(*trillian.Tree)
 	preorderedTree.TreeId = 12
 
 	charge1 := "alpaca"
@@ -432,8 +432,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 }
 
 func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
-
-	logTree := *testonly.LogTree
+	logTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	logTree.TreeId = 10
 
 	tests := []struct {
@@ -631,7 +630,7 @@ func TestTrillianInterceptor_NotIntercepted(t *testing.T) {
 // difficult/impossible to get unless the methods are called separately (i.e., not via
 // UnaryInterceptor()).
 func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
-	logTree := *testonly.LogTree
+	logTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	logTree.TreeId = 10
 
 	qm := quota.Noop()

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -83,7 +83,7 @@ var (
 	fixedSigner   = tcrypto.NewSigner(0, fixedGoSigner, crypto.SHA256)
 
 	tree1              = addTreeID(stestonly.LogTree, logID1)
-	getLogRootRequest1 = trillian.GetLatestSignedLogRootRequest{LogId: logID1}
+	getLogRootRequest1 = &trillian.GetLatestSignedLogRootRequest{LogId: logID1}
 	revision1          = int64(5)
 	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7, Revision: uint64(revision1)}
 	signedRoot1, _     = fixedSigner.SignLogRoot(root1)
@@ -576,13 +576,13 @@ func TestAddSequencedLeaves(t *testing.T) {
 }
 
 type latestRootTest struct {
-	req         trillian.GetLatestSignedLogRootRequest
-	wantRoot    trillian.GetLatestSignedLogRootResponse
+	req         *trillian.GetLatestSignedLogRootRequest
+	wantRoot    *trillian.GetLatestSignedLogRootResponse
 	errStr      string
 	noSnap      bool
 	snapErr     error
 	noRoot      bool
-	storageRoot trillian.SignedLogRoot
+	storageRoot *trillian.SignedLogRoot
 	rootErr     error
 	noCommit    bool
 	commitErr   error
@@ -619,8 +619,8 @@ func TestGetLatestSignedLogRoot(t *testing.T) {
 		{
 			// Test normal case where a root is returned correctly.
 			req:         getLogRootRequest1,
-			wantRoot:    trillian.GetLatestSignedLogRootResponse{SignedLogRoot: signedRoot1},
-			storageRoot: *signedRoot1,
+			wantRoot:    &trillian.GetLatestSignedLogRootResponse{SignedLogRoot: signedRoot1},
+			storageRoot: proto.Clone(signedRoot1).(*trillian.SignedLogRoot),
 		},
 	}
 
@@ -645,7 +645,7 @@ func TestGetLatestSignedLogRoot(t *testing.T) {
 			LogStorage:   fakeStorage,
 		}
 		s := NewTrillianLogRPCServer(registry, fakeTimeSource)
-		got, err := s.GetLatestSignedLogRoot(context.Background(), &test.req)
+		got, err := s.GetLatestSignedLogRoot(context.Background(), test.req)
 		if len(test.errStr) > 0 {
 			if err == nil || !strings.Contains(err.Error(), test.errStr) {
 				t.Errorf("GetLatestSignedLogRoot(%+v)=_,nil, want: _,err contains: %s but got: %v", test.req, test.errStr, err)
@@ -2063,7 +2063,7 @@ func TestInitLog(t *testing.T) {
 		getRootErr error
 		storeErr   error
 		wantInit   bool
-		slr        trillian.SignedLogRoot
+		slr        *trillian.SignedLogRoot
 		wantCode   codes.Code
 		wantErrStr string
 	}{
@@ -2075,7 +2075,7 @@ func TestInitLog(t *testing.T) {
 		{desc: "init new log", getRootErr: storage.ErrTreeNeedsInit, wantInit: true, wantCode: codes.OK},
 		{desc: "init new preordered log", preordered: true, getRootErr: storage.ErrTreeNeedsInit, wantInit: true, wantCode: codes.OK},
 		{desc: "init new log, no err", wantInit: true, wantCode: codes.OK},
-		{desc: "init already initialised log", wantInit: false, slr: *signedRoot, wantCode: codes.AlreadyExists},
+		{desc: "init already initialised log", wantInit: false, slr: proto.Clone(signedRoot).(*trillian.SignedLogRoot), wantCode: codes.AlreadyExists},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
@@ -2278,9 +2278,9 @@ type storageParams struct {
 }
 
 func fakeAdminStorage(ctrl *gomock.Controller, params storageParams) storage.AdminStorage {
-	tree := *stestonly.LogTree
+	tree := proto.Clone(stestonly.LogTree).(*trillian.Tree)
 	if params.preordered {
-		tree = *stestonly.PreorderedLogTree
+		tree = proto.Clone(stestonly.PreorderedLogTree).(*trillian.Tree)
 	}
 	tree.TreeId = params.treeID
 

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -338,7 +338,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 }
 
 func fakeAdminStorageForMap(ctrl *gomock.Controller, times int, treeID int64) storage.AdminStorage {
-	tree := *stestonly.MapTree
+	tree := proto.Clone(stestonly.MapTree).(*trillian.Tree)
 	tree.TreeId = treeID
 
 	adminTX := storage.NewMockReadOnlyAdminTX(ctrl)

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -346,7 +346,7 @@ func fakeAdminStorageForMap(ctrl *gomock.Controller, times int, treeID int64) st
 		ReadOnlyTX: []storage.ReadOnlyAdminTX{adminTX},
 	}
 
-	adminTX.EXPECT().GetTree(gomock.Any(), treeID).MaxTimes(times).Return(&tree, nil)
+	adminTX.EXPECT().GetTree(gomock.Any(), treeID).MaxTimes(times).Return(tree, nil)
 	adminTX.EXPECT().Close().MaxTimes(times).Return(nil)
 	adminTX.EXPECT().Commit().MaxTimes(times).Return(nil)
 

--- a/storage/cloudspanner/admin.go
+++ b/storage/cloudspanner/admin.go
@@ -508,9 +508,9 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	if err != nil {
 		return nil, err
 	}
-	beforeTree := *tree
+	beforeTree := proto.Clone(tree).(*trillian.Tree)
 	updateFunc(tree)
-	if err = storage.ValidateTreeForUpdate(ctx, &beforeTree, tree); err != nil {
+	if err = storage.ValidateTreeForUpdate(ctx, beforeTree, tree); err != nil {
 		return nil, err
 	}
 	if !proto.Equal(beforeTree.StorageSettings, tree.StorageSettings) {

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -114,7 +114,7 @@ func (a kv) Less(b btree.Item) bool {
 func newTree(t *trillian.Tree) *tree {
 	ret := &tree{
 		store: btree.New(degree),
-		meta:  t,
+		meta:  proto.Clone(t).(*trillian.Tree),
 	}
 	k := unseqKey(t.TreeId)
 	k.(*kv).v = list.New()

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -111,10 +111,10 @@ func (a kv) Less(b btree.Item) bool {
 }
 
 // newTree creates and initializes a tree struct.
-func newTree(t trillian.Tree) *tree {
+func newTree(t *trillian.Tree) *tree {
 	ret := &tree{
 		store: btree.New(degree),
-		meta:  &t,
+		meta:  t,
 	}
 	k := unseqKey(t.TreeId)
 	k.(*kv).v = list.New()

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -246,7 +246,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	nowMillis := storage.ToMillisSinceEpoch(time.Now())
 	now := storage.FromMillisSinceEpoch(nowMillis)
 
-	newTree := *tree
+	newTree := proto.Clone(tree).(*trillian.Tree)
 	newTree.TreeId = id
 	newTree.CreateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
@@ -340,7 +340,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 		return nil, err
 	}
 
-	return &newTree, nil
+	return newTree, nil
 }
 
 func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error) {
@@ -349,9 +349,9 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 		return nil, err
 	}
 
-	beforeUpdate := *tree
+	beforeUpdate := proto.Clone(tree).(*trillian.Tree)
 	updateFunc(tree)
-	if err := storage.ValidateTreeForUpdate(ctx, &beforeUpdate, tree); err != nil {
+	if err := storage.ValidateTreeForUpdate(ctx, beforeUpdate, tree); err != nil {
 		return nil, err
 	}
 	if err := validateStorageSettings(tree); err != nil {

--- a/storage/mysql/admin_storage_test.go
+++ b/storage/mysql/admin_storage_test.go
@@ -165,9 +165,9 @@ func TestAdminTX_StorageSettingsNotSupported(t *testing.T) {
 		{
 			desc: "CreateTree",
 			fn: func(s storage.AdminStorage) error {
-				tree := *testonly.LogTree
+				tree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 				tree.StorageSettings = settings
-				_, err := storage.CreateTree(ctx, s, &tree)
+				_, err := storage.CreateTree(ctx, s, tree)
 				return err
 			},
 		},

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -1206,12 +1206,12 @@ func TestGetActiveLogIDs(t *testing.T) {
 	map1 := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	map2 := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	deletedMap := proto.Clone(testonly.MapTree).(*trillian.Tree)
-	for _, tree := range []*trillian.Tree{log1, log2, log3, drainingLog, frozenLog, deletedLog, map1, map2, deletedMap} {
-		newTree, err := storage.CreateTree(ctx, admin, tree)
+	for _, tree := range []**trillian.Tree{&log1, &log2, &log3, &drainingLog, &frozenLog, &deletedLog, &map1, &map2, &deletedMap} {
+		newTree, err := storage.CreateTree(ctx, admin, *tree)
 		if err != nil {
 			t.Fatalf("CreateTree(%+v) returned err = %v", tree, err)
 		}
-		*tree = *newTree
+		*tree = newTree
 	}
 
 	// FROZEN is not a valid initial state, so we have to update it separately.

--- a/storage/postgres/admin_storage.go
+++ b/storage/postgres/admin_storage.go
@@ -285,7 +285,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	nowMillis := storage.ToMillisSinceEpoch(time.Now())
 	now := storage.FromMillisSinceEpoch(nowMillis)
 
-	newTree := *tree
+	newTree := proto.Clone(tree).(*trillian.Tree)
 	newTree.TreeId = id
 	newTree.CreateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
@@ -347,7 +347,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 		return nil, err
 	}
 
-	return &newTree, nil
+	return newTree, nil
 }
 
 func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(*trillian.Tree)) (*trillian.Tree, error) {
@@ -356,9 +356,9 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 		return nil, err
 	}
 
-	beforeUpdate := *tree
+	beforeUpdate := proto.Clone(tree).(*trillian.Tree)
 	updateFunc(tree)
-	if err := storage.ValidateTreeForUpdate(ctx, &beforeUpdate, tree); err != nil {
+	if err := storage.ValidateTreeForUpdate(ctx, beforeUpdate, tree); err != nil {
 		return nil, err
 	}
 	if err := validateStorageSettings(tree); err != nil {

--- a/storage/postgres/admin_storage_test.go
+++ b/storage/postgres/admin_storage_test.go
@@ -168,9 +168,9 @@ func TestAdminTX_StorageSettingsNotSupported(t *testing.T) {
 		{
 			desc: "CreateTree",
 			fn: func(s storage.AdminStorage) error {
-				tree := *testonly.LogTree
+				tree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 				tree.StorageSettings = settings
-				_, err := storage.CreateTree(ctx, s, &tree)
+				_, err := storage.CreateTree(ctx, s, tree)
 				return err
 			},
 		},

--- a/storage/postgres/log_storage_test.go
+++ b/storage/postgres/log_storage_test.go
@@ -1101,12 +1101,12 @@ func TestGetActiveLogIDs(t *testing.T) {
 	map1 := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	map2 := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	deletedMap := proto.Clone(testonly.MapTree).(*trillian.Tree)
-	for _, tree := range []*trillian.Tree{log1, log2, log3, drainingLog, frozenLog, deletedLog, map1, map2, deletedMap} {
-		newTree, err := storage.CreateTree(ctx, admin, tree)
+	for _, tree := range []**trillian.Tree{&log1, &log2, &log3, &drainingLog, &frozenLog, &deletedLog, &map1, &map2, &deletedMap} {
+		newTree, err := storage.CreateTree(ctx, admin, *tree)
 		if err != nil {
 			t.Fatalf("CreateTree(%+v) returned err = %v", tree, err)
 		}
-		*tree = *newTree
+		*tree = newTree
 	}
 
 	// FROZEN is not a valid initial state, so we have to update it separately.

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -297,7 +297,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 		tree.DisplayName = ""
 		tree.Description = ""
 	}
-	validLogWithoutOptionals := referenceLog
+	validLogWithoutOptionals := proto.Clone(referenceLog).(*trillian.Tree)
 	validLogWithoutOptionalsFunc(validLogWithoutOptionals)
 
 	invalidLogFunc := func(tree *trillian.Tree) {

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -187,14 +187,14 @@ func (tester *AdminStorageTester) RunAllTests(t *testing.T) {
 func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 	// Check that validation runs, but leave details to the validation
 	// tests.
-	invalidTree := *LogTree
+	invalidTree := proto.Clone(LogTree).(*trillian.Tree)
 	invalidTree.TreeType = trillian.TreeType_UNKNOWN_TREE_TYPE
 
-	validTree1 := *LogTree
-	validTree2 := *MapTree
-	validTree3 := *PreorderedLogTree
+	validTree1 := proto.Clone(LogTree).(*trillian.Tree)
+	validTree2 := proto.Clone(MapTree).(*trillian.Tree)
+	validTree3 := proto.Clone(PreorderedLogTree).(*trillian.Tree)
 
-	validTreeWithoutOptionals := *LogTree
+	validTreeWithoutOptionals := proto.Clone(LogTree).(*trillian.Tree)
 	validTreeWithoutOptionals.DisplayName = ""
 	validTreeWithoutOptionals.Description = ""
 
@@ -205,24 +205,24 @@ func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 	}{
 		{
 			desc:    "invalidTree",
-			tree:    &invalidTree,
+			tree:    invalidTree,
 			wantErr: true,
 		},
 		{
 			desc: "validTree1",
-			tree: &validTree1,
+			tree: validTree1,
 		},
 		{
 			desc: "validTree2",
-			tree: &validTree2,
+			tree: validTree2,
 		},
 		{
 			desc: "validTree3",
-			tree: &validTree3,
+			tree: validTree3,
 		},
 		{
 			desc: "validTreeWithoutOptionals",
-			tree: &validTreeWithoutOptionals,
+			tree: validTreeWithoutOptionals,
 		},
 	}
 
@@ -256,13 +256,13 @@ func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 				return
 			}
 
-			wantTree := *test.tree
+			wantTree := proto.Clone(test.tree).(*trillian.Tree)
 			wantTree.TreeId = newTree.TreeId
 			wantTree.CreateTime = createTime
 			wantTree.UpdateTime = updateTime
 			// Ignore storage_settings changes (OK to vary between implementations)
 			wantTree.StorageSettings = newTree.StorageSettings
-			if !proto.Equal(newTree, &wantTree) {
+			if !proto.Equal(newTree, wantTree) {
 				diff := pretty.Compare(newTree, &wantTree)
 				t.Errorf("%v: post-CreateTree diff:\n%v", test.desc, diff)
 				return
@@ -282,7 +282,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 
 	unrelatedTree := makeTreeOrFail(ctx, s, spec{Tree: MapTree}, t.Fatalf)
 
-	referenceLog := *LogTree
+	referenceLog := proto.Clone(LogTree).(*trillian.Tree)
 	validLog := referenceLog
 	validLog.TreeState = trillian.TreeState_FROZEN
 	validLog.DisplayName = "Frozen Tree"
@@ -298,7 +298,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 		tree.Description = ""
 	}
 	validLogWithoutOptionals := referenceLog
-	validLogWithoutOptionalsFunc(&validLogWithoutOptionals)
+	validLogWithoutOptionalsFunc(validLogWithoutOptionals)
 
 	invalidLogFunc := func(tree *trillian.Tree) {
 		tree.TreeState = trillian.TreeState_UNKNOWN_TREE_STATE
@@ -308,7 +308,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 		tree.TreeType = trillian.TreeType_MAP
 	}
 
-	referenceMap := *MapTree
+	referenceMap := proto.Clone(MapTree).(*trillian.Tree)
 	validMap := referenceMap
 	validMap.DisplayName = "Updated Map"
 	validMapFunc := func(tree *trillian.Tree) {
@@ -316,7 +316,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 	}
 
 	newPrivateKey := &empty.Empty{}
-	privateKeyChangedButKeyMaterialSameTree := *LogTree
+	privateKeyChangedButKeyMaterialSameTree := proto.Clone(LogTree).(*trillian.Tree)
 	privateKeyChangedButKeyMaterialSameTree.PrivateKey = testonly.MustMarshalAny(t, newPrivateKey)
 	keys.RegisterHandler(newPrivateKey, func(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
 		return pem.UnmarshalPrivateKey(privateKeyPEM, privateKeyPass)
@@ -346,43 +346,43 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 	}{
 		{
 			desc:       "validLog",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: validLogFunc,
-			want:       &validLog,
+			want:       validLog,
 		},
 		{
 			desc:       "validLogWithoutOptionals",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: validLogWithoutOptionalsFunc,
-			want:       &validLogWithoutOptionals,
+			want:       validLogWithoutOptionals,
 		},
 		{
 			desc:       "invalidLog",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: invalidLogFunc,
 			wantErr:    true,
 		},
 		{
 			desc:       "readonlyChanged",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: readonlyChangedFunc,
 			wantErr:    true,
 		},
 		{
 			desc:       "validMap",
-			create:     &referenceMap,
+			create:     referenceMap,
 			updateFunc: validMapFunc,
-			want:       &validMap,
+			want:       validMap,
 		},
 		{
 			desc:       "privateKeyChangedButKeyMaterialSame",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: privateKeyChangedButKeyMaterialSameFunc,
-			want:       &privateKeyChangedButKeyMaterialSameTree,
+			want:       privateKeyChangedButKeyMaterialSameTree,
 		},
 		{
 			desc:       "privateKeyChangedAndKeyMaterialDifferent",
-			create:     &referenceLog,
+			create:     referenceLog,
 			updateFunc: privateKeyChangedAndKeyMaterialDifferentFunc,
 			wantErr:    true,
 		},
@@ -420,13 +420,13 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 			t.Errorf("%v: UpdateTime = %v, want >= %v", test.desc, updatedTree.UpdateTime, createdTree.UpdateTime)
 		}
 		// Copy storage-generated values to want before comparing
-		wantTree := *test.want
+		wantTree := proto.Clone(test.want).(*trillian.Tree)
 		wantTree.TreeId = updatedTree.TreeId
 		wantTree.CreateTime = updatedTree.CreateTime
 		wantTree.UpdateTime = updatedTree.UpdateTime
 		// Ignore storage_settings changes (OK to vary between implementations)
 		wantTree.StorageSettings = updatedTree.StorageSettings
-		if !proto.Equal(updatedTree, &wantTree) {
+		if !proto.Equal(updatedTree, wantTree) {
 			diff := pretty.Compare(updatedTree, &wantTree)
 			t.Errorf("%v: updatedTree doesn't match wantTree:\n%s", test.desc, diff)
 		}

--- a/storage/tree_validation_test.go
+++ b/storage/tree_validation_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -423,10 +424,10 @@ func TestValidateTreeForUpdate(t *testing.T) {
 			tree.TreeState = test.treeState
 		}
 
-		baseTree := *tree
+		baseTree := proto.Clone(tree).(*trillian.Tree)
 		test.updatefn(tree)
 
-		err := ValidateTreeForUpdate(ctx, &baseTree, tree)
+		err := ValidateTreeForUpdate(ctx, baseTree, tree)
 		switch hasErr := err != nil; {
 		case hasErr != test.wantErr:
 			t.Errorf("%v: ValidateTreeForUpdate() = %v, wantErr = %v", test.desc, err, test.wantErr)

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -64,21 +64,21 @@ func TestFromContext(t *testing.T) {
 }
 
 func TestGetTree(t *testing.T) {
-	logTree := *testonly.LogTree
+	logTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	logTree.TreeId = 1
 
-	mapTree := *testonly.MapTree
+	mapTree := proto.Clone(testonly.MapTree).(*trillian.Tree)
 	mapTree.TreeId = 2
 
-	frozenTree := *testonly.LogTree
+	frozenTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	frozenTree.TreeId = 3
 	frozenTree.TreeState = trillian.TreeState_FROZEN
 
-	drainingTree := *testonly.LogTree
+	drainingTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	drainingTree.TreeId = 3
 	drainingTree.TreeState = trillian.TreeState_DRAINING
 
-	softDeletedTree := *testonly.LogTree
+	softDeletedTree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 	softDeletedTree.Deleted = true
 	softDeletedTree.DeleteTime = ptypes.TimestampNow()
 
@@ -95,42 +95,42 @@ func TestGetTree(t *testing.T) {
 			desc:        "anyTree",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query),
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:        "logTree",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:        "mapTree",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_MAP),
-			storageTree: &mapTree,
-			wantTree:    &mapTree,
+			storageTree: mapTree,
+			wantTree:    mapTree,
 		},
 		{
 			desc:        "logTreeButMaybeMap",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG, trillian.TreeType_MAP),
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:        "mapTreeButMaybeLog",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG, trillian.TreeType_MAP),
-			storageTree: &mapTree,
-			wantTree:    &mapTree,
+			storageTree: mapTree,
+			wantTree:    mapTree,
 		},
 		{
 			desc:        "wrongType1",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_MAP),
-			storageTree: &logTree,
+			storageTree: logTree,
 			wantErr:     true,
 			code:        codes.InvalidArgument,
 		},
@@ -138,7 +138,7 @@ func TestGetTree(t *testing.T) {
 			desc:        "wrongType2",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &mapTree,
+			storageTree: mapTree,
 			wantErr:     true,
 			code:        codes.InvalidArgument,
 		},
@@ -146,7 +146,7 @@ func TestGetTree(t *testing.T) {
 			desc:        "wrongType3",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG, trillian.TreeType_PREORDERED_LOG),
-			storageTree: &mapTree,
+			storageTree: mapTree,
 			wantErr:     true,
 			code:        codes.InvalidArgument,
 		},
@@ -154,8 +154,8 @@ func TestGetTree(t *testing.T) {
 			desc:        "adminLog",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Admin, trillian.TreeType_LOG),
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:        "adminPreordered",
@@ -168,22 +168,22 @@ func TestGetTree(t *testing.T) {
 			desc:        "adminFrozen",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Admin, trillian.TreeType_LOG),
-			storageTree: &frozenTree,
-			wantTree:    &frozenTree,
+			storageTree: frozenTree,
+			wantTree:    frozenTree,
 		},
 		{
 			desc:        "adminMap",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Admin, trillian.TreeType_MAP),
-			storageTree: &mapTree,
-			wantTree:    &mapTree,
+			storageTree: mapTree,
+			wantTree:    mapTree,
 		},
 		{
 			desc:        "queryLog",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:        "queryPreordered",
@@ -196,22 +196,22 @@ func TestGetTree(t *testing.T) {
 			desc:        "queryMap",
 			treeID:      mapTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_MAP),
-			storageTree: &mapTree,
-			wantTree:    &mapTree,
+			storageTree: mapTree,
+			wantTree:    mapTree,
 		},
 		{
 			desc:        "queryFrozen",
 			treeID:      frozenTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &frozenTree,
-			wantTree:    &frozenTree,
+			storageTree: frozenTree,
+			wantTree:    frozenTree,
 		},
 		{
 			desc:        "sequenceFrozen",
 			treeID:      frozenTree.TreeId,
 			opts:        NewGetOpts(SequenceLog, trillian.TreeType_LOG),
-			storageTree: &frozenTree,
-			wantTree:    &frozenTree,
+			storageTree: frozenTree,
+			wantTree:    frozenTree,
 			wantErr:     true,
 			code:        codes.PermissionDenied,
 		},
@@ -219,8 +219,8 @@ func TestGetTree(t *testing.T) {
 			desc:        "queueFrozen",
 			treeID:      frozenTree.TreeId,
 			opts:        NewGetOpts(QueueLog, trillian.TreeType_LOG),
-			storageTree: &frozenTree,
-			wantTree:    &frozenTree,
+			storageTree: frozenTree,
+			wantTree:    frozenTree,
 			wantErr:     true,
 			code:        codes.PermissionDenied,
 		},
@@ -228,22 +228,22 @@ func TestGetTree(t *testing.T) {
 			desc:        "queryDraining",
 			treeID:      drainingTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &drainingTree,
-			wantTree:    &drainingTree,
+			storageTree: drainingTree,
+			wantTree:    drainingTree,
 		},
 		{
 			desc:        "sequenceDraining",
 			treeID:      drainingTree.TreeId,
 			opts:        NewGetOpts(SequenceLog, trillian.TreeType_LOG),
-			storageTree: &drainingTree,
-			wantTree:    &drainingTree,
+			storageTree: drainingTree,
+			wantTree:    drainingTree,
 		},
 		{
 			desc:        "queueDraining",
 			treeID:      drainingTree.TreeId,
 			opts:        NewGetOpts(QueueLog, trillian.TreeType_LOG),
-			storageTree: &drainingTree,
-			wantTree:    &drainingTree,
+			storageTree: drainingTree,
+			wantTree:    drainingTree,
 			wantErr:     true,
 			code:        codes.PermissionDenied,
 		},
@@ -251,7 +251,7 @@ func TestGetTree(t *testing.T) {
 			desc:        "softDeleted",
 			treeID:      softDeletedTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			storageTree: &softDeletedTree,
+			storageTree: softDeletedTree,
 			wantErr:     true, // Deleted = true makes the tree "invisible" for most RPCs
 			code:        codes.NotFound,
 		},
@@ -259,16 +259,16 @@ func TestGetTree(t *testing.T) {
 			desc:     "treeInCtx",
 			treeID:   logTree.TreeId,
 			opts:     NewGetOpts(Query, trillian.TreeType_LOG),
-			ctxTree:  &logTree,
-			wantTree: &logTree,
+			ctxTree:  logTree,
+			wantTree: logTree,
 		},
 		{
 			desc:        "wrongTreeInCtx",
 			treeID:      logTree.TreeId,
 			opts:        NewGetOpts(Query, trillian.TreeType_LOG),
-			ctxTree:     &mapTree,
-			storageTree: &logTree,
-			wantTree:    &logTree,
+			ctxTree:     mapTree,
+			storageTree: logTree,
+			wantTree:    logTree,
 		},
 		{
 			desc:     "beginErr",
@@ -338,10 +338,10 @@ func TestHash(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tree := *testonly.LogTree
+		tree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 		tree.HashAlgorithm = test.hashAlgo
 
-		hash, err := Hash(&tree)
+		hash, err := Hash(tree)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("Hash(%s) = (_, %q), wantErr = %v", test.hashAlgo, err, test.wantErr)
 			continue
@@ -414,7 +414,7 @@ func TestSigner(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			tree := *testonly.LogTree
+			tree := proto.Clone(testonly.LogTree).(*trillian.Tree)
 			tree.HashAlgorithm = sigpb.DigitallySigned_SHA256
 			tree.HashStrategy = trillian.HashStrategy_RFC6962_SHA256
 			tree.SignatureAlgorithm = test.sigAlgo
@@ -432,7 +432,7 @@ func TestSigner(t *testing.T) {
 			})
 			defer keys.UnregisterHandler(wantKeyProto.Message)
 
-			signer, err := Signer(ctx, &tree)
+			signer, err := Signer(ctx, tree)
 			if hasErr := err != nil; hasErr != test.wantErr {
 				t.Fatalf("Signer(_, %s) = (_, %q), wantErr = %v", test.sigAlgo, err, test.wantErr)
 			} else if hasErr {


### PR DESCRIPTION
Also where they were being compared in ways liable to break. The impact is mostly limited to tests but includes minor changes to admin storage implementations.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
