### PR TITLE
Enable goproxy in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
 env:
   global:
   - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
   matrix:
   - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters"


### PR DESCRIPTION
Trial using the Google module proxy in travis builds:
 - in preparation for [Golang module transparency](https://blog.golang.org/modules2019)
 - Make dep fetching faster and more reliable.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
