### PR TITLE
Move STORAGE_FLAG into Kubernetes secret

### DIFF
--- a/examples/deployment/kubernetes/trillian-cloudspanner.yaml
+++ b/examples/deployment/kubernetes/trillian-cloudspanner.yaml
@@ -1,10 +1,17 @@
 apiVersion: v1
+kind: Secret
+metadata:
+  name: trillian-secrets
+type: Opaque
+stringData:
+  STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-spanner/databases/trillian-db
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deploy-config
 data:
   STORAGE_SYSTEM: cloud_spanner
-  STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-spanner/databases/trillian-db
   GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
   SIGNER_DEQUEUE_BUCKET_FRACTION: "0.0078"
   SIGNER_BATCH_SIZE: "1800"

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       restartPolicy: Always
       containers:
       - name: trillian-logserver
+        # TODO(RJPercival): Pass STORAGE_FLAG via --config to protect any
+        # sensitive contents (e.g. passwords) from being seen in process list.
         args: [
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
@@ -31,8 +33,10 @@ spec:
         "--alsologtostderr"
         ]
         envFrom:
-          - configMapRef:
-              name: deploy-config
+        - configMapRef:
+            name: deploy-config
+        - secretRef:
+            name: trillian-secrets
         image: gcr.io/${PROJECT_ID}/log_server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -19,7 +19,10 @@ spec:
           secretName: trillian-key
       restartPolicy: Always
       containers:
-      - args: [
+      - name: trillian-log-signer
+        # TODO(RJPercival): Pass STORAGE_FLAG via --config to protect any
+        # sensitive contents (e.g. passwords) from being seen in process list.
+        args: [
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
         "--etcd_servers=trillian-etcd-cluster-client:2379",
@@ -35,8 +38,10 @@ spec:
         "--alsologtostderr"
         ]
         envFrom:
-          - configMapRef:
-              name: deploy-config
+        - configMapRef:
+            name: deploy-config
+        - secretRef:
+            name: trillian-secrets
         # Update this with the name of your project:
         image: gcr.io/${PROJECT_ID}/log_signer:${IMAGE_TAG}
         imagePullPolicy: Always
@@ -52,7 +57,6 @@ spec:
           failureThreshold: 3
           periodSeconds: 30
           timeoutSeconds: 5
-        name: trillian-log-signer
         ports:
         - containerPort: 8091
           name: http-metrics

--- a/examples/deployment/kubernetes/trillian-map-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-map-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       restartPolicy: Always
       containers:
       - name: trillian-mapserver
+        # TODO(RJPercival): Pass STORAGE_FLAG via --config to protect any
+        # sensitive contents (e.g. passwords) from being seen in process list.
         args: [
         "$(STORAGE_FLAG)",
         "--storage_system=$(STORAGE_SYSTEM)",
@@ -30,8 +32,10 @@ spec:
         "--alsologtostderr"
         ]
         envFrom:
-          - configMapRef:
-              name: deploy-config
+        - configMapRef:
+            name: deploy-config
+        - secretRef:
+            name: trillian-secrets
         image: gcr.io/${PROJECT_ID}/map_server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:


### PR DESCRIPTION
It may contain a username and password if used for connecting to a MySQL server. This change leaves it less exposed to anyone that has access to the Kubernetes UI or API with permission to read ConfigMaps but not Secrets. However, this still leaves it exposed in the process list (since it's being passed by flag) and in the environment (since it's being exposed as an environment variable). A future PR should develop this further to expose the secret via a file, which can be passed to the binary using the --config flag.

Contributes to #1771.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
