### PR TITLE
Separate lint tests out into their own travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
   matrix:
-  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage"
+  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--no-build --no-generate"  # only lint
+  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters"
   - PRESUB_TESTS=true GOFLAGS='-race' WITH_ETCD=true       PRESUBMIT_OPTS="--no-linters"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,18 +67,26 @@ install:
   - export PATH="$(pwd)/../protoc/bin:$PATH"
   # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
   - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
-  - GOPROXY=direct go install
-        github.com/golang/mock/mockgen
-        github.com/golang/protobuf/proto
-        github.com/golang/protobuf/protoc-gen-go
-        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-        github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
-        github.com/uber/prototool/cmd/prototool
-        golang.org/x/tools/cmd/stringer
-        github.com/golangci/golangci-lint/cmd/golangci-lint
-        go.etcd.io/etcd
-        go.etcd.io/etcd/etcdctl
-
+  - |
+    export TOOLS=""
+    if [[ "${PRESUBMIT_OPTS}" != *no-generate* ]]; then
+      TOOLS+=" github.com/golang/mock/mockgen"
+      TOOLS+=" github.com/golang/protobuf/proto"
+      TOOLS+=" github.com/golang/protobuf/protoc-gen-go"
+      TOOLS+=" github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
+      TOOLS+=" github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+      TOOLS+=" golang.org/x/tools/cmd/stringer"
+    fi
+    if [[ "${PRESUBMIT_OPTS}" != *no-build* ]]; then
+      TOOLS+=" go.etcd.io/etcd"
+      TOOLS+=" go.etcd.io/etcd/etcdctl"
+    fi
+    if [[ "${PRESUBMIT_OPTS}" != *no-linters* ]]; then
+      TOOLS+=" github.com/golangci/golangci-lint/cmd/golangci-lint"
+      TOOLS+=" github.com/uber/prototool/cmd/prototool"
+    fi
+    echo Installing ${TOOLS}...
+    GOPROXY=direct go install ${TOOLS}
   # install bazel
   - |
     (

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,19 @@ env:
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
   matrix:
-  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--no-build --no-generate"  # only lint
-  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters"
-  - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters"
-  - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters"
-  - PRESUB_TESTS=true GOFLAGS='-race' WITH_ETCD=true       PRESUBMIT_OPTS="--no-linters"
-  - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters"
-  - INTEG_TESTS=true                                       PRESUBMIT_OPTS="--coverage --no-linters"
-  - INTEG_TESTS=true GOFLAGS='-race'                       PRESUBMIT_OPTS="--no-linters"
-  - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters"
-  - INTEG_TESTS=true GOFLAGS='-race' WITH_ETCD=true        PRESUBMIT_OPTS="--no-linters"
-  - INTEG_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters"
-  - BAZEL_TESTS=true                                       PRESUBMIT_OPTS="--no-linters"
-  - DOCKER_TESTS=true                                      PRESUBMIT_OPTS="--no-linters"
+  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--no-build"  # only lint & generate
+  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
+  - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
+  - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
+  - PRESUB_TESTS=true GOFLAGS='-race' WITH_ETCD=true       PRESUBMIT_OPTS="--no-linters --no-generate"
+  - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
+  - INTEG_TESTS=true                                       PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
+  - INTEG_TESTS=true GOFLAGS='-race'                       PRESUBMIT_OPTS="--no-linters --no-generate"
+  - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters --no-generate"
+  - INTEG_TESTS=true GOFLAGS='-race' WITH_ETCD=true        PRESUBMIT_OPTS="--no-linters --no-generate"
+  - INTEG_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
+  - BAZEL_TESTS=true                                       PRESUBMIT_OPTS="--no-linters --no-generate"
+  - DOCKER_TESTS=true                                      PRESUBMIT_OPTS="--no-linters --no-generate"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Lint tests take *ages*, make them run concurrently with other test envs on Travis.

Timings:

| type | flags  | before | after |
| :----: | :---- | :---: | :---: |
| presub | PRESUBMIT_OPTS="--no-build" | -- | 3:55 |
| presub | PRESUBMIT_OPTS="--coverage" | 7:10 | 5:06 |
| presub | GOFLAGS='-race' PRESUBMIT_OPTS="--no-linters" | 11:09 |  8:52  |
| presub | GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters" | 11:53 |  8:58  |
| presub | GOFLAGS='-race' WITH_ETCD=true PRESUBMIT_OPTS="--no-linters" | 10:08 | 8:15   |
| integ | GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters" | 10:13 | 8:54 |
| integ | PRESUBMIT_OPTS="--coverage --no-linters" |  6:47  |  6:18 |
| integ | GOFLAGS='-race' PRESUBMIT_OPTS="--no-linters" | 12:11 | 12:07  |
| integ | GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters" | 11:58 |  11:35 |
| integ | GOFLAGS='-race' WITH_ETCD=true PRESUBMIT_OPTS="--no-linters" | 12:27 | 11:44 |
| integ | GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters" | 13:13 |  11:25  |
| bazel | PRESUBMIT_OPTS="--no-linters" | 6:29 |  8:14 |
| docker | PRESUBMIT_OPTS="--no-linters" | 9:58 | 9:48 |

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
