### PR TITLE
Stop removing ConfigMaps when deploying Trillian on Kubernetes

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -126,9 +126,6 @@ steps:
   - -f=examples/deployment/kubernetes/trillian-log-service.yaml
   - -f=examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
   - -f=examples/deployment/kubernetes/trillian-log-signer-service.yaml
-  - --prune
-  - --all
-  - --prune-whitelist=core/v1/ConfigMap
   env:
   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}


### PR DESCRIPTION
This would delete a CTFE's ConfigMap if it's already present, which is undesirable.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
