### PR TITLE
Ensure MapHammer deadline errors are propagated

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -166,8 +166,7 @@ func (c MapConfig) String() string {
 }
 
 // HitMap performs load/stress operations according to given config.
-func HitMap(cfg MapConfig) error {
-	ctx := context.Background()
+func HitMap(ctx context.Context, cfg MapConfig) error {
 	var firstErr error
 
 	if cfg.MapID == 0 {

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -481,6 +481,10 @@ func (s *hammerState) retryOneOp(ctx context.Context) (err error) {
 		}
 
 		if time.Now().After(deadline) {
+			if firstErr == nil {
+				// If there was no other error, we've probably hit the deadline - make sure we bubble that up.
+				firstErr = ctx.Err()
+			}
 			glog.Warningf("%d: gave up on operation %v after %v, returning first err %v", s.cfg.MapID, ep, s.cfg.OperationDeadline, firstErr)
 			done = true
 		}

--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,55 @@ var (
 	operations = flag.Uint64("operations", 20, "Number of operations to perform")
 	singleTX   = flag.Bool("single_transaction", false, "Experimental: whether to use a single transaction when updating the map")
 )
+
+func TestRetryExposesDeadlineError(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	env, err := integration.NewMapEnv(ctx, *singleTX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+
+	bias := MapBias{
+		Bias: map[MapEntrypointName]int{
+			GetLeavesName:    10,
+			GetLeavesRevName: 10,
+			SetLeavesName:    10,
+			GetSMRName:       10,
+			GetSMRRevName:    10,
+		},
+		InvalidChance: map[MapEntrypointName]int{
+			GetLeavesName:    10,
+			GetLeavesRevName: 10,
+			SetLeavesName:    10,
+			GetSMRName:       0,
+			GetSMRRevName:    10,
+		},
+	}
+
+	seed := time.Now().UTC().UnixNano() & 0xFFFFFFFF
+	cfg := MapConfig{
+		MapID:         0, // ephemeral tree
+		Client:        env.Map,
+		Admin:         env.Admin,
+		MetricFactory: monitoring.InertMetricFactory{},
+		RandSource:    rand.NewSource(seed),
+		EPBias:        bias,
+		LeafSize:      1000,
+		ExtraSize:     100,
+		MinLeaves:     800,
+		MaxLeaves:     1200,
+		Operations:    *operations,
+		NumCheckers:   1,
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
+	defer cancel()
+	if err, wantErr := HitMap(ctx, cfg), context.DeadlineExceeded; !strings.Contains(err.Error(), wantErr.Error()) {
+		t.Fatalf("Got err %q, expected %q", err, wantErr)
+	}
+}
 
 func TestInProcessMapHammer(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)

--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -75,7 +75,7 @@ func TestInProcessMapHammer(t *testing.T) {
 		Operations:    *operations,
 		NumCheckers:   1,
 	}
-	if err := HitMap(cfg); err != nil {
+	if err := HitMap(ctx, cfg); err != nil {
 		t.Fatalf("hammer failure: %v", err)
 	}
 }

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -190,7 +191,7 @@ func main() {
 		wg.Add(1)
 		go func(cfg hammer.MapConfig) {
 			defer wg.Done()
-			err := hammer.HitMap(cfg)
+			err := hammer.HitMap(context.Background(), cfg)
 			results <- result{mapID: cfg.MapID, err: err}
 		}(cfg)
 	}


### PR DESCRIPTION
Previously, if the MapHammer simply timed out on an RPC, no error would be returned.
This PR attempts to correct that.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
