### PR TITLE
merkle: Helper to get node IDs of a compact range

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -140,7 +140,7 @@ func (s Sequencer) initCompactRangeFromStorage(ctx context.Context, root *types.
 		return fact.NewEmptyRange(0), nil
 	}
 
-	ids := compact.RangeNodesForPrefix(root.TreeSize)
+	ids := compact.RangeNodes(0, root.TreeSize)
 	storIDs := make([]storage.NodeID, len(ids))
 	for i, id := range ids {
 		nodeID, err := storage.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)

--- a/merkle/compact/nodes.go
+++ b/merkle/compact/nodes.go
@@ -43,14 +43,10 @@ func RangeNodesForPrefix(size uint64) []NodeID {
 	ids := make([]NodeID, 0, bits.OnesCount64(size))
 	// Iterate over perfect subtrees along the right border of the tree. Those
 	// correspond to the bits of the tree size that are set to one.
-	for sz := size; sz != 0; sz &= sz - 1 {
-		level := uint(bits.TrailingZeros64(sz))
-		index := (sz - 1) >> level
-		ids = append(ids, NewNodeID(level, index))
-	}
-	// Note: Right border nodes of compact.Range are ordered from root to leaves.
-	for i, j := 0, len(ids)-1; i < j; i, j = i+1, j-1 {
-		ids[i], ids[j] = ids[j], ids[i]
+	for pos, bit := uint64(0), uint64(0); size != 0; pos, size = pos+bit, size^bit {
+		level := uint(bits.Len64(size)) - 1
+		bit = uint64(1) << level
+		ids = append(ids, NewNodeID(level, pos>>level))
 	}
 	return ids
 }

--- a/merkle/compact/nodes.go
+++ b/merkle/compact/nodes.go
@@ -37,14 +37,6 @@ func NewNodeID(level uint, index uint64) NodeID {
 	return NodeID{Level: level, Index: index}
 }
 
-// RangeNodesForPrefix returns the list of node IDs that comprise the [0, size)
-// compact range. Nodes are ordered from upper to lower levels.
-//
-// TODO(pavelkalinnikov): Use RangeNodes directly.
-func RangeNodesForPrefix(size uint64) []NodeID {
-	return RangeNodes(0, size)
-}
-
 // RangeNodes returns node IDs that comprise the [begin, end) compact range.
 func RangeNodes(begin, end uint64) []NodeID {
 	left, right := decompose(begin, end)

--- a/merkle/compact/nodes.go
+++ b/merkle/compact/nodes.go
@@ -39,14 +39,33 @@ func NewNodeID(level uint, index uint64) NodeID {
 
 // RangeNodesForPrefix returns the list of node IDs that comprise the [0, size)
 // compact range. Nodes are ordered from upper to lower levels.
+//
+// TODO(pavelkalinnikov): Use RangeNodes directly.
 func RangeNodesForPrefix(size uint64) []NodeID {
-	ids := make([]NodeID, 0, bits.OnesCount64(size))
-	// Iterate over perfect subtrees along the right border of the tree. Those
-	// correspond to the bits of the tree size that are set to one.
-	for pos, bit := uint64(0), uint64(0); size != 0; pos, size = pos+bit, size^bit {
-		level := uint(bits.Len64(size)) - 1
+	return RangeNodes(0, size)
+}
+
+// RangeNodes returns node IDs that comprise the [begin, end) compact range.
+func RangeNodes(begin, end uint64) []NodeID {
+	left, right := decompose(begin, end)
+	ids := make([]NodeID, 0, bits.OnesCount64(left)+bits.OnesCount64(right))
+
+	pos := begin
+	// Iterate over perfect subtrees along the left border of the range, ordered
+	// from lower to upper levels.
+	for bit := uint64(0); left != 0; pos, left = pos+bit, left^bit {
+		level := uint(bits.TrailingZeros64(left))
 		bit = uint64(1) << level
 		ids = append(ids, NewNodeID(level, pos>>level))
 	}
+
+	// Iterate over perfect subtrees along the right border of the range, ordered
+	// from upper to lower levels.
+	for bit := uint64(0); right != 0; pos, right = pos+bit, right^bit {
+		level := uint(bits.Len64(right)) - 1
+		bit = uint64(1) << level
+		ids = append(ids, NewNodeID(level, pos>>level))
+	}
+
 	return ids
 }

--- a/merkle/compact/nodes_test.go
+++ b/merkle/compact/nodes_test.go
@@ -20,31 +20,6 @@ import (
 	"testing"
 )
 
-func TestRangeNodesForPrefix(t *testing.T) {
-	for _, tc := range []struct {
-		size uint64
-		want []NodeID
-	}{
-		{size: 0, want: []NodeID{}},
-		{size: 1, want: []NodeID{{Level: 0, Index: 0}}},
-		{size: 2, want: []NodeID{{Level: 1, Index: 0}}},
-		{size: 3, want: []NodeID{{Level: 1, Index: 0}, {Level: 0, Index: 2}}},
-		{size: 4, want: []NodeID{{Level: 2, Index: 0}}},
-		{size: 5, want: []NodeID{{Level: 2, Index: 0}, {Level: 0, Index: 4}}},
-		{size: 15, want: []NodeID{{Level: 3, Index: 0}, {Level: 2, Index: 2}, {Level: 1, Index: 6}, {Level: 0, Index: 14}}},
-		{size: 100, want: []NodeID{{Level: 6, Index: 0}, {Level: 5, Index: 2}, {Level: 2, Index: 24}}},
-		{size: 513, want: []NodeID{{Level: 9, Index: 0}, {Level: 0, Index: 512}}},
-		{size: uint64(1) << 63, want: []NodeID{{Level: 63, Index: 0}}},
-		{size: (uint64(1) << 63) + (uint64(1) << 57), want: []NodeID{{Level: 63, Index: 0}, {Level: 57, Index: 64}}},
-	} {
-		t.Run(fmt.Sprintf("size:%d", tc.size), func(t *testing.T) {
-			if got, want := RangeNodesForPrefix(tc.size), tc.want; !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("RangeNodesForPrefix: got %v, want %v", got, want)
-			}
-		})
-	}
-}
-
 func TestRangeNodes(t *testing.T) {
 	n := func(level uint, index uint64) NodeID {
 		return NewNodeID(level, index)
@@ -66,6 +41,17 @@ func TestRangeNodes(t *testing.T) {
 		{begin: 10, end: 12, want: []NodeID{n(1, 5)}},
 		{begin: 1024, end: 1026, want: []NodeID{n(1, 512)}},
 		{begin: 1025, end: 1027, want: []NodeID{n(0, 1025), n(0, 1026)}},
+		// Only right border.
+		{end: 1, want: []NodeID{n(0, 0)}},
+		{end: 2, want: []NodeID{n(1, 0)}},
+		{end: 3, want: []NodeID{n(1, 0), n(0, 2)}},
+		{end: 4, want: []NodeID{n(2, 0)}},
+		{end: 5, want: []NodeID{n(2, 0), n(0, 4)}},
+		{end: 15, want: []NodeID{n(3, 0), n(2, 2), n(1, 6), n(0, 14)}},
+		{end: 100, want: []NodeID{n(6, 0), n(5, 2), n(2, 24)}},
+		{end: 513, want: []NodeID{n(9, 0), n(0, 512)}},
+		{end: uint64(1) << 63, want: []NodeID{n(63, 0)}},
+		{end: (uint64(1) << 63) + (uint64(1) << 57), want: []NodeID{n(63, 0), n(57, 64)}},
 		// Only left border.
 		{begin: 0, end: 16, want: []NodeID{n(4, 0)}},
 		{begin: 1, end: 16, want: []NodeID{n(0, 1), n(1, 1), n(2, 1), n(3, 1)}},

--- a/merkle/compact/nodes_test.go
+++ b/merkle/compact/nodes_test.go
@@ -44,3 +44,46 @@ func TestRangeNodesForPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestRangeNodes(t *testing.T) {
+	n := func(level uint, index uint64) NodeID {
+		return NewNodeID(level, index)
+	}
+	for _, tc := range []struct {
+		begin uint64
+		end   uint64
+		want  []NodeID
+	}{
+		// Empty ranges.
+		{end: 0, want: []NodeID{}},
+		{begin: 10, end: 10, want: []NodeID{}},
+		{begin: 1024, end: 1024, want: []NodeID{}},
+		// One entry.
+		{begin: 10, end: 11, want: []NodeID{n(0, 10)}},
+		{begin: 1024, end: 1025, want: []NodeID{n(0, 1024)}},
+		{begin: 1025, end: 1026, want: []NodeID{n(0, 1025)}},
+		// Two entries.
+		{begin: 10, end: 12, want: []NodeID{n(1, 5)}},
+		{begin: 1024, end: 1026, want: []NodeID{n(1, 512)}},
+		{begin: 1025, end: 1027, want: []NodeID{n(0, 1025), n(0, 1026)}},
+		// Only left border.
+		{begin: 0, end: 16, want: []NodeID{n(4, 0)}},
+		{begin: 1, end: 16, want: []NodeID{n(0, 1), n(1, 1), n(2, 1), n(3, 1)}},
+		{begin: 1, end: 16, want: []NodeID{n(0, 1), n(1, 1), n(2, 1), n(3, 1)}},
+		{begin: 2, end: 16, want: []NodeID{n(1, 1), n(2, 1), n(3, 1)}},
+		{begin: 3, end: 16, want: []NodeID{n(0, 3), n(2, 1), n(3, 1)}},
+		{begin: 4, end: 16, want: []NodeID{n(2, 1), n(3, 1)}},
+		{begin: 6, end: 16, want: []NodeID{n(1, 3), n(3, 1)}},
+		{begin: 8, end: 16, want: []NodeID{n(3, 1)}},
+		{begin: 11, end: 16, want: []NodeID{n(0, 11), n(2, 3)}},
+		// Two-sided.
+		{begin: 1, end: 31, want: []NodeID{n(0, 1), n(1, 1), n(2, 1), n(3, 1), n(3, 2), n(2, 6), n(1, 14), n(0, 30)}},
+		{begin: 1, end: 17, want: []NodeID{n(0, 1), n(1, 1), n(2, 1), n(3, 1), n(0, 16)}},
+	} {
+		t.Run(fmt.Sprintf("range:%d:%d", tc.begin, tc.end), func(t *testing.T) {
+			if got, want := RangeNodes(tc.begin, tc.end), tc.want; !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("RangeNodes: got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -366,7 +366,7 @@ func TestNewRangeWithStorage(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("%d: Append: %v", i, err)
 		}
-		hashes := getHashes(RangeNodesForPrefix(i + 1))
+		hashes := getHashes(RangeNodes(0, i+1))
 		var err error
 		if cr, err = factory.NewRange(0, i+1, hashes); err != nil {
 			t.Fatalf("%d: NewRange: %v", i+1, err)


### PR DESCRIPTION
This change adds the `RangeNodes` function that returns IDs of nodes comprising a compact range.
It supersedes `RangeNodesForPrefix` function, which is now removed.