### PR TITLE
Remove tracing for recursive subtree calls.

### DIFF
--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -189,9 +189,6 @@ func (s *subtreeWriter) SetLeaf(ctx context.Context, index []byte, hash []byte) 
 // CalculateRoot initiates the process of calculating the subtree root.
 // The leafGeneratorQueue is closed.
 func (s *subtreeWriter) CalculateRoot(ctx context.Context) {
-	ctx, spanEnd := spanFor(ctx, "subtreeWriter.CalculateRoot")
-	defer spanEnd()
-
 	close(s.leafGeneratorQueue)
 
 	for _, v := range s.children {


### PR DESCRIPTION
This created a lot of spans due to the depth of the recursion, which can overwhelm tracing frameworks and wouldn't provide useful information anyway. The top level writer.CalculateRoot is still there to wrap up the whole set of recursive calls in a span.