### PR TITLE
Avoid SEGV if there is no latest STH

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -338,7 +338,7 @@ func (s Sequencer) IntegrateBatch(ctx context.Context, tree *trillian.Tree, limi
 
 		// Get the latest known root from storage
 		sth, err := tx.LatestSignedLogRoot(ctx)
-		if err != nil {
+		if err != nil || sth == nil {
 			return fmt.Errorf("%v: Sequencer failed to get latest root: %v", tree.TreeId, err)
 		}
 		// There is no trust boundary between the signer and the


### PR DESCRIPTION


### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
