### PR TITLE
Stop Istio injecting sidecar into Etcd nodes

### DIFF
--- a/examples/deployment/kubernetes/etcd-cluster.yaml
+++ b/examples/deployment/kubernetes/etcd-cluster.yaml
@@ -8,6 +8,12 @@ spec:
   size: 3
   version: "3.2.13"
   pod:
+    annotations:
+      # Do not inject an Istio sidecar, because Etcd nodes require a network
+      # connection on startup and don't retry on failure. This is a problem for
+      # Istio because it takes a moment to start its proxy sidecar and, during
+      # that time, all network connections will be blocked.
+      sidecar.istio.io/inject: "false"
     affinity:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The Istio sidecar proxies network connections, but blocks connections until it is ready. This interferes with Etcd nodes, which demand a network connection to the other nodes on startup else they fail and never recover.

Relevant documentation:
- https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#policy
- https://github.com/coreos/etcd-operator/blob/v0.9.1/doc/user/spec_examples.md#custom-pod-annotations

Contributes to #1772.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).