### PR TITLE
Don't install test deps each time

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -88,9 +88,6 @@ main() {
     go build ./...
 
     echo 'running go test'
-    # Install test deps so that individual test runs below can reuse them.
-    echo 'installing test deps'
-    go test -i ./...
 
     if [[ ${coverage} -eq 1 ]]; then
         local coverflags="-covermode=atomic -coverprofile=coverage.txt"


### PR DESCRIPTION
Should be no need for this anymore, and it seems to speed Travis tests up by between 30s-2m.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
