### PR TITLE
Increase Cloud Build timeout from 15 mins to 20 mins

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 900s
+timeout: 1200s
 substitutions:
   _MYSQL_TAG: "5.7"
 steps:

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -1,4 +1,4 @@
-timeout: 900s
+timeout: 1200s
 substitutions:
   _CLUSTER_NAME: trillian-opensource-ci
   _MASTER_ZONE: us-central1-a

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,4 +1,4 @@
-timeout: 900s
+timeout: 1200s
 substitutions:
   _MYSQL_TAG: "5.7"
 steps:


### PR DESCRIPTION
Since we enabled Go Modules, builds are taking significantly longer and
often timing out.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
