### PR TITLE
Refactored logical operations into methods from within SetLeaves.

### DIFF
--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -359,7 +359,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 			return err
 		}
 
-		hkv , err := t.writeLeaves(ctx, tree, hasher, tx, req.Leaves, writeRev)
+		hkv, err := t.writeLeaves(ctx, tree, hasher, tx, req.Leaves, writeRev)
 		if err != nil {
 			return err
 		}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -374,9 +374,8 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 	return &trillian.SetMapLeavesResponse{MapRoot: newRoot}, nil
 }
 
-// writeRevision ensures the desired write revision is available and claim a lock on this revision
-// in this transaction so that competing writes transactinos for the next revision cannot all be
-// committed.
+// writeRevision ensures the desired write revision is available and claims a lock on this revision
+// in this transaction so that competing writes transactions cannot be committed.
 func (t *TrillianMapServer) writeRevision(ctx context.Context, tree *trillian.Tree, tx storage.MapTreeTX, rev int64) (int64, error) {
 	writeRev, err := tx.WriteRevision(ctx)
 	if err != nil {

--- a/storage/map_storage.go
+++ b/storage/map_storage.go
@@ -66,6 +66,8 @@ type MapTreeTX interface {
 	// StoreSignedMapRoot stores root.
 	StoreSignedMapRoot(ctx context.Context, root *trillian.SignedMapRoot) error
 	// Set sets key to leaf
+	// TODO(mhutchinson): Remove the keyHash parameter or document why it is redundantly passed in
+	// (it is also inside the MapLeaf)
 	Set(ctx context.Context, keyHash []byte, value *trillian.MapLeaf) error
 }
 


### PR DESCRIPTION
This herds the code in a direction where updateTree() can be called asynchronously, thus allowing for greater parallelism in the write path. This is a pure refactoring; no functional changes are intended here.