### PR TITLE
Replace whole operation timeout with per-rpc timeout

### DIFF
--- a/client/timeout/timeout.go
+++ b/client/timeout/timeout.go
@@ -1,0 +1,18 @@
+// Package timeout enforces a maximum timeout on all outgoing rpcs.
+package timeout
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// UnaryClientInterceptor returns a new maximum timout client interceptor.
+func UnaryClientInterceptor(maxTimeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(parentCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		callCtx, cancel := context.WithTimeout(parentCtx, maxTimeout)
+		defer cancel()
+		return invoker(callCtx, method, req, reply, cc, opts...)
+	}
+}

--- a/client/timeout/timeout.go
+++ b/client/timeout/timeout.go
@@ -22,7 +22,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-// UnaryClientInterceptor returns a new maximum timout client interceptor.
+// UnaryClientInterceptor returns a new maximum timeout client interceptor.
+// This interceptor will set a timeout when no timeout has been set.
+// If the timeout on parentCtx is longer than maxTimeout, it will be replaced with maxTimeout.
+// If parentCtx has a timeout shorter than maxTimeout it will not be modified.
 func UnaryClientInterceptor(maxTimeout time.Duration) grpc.UnaryClientInterceptor {
 	return func(parentCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		callCtx, cancel := context.WithTimeout(parentCtx, maxTimeout)

--- a/client/timeout/timeout.go
+++ b/client/timeout/timeout.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package timeout enforces a maximum timeout on all outgoing rpcs.
 package timeout
 

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -440,7 +440,7 @@ func (s *hammerState) retryOneOp(ctx context.Context) (err error) {
 	}(time.Now())
 
 	deadline := time.Now().Add(s.cfg.OperationDeadline)
-	ctx, cancel := context.WithDeadline(ctx, deadline)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var firstErr error

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -36,12 +36,12 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/testonly/hammer"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 
 	_ "github.com/google/trillian/merkle/coniks"    // register CONIKS_SHA512_256
 	_ "github.com/google/trillian/merkle/maphasher" // register TEST_MAP_HASHER
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 )
 
 var (


### PR DESCRIPTION
When timeouts are used across multiple RPCs, we can create a situation 
where the client tries to send an RPC right before the deadline. Smart RPC
frameworks detect this and return a client side error.