### PR TITLE
Avoid potential SEGV in sequencer if log is not initialised

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -822,6 +822,10 @@ func (t *logTreeTX) LatestSignedLogRoot(ctx context.Context) (*trillian.SignedLo
 	t.treeTX.mu.Lock()
 	defer t.treeTX.mu.Unlock()
 
+	if t.slr == nil {
+		return nil, storage.ErrTreeNeedsInit
+	}
+
 	return t.slr, nil
 }
 


### PR DESCRIPTION
Makes `LatestSignedLogRoot()` return `ErrTreeNeedsInit` when it does, so that `IntegrateBatch` will early abort.

I think this was introduced by accident in #1735 .

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
