### PR TITLE
Use %w in fmt.Errorf() to wrap errors

### DIFF
--- a/client/log_client.go
+++ b/client/log_client.go
@@ -65,10 +65,10 @@ func NewFromTree(client trillian.TrillianLogClient, config *trillian.Tree, root 
 // Blocks and continuously updates the trusted root until it has been included in a signed log root.
 func (c *LogClient) AddSequencedLeafAndWait(ctx context.Context, data []byte, index int64) error {
 	if err := c.AddSequencedLeaf(ctx, data, index); err != nil {
-		return fmt.Errorf("QueueLeaf(): %v", err)
+		return fmt.Errorf("QueueLeaf(): %w", err)
 	}
 	if err := c.WaitForInclusion(ctx, data); err != nil {
-		return fmt.Errorf("WaitForInclusion(): %v", err)
+		return fmt.Errorf("WaitForInclusion(): %w", err)
 	}
 	return nil
 }
@@ -78,10 +78,10 @@ func (c *LogClient) AddSequencedLeafAndWait(ctx context.Context, data []byte, in
 // can be retrieved.
 func (c *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 	if err := c.QueueLeaf(ctx, data); err != nil {
-		return fmt.Errorf("QueueLeaf(): %v", err)
+		return fmt.Errorf("QueueLeaf(): %w", err)
 	}
 	if err := c.WaitForInclusion(ctx, data); err != nil {
-		return fmt.Errorf("WaitForInclusion(): %v", err)
+		return fmt.Errorf("WaitForInclusion(): %w", err)
 	}
 	return nil
 }
@@ -347,7 +347,7 @@ func (c *LogClient) getAndVerifyInclusionProof(ctx context.Context, leafHash []b
 	}
 	for _, proof := range resp.Proof {
 		if err := c.VerifyInclusionByHash(sth, leafHash, proof); err != nil {
-			return false, fmt.Errorf("VerifyInclusionByHash(): %v", err)
+			return false, fmt.Errorf("VerifyInclusionByHash(): %w", err)
 		}
 	}
 	return true, nil

--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -44,12 +44,12 @@ func addSequencedLeaves(ctx context.Context, env *integration.LogEnv, client *Lo
 	}
 	for i, l := range leaves {
 		if err := client.AddSequencedLeaf(ctx, l, int64(i)); err != nil {
-			return fmt.Errorf("AddSequencedLeaf(): %v", err)
+			return fmt.Errorf("AddSequencedLeaf(): %w", err)
 		}
 	}
 	env.Sequencer.OperationSingle(ctx)
 	if err := client.WaitForInclusion(ctx, leaves[len(leaves)-1]); err != nil {
-		return fmt.Errorf("WaitForInclusion(): %v", err)
+		return fmt.Errorf("WaitForInclusion(): %w", err)
 	}
 	return nil
 }

--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -65,17 +65,17 @@ func NewLogVerifierFromTree(config *trillian.Tree) (*LogVerifier, error) {
 
 	logHasher, err := hashers.NewLogHasher(config.HashStrategy)
 	if err != nil {
-		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): NewLogHasher(): %v", err)
+		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): NewLogHasher(): %w", err)
 	}
 
 	logPubKey, err := der.UnmarshalPublicKey(config.PublicKey.GetDer())
 	if err != nil {
-		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log public key: %v", err)
+		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log public key: %w", err)
 	}
 
 	sigHash, err := trees.Hash(config)
 	if err != nil {
-		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log signature hash: %v", err)
+		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): Failed parsing Log signature hash: %w", err)
 	}
 
 	return NewLogVerifier(logHasher, logPubKey, sigHash), nil
@@ -102,7 +102,7 @@ func (c *LogVerifier) VerifyRoot(trusted *types.LogRootV1, newRoot *trillian.Sig
 	if trusted.TreeSize != 0 {
 		// Verify consistency proof.
 		if err := c.v.VerifyConsistencyProof(int64(trusted.TreeSize), int64(r.TreeSize), trusted.RootHash, r.RootHash, consistency); err != nil {
-			return nil, fmt.Errorf("failed to verify consistency proof from %d->%d %x->%x: %v", trusted.TreeSize, r.TreeSize, trusted.RootHash, r.RootHash, err)
+			return nil, fmt.Errorf("failed to verify consistency proof from %d->%d %x->%x: %w", trusted.TreeSize, r.TreeSize, trusted.RootHash, r.RootHash, err)
 		}
 	}
 	return r, nil

--- a/client/map_verifier.go
+++ b/client/map_verifier.go
@@ -59,7 +59,7 @@ func NewMapVerifier(config *trillian.Tree, rootVerifier *maps.RootVerifier) (*Ma
 
 	mapHasher, err := hashers.NewMapHasher(config.HashStrategy)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating MapHasher: %v", err)
+		return nil, fmt.Errorf("failed creating MapHasher: %w", err)
 	}
 
 	return &MapVerifier{

--- a/cmd/createtree/main.go
+++ b/cmd/createtree/main.go
@@ -79,12 +79,12 @@ func createTree(ctx context.Context) (*trillian.Tree, error) {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine dial options: %v", err)
+		return nil, fmt.Errorf("failed to determine dial options: %w", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial %v: %v", *adminServerAddr, err)
+		return nil, fmt.Errorf("failed to dial %v: %w", *adminServerAddr, err)
 	}
 	defer conn.Close()
 

--- a/cmd/createtree/pem.go
+++ b/cmd/createtree/pem.go
@@ -57,12 +57,12 @@ func privateKeyProtoFromFlags() (proto.Message, error) {
 
 	key, err := pem.ReadPrivateKeyFile(*pemKeyPath, *pemKeyPass)
 	if err != nil {
-		return nil, fmt.Errorf("error reading reading private key file: %v", err)
+		return nil, fmt.Errorf("error reading reading private key file: %w", err)
 	}
 
 	keyDER, err := der.MarshalPrivateKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling private key as DER: %v", err)
+		return nil, fmt.Errorf("error marshaling private key as DER: %w", err)
 	}
 
 	return &keyspb.PrivateKey{Der: keyDER}, nil

--- a/cmd/createtree/pkcs11.go
+++ b/cmd/createtree/pkcs11.go
@@ -43,17 +43,17 @@ func pkcs11ConfigProtoFromFlags() (proto.Message, error) {
 
 	configBytes, err := ioutil.ReadFile(*pkcs11ConfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading PKCS#11 config file: %v", err)
+		return nil, fmt.Errorf("error reading PKCS#11 config file: %w", err)
 	}
 
 	var config pkcs11key.Config
 	if err = json.Unmarshal(configBytes, &config); err != nil {
-		return nil, fmt.Errorf("error parsing PKCS#11 config file: %v", err)
+		return nil, fmt.Errorf("error parsing PKCS#11 config file: %w", err)
 	}
 
 	pubKeyPEM, err := ioutil.ReadFile(config.PublicKeyPath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading PKCS#11 public key file: %v", err)
+		return nil, fmt.Errorf("error reading PKCS#11 public key file: %w", err)
 	}
 
 	return &keyspb.PKCS11Config{

--- a/cmd/get_tree_public_key/main.go
+++ b/cmd/get_tree_public_key/main.go
@@ -42,19 +42,19 @@ func getPublicKeyPEM() (string, error) {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return "", fmt.Errorf("failed to determine dial options: %v", err)
+		return "", fmt.Errorf("failed to determine dial options: %w", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
-		return "", fmt.Errorf("failed to dial %v: %v", *adminServerAddr, err)
+		return "", fmt.Errorf("failed to dial %v: %w", *adminServerAddr, err)
 	}
 	defer conn.Close()
 
 	a := trillian.NewTrillianAdminClient(conn)
 	tree, err := a.GetTree(context.Background(), &trillian.GetTreeRequest{TreeId: *logID})
 	if err != nil {
-		return "", fmt.Errorf("call to GetTree failed: %v", err)
+		return "", fmt.Errorf("call to GetTree failed: %w", err)
 	}
 
 	if tree == nil {

--- a/cmd/updatetree/main.go
+++ b/cmd/updatetree/main.go
@@ -95,12 +95,12 @@ func updateTree(ctx context.Context) (*trillian.Tree, error) {
 
 	dialOpts, err := rpcflags.NewClientDialOptionsFromFlags()
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine dial options: %v", err)
+		return nil, fmt.Errorf("failed to determine dial options: %w", err)
 	}
 
 	conn, err := grpc.Dial(*adminServerAddr, dialOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial %v: %v", *adminServerAddr, err)
+		return nil, fmt.Errorf("failed to dial %v: %w", *adminServerAddr, err)
 	}
 	defer conn.Close()
 
@@ -115,7 +115,7 @@ func updateTree(ctx context.Context) (*trillian.Tree, error) {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		return nil, fmt.Errorf("failed to UpdateTree(%+v): %T %v", req, err, err)
+		return nil, fmt.Errorf("failed to UpdateTree(%+v): %w", req, err)
 	}
 }
 

--- a/crypto/keys/der/der.go
+++ b/crypto/keys/der/der.go
@@ -36,12 +36,12 @@ func FromProto(pb *keyspb.PrivateKey) (crypto.Signer, error) {
 func NewProtoFromSpec(spec *keyspb.Specification) (*keyspb.PrivateKey, error) {
 	key, err := keys.NewFromSpec(spec)
 	if err != nil {
-		return nil, fmt.Errorf("der: error generating key: %v", err)
+		return nil, fmt.Errorf("der: error generating key: %w", err)
 	}
 
 	der, err := MarshalPrivateKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("der: error marshaling private key: %v", err)
+		return nil, fmt.Errorf("der: error marshaling private key: %w", err)
 	}
 
 	return &keyspb.PrivateKey{Der: der}, nil

--- a/crypto/keys/pem/pem.go
+++ b/crypto/keys/pem/pem.go
@@ -40,12 +40,12 @@ func ReadPrivateKeyFile(file, password string) (crypto.Signer, error) {
 
 	keyPEM, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("pemfile: error reading file %q: %v", file, err)
+		return nil, fmt.Errorf("pemfile: error reading file %q: %w", file, err)
 	}
 
 	k, err := UnmarshalPrivateKey(string(keyPEM), password)
 	if err != nil {
-		return nil, fmt.Errorf("pemfile: error decoding private key from file %q: %v", file, err)
+		return nil, fmt.Errorf("pemfile: error decoding private key from file %q: %w", file, err)
 	}
 
 	return k, nil
@@ -55,7 +55,7 @@ func ReadPrivateKeyFile(file, password string) (crypto.Signer, error) {
 func ReadPublicKeyFile(file string) (crypto.PublicKey, error) {
 	keyPEM, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("pemfile: error reading %q: %v", file, err)
+		return nil, fmt.Errorf("pemfile: error reading %q: %w", file, err)
 	}
 
 	return UnmarshalPublicKey(string(keyPEM))
@@ -76,7 +76,7 @@ func UnmarshalPrivateKey(keyPEM, password string) (crypto.Signer, error) {
 	if password != "" {
 		pwdDer, err := x509.DecryptPEMBlock(block, []byte(password))
 		if err != nil {
-			return nil, fmt.Errorf("pemfile: failed to decrypt: %v", err)
+			return nil, fmt.Errorf("pemfile: failed to decrypt: %w", err)
 		}
 		keyDER = pwdDer
 	}

--- a/crypto/keys/pkcs11/pkcs11.go
+++ b/crypto/keys/pkcs11/pkcs11.go
@@ -36,7 +36,7 @@ func FromConfig(modulePath string, config *keyspb.PKCS11Config) (crypto.Signer, 
 	pubKeyPEM := config.GetPublicKey()
 	pubKey, err := pem.UnmarshalPublicKey(pubKeyPEM)
 	if err != nil {
-		return nil, fmt.Errorf("pkcs11: error loading public key from %q: %v", pubKeyPEM, err)
+		return nil, fmt.Errorf("pkcs11: error loading public key from %q: %w", pubKeyPEM, err)
 	}
 
 	return pkcs11key.New(modulePath, config.GetTokenLabel(), config.GetPin(), pubKey)

--- a/examples/ct/ctmapper/mapper/mapper.go
+++ b/examples/ct/ctmapper/mapper/mapper.go
@@ -89,7 +89,7 @@ func (m *CTMapper) oneMapperRun(ctx context.Context) (bool, error) {
 
 	mapperMetadata := &ctmapperpb.MapperMetadata{}
 	if err := proto.Unmarshal(mapRoot.Metadata, mapperMetadata); err != nil {
-		return false, fmt.Errorf("failed to unmarshal MapRoot.Metadata: %v", err)
+		return false, fmt.Errorf("failed to unmarshal MapRoot.Metadata: %w", err)
 	}
 
 	startEntry := mapperMetadata.HighestFullyCompletedSeq + 1
@@ -193,7 +193,7 @@ func (m *CTMapper) oneMapperRun(ctx context.Context) (bool, error) {
 
 	mapperBytes, err := proto.Marshal(mapperMetadata)
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal mapper metadata as 'bytes': err %v", err)
+		return false, fmt.Errorf("failed to marshal mapper metadata as 'bytes': err %w", err)
 	}
 
 	setReq.Metadata = mapperBytes

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -87,7 +87,7 @@ func createBatchLeaves(batch, n int) []*trillian.MapLeaf {
 func isEmptyMap(ctx context.Context, tmap trillian.TrillianMapClient, tree *trillian.Tree) error {
 	r, err := tmap.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{MapId: tree.TreeId})
 	if err != nil {
-		return fmt.Errorf("failed to get empty map head: %v", err)
+		return fmt.Errorf("failed to get empty map head: %w", err)
 	}
 
 	var mapRoot types.MapRootV1
@@ -139,7 +139,7 @@ func verifyGetMapLeavesResponse(mapVerifier *client.MapVerifier, getResp *trilli
 			}
 		}
 		if err := mapVerifier.VerifyMapLeafInclusion(getResp.GetMapRoot(), incl); err != nil {
-			return fmt.Errorf("VerifyMapLeafInclusion(%x): %v", index, err)
+			return fmt.Errorf("VerifyMapLeafInclusion(%x): %w", index, err)
 		}
 	}
 	return nil

--- a/integration/quota/quota_test.go
+++ b/integration/quota/quota_test.go
@@ -129,13 +129,13 @@ func TestMySQLRateLimiting(t *testing.T) {
 func runRateLimitingTest(ctx context.Context, s *testServer, numTokens int) error {
 	tree, err := s.admin.CreateTree(ctx, &trillian.CreateTreeRequest{Tree: testonly.LogTree})
 	if err != nil {
-		return fmt.Errorf("CreateTree() returned err = %v", err)
+		return fmt.Errorf("CreateTree() returned err = %w", err)
 	}
 	// InitLog costs 1 token
 	numTokens--
 	_, err = s.log.InitLog(ctx, &trillian.InitLogRequest{LogId: tree.TreeId})
 	if err != nil {
-		return fmt.Errorf("InitLog() returned err = %v", err)
+		return fmt.Errorf("InitLog() returned err = %w", err)
 	}
 	hasherFn, err := trees.Hash(tree)
 	if err != nil {
@@ -147,7 +147,7 @@ func runRateLimitingTest(ctx context.Context, s *testServer, numTokens int) erro
 	// Requests where leaves < numTokens should work
 	for i := 0; i < numTokens; i++ {
 		if err := lw.queueLeaf(ctx); err != nil {
-			return fmt.Errorf("queueLeaf(@%d) returned err = %v", i, err)
+			return fmt.Errorf("queueLeaf(@%d) returned err = %w", i, err)
 		}
 	}
 
@@ -164,7 +164,7 @@ func runRateLimitingTest(ctx context.Context, s *testServer, numTokens int) erro
 				continue // Rate liming hasn't kicked in yet
 			}
 			if s, ok := status.FromError(err); !ok || s.Code() != codes.ResourceExhausted {
-				return fmt.Errorf("queueLeaf() returned err = %v", err)
+				return fmt.Errorf("queueLeaf() returned err = %w", err)
 			}
 			stop = true
 		}

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -147,17 +147,17 @@ func NewOperationManager(info OperationInfo, logOperation Operation) *OperationM
 func (o *OperationManager) getActiveLogIDs(ctx context.Context) ([]int64, error) {
 	tx, err := o.info.Registry.LogStorage.Snapshot(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transaction: %v", err)
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
 	}
 	defer tx.Close()
 
 	logIDs, err := tx.GetActiveLogIDs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get active logIDs: %v", err)
+		return nil, fmt.Errorf("failed to get active logIDs: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("failed to commit: %v", err)
+		return nil, fmt.Errorf("failed to commit: %w", err)
 	}
 	return logIDs, nil
 }
@@ -233,7 +233,7 @@ func (o *OperationManager) masterFor(ctx context.Context, allIDs []int64) ([]int
 		el, err := o.info.Registry.ElectionFactory.NewElection(innerCtx, logID)
 		if err != nil {
 			cancel()
-			return nil, fmt.Errorf("failed to create election for %v: %v", logID, err)
+			return nil, fmt.Errorf("failed to create election for %v: %w", logID, err)
 		}
 		o.electionRunner[logID] = election.NewRunner(logID, &o.info.ElectionConfig, o.tracker, cancel, el)
 		o.runnerWG.Add(1)
@@ -284,14 +284,14 @@ func (o *OperationManager) getLogsAndExecutePass(ctx context.Context) error {
 
 	activeIDs, err := o.getActiveLogIDs(runCtx)
 	if err != nil {
-		return fmt.Errorf("failed to list active log IDs: %v", err)
+		return fmt.Errorf("failed to list active log IDs: %w", err)
 	}
 	// Find the logs we are master for, skipping those logs that are not active,
 	// e.g. deleted or FROZEN ones.
 	// TODO(pavelkalinnikov): Resign mastership for the inactive logs.
 	logIDs, err := o.masterFor(ctx, activeIDs)
 	if err != nil {
-		return fmt.Errorf("failed to determine log IDs we're master for: %v", err)
+		return fmt.Errorf("failed to determine log IDs we're master for: %w", err)
 	}
 	o.updateHeldIDs(ctx, logIDs, activeIDs)
 

--- a/log/sequencer_manager.go
+++ b/log/sequencer_manager.go
@@ -57,18 +57,18 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *O
 
 	tree, err := trees.GetTree(ctx, s.registry.AdminStorage, logID, seqOpts)
 	if err != nil {
-		return 0, fmt.Errorf("error retrieving log %v: %v", logID, err)
+		return 0, fmt.Errorf("error retrieving log %v: %w", logID, err)
 	}
 	ctx = trees.NewContext(ctx, tree)
 
 	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
 	if err != nil {
-		return 0, fmt.Errorf("error getting hasher for log %v: %v", logID, err)
+		return 0, fmt.Errorf("error getting hasher for log %v: %w", logID, err)
 	}
 
 	signer, err := s.getSigner(ctx, tree)
 	if err != nil {
-		return 0, fmt.Errorf("error getting signer for log %v: %v", logID, err)
+		return 0, fmt.Errorf("error getting signer for log %v: %w", logID, err)
 	}
 
 	sequencer := NewSequencer(hasher, info.TimeSource, s.registry.LogStorage, signer, s.registry.MetricFactory, s.registry.QuotaManager)
@@ -80,7 +80,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *O
 	}
 	leaves, err := sequencer.IntegrateBatch(ctx, tree, info.BatchSize, s.guardWindow, maxRootDuration)
 	if err != nil {
-		return 0, fmt.Errorf("failed to integrate batch for %v: %v", logID, err)
+		return 0, fmt.Errorf("failed to integrate batch for %v: %w", logID, err)
 	}
 	return leaves, nil
 }

--- a/maps/root_verifier.go
+++ b/maps/root_verifier.go
@@ -47,12 +47,12 @@ func NewRootVerifierFromTree(config *trillian.Tree) (*RootVerifier, error) {
 
 	mapPubKey, err := der.UnmarshalPublicKey(config.PublicKey.GetDer())
 	if err != nil {
-		return nil, fmt.Errorf("failed parsing Map public key: %v", err)
+		return nil, fmt.Errorf("failed parsing Map public key: %w", err)
 	}
 
 	sigHash, err := trees.Hash(config)
 	if err != nil {
-		return nil, fmt.Errorf("maps: NewRootVerifierFromTree(): Failed parsing Map signature hash: %v", err)
+		return nil, fmt.Errorf("maps: NewRootVerifierFromTree(): Failed parsing Map signature hash: %w", err)
 	}
 
 	return &RootVerifier{

--- a/quota/etcd/etcdqm/etcdqm_test.go
+++ b/quota/etcd/etcdqm/etcdqm_test.go
@@ -346,7 +346,7 @@ func drain(ctx context.Context, qs *storage.QuotaStorage, cfgs *storagepb.Config
 	}
 	for _, cfg := range cfgs.Configs {
 		if err := qs.Get(ctx, []string{cfg.Name}, cfg.MaxTokens); err != nil {
-			return fmt.Errorf("%v: %v", cfg.Name, err)
+			return fmt.Errorf("%v: %w", cfg.Name, err)
 		}
 	}
 	return nil
@@ -357,7 +357,7 @@ func reset(ctx context.Context, qs *storage.QuotaStorage, cfgs *storagepb.Config
 		(*c).Reset()
 		proto.Merge(c, cfgs)
 	}); err != nil {
-		return fmt.Errorf("UpdateConfigs() returned err = %v", err)
+		return fmt.Errorf("UpdateConfigs() returned err = %w", err)
 	}
 	return nil
 }
@@ -381,7 +381,7 @@ func (d *quotaDiffer) snapshot(ctx context.Context) error {
 func (d *quotaDiffer) assertDiff(ctx context.Context, desc string, want int) error {
 	currentTokens, err := d.qs.Peek(ctx, d.names)
 	if err != nil {
-		return fmt.Errorf("in %s: Peek() returned err = %v", desc, err)
+		return fmt.Errorf("in %s: Peek() returned err = %w", desc, err)
 	}
 	want64 := int64(want)
 	for k, v := range currentTokens {

--- a/quota/etcd/quotaapi/quota_server_test.go
+++ b/quota/etcd/quotaapi/quota_server_test.go
@@ -467,14 +467,14 @@ type upsertRPC func(ctx context.Context, req interface{}) (*quotapb.Config, erro
 // Storage is reset() before the test is executed.
 func runUpsertTest(ctx context.Context, test upsertTest, rpc upsertRPC, rpcName string) error {
 	if err := reset(ctx); err != nil {
-		return fmt.Errorf("%v: reset() returned err = %v", test.desc, err)
+		return fmt.Errorf("%v: reset() returned err = %w", test.desc, err)
 	}
 	if test.baseCfg != nil {
 		if _, err := quotaClient.CreateConfig(ctx, &quotapb.CreateConfigRequest{
 			Name:   test.baseCfg.Name,
 			Config: test.baseCfg,
 		}); err != nil {
-			return fmt.Errorf("%v: CreateConfig() returned err = %v", test.desc, err)
+			return fmt.Errorf("%v: CreateConfig() returned err = %w", test.desc, err)
 		}
 	}
 
@@ -490,7 +490,7 @@ func runUpsertTest(ctx context.Context, test upsertTest, rpc upsertRPC, rpcName 
 
 	switch stored, err := quotaClient.GetConfig(ctx, &quotapb.GetConfigRequest{Name: test.req.GetName()}); {
 	case err != nil:
-		return fmt.Errorf("%v: GetConfig() returned err = %v", test.desc, err)
+		return fmt.Errorf("%v: GetConfig() returned err = %w", test.desc, err)
 	case !proto.Equal(stored, test.wantCfg):
 		return fmt.Errorf("%v: post-GetConfig() diff:\n%v", test.desc, pretty.Compare(stored, test.wantCfg))
 	}

--- a/quota/etcd/storage/quota_storage.go
+++ b/quota/etcd/storage/quota_storage.go
@@ -358,7 +358,7 @@ func getConfigs(s concurrency.STM) (*storagepb.Configs, error) {
 		return cfgs, nil
 	}
 	if err := proto.Unmarshal([]byte(val), cfgs); err != nil {
-		return nil, fmt.Errorf("error unmarshaling %v: %v", configsKey, err)
+		return nil, fmt.Errorf("error unmarshaling %v: %w", configsKey, err)
 	}
 	return cfgs, nil
 }
@@ -375,7 +375,7 @@ func modBucket(s concurrency.STM, cfg *storagepb.Config, now time.Time, add int6
 	val := s.Get(key)
 	var prevBucket storagepb.Bucket
 	if err := proto.Unmarshal([]byte(val), &prevBucket); err != nil {
-		return 0, fmt.Errorf("error unmarshaling %v: %v", key, err)
+		return 0, fmt.Errorf("error unmarshaling %v: %w", key, err)
 	}
 	newBucket := proto.Clone(&prevBucket).(*storagepb.Bucket)
 

--- a/quota/etcd/storage/quota_storage_test.go
+++ b/quota/etcd/storage/quota_storage_test.go
@@ -938,7 +938,7 @@ func setupTimeSource(ts clock.TimeSource) func() {
 // initialTokens.
 func setupTokens(ctx context.Context, qs *QuotaStorage, cfgs *storagepb.Configs, initialTokens map[string]int64) error {
 	if _, err := qs.UpdateConfigs(ctx, true /* reset */, updater(cfgs)); err != nil {
-		return fmt.Errorf("UpdateConfigs() returned err = %v", err)
+		return fmt.Errorf("UpdateConfigs() returned err = %w", err)
 	}
 	for name, wantTokens := range initialTokens {
 		names := []string{name}

--- a/server/admin/tree_gc.go
+++ b/server/admin/tree_gc.go
@@ -119,7 +119,7 @@ func (gc *DeletedTreeGC) RunOnce(ctx context.Context) (int, error) {
 	// deleted trees are unlikely to change, specially those deleted for a while.
 	trees, err := storage.ListTrees(ctx, gc.admin, true /* includeDeleted */)
 	if err != nil {
-		return 0, fmt.Errorf("error listing trees: %v", err)
+		return 0, fmt.Errorf("error listing trees: %w", err)
 	}
 
 	count := 0
@@ -130,7 +130,7 @@ func (gc *DeletedTreeGC) RunOnce(ctx context.Context) (int, error) {
 		}
 		deleteTime, err := ptypes.Timestamp(tree.DeleteTime)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error parsing delete_time of tree %v: %v", tree.TreeId, err))
+			errs = append(errs, fmt.Errorf("error parsing delete_time of tree %v: %w", tree.TreeId, err))
 			incHardDeleteCounter(tree.TreeId, false, timestampParseErrReson)
 			continue
 		}
@@ -141,7 +141,7 @@ func (gc *DeletedTreeGC) RunOnce(ctx context.Context) (int, error) {
 
 		glog.Infof("DeletedTreeGC.RunOnce: Hard-deleting tree %v after %v", tree.TreeId, durationSinceDelete)
 		if err := storage.HardDeleteTree(ctx, gc.admin, tree.TreeId); err != nil {
-			errs = append(errs, fmt.Errorf("error hard-deleting tree %v: %v", tree.TreeId, err))
+			errs = append(errs, fmt.Errorf("error hard-deleting tree %v: %w", tree.TreeId, err))
 			incHardDeleteCounter(tree.TreeId, false, deleteErrReason)
 			continue
 		}

--- a/server/etcd_quota_provider.go
+++ b/server/etcd_quota_provider.go
@@ -50,7 +50,7 @@ func newEtcdQuotaManager() (quota.Manager, error) {
 	}
 	client, err := etcd.NewClientFromString(*EtcdServers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to etcd at %v: %v", *EtcdServers, err)
+		return nil, fmt.Errorf("failed to connect to etcd at %v: %w", *EtcdServers, err)
 	}
 
 	qm := etcdqm.New(client)

--- a/skylog/core/builder.go
+++ b/skylog/core/builder.go
@@ -58,11 +58,11 @@ func (b *BuildWorker) Process(ctx context.Context, job BuildJob) (*compact.Range
 		visit(compact.NewNodeID(0, job.RangeStart+uint64(i)), hash)
 		// Add the internal tree nodes.
 		if err := rng.Append(hash, visit); err != nil {
-			return nil, fmt.Errorf("appending hash: %v", err)
+			return nil, fmt.Errorf("appending hash: %w", err)
 		}
 	}
 	if err := b.tw.Write(ctx, nodes); err != nil {
-		return nil, fmt.Errorf("writing tree nodes: %v", err)
+		return nil, fmt.Errorf("writing tree nodes: %w", err)
 	}
 	return rng, nil
 }

--- a/skylog/storage/gcp/cloudfunc/worker.go
+++ b/skylog/storage/gcp/cloudfunc/worker.go
@@ -50,7 +50,7 @@ type BuildMessage struct {
 func BuildSubtree(ctx context.Context, msg BuildMessage) error {
 	client, err := spannerClient(ctx)
 	if err != nil {
-		return fmt.Errorf("connecting to Spanner failed: %v", err)
+		return fmt.Errorf("connecting to Spanner failed: %w", err)
 	}
 
 	var job pb.BuildJob
@@ -105,7 +105,7 @@ func spannerClient(ctx context.Context) (*spanner.Client, error) {
 
 	var err error
 	if client, err = spanner.NewClient(ctx, db); err != nil {
-		return nil, fmt.Errorf("spanner.NewClient: %v", err)
+		return nil, fmt.Errorf("spanner.NewClient: %w", err)
 	}
 	log.Printf("Connected to Cloud Spanner: %s", db)
 	return client, err

--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -96,7 +96,7 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFu
 		}
 		root, err := cr.GetRootHash(store)
 		if err != nil {
-			return fmt.Errorf("failed to compute root hash: %v", err)
+			return fmt.Errorf("failed to compute root hash: %w", err)
 		}
 		st.RootHash = root
 

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -408,7 +408,7 @@ func readLeaves(ctx context.Context, stx *spanner.ReadOnlyTransaction, logID int
 		var err error
 		l.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 		if err != nil {
-			return fmt.Errorf("got invalid queue timestamp: %v", err)
+			return fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		f(&l)
 		return nil
@@ -486,7 +486,7 @@ func (tx *logTX) DequeueLeaves(ctx context.Context, limit int, cutoff time.Time)
 		var err error
 		l.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qe.timestamp))
 		if err != nil {
-			return fmt.Errorf("got invalid queue timestamp: %v", err)
+			return fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		k := string(l.LeafIdentityHash)
 		if tx.dequeued[k] != nil {
@@ -530,7 +530,7 @@ func (tx *logTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.L
 
 		iTimestamp, err := ptypes.Timestamp(l.IntegrateTimestamp)
 		if err != nil {
-			return fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 
 		// Add the sequence mapping...
@@ -542,7 +542,7 @@ func (tx *logTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.L
 
 		tx.numSequenced++
 		if err := stx.BufferWrite([]*spanner.Mutation{m1, m2}); err != nil {
-			return fmt.Errorf("bufferwrite(): %v", err)
+			return fmt.Errorf("bufferwrite(): %w", err)
 		}
 	}
 
@@ -588,11 +588,11 @@ func (l leafmap) addFullRow(r *spanner.Row) error {
 	var err error
 	leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 	if err != nil {
-		return fmt.Errorf("got invalid queue timestamp %v", err)
+		return fmt.Errorf("got invalid queue timestamp %w", err)
 	}
 	leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, iTimestamp))
 	if err != nil {
-		return fmt.Errorf("got invalid integrate timestamp %v", err)
+		return fmt.Errorf("got invalid integrate timestamp %w", err)
 	}
 
 	l[sequenceNumber] = leaf
@@ -614,7 +614,7 @@ func (b leavesByHash) addRow(r *spanner.Row) error {
 	}
 	queueTimestamp, err := ptypes.TimestampProto(time.Unix(0, qTimestamp))
 	if err != nil {
-		return fmt.Errorf("got invalid queue timestamp: %v", err)
+		return fmt.Errorf("got invalid queue timestamp: %w", err)
 	}
 
 	leaves, ok := b[string(h)]
@@ -873,7 +873,7 @@ func (tx *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 		return nil
 	}); err != nil {
 		glog.Warningf("GetActiveLogIDs: %v", err)
-		return nil, fmt.Errorf("problem executing getActiveLogIDsSQL: %v", err)
+		return nil, fmt.Errorf("problem executing getActiveLogIDsSQL: %w", err)
 	}
 	return ids, nil
 }
@@ -890,7 +890,7 @@ func (tx *readOnlyLogTX) GetUnsequencedCounts(ctx context.Context) (storage.Coun
 		ret[id] = c
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("problem executing unsequencedCountSQL: %v", err)
+		return nil, fmt.Errorf("problem executing unsequencedCountSQL: %w", err)
 	}
 	return ret, nil
 }

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -210,7 +210,7 @@ func (t *treeTX) writeRev(ctx context.Context) (int64, error) {
 	if err := t.getLatestRoot(ctx); err == storage.ErrTreeNeedsInit {
 		return 0, nil
 	} else if err != nil {
-		return -1, fmt.Errorf("writeRev(): %v", err)
+		return -1, fmt.Errorf("writeRev(): %w", err)
 	}
 	return t._writeRev, nil
 }

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -164,7 +164,7 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 		// ErrNoRows doesn't provide useful information, so we don't forward it.
 		return nil, status.Errorf(codes.NotFound, "tree %v not found", treeID)
 	case err != nil:
-		return nil, fmt.Errorf("error reading tree %v: %v", treeID, err)
+		return nil, fmt.Errorf("error reading tree %v: %w", treeID, err)
 	}
 	return tree, nil
 }
@@ -250,15 +250,15 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	newTree.TreeId = id
 	newTree.CreateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build create time: %v", err)
+		return nil, fmt.Errorf("failed to build create time: %w", err)
 	}
 	newTree.UpdateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build update time: %v", err)
+		return nil, fmt.Errorf("failed to build update time: %w", err)
 	}
 	rootDuration, err := ptypes.Duration(newTree.MaxRootDuration)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse MaxRootDuration: %v", err)
+		return nil, fmt.Errorf("could not parse MaxRootDuration: %w", err)
 	}
 
 	insertTreeStmt, err := t.tx.PrepareContext(
@@ -285,7 +285,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 
 	privateKey, err := proto.Marshal(newTree.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+		return nil, fmt.Errorf("could not marshal PrivateKey: %w", err)
 	}
 
 	_, err = insertTreeStmt.ExecContext(
@@ -314,7 +314,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	if _, err := t.GetTree(ctx, newTree.TreeId); err != nil {
 		// GetTree will fail for truncated enums (they get recorded as
 		// empty strings, which will not match any known value).
-		return nil, fmt.Errorf("enum truncated: %v", err)
+		return nil, fmt.Errorf("enum truncated: %w", err)
 	}
 
 	insertControlStmt, err := t.tx.PrepareContext(
@@ -366,16 +366,16 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	now := storage.FromMillisSinceEpoch(nowMillis)
 	tree.UpdateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build update time: %v", err)
+		return nil, fmt.Errorf("failed to build update time: %w", err)
 	}
 	rootDuration, err := ptypes.Duration(tree.MaxRootDuration)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse MaxRootDuration: %v", err)
+		return nil, fmt.Errorf("could not parse MaxRootDuration: %w", err)
 	}
 
 	privateKey, err := proto.Marshal(tree.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+		return nil, fmt.Errorf("could not marshal PrivateKey: %w", err)
 	}
 
 	stmt, err := t.tx.PrepareContext(ctx, updateTreeSQL)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -462,7 +462,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(queueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 	}
 	start := time.Now()
@@ -478,7 +478,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		leafStart := time.Now()
 		qTimestamp, err := ptypes.Timestamp(leaf.QueueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		_, err = t.tx.ExecContext(ctx, insertLeafDataSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, qTimestamp.UnixNano())
 		insertDuration := time.Since(leafStart)
@@ -503,7 +503,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		}
 		queueTimestamp, err := ptypes.Timestamp(leaf.QueueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		args = append(args, queueArgs(t.treeID, leaf.LeafIdentityHash, queueTimestamp)...)
 		_, err = t.tx.ExecContext(
@@ -535,7 +535,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 	}
 	results, err := t.getLeafDataByIdentityHash(ctx, toRetrieve)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve existing leaves: %v", err)
+		return nil, fmt.Errorf("failed to retrieve existing leaves: %w", err)
 	}
 	if len(results) != len(toRetrieve) {
 		return nil, fmt.Errorf("failed to retrieve all existing leaves: got %d, want %d", len(results), len(toRetrieve))
@@ -708,11 +708,11 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, iTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		ret = append(ret, leaf)
 	}
@@ -783,11 +783,11 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, iTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		ret = append(ret, leaf)
 	}
@@ -923,12 +923,12 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, queueTS))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		if integrateTS.Valid {
 			leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, integrateTS.Int64))
 			if err != nil {
-				return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+				return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 			}
 		}
 

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -66,7 +66,7 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 	// supplied data was already written to LeafData as part of queueing the leaf.
 	queueTimestampProto, err := ptypes.TimestampProto(time.Unix(0, queueTimestamp))
 	if err != nil {
-		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %v", err)
+		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %w", err)
 	}
 	leaf := &trillian.LogLeaf{
 		LeafIdentityHash: leafIDHash,
@@ -89,7 +89,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 
 		iTimestamp, err := ptypes.Timestamp(leaf.IntegrateTimestamp)
 		if err != nil {
-			return fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		_, err = t.tx.ExecContext(
 			ctx,

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -62,7 +62,7 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 
 	queueTimestampProto, err := ptypes.TimestampProto(time.Unix(0, queueTimestamp))
 	if err != nil {
-		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %v", err)
+		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %w", err)
 	}
 	// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
 	// sequencer. The sequencer only writes to the SequencedLeafData table and the client
@@ -98,7 +98,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 	for _, leaf := range leaves {
 		iTimestamp, err := ptypes.Timestamp(leaf.IntegrateTimestamp)
 		if err != nil {
-			return fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		querySuffix = append(querySuffix, valuesPlaceholder5)
 		args = append(args, t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano())

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -251,10 +251,10 @@ func mustSignAndStoreLogRoot(ctx context.Context, t *testing.T, l storage.LogSto
 	err := l.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 		root, err := signer.SignLogRoot(&types.LogRootV1{TreeSize: treeSize, RootHash: []byte{0}})
 		if err != nil {
-			return fmt.Errorf("error creating new SignedLogRoot: %v", err)
+			return fmt.Errorf("error creating new SignedLogRoot: %w", err)
 		}
 		if err := tx.StoreSignedLogRoot(ctx, root); err != nil {
-			return fmt.Errorf("error storing new SignedLogRoot: %v", err)
+			return fmt.Errorf("error storing new SignedLogRoot: %w", err)
 		}
 		return nil
 	})

--- a/storage/postgres/admin_storage.go
+++ b/storage/postgres/admin_storage.go
@@ -195,7 +195,7 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 		// ErrNoRows doesn't provide useful information, so we don't forward it.
 		return nil, status.Errorf(codes.NotFound, "tree %v not found", treeID)
 	case err != nil:
-		return nil, fmt.Errorf("error reading tree %v: %v", treeID, err)
+		return nil, fmt.Errorf("error reading tree %v: %w", treeID, err)
 	}
 	return tree, nil
 }
@@ -289,15 +289,15 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	newTree.TreeId = id
 	newTree.CreateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build create time: %v", err)
+		return nil, fmt.Errorf("failed to build create time: %w", err)
 	}
 	newTree.UpdateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build update time: %v", err)
+		return nil, fmt.Errorf("failed to build update time: %w", err)
 	}
 	rootDuration, err := ptypes.Duration(newTree.MaxRootDuration)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse MaxRootDuration: %v", err)
+		return nil, fmt.Errorf("could not parse MaxRootDuration: %w", err)
 	}
 
 	insertTreeStmt, err := t.tx.PrepareContext(ctx, insertSQL)
@@ -308,7 +308,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 
 	privateKey, err := proto.Marshal(newTree.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+		return nil, fmt.Errorf("could not marshal PrivateKey: %w", err)
 	}
 
 	_, err = insertTreeStmt.ExecContext(
@@ -370,16 +370,16 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	now := storage.FromMillisSinceEpoch(nowMillis)
 	tree.UpdateTime, err = ptypes.TimestampProto(now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build tree.UpdateTime: %v", err)
+		return nil, fmt.Errorf("failed to build tree.UpdateTime: %w", err)
 	}
 	rootDuration, err := ptypes.Duration(tree.MaxRootDuration)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse MaxRootDuration: %v", err)
+		return nil, fmt.Errorf("could not parse MaxRootDuration: %w", err)
 	}
 
 	privateKey, err := proto.Marshal(tree.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal PrivateKey: %v", err)
+		return nil, fmt.Errorf("could not marshal PrivateKey: %w", err)
 	}
 
 	stmt, err := t.tx.PrepareContext(ctx, updateTreeSQL)

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -457,7 +457,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(queueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 	}
 	start := time.Now()
@@ -473,11 +473,11 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		leafStart := time.Now()
 		qTimestamp, err := ptypes.Timestamp(leaf.QueueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		dupCheckRow, err := t.tx.QueryContext(ctx, insertLeafDataSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, qTimestamp.UnixNano())
 		if err != nil {
-			return nil, fmt.Errorf("dupecheck failed: %v", err)
+			return nil, fmt.Errorf("dupecheck failed: %w", err)
 		}
 		insertDuration := time.Since(leafStart)
 		observe(queueInsertLeafLatency, insertDuration, label)
@@ -485,7 +485,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		for dupCheckRow.Next() {
 			err := dupCheckRow.Scan(&resultData)
 			if err != nil {
-				return nil, fmt.Errorf("dupecheck failed: %v", err)
+				return nil, fmt.Errorf("dupecheck failed: %w", err)
 			}
 			if !resultData {
 				break
@@ -509,7 +509,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		}
 		queueTimestamp, err := ptypes.Timestamp(leaf.QueueTimestamp)
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		args = append(args, queueArgs(t.treeID, leaf.LeafIdentityHash, queueTimestamp)...)
 		_, err = t.tx.ExecContext(
@@ -709,11 +709,11 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, iTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		ret = append(ret, leaf)
 	}
@@ -778,11 +778,11 @@ func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, qTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, iTimestamp))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		ret = append(ret, leaf)
 	}
@@ -906,12 +906,12 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		var err error
 		leaf.QueueTimestamp, err = ptypes.TimestampProto(time.Unix(0, queueTS))
 		if err != nil {
-			return nil, fmt.Errorf("got invalid queue timestamp: %v", err)
+			return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
 		}
 		if integrateTS.Valid {
 			leaf.IntegrateTimestamp, err = ptypes.TimestampProto(time.Unix(0, integrateTS.Int64))
 			if err != nil {
-				return nil, fmt.Errorf("got invalid integrate timestamp: %v", err)
+				return nil, fmt.Errorf("got invalid integrate timestamp: %w", err)
 			}
 		}
 
@@ -943,7 +943,7 @@ func (t *readOnlyLogTX) GetUnsequencedCounts(ctx context.Context) (storage.Count
 	for rows.Next() {
 		var logID, count int64
 		if err := rows.Scan(&logID, &count); err != nil {
-			return nil, fmt.Errorf("failed to scan row from unsequenced counts: %v", err)
+			return nil, fmt.Errorf("failed to scan row from unsequenced counts: %w", err)
 		}
 		ret[logID] = count
 	}

--- a/storage/postgres/queue.go
+++ b/storage/postgres/queue.go
@@ -65,7 +65,7 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 	// supplied data was already written to LeafData as part of queueing the leaf.
 	queueTimestampProto, err := ptypes.TimestampProto(time.Unix(0, queueTimestamp))
 	if err != nil {
-		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %v", err)
+		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %w", err)
 	}
 	leaf := &trillian.LogLeaf{
 		LeafIdentityHash: leafIDHash,
@@ -88,7 +88,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 
 		iTimestamp, err := ptypes.Timestamp(leaf.IntegrateTimestamp)
 		if err != nil {
-			return fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		_, err = t.tx.ExecContext(
 			ctx,

--- a/storage/postgres/queue_batching.go
+++ b/storage/postgres/queue_batching.go
@@ -62,7 +62,7 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 
 	queueTimestampProto, err := ptypes.TimestampProto(time.Unix(0, queueTimestamp))
 	if err != nil {
-		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %v", err)
+		return nil, dequeuedLeaf{}, fmt.Errorf("got invalid queue timestamp: %w", err)
 	}
 	// Note: the LeafData and ExtraData being nil here is OK as this is only used by the
 	// sequencer. The sequencer only writes to the SequencedLeafData table and the client
@@ -98,7 +98,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 	for _, leaf := range leaves {
 		iTimestamp, err := ptypes.Timestamp(leaf.IntegrateTimestamp)
 		if err != nil {
-			return fmt.Errorf("got invalid integrate timestamp: %v", err)
+			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		querySuffix = append(querySuffix, valuesPlaceholder5)
 		args = append(args, t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano())

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -125,10 +125,10 @@ func createFakeSignedLogRoot(db *sql.DB, tree *trillian.Tree, treeSize uint64) {
 	err := l.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
 		root, err := signer.SignLogRoot(&types.LogRootV1{TreeSize: treeSize, RootHash: []byte{0}})
 		if err != nil {
-			return fmt.Errorf("error creating new SignedLogRoot: %v", err)
+			return fmt.Errorf("error creating new SignedLogRoot: %w", err)
 		}
 		if err := tx.StoreSignedLogRoot(ctx, root); err != nil {
-			return fmt.Errorf("error storing new SignedLogRoot: %v", err)
+			return fmt.Errorf("error storing new SignedLogRoot: %w", err)
 		}
 		return nil
 	})

--- a/storage/postgres/testdb/testdb.go
+++ b/storage/postgres/testdb/testdb.go
@@ -86,7 +86,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, func(context.Context), error) {
 	name := fmt.Sprintf("trl_%v", time.Now().UnixNano())
 	stmt := fmt.Sprintf("CREATE DATABASE %v", name)
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return nil, nil, fmt.Errorf("error running statement %q: %v", stmt, err)
+		return nil, nil, fmt.Errorf("error running statement %q: %w", stmt, err)
 	}
 	db.Close()
 	db, err = sql.Open("postgres", getConnStr(name))
@@ -124,7 +124,7 @@ func NewTrillianDB(ctx context.Context) (*sql.DB, func(context.Context), error) 
 			continue
 		}
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			return nil, nil, fmt.Errorf("error running statement %q: %v", stmt, err)
+			return nil, nil, fmt.Errorf("error running statement %q: %w", stmt, err)
 		}
 	}
 	return db, done, nil

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -126,17 +126,17 @@ func ReadTree(row Row) (*trillian.Tree, error) {
 
 	tree.CreateTime, err = ptypes.TimestampProto(FromMillisSinceEpoch(createMillis))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse create time: %v", err)
+		return nil, fmt.Errorf("failed to parse create time: %w", err)
 	}
 	tree.UpdateTime, err = ptypes.TimestampProto(FromMillisSinceEpoch(updateMillis))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse update time: %v", err)
+		return nil, fmt.Errorf("failed to parse update time: %w", err)
 	}
 	tree.MaxRootDuration = ptypes.DurationProto(time.Duration(maxRootDurationMillis * int64(time.Millisecond)))
 
 	tree.PrivateKey = &any.Any{}
 	if err := proto.Unmarshal(privateKey, tree.PrivateKey); err != nil {
-		return nil, fmt.Errorf("could not unmarshal PrivateKey: %v", err)
+		return nil, fmt.Errorf("could not unmarshal PrivateKey: %w", err)
 	}
 	tree.PublicKey = &keyspb.PublicKey{Der: publicKey}
 
@@ -144,7 +144,7 @@ func ReadTree(row Row) (*trillian.Tree, error) {
 	if tree.Deleted && deleteMillis.Valid {
 		tree.DeleteTime, err = ptypes.TimestampProto(FromMillisSinceEpoch(deleteMillis.Int64))
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse delete time: %v", err)
+			return nil, fmt.Errorf("failed to parse delete time: %w", err)
 		}
 	}
 

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -88,7 +88,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, func(context.Context), error) {
 
 	stmt := fmt.Sprintf("CREATE DATABASE %v", name)
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return nil, nil, fmt.Errorf("error running statement %q: %v", stmt, err)
+		return nil, nil, fmt.Errorf("error running statement %q: %w", stmt, err)
 	}
 
 	db.Close()
@@ -127,7 +127,7 @@ func NewTrillianDB(ctx context.Context) (*sql.DB, func(context.Context), error) 
 			continue
 		}
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			return nil, nil, fmt.Errorf("error running statement %q: %v", stmt, err)
+			return nil, nil, fmt.Errorf("error running statement %q: %w", stmt, err)
 		}
 	}
 	return db, done, nil

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -447,7 +447,7 @@ func (tester *AdminStorageTester) TestListTrees(t *testing.T) {
 func runListTreeIDsTest(ctx context.Context, tx storage.ReadOnlyAdminTX, includeDeleted bool, wantTrees []*trillian.Tree) error {
 	got, err := tx.ListTreeIDs(ctx, includeDeleted)
 	if err != nil {
-		return fmt.Errorf("ListTreeIDs() returned err = %v", err)
+		return fmt.Errorf("ListTreeIDs() returned err = %w", err)
 	}
 
 	want := make([]int64, 0, len(wantTrees))
@@ -466,7 +466,7 @@ func runListTreeIDsTest(ctx context.Context, tx storage.ReadOnlyAdminTX, include
 func runListTreesTest(ctx context.Context, tx storage.ReadOnlyAdminTX, includeDeleted bool, wantTrees []*trillian.Tree) error {
 	got, err := tx.ListTrees(ctx, includeDeleted)
 	if err != nil {
-		return fmt.Errorf("ListTrees() returned err = %v", err)
+		return fmt.Errorf("ListTrees() returned err = %w", err)
 	}
 
 	if len(got) != len(wantTrees) {
@@ -705,7 +705,7 @@ func (tester *AdminStorageTester) TestAdminTXReadWriteTransaction(t *testing.T) 
 func assertStoredTree(ctx context.Context, s storage.AdminStorage, want *trillian.Tree) error {
 	got, err := storage.GetTree(ctx, s, want.TreeId)
 	if err != nil {
-		return fmt.Errorf("GetTree() returned err = %v", err)
+		return fmt.Errorf("GetTree() returned err = %w", err)
 	}
 	if !proto.Equal(got, want) {
 		return fmt.Errorf("post-GetTree() diff (-got +want):\n%v", pretty.Compare(got, want))

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -130,13 +130,13 @@ func NewMultiFakeNodeReaderFromLeaves(batches []LeafBatch) *MultiFakeNodeReader 
 			// Store the new leaf node, and all new perfect nodes.
 			store(compact.NewNodeID(0, cr.End()), hash)
 			if err := cr.Append(hash, store); err != nil {
-				panic(fmt.Errorf("Append: %v", err))
+				panic(fmt.Errorf("Append: %w", err))
 			}
 		}
 		// TODO(pavelkalinnikov): Use testing.T.Fatalf instead of panics.
 		root, err := cr.GetRootHash(store) // Store the ephemeral nodes as well.
 		if err != nil {
-			panic(fmt.Errorf("GetRootHash: %v", err))
+			panic(fmt.Errorf("GetRootHash: %w", err))
 		}
 		if cr.End() == 0 {
 			root = hasher.EmptyRoot()

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -265,7 +265,7 @@ func Main(args Options) string {
 			glog.Fatalf("LatestSignedLogRoot: %v", err)
 		}
 		if err := root.UnmarshalBinary(sth.LogRoot); err != nil {
-			return fmt.Errorf("could not parse current log root: %v", err)
+			return fmt.Errorf("could not parse current log root: %w", err)
 		}
 
 		glog.Infof("STH at size %d has hash %s@%d",

--- a/testonly/hammer/tree.go
+++ b/testonly/hammer/tree.go
@@ -31,7 +31,7 @@ func destroyMap(ctx context.Context, adminClient trillian.TrillianAdminClient, m
 	req := &trillian.DeleteTreeRequest{TreeId: mapID}
 	glog.Infof("Soft-delete transient Trillian Map with TreeID=%d", mapID)
 	if _, err := adminClient.DeleteTree(ctx, req); err != nil {
-		return fmt.Errorf("failed to DeleteTree(%d): %v", mapID, err)
+		return fmt.Errorf("failed to DeleteTree(%d): %w", mapID, err)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func makeNewMap(ctx context.Context, adminClient trillian.TrillianAdminClient, m
 
 	tree, err := client.CreateAndInitTree(ctx, req, adminClient, mapClient, nil)
 	if err != nil {
-		return -1, fmt.Errorf("client.CreateAndInitTree(%v) failed with err: %v", req, err)
+		return -1, fmt.Errorf("client.CreateAndInitTree(%v) failed with err: %w", req, err)
 	}
 	glog.Infof("Made new Trillian Map with TreeID=%d", tree.TreeId)
 

--- a/testonly/integration/port.go
+++ b/testonly/integration/port.go
@@ -23,11 +23,11 @@ import (
 func listen() (string, net.Listener, error) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to listen: %v", err)
+		return "", nil, fmt.Errorf("failed to listen: %w", err)
 	}
 	_, port, err := net.SplitHostPort(lis.Addr().String())
 	if err != nil {
-		return "", nil, fmt.Errorf("unrecognized format for listen address %v: %v", lis.Addr().String(), err)
+		return "", nil, fmt.Errorf("unrecognized format for listen address %v: %w", lis.Addr().String(), err)
 	}
 	addr := "localhost:" + port
 	return addr, lis, nil

--- a/testonly/mdm/mdm.go
+++ b/testonly/mdm/mdm.go
@@ -65,11 +65,11 @@ func NewMonitor(ctx context.Context, logID int64, cl trillian.TrillianLogClient,
 
 	tree, err := adminCl.GetTree(ctx, &trillian.GetTreeRequest{TreeId: logID})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get tree %d: %v", logID, err)
+		return nil, fmt.Errorf("failed to get tree %d: %w", logID, err)
 	}
 	verifier, err := client.NewLogVerifierFromTree(tree)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build verifier: %v", err)
+		return nil, fmt.Errorf("failed to build verifier: %w", err)
 	}
 	clients := make([]*client.LogClient, opts.ParallelAdds)
 	for i := 0; i < opts.ParallelAdds; i++ {
@@ -141,7 +141,7 @@ func (m *MergeDelayMonitor) monitor(ctx context.Context, idx int) error {
 		err := m.client[idx].AddLeaf(cctx, data)
 		cancel()
 		if err != nil {
-			return fmt.Errorf("failed to QueueLeaf: %v", err)
+			return fmt.Errorf("failed to QueueLeaf: %w", err)
 		}
 		mergeDelay := time.Since(start)
 		mergeDelayDist.Observe(mergeDelay.Seconds(), logIDLabel, newLeafLabel[createNew])

--- a/testonly/mdm/mdmtest/main.go
+++ b/testonly/mdm/mdmtest/main.go
@@ -140,14 +140,14 @@ func innerMain(ctx context.Context) error {
 	}
 	monitor, err := mdm.NewMonitor(ctx, *logID, cl, adminCl, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build merge delay monitor: %v", err)
+		return fmt.Errorf("failed to build merge delay monitor: %w", err)
 	}
 
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go util.AwaitSignal(ctx, cancel)
 	if err := monitor.Monitor(cctx); err != nil {
-		return fmt.Errorf("merge delay monitoring failed: %v", err)
+		return fmt.Errorf("merge delay monitoring failed: %w", err)
 	}
 	return nil
 }

--- a/trees/trees.go
+++ b/trees/trees.go
@@ -206,7 +206,7 @@ func Signer(ctx context.Context, tree *trillian.Tree) (*tcrypto.Signer, error) {
 
 	var keyProto ptypes.DynamicAny
 	if err := ptypes.UnmarshalAny(tree.PrivateKey, &keyProto); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal tree.PrivateKey: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal tree.PrivateKey: %w", err)
 	}
 
 	signer, err := keys.NewSigner(ctx, keyProto.Message)

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -125,7 +125,7 @@ func (er *Runner) Run(ctx context.Context, pending chan<- Resignation) {
 func (er *Runner) beMaster(ctx context.Context, pending chan<- Resignation) error {
 	glog.V(1).Infof("%s: When I left you, I was but the learner", er.id)
 	if err := er.election.Await(ctx); err != nil {
-		return fmt.Errorf("election.Await() failed: %v", err)
+		return fmt.Errorf("election.Await() failed: %w", err)
 	}
 	glog.Infof("%s: Now, I am the master", er.id)
 	er.tracker.Set(er.id, true)
@@ -133,7 +133,7 @@ func (er *Runner) beMaster(ctx context.Context, pending chan<- Resignation) erro
 
 	mctx, err := er.election.WithMastership(ctx)
 	if err != nil {
-		return fmt.Errorf("election.WithMastership() failed: %v", err)
+		return fmt.Errorf("election.WithMastership() failed: %w", err)
 	}
 
 	timer := er.cfg.TimeSource.NewTimer(er.cfg.ResignDelay())

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -148,7 +148,7 @@ func (f *Factory) NewElection(ctx context.Context, resourceID string) (election2
 	// TODO(pavelkalinnikov): Share the same session between Election instances.
 	session, err := concurrency.NewSession(f.client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create etcd session: %v", err)
+		return nil, fmt.Errorf("failed to create etcd session: %w", err)
 	}
 	lockFile := fmt.Sprintf("%s/%s", strings.TrimRight(f.lockDir, "/"), resourceID)
 	election := concurrency.NewElection(session, lockFile)


### PR DESCRIPTION
See https://golang.org/doc/go1.13#error_wrapping.
Only works in Go 1.13 upwards.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
