### PR TITLE
Fix opencensus deprecation of DefaultServerViews.

### DIFF
--- a/monitoring/opencensus/trace.go
+++ b/monitoring/opencensus/trace.go
@@ -27,6 +27,17 @@ import (
 	"google.golang.org/grpc"
 )
 
+// This is the same set of views that used to be the default before that
+// was deprecated. Possibly some of these are not useful but for the moment
+// we don't really know that.
+var serverViews = []*view.View{ochttp.ServerRequestCountView,
+	ochttp.ServerRequestBytesView,
+	ochttp.ServerResponseBytesView,
+	ochttp.ServerLatencyView,
+	ochttp.ServerRequestCountByMethod,
+	ochttp.ServerResponseCountByStatusCode,
+}
+
 // EnableRPCServerTracing turns on Stackdriver tracing. The returned
 // options must be passed to the GRPC server. The supplied
 // projectID can be nil for GCP but might need to be set for other
@@ -62,7 +73,7 @@ func EnableHTTPServerTracing(projectID string, percent int) (http.Handler, error
 	if err := applyConfig(percent); err != nil {
 		return nil, err
 	}
-	if err := view.Register(ochttp.DefaultServerViews...); err != nil {
+	if err := view.Register(serverViews...); err != nil {
 		return nil, err
 	}
 	return &ochttp.Handler{}, nil


### PR DESCRIPTION
There is no longer a default view list, you have to request them explicitly. This copies in the ones that were registered before.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
