### PR TITLE
Increase Cloud Build timeout from 20 minutes to 30 minutes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s
+timeout: 1800s
 substitutions:
   _MYSQL_TAG: "5.7"
 steps:
@@ -51,4 +51,3 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --cache=true
   waitFor: ["-"]
-

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s
+timeout: 1800s
 substitutions:
   _CLUSTER_NAME: trillian-opensource-ci
   _MASTER_ZONE: us-central1-a

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s
+timeout: 1800s
 substitutions:
   _MYSQL_TAG: "5.7"
 steps:
@@ -51,4 +51,3 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
   - --cache=true
   waitFor: ["-"]
-


### PR DESCRIPTION
Still getting timeouts when the build cache is invalidated and it has to do a full download of all Go modules.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
