### PR TITLE
Always deploy etcd-operator to default namespace

### DIFF
--- a/examples/deployment/kubernetes/etcd-deployment.yaml
+++ b/examples/deployment/kubernetes/etcd-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: trillian-etcd-operator
+  # Cluster-wide etcd-operator, so should always be in default namespace.
+  namespace: default
 spec:
   replicas: 1
   template:

--- a/examples/deployment/kubernetes/etcd-role-binding.yaml
+++ b/examples/deployment/kubernetes/etcd-role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: ${NAMESPACE}
+  namespace: default


### PR DESCRIPTION
It's configured to be cluster-wide, and so will control EtcdClusters no matter what namespace they are in (so long as they're annotated with "etcd.database.coreos.com/scope: clusterwide").

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
