### PR TITLE
Fix incorrect copying / other usages of trillian log api protos.

### DIFF
--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -254,7 +254,7 @@ func (t *TrillianLogRPCServer) GetInclusionProof(ctx context.Context, req *trill
 		return nil, err
 	}
 
-	r.Proof = &proof
+	r.Proof = proof
 
 	return r, nil
 }
@@ -310,7 +310,7 @@ func (t *TrillianLogRPCServer) GetInclusionProofByHash(ctx context.Context, req 
 		if err != nil {
 			return nil, err
 		}
-		proofs = append(proofs, &proof)
+		proofs = append(proofs, proof)
 		t.recordIndexPercent(leaf.LeafIndex, root.TreeSize)
 	}
 
@@ -453,7 +453,7 @@ func tryGetConsistencyProof(ctx context.Context, firstTreeSize, secondTreeSize, 
 	if err != nil {
 		return nil, err
 	}
-	return &proof, nil
+	return proof, nil
 }
 
 // GetSequencedLeafCount returns the number of leaves that have been integrated into the Merkle
@@ -676,7 +676,7 @@ func (t *TrillianLogRPCServer) GetEntryAndProof(ctx context.Context, req *trilli
 		t.recordIndexPercent(req.LeafIndex, root.TreeSize)
 
 		// Work is complete, we have everything we need for the response
-		r.Proof = &proof
+		r.Proof = proof
 		r.Leaf = leaves[0]
 	}
 
@@ -705,16 +705,16 @@ func (t *TrillianLogRPCServer) closeAndLog(ctx context.Context, logID int64, tx 
 // getInclusionProofForLeafIndex is used by multiple handlers. It does the storage fetching
 // and makes additional checks on the returned proof. Returns a Proof suitable for inclusion in
 // an RPC response
-func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTreeTX, hasher hashers.LogHasher, snapshot, leafIndex, treeSize int64) (trillian.Proof, error) {
+func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTreeTX, hasher hashers.LogHasher, snapshot, leafIndex, treeSize int64) (*trillian.Proof, error) {
 	// We have the tree size and leaf index so we know the nodes that we need to serve the proof
 	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize, proofMaxBitLen)
 	if err != nil {
-		return trillian.Proof{}, err
+		return nil, err
 	}
 
 	rev, err := tx.ReadRevision(ctx)
 	if err != nil {
-		return trillian.Proof{}, err
+		return nil, err
 	}
 	return fetchNodesAndBuildProof(ctx, tx, hasher, rev, leafIndex, proofNodeIDs)
 }

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -29,12 +29,12 @@ import (
 // This includes rehashing where necessary to serve proofs for tree sizes between stored tree
 // revisions. This code only relies on the NodeReader interface so can be tested without
 // a complete storage implementation.
-func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hashers.LogHasher, treeRevision, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (trillian.Proof, error) {
+func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hashers.LogHasher, treeRevision, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (*trillian.Proof, error) {
 	ctx, spanEnd := spanFor(ctx, "fetchNodesAndBuildProof")
 	defer spanEnd()
 	proofNodes, err := fetchNodes(ctx, tx, treeRevision, proofNodeFetches)
 	if err != nil {
-		return trillian.Proof{}, err
+		return nil, err
 	}
 
 	r := &rehasher{th: th}
@@ -92,9 +92,9 @@ func (r *rehasher) endRehashing() {
 	}
 }
 
-func (r *rehasher) rehashedProof(leafIndex int64) (trillian.Proof, error) {
+func (r *rehasher) rehashedProof(leafIndex int64) (*trillian.Proof, error) {
 	r.endRehashing()
-	return trillian.Proof{
+	return &trillian.Proof{
 		LeafIndex: leafIndex,
 		Hashes:    r.proof,
 	}, r.proofError

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -35,7 +35,7 @@ type rehashTest struct {
 	index   int64
 	nodes   []storage.Node
 	fetches []merkle.NodeFetch
-	output  trillian.Proof
+	output  *trillian.Proof
 }
 
 // An arbitrary tree revision to be used in tests.
@@ -63,7 +63,7 @@ func TestRehasher(t *testing.T) {
 			index:   126,
 			nodes:   []storage.Node{sn1, sn2, sn3},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: false}, {Rehash: false}},
-			output: trillian.Proof{
+			output: &trillian.Proof{
 				LeafIndex: 126,
 				Hashes:    [][]byte{h1, h2, h3},
 			},
@@ -73,7 +73,7 @@ func TestRehasher(t *testing.T) {
 			index:   999,
 			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: false}},
-			output: trillian.Proof{
+			output: &trillian.Proof{
 				LeafIndex: 999,
 				Hashes:    [][]byte{h1, th.HashChildren(h3, h2), h4, h5},
 			},
@@ -83,7 +83,7 @@ func TestRehasher(t *testing.T) {
 			index:   11,
 			nodes:   []storage.Node{sn1, sn2, sn3},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}},
-			output: trillian.Proof{
+			output: &trillian.Proof{
 				LeafIndex: 11,
 				Hashes:    [][]byte{h1, th.HashChildren(h3, h2)},
 			},
@@ -93,7 +93,7 @@ func TestRehasher(t *testing.T) {
 			index:   23,
 			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: true}, {Rehash: false}},
-			output: trillian.Proof{
+			output: &trillian.Proof{
 				LeafIndex: 23,
 				Hashes:    [][]byte{h1, th.HashChildren(h4, th.HashChildren(h3, h2)), h5},
 			},
@@ -103,7 +103,7 @@ func TestRehasher(t *testing.T) {
 			index:   45,
 			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: true}, {Rehash: true}},
-			output: trillian.Proof{
+			output: &trillian.Proof{
 				LeafIndex: 45,
 				Hashes:    [][]byte{th.HashChildren(h2, h1), h3, th.HashChildren(h5, h4)},
 			},
@@ -123,7 +123,7 @@ func TestRehasher(t *testing.T) {
 			t.Fatalf("rehash test %s unexpected error: %v", rehashTest.desc, err)
 		}
 
-		if !proto.Equal(&got, &want) {
+		if !proto.Equal(got, want) {
 			t.Errorf("rehash test %s:\ngot: %v\nwant: %v", rehashTest.desc, got, want)
 		}
 	}


### PR DESCRIPTION
Mostly in tests but minor tweak to internal rehashing API to return *Proof.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
