### PR TITLE
HStar2: Add and use prefetching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,3 +87,5 @@ require (
 	mvdan.cc/unparam v0.0.0-20190310220240-1b9ccfa71afe // indirect
 	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -87,5 +87,3 @@ require (
 	mvdan.cc/unparam v0.0.0-20190310220240-1b9ccfa71afe // indirect
 	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect
 )
-
-go 1.13

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -59,7 +59,11 @@ func NewHStar2(treeID int64, hasher hashers.MapHasher) HStar2 {
 // which contains the given set of non-null leaves.
 func (s *HStar2) HStar2Root(depth int, values []*HStar2LeafHash) ([]byte, error) {
 	sort.Sort(ByIndex{values})
-	return s.hStar2b(0, depth, values, smtZero, nil, nil)
+	combine := func(depth int, offset *big.Int, lhs, rhs []byte) ([]byte, error) {
+		h := s.hasher.HashChildren(lhs, rhs)
+		return h, nil
+	}
+	return s.hStar2b(0, depth, values, smtZero, nil, combine)
 }
 
 // SparseGetNodeFunc should return any pre-existing node hash for the node address.
@@ -83,6 +87,38 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []*HStar2Le
 			glog.Infof("  %x: %x", v.Index.Bytes(), v.LeafHash)
 		}
 	}
+	combine := func(depth int, offset *big.Int, lhs, rhs []byte) ([]byte, error) {
+		h := s.hasher.HashChildren(lhs, rhs)
+		if err := s.set(offset, depth, h, set); err != nil {
+			return nil, err
+		}
+		return h, nil
+	}
+	return s.run(prefix, subtreeDepth, values, get, combine)
+}
+
+// Prefetch does a dry run of HStar2 algorithm, and reports all Merkle tree
+// nodes that it needs through the passed-in visit function. Note that the
+// return value of the visit function is ignored, unless it is an error.
+//
+// This function can be useful, for example, if the caller prefers to collect
+// the node IDs and read them from storage in one batch. Then they can run
+// HStar2Nodes in such a way that it reads from the prefetched set.
+func (s *HStar2) Prefetch(prefix []byte, subtreeDepth int, values []*HStar2LeafHash, visit SparseGetNodeFunc) error {
+	combine := func(depth int, offset *big.Int, lhs, rhs []byte) ([]byte, error) {
+		return nil, nil
+	}
+	_, err := s.run(prefix, subtreeDepth, values, visit, combine)
+	return err
+}
+
+// combineFunc returns a node hash based on two child hashes. It may also do
+// side effects, e.g. put the resulting node to storage.
+type combineFunc func(depth int, offset *big.Int, lhs, rhs []byte) ([]byte, error)
+
+// run runs the HStar2 algorithm.
+func (s *HStar2) run(prefix []byte, subtreeDepth int, values []*HStar2LeafHash,
+	get SparseGetNodeFunc, combine combineFunc) ([]byte, error) {
 	depth := len(prefix) * 8
 	totalDepth := depth + subtreeDepth
 	if totalDepth > s.hasher.BitLen() {
@@ -90,12 +126,12 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []*HStar2Le
 	}
 	sort.Sort(ByIndex{values})
 	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, s.hasher.BitLen()).BigInt()
-	return s.hStar2b(depth, totalDepth, values, offset, get, set)
+	return s.hStar2b(depth, totalDepth, values, offset, get, combine)
 }
 
 // hStar2b computes a sparse Merkle tree root value recursively.
 func (s *HStar2) hStar2b(depth, maxDepth int, values []*HStar2LeafHash, offset *big.Int,
-	get SparseGetNodeFunc, set SparseSetNodeFunc) ([]byte, error) {
+	get SparseGetNodeFunc, combine combineFunc) ([]byte, error) {
 	if depth == maxDepth {
 		switch {
 		case len(values) == 0:
@@ -115,19 +151,15 @@ func (s *HStar2) hStar2b(depth, maxDepth int, values []*HStar2LeafHash, offset *
 	split := new(big.Int).Lsh(smtOne, uint(bitsLeft-1))
 	split.Add(split, offset)
 	i := sort.Search(len(values), func(i int) bool { return values[i].Index.Cmp(split) >= 0 })
-	lhs, err := s.hStar2b(depth+1, maxDepth, values[:i], offset, get, set)
+	lhs, err := s.hStar2b(depth+1, maxDepth, values[:i], offset, get, combine)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := s.hStar2b(depth+1, maxDepth, values[i:], split, get, set)
+	rhs, err := s.hStar2b(depth+1, maxDepth, values[i:], split, get, combine)
 	if err != nil {
 		return nil, err
 	}
-	h := s.hasher.HashChildren(lhs, rhs)
-	if err := s.set(offset, depth, h, set); err != nil {
-		return nil, err
-	}
-	return h, nil
+	return combine(depth, offset, lhs, rhs)
 }
 
 // get attempts to use getter. If getter fails, returns the HashEmpty value.

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -66,8 +66,8 @@ func (s *HStar2) HStar2Root(depth int, values []*HStar2LeafHash) ([]byte, error)
 	return s.hStar2b(0, depth, values, smtZero, nil, combine)
 }
 
-// PrefetchNodeFunc reports coordinates of a Merkle tree node to prefetch.
-type PrefetchNodeFunc func(depth int, index *big.Int)
+// PrefetchNodeVisitor reports coordinates of a Merkle tree node to prefetch.
+type PrefetchNodeVisitor func(depth int, index *big.Int)
 
 // SparseGetNodeFunc should return any pre-existing node hash for the node address.
 type SparseGetNodeFunc func(depth int, index *big.Int) ([]byte, error)
@@ -101,14 +101,14 @@ func (s *HStar2) HStar2Nodes(prefix []byte, subtreeDepth int, values []*HStar2Le
 }
 
 // Prefetch does a dry run of HStar2 algorithm, and reports all Merkle tree
-// nodes that it needs through the passed-in fetch function.
+// nodes that it needs through the passed-in visit function.
 //
 // This function can be useful, for example, if the caller prefers to collect
 // the node IDs and read them from storage in one batch. Then they can run
 // HStar2Nodes in such a way that it reads from the prefetched set.
-func (s *HStar2) Prefetch(prefix []byte, subtreeDepth int, values []*HStar2LeafHash, fetch PrefetchNodeFunc) error {
+func (s *HStar2) Prefetch(prefix []byte, subtreeDepth int, values []*HStar2LeafHash, visit PrefetchNodeVisitor) error {
 	get := func(depth int, index *big.Int) ([]byte, error) {
-		fetch(depth, index)
+		visit(depth, index)
 		return nil, nil
 	}
 	combine := func(depth int, index *big.Int, lhs, rhs []byte) ([]byte, error) {

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/google/trillian/merkle/coniks"
@@ -109,57 +110,57 @@ func TestHStar2GetSet(t *testing.T) {
 	cache := make(map[string][]byte)
 	hasher := maphasher.Default
 
-	for i, x := range simpleTestVector {
-		t.Logf("Iteration %d", i)
+	toID := func(depth int, index *big.Int) string {
+		return fmt.Sprintf("%x/%d", index, depth)
+	}
 
-		s := NewHStar2(treeID, hasher)
+	for i, x := range simpleTestVector {
 		values := createHStar2Leaves(treeID, hasher, x.index, x.value)
 		// Ensure we're going incrementally, one leaf at a time.
-		if len(values) != 1 {
-			t.Fatalf("Should only have 1 leaf per run, got %d", len(values))
+		if cnt := len(values); cnt != 1 {
+			t.Fatalf("Should only have 1 leaf per run, got %d", cnt)
 		}
 
-		toID := func(depth int, index *big.Int) string {
-			return fmt.Sprintf("%x/%d", index, depth)
-		}
-
-		visited := make(map[string]bool)
-		err := s.Prefetch(nil, s.hasher.BitLen(), values,
-			func(depth int, index *big.Int) ([]byte, error) {
-				id := toID(depth, index)
-				if visited[id] {
-					return nil, fmt.Errorf("visited node %v twice", id)
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			s := NewHStar2(treeID, hasher)
+			visited := make(map[string]int)
+			err := s.Prefetch(nil, s.hasher.BitLen(), values,
+				func(depth int, index *big.Int) {
+					visited[toID(depth, index)]++
+				})
+			if err != nil {
+				t.Errorf("Prefetch(): %v", err)
+			}
+			for id, times := range visited {
+				if times != 1 {
+					t.Errorf("Node %v visited %d times. Skipping other nodes.", id, times)
+					break
 				}
-				visited[id] = true
-				return nil, nil
-			})
-		if err != nil {
-			t.Errorf("Prefetch(): %v", err)
-		}
+			}
 
-		root, err := s.HStar2Nodes(nil, s.hasher.BitLen(), values,
-			func(depth int, index *big.Int) ([]byte, error) {
-				id := toID(depth, index)
-				if !visited[id] {
-					return nil, fmt.Errorf("node not in Prefetch, or fetched twice: %v", id)
-				}
-				delete(visited, id)
-				return cache[id], nil
-			},
-			func(depth int, index *big.Int, hash []byte) error {
-				cache[toID(depth, index)] = hash
-				return nil
-			})
-		if err != nil {
-			t.Errorf("HStar2Nodes(): %v", err)
-			continue
-		}
-		if got := len(visited); got != 0 {
-			t.Errorf("Prefetched %d more nodes than necessary", got)
-		}
-		if got, want := root, x.root; !bytes.Equal(got, want) {
-			t.Errorf("Root: %x, want: %x", got, want)
-		}
+			root, err := s.HStar2Nodes(nil, s.hasher.BitLen(), values,
+				func(depth int, index *big.Int) ([]byte, error) {
+					id := toID(depth, index)
+					visited[id]--
+					if visited[id] == 0 {
+						delete(visited, id)
+					}
+					return cache[id], nil
+				},
+				func(depth int, index *big.Int, hash []byte) error {
+					cache[toID(depth, index)] = hash
+					return nil
+				})
+			if err != nil {
+				t.Fatalf("HStar2Nodes(): %v", err)
+			}
+			if cnt := len(visited); cnt != 0 {
+				t.Errorf("Prefetched %d more nodes than necessary", cnt)
+			}
+			if got, want := root, x.root; !bytes.Equal(got, want) {
+				t.Errorf("Root: %x, want: %x", got, want)
+			}
+		})
 	}
 }
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -100,7 +100,7 @@ func TestHStar2SimpleDataSetKAT(t *testing.T) {
 
 // TestHStar2GetSet ensures that we get the same roots as above when we
 // incrementally calculate roots. It also makes sure that Prefetch visits the
-// same set of node that HStar2Nodes fetches.
+// same set of nodes that HStar2Nodes fetches.
 func TestHStar2GetSet(t *testing.T) {
 	t.Parallel()
 

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -213,10 +213,6 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 		leaves := make([]*HStar2LeafHash, 0, queueSize)
 		nodesToStore := make([]storage.Node, 0, queueSize*2)
 
-		// sibs will hold the list of sibling node IDs for all nodes we'll end up
-		// wanting to write - we'll use this to prewarm the subtree cache.
-		var sibs []storage.NodeID
-
 		// The go-routine will block here until the channel is closed via
 		// CalculateRoot, at which point we can proceed with completing the
 		// subtree building and calculation
@@ -226,8 +222,6 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 				return err
 			}
 			nodeID := storage.NewNodeIDFromPrefixSuffix(ih.index, storage.EmptySuffix, s.hasher.BitLen())
-			sibs = append(sibs, nodeID.Siblings()...)
-
 			leaves = append(leaves, &HStar2LeafHash{
 				Index:    nodeID.BigInt(),
 				LeafHash: ih.hash,
@@ -243,15 +237,25 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 		ctx, postQueueCloseEnd := spanFor(ctx, "buildSubtree.runTX.postQueueClose")
 		defer postQueueCloseEnd()
 
-		// Prewarm the cache:
-		if _, err := tx.GetMerkleNodes(ctx, s.treeRevision, sibs); err != nil {
+		// nodeIDs will hold the list of node IDs that HStar2 algorithm will read.
+		var nodeIDs []storage.NodeID
+		hs2 := NewHStar2(s.treeID, s.hasher)
+		err := hs2.Prefetch(s.prefix, s.subtreeDepth, leaves,
+			func(depth int, index *big.Int) ([]byte, error) {
+				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
+				nodeIDs = append(nodeIDs, nodeID)
+				return nil, nil
+			})
+		if err != nil {
+			return err
+		}
+		// Prewarm the Merkle tree cache.
+		if _, err := tx.GetMerkleNodes(ctx, s.treeRevision, nodeIDs); err != nil {
 			return fmt.Errorf("failed to preload node hash cache: %s", err)
 		}
 
 		hsCtx, hstar2SpanEnd := spanFor(ctx, "buildSubtree.runTX.hstar2")
-		// calculate new root, and intermediate nodes:
-		hs2 := NewHStar2(s.treeID, s.hasher)
-		var err error
+		// Calculate new root hash, and intermediate nodes.
 		root, err = hs2.HStar2Nodes(s.prefix, s.subtreeDepth, leaves,
 			func(depth int, index *big.Int) ([]byte, error) {
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
@@ -259,6 +263,8 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 					glog.Infof("buildSubtree.get(%x, %d) nid: %x, %v",
 						index.Bytes(), depth, nodeID.Path, nodeID.PrefixLenBits)
 				}
+				// TODO(pavelkalinnikov): Reuse the result of prefetch GetMerkleNodes.
+				// This will also eliminate cache contention.
 				nodes, err := tx.GetMerkleNodes(hsCtx, s.treeRevision, []storage.NodeID{nodeID})
 				if err != nil {
 					return nil, err

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -241,10 +241,9 @@ func (s *subtreeWriter) buildSubtree(ctx context.Context, queueSize int) {
 		var nodeIDs []storage.NodeID
 		hs2 := NewHStar2(s.treeID, s.hasher)
 		err := hs2.Prefetch(s.prefix, s.subtreeDepth, leaves,
-			func(depth int, index *big.Int) ([]byte, error) {
+			func(depth int, index *big.Int) {
 				nodeID := storage.NewNodeIDFromBigInt(depth, index, s.hasher.BitLen())
 				nodeIDs = append(nodeIDs, nodeID)
-				return nil, nil
 			})
 		if err != nil {
 			return err


### PR DESCRIPTION
This change adds a new `Prefetch` method to `HStar2` algorithm, which lists all nodes that the algorithm will read. This method is now used instead of the half-baked cache prefetch optimization that read all siblings of nodes on the paths to all the written leaves.