### PR TITLE
Correct name of build steps in cloudbuild_master.yaml

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -93,6 +93,5 @@ steps:
   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
   waitFor:
   - envsubst_kubernetes_configs
-  - push_log_server
-  - push_log_signer
-
+  - build_log_server
+  - build_log_signer


### PR DESCRIPTION
`push_log_*` steps were merged into `build_log_*` steps.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
