### PR TITLE
merkle: Drop dependency on storage.NodeID for logs

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -80,13 +80,13 @@ const (
 )
 
 var (
-	treeSize  = flag.Int64("tree_size", 23, "Size of tree to produce")
+	treeSize  = flag.Uint64("tree_size", 23, "Size of tree to produce")
 	inclusion = flag.Int64("inclusion", -1, "Leaf index to show inclusion proof")
-	megaMode  = flag.Int64("megamode_threshold", 4, "Treat perfect trees larger than this many layers as a single entity")
+	megaMode  = flag.Uint("megamode_threshold", 4, "Treat perfect trees larger than this many layers as a single entity")
 	ranges    = flag.String("ranges", "", "Comma-separated Open-Closed ranges of the form L:R")
 
 	// nInfo holds nodeInfo data for the tree.
-	nInfo = make(map[string]nodeInfo)
+	nInfo = make(map[compact.NodeID]nodeInfo)
 )
 
 // nodeInfo represents the style to be applied to a tree node.
@@ -147,38 +147,35 @@ func (n nodeInfo) String() string {
 	return strings.Join(attr, ", ")
 }
 
-// modifyNodeInfo applies f to the nodeInfo associated with node k.
-func modifyNodeInfo(k string, f func(*nodeInfo)) {
-	n, ok := nInfo[k]
-	if !ok {
-		n = nodeInfo{}
-	}
+// modifyNodeInfo applies f to the nodeInfo associated with node id.
+func modifyNodeInfo(id compact.NodeID, f func(*nodeInfo)) {
+	n := nInfo[id] // Note: Returns an empty nodeInfo if id is not found.
 	f(&n)
-	nInfo[k] = n
+	nInfo[id] = n
 }
 
 // perfectMega renders a large perfect subtree as a single entity.
-func perfectMega(prefix string, height, leafIndex int64) {
-	stLeaves := int64(1) << uint(height)
+func perfectMega(prefix string, height uint, leafIndex uint64) {
+	stLeaves := uint64(1) << height
 	stWidth := float32(stLeaves) / float32(*treeSize)
 	fmt.Printf("%s [%d\\dots%d, edge label={node[midway, above]{%d}}, perfect, tier=leaf, minimum width=%f\\linewidth ]\n", prefix, leafIndex, leafIndex+stLeaves, stLeaves, stWidth)
 
 	// Create some hidden nodes to preseve the tier spacings:
 	fmt.Printf("%s", prefix)
-	for i := height - 2; i > 0; i-- {
+	for i := int(height - 2); i > 0; i-- {
 		fmt.Printf(" [, no edge, tier=%d ", i)
 		defer fmt.Printf(" ] ")
 	}
 }
 
 // perfect renders a perfect subtree.
-func perfect(prefix string, height, index int64) {
+func perfect(prefix string, height uint, index uint64) {
 	perfectInner(prefix, height, index, true)
 }
 
 // drawLeaf emits TeX code to render a leaf.
-func drawLeaf(prefix string, index int64) {
-	a := nInfo[nodeKey(0, index)]
+func drawLeaf(prefix string, index uint64) {
+	a := nInfo[compact.NewNodeID(0, index)]
 	fmt.Printf("%s [%d, %s, tier=leaf]\n", prefix, index, a.String())
 }
 
@@ -186,45 +183,40 @@ func drawLeaf(prefix string, index int64) {
 // The caller may emit any number of child nodes before calling the returned
 // func to close the node.
 // Returns a func to be called to close the node.
-//
-func openInnerNode(prefix string, height, index int64) func() {
-	attr := nInfo[nodeKey(height, index)].String()
-	fmt.Printf("%s [%d.%d, %s, tier=%d\n", prefix, height, index, attr, height-1)
+func openInnerNode(prefix string, id compact.NodeID) func() {
+	attr := nInfo[id].String()
+	fmt.Printf("%s [%d.%d, %s, tier=%d\n", prefix, id.Level, id.Index, attr, id.Index-1)
 	return func() { fmt.Printf("%s ]\n", prefix) }
 }
 
 // perfectInner renders the nodes of a perfect internal subtree.
-func perfectInner(prefix string, height, index int64, top bool) {
-	nk := nodeKey(height, index)
-	modifyNodeInfo(nk, func(n *nodeInfo) {
-		n.leaf = height == 0
+func perfectInner(prefix string, level uint, index uint64, top bool) {
+	id := compact.NewNodeID(level, index)
+	modifyNodeInfo(id, func(n *nodeInfo) {
+		n.leaf = id.Level == 0
 		n.perfectRoot = top
 	})
 
-	if height == 0 {
+	if level == 0 {
 		drawLeaf(prefix, index)
 		return
 	}
-	c := openInnerNode(prefix, height, index)
+	c := openInnerNode(prefix, id)
 	childIndex := index << 1
-	if height > *megaMode {
-		perfectMega(prefix, height, index<<uint(height))
+	if level > *megaMode {
+		perfectMega(prefix, level, index<<level)
 	} else {
-		perfectInner(prefix+" ", height-1, childIndex, false)
-		perfectInner(prefix+" ", height-1, childIndex+1, false)
+		perfectInner(prefix+" ", level-1, childIndex, false)
+		perfectInner(prefix+" ", level-1, childIndex+1, false)
 	}
 	c()
 }
 
 // renderTree renders a tree node and recurses if necessary.
-func renderTree(prefix string, treeSize, index int64) {
-	if treeSize <= 0 {
-		return
-	}
-
+func renderTree(prefix string, treeSize, index uint64) {
 	// Look at the bit of the treeSize corresponding to the current level:
-	height := int64(bits.Len64(uint64(treeSize)) - 1)
-	b := int64(1) << uint(height)
+	height := uint(bits.Len64(treeSize) - 1)
+	b := uint64(1) << height
 	rest := treeSize - b
 	// left child is a perfect subtree.
 
@@ -232,26 +224,15 @@ func renderTree(prefix string, treeSize, index int64) {
 	// parent. (Otherwise we'll just keep quiet, and recurse down - this is how
 	// we arrange for leaves to always be on the bottom level.)
 	if rest > 0 {
-		ch := height + 1
-		ci := index >> uint(ch)
-		modifyNodeInfo(nodeKey(ch, ci), func(n *nodeInfo) { n.ephemeral = true })
-		c := openInnerNode(prefix, ch, ci)
+		childHeight := height + 1
+		id := compact.NewNodeID(childHeight, index>>childHeight)
+		modifyNodeInfo(id, func(n *nodeInfo) { n.ephemeral = true })
+		c := openInnerNode(prefix, id)
 		defer c()
 	}
-	perfect(prefix+" ", height, index>>uint(height))
+	perfect(prefix+" ", height, index>>height)
 	index += b
 	renderTree(prefix+" ", rest, index)
-}
-
-// nodeKey returns a stable node identifier for the passed in node coordinate.
-func nodeKey(level, index int64) string {
-	return fmt.Sprintf("%d.%d", level, index)
-}
-
-// toNodeKey converts a compact.NodeID to the corresponding stable node
-// identifier used by this tool.
-func toNodeKey(n compact.NodeID) string {
-	return nodeKey(int64(n.Level), int64(n.Index))
 }
 
 // decompose splits out a range into component subtrees.
@@ -277,31 +258,29 @@ func decomposeRange(begin, end uint64) (uint64, uint64) {
 // parseRanges parses and validates a string of comma-separates open-closed
 // ranges of the form L:R.
 // Returns the parsed ranges, or an error if there's a problem.
-func parseRanges(ranges string, treeSize int64) ([][2]int64, error) {
+func parseRanges(ranges string, treeSize uint64) ([][2]uint64, error) {
 	rangePairs := strings.Split(ranges, ",")
 	numRanges := len(rangePairs)
 	if num, max := numRanges, maxRanges; num > max {
 		return nil, fmt.Errorf("too many ranges %d, must be %d or fewer", num, max)
 	}
-	ret := make([][2]int64, 0, numRanges)
+	ret := make([][2]uint64, 0, numRanges)
 	for _, rng := range rangePairs {
 		lr := strings.Split(rng, ":")
 		if len(lr) != 2 {
 			return nil, fmt.Errorf("specified range %q is invalid", rng)
 		}
-		var l, r int64
+		var l, r uint64
 		if _, err := fmt.Sscanf(rng, "%d:%d", &l, &r); err != nil {
 			return nil, fmt.Errorf("range %q is malformed: %s", rng, err)
 		}
 		switch {
 		case r > treeSize:
 			return nil, fmt.Errorf("range %q extends past end of tree (%d)", lr, treeSize)
-		case l < 0:
-			return nil, fmt.Errorf("range %q has negative beginning", rng)
 		case l > r:
 			return nil, fmt.Errorf("range elements in %q are out of order", rng)
 		}
-		ret = append(ret, [2]int64{l, r})
+		ret = append(ret, [2]uint64{l, r})
 	}
 	return ret, nil
 }
@@ -319,28 +298,31 @@ func modifyRangeNodeInfo() error {
 		l, r := lr[0], lr[1]
 		// Set leaves:
 		for i := l; i < r; i++ {
-			modifyNodeInfo(nodeKey(0, i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
+			id := compact.NewNodeID(0, i)
+			modifyNodeInfo(id, func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
 		}
 
 		// Now perfect roots which comprise the range:
-		maskL, maskR := decomposeRange(uint64(l), uint64(r))
+		maskL, maskR := decomposeRange(l, r)
 		p := l
 		// Do left perfect subtree roots:
 		nBitsL := uint(bits.Len64(maskL))
 		for i, bit := uint(0), uint64(1); i < nBitsL; i, bit = i+1, bit<<1 {
 			if maskL&bit != 0 {
 				if i > 0 {
-					modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
+					id := compact.NewNodeID(i, p>>i)
+					modifyNodeInfo(id, func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
 				}
-				p += int64(bit)
+				p += bit
 			}
 		}
 		// Do right perfect subtree roots:
 		nBitsR := uint(bits.Len64(maskR))
 		for i, bit := nBitsR, uint64(1<<nBitsR); i > 1; i, bit = i-1, bit>>1 {
 			if maskR&bit != 0 {
-				modifyNodeInfo(nodeKey(int64(i), p>>i), func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
-				p += int64(bit)
+				id := compact.NewNodeID(i, p>>i)
+				modifyNodeInfo(id, func(n *nodeInfo) { n.rangeIndices = append(n.rangeIndices, ri) })
+				p += bit
 			}
 		}
 	}
@@ -351,19 +333,21 @@ func modifyRangeNodeInfo() error {
 func main() {
 	// TODO(al): check flag validity.
 	flag.Parse()
-	height := int64(bits.Len(uint(*treeSize-1)) + 1)
+	height := uint(bits.Len64(*treeSize-1)) + 1
 
 	if *inclusion > 0 {
-		modifyNodeInfo(nodeKey(0, *inclusion), func(n *nodeInfo) { n.target = true })
-		nf, err := merkle.CalcInclusionProofNodeAddresses(*treeSize, *inclusion, *treeSize)
+		leafID := compact.NewNodeID(0, uint64(*inclusion))
+		modifyNodeInfo(leafID, func(n *nodeInfo) { n.target = true })
+		nf, err := merkle.CalcInclusionProofNodeAddresses(int64(*treeSize), *inclusion, int64(*treeSize))
 		if err != nil {
 			log.Fatalf("Failed to calculate inclusion proof addresses: %s", err)
 		}
 		for _, n := range nf {
-			modifyNodeInfo(toNodeKey(n.ID), func(n *nodeInfo) { n.incProof = true })
+			modifyNodeInfo(n.ID, func(n *nodeInfo) { n.incProof = true })
 		}
-		for h, i := int64(0), *inclusion; h < height; h, i = h+1, i>>1 {
-			modifyNodeInfo(nodeKey(h, i), func(n *nodeInfo) { n.incPath = true })
+		for h, i := uint(0), leafID.Index; h < height; h, i = h+1, i>>1 {
+			id := compact.NewNodeID(h, i)
+			modifyNodeInfo(id, func(n *nodeInfo) { n.incPath = true })
 		}
 	}
 

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -36,11 +36,6 @@ type NodeFetch struct {
 	Rehash bool
 }
 
-// Equivalent return true iff the other represents the same rehash state and NodeID as the other.
-func (n NodeFetch) Equivalent(other NodeFetch) bool {
-	return n.Rehash == other.Rehash && n.ID == other.ID
-}
-
 // checkSnapshot performs a couple of simple sanity checks on ss and treeSize
 // and returns an error if there's a problem.
 func checkSnapshot(ssDesc string, ss, treeSize int64) error {

--- a/merkle/merkle_path.go
+++ b/merkle/merkle_path.go
@@ -20,7 +20,7 @@ import (
 	"math/bits"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/merkle/compact"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -32,13 +32,13 @@ const vvLevel = 4
 // NodeFetch bundles a nodeID with additional information on how to use the node to construct the
 // correct proof.
 type NodeFetch struct {
-	NodeID storage.NodeID
+	ID     compact.NodeID
 	Rehash bool
 }
 
 // Equivalent return true iff the other represents the same rehash state and NodeID as the other.
 func (n NodeFetch) Equivalent(other NodeFetch) bool {
-	return n.Rehash == other.Rehash && n.NodeID.Equivalent(other.NodeID)
+	return n.Rehash == other.Rehash && n.ID == other.ID
 }
 
 // checkSnapshot performs a couple of simple sanity checks on ss and treeSize
@@ -53,12 +53,11 @@ func checkSnapshot(ssDesc string, ss, treeSize int64) error {
 	return nil
 }
 
-// CalcInclusionProofNodeAddresses returns the tree node IDs needed to
-// build an inclusion proof for a specified leaf and tree size. The snapshot parameter
-// is the tree size being queried for, treeSize is the actual size of the tree at the revision
-// we are using to fetch nodes (this can be > snapshot). The maxBitLen parameter
-// is copied into all the returned nodeIDs.
-func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+// CalcInclusionProofNodeAddresses returns the tree node IDs needed to build an
+// inclusion proof for a specified leaf and tree size. The snapshot parameter
+// is the tree size being queried for, treeSize is the actual size of the tree
+// at the revision we are using to fetch nodes (this can be > snapshot).
+func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64) ([]NodeFetch, error) {
 	if err := checkSnapshot("snapshot", snapshot, treeSize); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for inclusion proof: %v", err)
 	}
@@ -68,22 +67,21 @@ func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64, maxBitLen 
 	if index < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for inclusion proof: index %d is < 0", index)
 	}
-	if maxBitLen <= 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for inclusion proof: maxBitLen %d <= 0", maxBitLen)
-	}
 
-	return pathFromNodeToRootAtSnapshot(index, 0, snapshot, treeSize, maxBitLen)
+	return pathFromNodeToRootAtSnapshot(index, 0, snapshot, treeSize)
 }
 
-// CalcConsistencyProofNodeAddresses returns the tree node IDs needed to
-// build a consistency proof between two specified tree sizes. snapshot1 and snapshot2 represent
-// the two tree sizes for which consistency should be proved, treeSize is the actual size of the
-// tree at the revision we are using to fetch nodes (this can be > snapshot2). The maxBitLen
-// parameter is copied into all the returned nodeIDs. The caller is responsible for checking that
-// the input tree sizes correspond to valid tree heads. All returned NodeIDs are tree
-// coordinates within the new tree. It is assumed that they will be fetched from storage
-// at a revision corresponding to the STH associated with the treeSize parameter.
-func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+// CalcConsistencyProofNodeAddresses returns the tree node IDs needed to build
+// a consistency proof between two specified tree sizes. snapshot1 and
+// snapshot2 represent the two tree sizes for which consistency should be
+// proved, treeSize is the actual size of the tree at the revision we are using
+// to fetch nodes (this can be > snapshot2).
+//
+// The caller is responsible for checking that the input tree sizes correspond
+// to valid tree heads. All returned NodeIDs are tree coordinates within the
+// new tree. It is assumed that they will be fetched from storage at a revision
+// corresponding to the STH associated with the treeSize parameter.
+func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64) ([]NodeFetch, error) {
 	if err := checkSnapshot("snapshot1", snapshot1, treeSize); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: %v", err)
 	}
@@ -93,16 +91,13 @@ func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64, max
 	if snapshot1 > snapshot2 {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: snapshot1 %d > snapshot2 %d", snapshot1, snapshot2)
 	}
-	if maxBitLen <= 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: maxBitLen %d <= 0", maxBitLen)
-	}
 
-	return snapshotConsistency(snapshot1, snapshot2, treeSize, maxBitLen)
+	return snapshotConsistency(snapshot1, snapshot2, treeSize)
 }
 
 // snapshotConsistency does the calculation of consistency proof node addresses between
 // two snapshots. Based on the C++ code used by CT but adjusted to fit our situation.
-func snapshotConsistency(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
+func snapshotConsistency(snapshot1, snapshot2, treeSize int64) ([]NodeFetch, error) {
 	proof := make([]NodeFetch, 0, bits.Len64(uint64(snapshot2))+1)
 
 	glog.V(vLevel).Infof("snapshotConsistency: %d -> %d", snapshot1, snapshot2)
@@ -125,23 +120,20 @@ func snapshotConsistency(snapshot1, snapshot2, treeSize int64, maxBitLen int) ([
 	if node != 0 {
 		glog.V(vvLevel).Infof("Not root snapshot1: %d", node)
 		// Not at the root of snapshot 1, record the node
-		n, err := storage.NewNodeIDForTreeCoords(int64(level), node, maxBitLen)
-		if err != nil {
-			return nil, err
-		}
-		proof = append(proof, NodeFetch{NodeID: n})
+		n := compact.NewNodeID(uint(level), uint64(node))
+		proof = append(proof, NodeFetch{ID: n})
 	}
 
 	// Now append the path from this node to the root of snapshot2.
-	p, err := pathFromNodeToRootAtSnapshot(node, level, snapshot2, treeSize, maxBitLen)
+	p, err := pathFromNodeToRootAtSnapshot(node, level, snapshot2, treeSize)
 	if err != nil {
 		return nil, err
 	}
 	return append(proof, p...), nil
 }
 
-func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int64, maxBitLen int) ([]NodeFetch, error) {
-	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot(%d, %d, %d, %d, %d)", node, level, snapshot, treeSize, maxBitLen)
+func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int64) ([]NodeFetch, error) {
+	glog.V(vLevel).Infof("pathFromNodeToRootAtSnapshot(%d, %d, %d, %d)", node, level, snapshot, treeSize)
 	proof := make([]NodeFetch, 0, bits.Len64(uint64(snapshot))+1)
 
 	if snapshot == 0 {
@@ -159,11 +151,8 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 			if glog.V(vvLevel) {
 				glog.Infof("Not last: S:%d L:%d", sibling, level)
 			}
-			n, err := storage.NewNodeIDForTreeCoords(int64(level), sibling, maxBitLen)
-			if err != nil {
-				return nil, err
-			}
-			proof = append(proof, NodeFetch{NodeID: n})
+			n := compact.NewNodeID(uint(level), uint64(sibling))
+			proof = append(proof, NodeFetch{ID: n})
 		} else if sibling == lastNode {
 			// The sibling is the last node of the level in the snapshot tree.
 			// We might need to recompute a previous hash value here. This can only occur on the
@@ -176,15 +165,12 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 				// No recomputation required as we're using the tree in its current state
 				// Account for non existent nodes - these can only be the rightmost node at an
 				// intermediate (non leaf) level in the tree so will always be a right sibling.
-				n, err := siblingIDSkipLevels(snapshot, lastNode, level, node, maxBitLen)
-				if err != nil {
-					return nil, err
-				}
-				proof = append(proof, NodeFetch{NodeID: n})
+				n := siblingIDSkipLevels(snapshot, lastNode, level, node)
+				proof = append(proof, NodeFetch{ID: n})
 			} else {
 				// We need to recompute this node, as it was at the prior snapshot point. We record
 				// the additional fetches needed to do this later
-				rehashFetches, err := recomputePastSnapshot(snapshot, treeSize, level, maxBitLen)
+				rehashFetches, err := recomputePastSnapshot(snapshot, treeSize, level)
 				if err != nil {
 					return nil, err
 				}
@@ -218,7 +204,7 @@ func pathFromNodeToRootAtSnapshot(node int64, level int, snapshot, treeSize int6
 // the output of this should always be exactly one node after resolving any rehashing.
 // Either a copy of one of the nodes in the tree or a rehashing of multiple nodes to a single
 // result node with the value it would have had if the prior snapshot had been stored.
-func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen int) ([]NodeFetch, error) {
+func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int) ([]NodeFetch, error) {
 	glog.V(vLevel).Infof("recompute s:%d ts:%d level:%d", snapshot, treeSize, nodeLevel)
 
 	fetches := []NodeFetch{}
@@ -246,12 +232,8 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 			if glog.V(vvLevel) {
 				glog.Infof("copying l:%d ln:%d", level, lastNode)
 			}
-			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
-			if err != nil {
-				return nil, err
-			}
-
-			return append(fetches, NodeFetch{Rehash: false, NodeID: nodeID}), nil
+			nodeID := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1)
+			return append(fetches, NodeFetch{Rehash: false, ID: nodeID}), nil
 		}
 
 		// Left sibling and parent exist at this snapshot and don't need to be rehashed
@@ -269,13 +251,10 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 
 	// lastNode is now the index of a left sibling with no right sibling. This is where the
 	// rehashing starts
-	savedNodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1, maxBitlen)
-	if err != nil {
-		return nil, err
-	}
+	savedNodeID := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, lastNode^1)
 
 	if nodeLevel == level {
-		return append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID}), nil
+		return append(fetches, NodeFetch{Rehash: true, ID: savedNodeID}), nil
 	}
 
 	rehash := false
@@ -291,20 +270,16 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 		}
 
 		if (lastNode & 1) != 0 {
-			nodeID, err := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, (lastNode-1)^1, maxBitlen)
-			if err != nil {
-				return nil, err
-			}
-
+			nodeID := siblingIDSkipLevels(snapshot, lastNodeAtLevel, level, (lastNode-1)^1)
 			if !rehash && !subRootEmitted {
-				fetches = append(fetches, NodeFetch{Rehash: true, NodeID: savedNodeID})
+				fetches = append(fetches, NodeFetch{Rehash: true, ID: savedNodeID})
 				subRootEmitted = true
 			}
 
 			if glog.V(vvLevel) {
-				glog.Infof("rehash with %s", nodeID.CoordString())
+				glog.Infof("rehash with %+v", nodeID)
 			}
-			fetches = append(fetches, NodeFetch{Rehash: true, NodeID: nodeID})
+			fetches = append(fetches, NodeFetch{Rehash: true, ID: nodeID})
 			rehash = true
 		}
 
@@ -313,7 +288,7 @@ func recomputePastSnapshot(snapshot, treeSize int64, nodeLevel int, maxBitlen in
 		level++
 
 		if nodeLevel == level && !subRootEmitted {
-			return append(fetches, NodeFetch{Rehash: rehash, NodeID: savedNodeID}), nil
+			return append(fetches, NodeFetch{Rehash: rehash, ID: savedNodeID}), nil
 		}
 
 		// Exit early if we've gone far enough up the tree to hit the level we're recomputing
@@ -458,7 +433,7 @@ func checkRecomputation(fetches []NodeFetch) error {
 // siblingIDSkipLevels creates a new NodeID for the supplied node, accounting for levels skipped
 // in storage. Note that it returns an ID for the node sibling so care should be taken to pass the
 // correct value for the node parameter.
-func siblingIDSkipLevels(snapshot, lastNode int64, level int, node int64, maxBitLen int) (storage.NodeID, error) {
+func siblingIDSkipLevels(snapshot, lastNode int64, level int, node int64) compact.NodeID {
 	l, sibling := skipMissingLevels(snapshot, lastNode, level, node)
-	return storage.NewNodeIDForTreeCoords(int64(l), sibling, maxBitLen)
+	return compact.NewNodeID(uint(l), uint64(sibling))
 }

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/merkle/compact"
 )
 
 type auditPathTestData struct {
@@ -69,23 +69,23 @@ const testUpToTreeSize = 99
 // populated from the bottom up, hence the gap at level 1, index 3 in the above picture.
 
 var expectedPathSize7Index0 = []NodeFetch{ // from a
-	MustCreateNodeFetchForTreeCoords(0, 1, 64, false), // b
-	MustCreateNodeFetchForTreeCoords(1, 1, 64, false), // h
-	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
+	NodeFetchForTreeCoords(0, 1, false), // b
+	NodeFetchForTreeCoords(1, 1, false), // h
+	NodeFetchForTreeCoords(2, 1, false), // l
 }
 var expectedPathSize7Index3 = []NodeFetch{ // from d
-	MustCreateNodeFetchForTreeCoords(0, 2, 64, false), // c
-	MustCreateNodeFetchForTreeCoords(1, 0, 64, false), // g
-	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
+	NodeFetchForTreeCoords(0, 2, false), // c
+	NodeFetchForTreeCoords(1, 0, false), // g
+	NodeFetchForTreeCoords(2, 1, false), // l
 }
 var expectedPathSize7Index4 = []NodeFetch{ // from e
-	MustCreateNodeFetchForTreeCoords(0, 5, 64, false), // f
-	MustCreateNodeFetchForTreeCoords(0, 6, 64, false), // j
-	MustCreateNodeFetchForTreeCoords(2, 0, 64, false), // k
+	NodeFetchForTreeCoords(0, 5, false), // f
+	NodeFetchForTreeCoords(0, 6, false), // j
+	NodeFetchForTreeCoords(2, 0, false), // k
 }
 var expectedPathSize7Index6 = []NodeFetch{ // from j
-	MustCreateNodeFetchForTreeCoords(1, 2, 64, false), // i
-	MustCreateNodeFetchForTreeCoords(2, 0, 64, false), // k
+	NodeFetchForTreeCoords(1, 2, false), // i
+	NodeFetchForTreeCoords(2, 0, false), // k
 }
 
 // Expected consistency proofs built from the examples in RFC 6962. Again, in our implementation
@@ -96,7 +96,7 @@ var expectedConsistencyProofFromSize1To2 = []NodeFetch{
 	//  hash0=a      =>         a b
 	//        |                 | |
 	//        d0               d0 d1
-	MustCreateNodeFetchForTreeCoords(0, 1, 64, false), // b
+	NodeFetchForTreeCoords(0, 1, false), // b
 }
 var expectedConsistencyProofFromSize1To4 = []NodeFetch{
 	//
@@ -113,8 +113,8 @@ var expectedConsistencyProofFromSize1To4 = []NodeFetch{
 	//                       d0 d1   d2 d3
 	//
 	//
-	MustCreateNodeFetchForTreeCoords(0, 1, 64, false), // b
-	MustCreateNodeFetchForTreeCoords(1, 1, 64, false), // h
+	NodeFetchForTreeCoords(0, 1, false), // b
+	NodeFetchForTreeCoords(1, 1, false), // h
 }
 var expectedConsistencyProofFromSize3To7 = []NodeFetch{
 	//                                             hash
@@ -132,10 +132,10 @@ var expectedConsistencyProofFromSize3To7 = []NodeFetch{
 	//    a b    c                      a b     c d    e f    j
 	//    | |    |                      | |     | |    | |    |
 	//   d0 d1   d2                     d0 d1   d2 d3  d4 d5  d6
-	MustCreateNodeFetchForTreeCoords(0, 2, 64, false), // c
-	MustCreateNodeFetchForTreeCoords(0, 3, 64, false), // d
-	MustCreateNodeFetchForTreeCoords(1, 0, 64, false), // g
-	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
+	NodeFetchForTreeCoords(0, 2, false), // c
+	NodeFetchForTreeCoords(0, 3, false), // d
+	NodeFetchForTreeCoords(1, 0, false), // g
+	NodeFetchForTreeCoords(2, 1, false), // l
 }
 var expectedConsistencyProofFromSize4To7 = []NodeFetch{
 	//                                             hash
@@ -153,7 +153,7 @@ var expectedConsistencyProofFromSize4To7 = []NodeFetch{
 	//    a b     c d                   a b     c d    e f    j
 	//    | |     | |                   | |     | |    | |    |
 	//   d0 d1   d2 d3                  d0 d1   d2 d3  d4 d5  d6
-	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
+	NodeFetchForTreeCoords(2, 1, false), // l
 }
 var expectedConsistencyProofFromSize6To7 = []NodeFetch{
 	//             hash2                           hash
@@ -171,9 +171,9 @@ var expectedConsistencyProofFromSize6To7 = []NodeFetch{
 	//   a b     c d     e f            a b     c d    e f    j
 	//   | |     | |     | |            | |     | |    | |    |
 	//   d0 d1   d2 d3  d4 d5           d0 d1   d2 d3  d4 d5  d6
-	MustCreateNodeFetchForTreeCoords(1, 2, 64, false), // i
-	MustCreateNodeFetchForTreeCoords(0, 6, 64, false), // j
-	MustCreateNodeFetchForTreeCoords(2, 0, 64, false), // k
+	NodeFetchForTreeCoords(1, 2, false), // i
+	NodeFetchForTreeCoords(0, 6, false), // j
+	NodeFetchForTreeCoords(2, 0, false), // k
 }
 var expectedConsistencyProofFromSize2To8 = []NodeFetch{
 	//                               hash8
@@ -191,8 +191,8 @@ var expectedConsistencyProofFromSize2To8 = []NodeFetch{
 	//    a b             a b     c d    e f    j m
 	//    | |             | |     | |    | |    | |
 	//   d0 d1            d0 d1   d2 d3  d4 d5 d6 d7
-	MustCreateNodeFetchForTreeCoords(1, 1, 64, false), // h
-	MustCreateNodeFetchForTreeCoords(2, 1, 64, false), // l
+	NodeFetchForTreeCoords(1, 1, false), // h
+	NodeFetchForTreeCoords(2, 1, false), // l
 }
 
 // These should all successfully compute the expected path
@@ -242,7 +242,7 @@ var consistencyTestsBad = []consistencyProofTestData{
 
 func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	for _, testCase := range pathTests {
-		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize, 64)
+		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
 
 		if err != nil {
 			t.Fatalf("unexpected error calculating path %v: %v", testCase, err)
@@ -254,7 +254,7 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 
 func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
 	for _, testCase := range pathTestBad {
-		_, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize, 64)
+		_, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
 
 		if err == nil {
 			t.Fatalf("incorrectly accepted bad params: %v", testCase)
@@ -262,17 +262,9 @@ func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
 	}
 }
 
-func TestCalcInclusionProofNodeAddressesRejectsBadBitLen(t *testing.T) {
-	_, err := CalcInclusionProofNodeAddresses(7, 3, 7, -64)
-
-	if err == nil {
-		t.Fatal("incorrectly accepted -ve maxBitLen")
-	}
-}
-
 func TestCalcConsistencyProofNodeAddresses(t *testing.T) {
 	for _, testCase := range consistencyTests {
-		proof, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize, 64)
+		proof, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize)
 
 		if err != nil {
 			t.Fatalf("failed to calculate consistency proof from %d to %d: %v", testCase.priorTreeSize, testCase.treeSize, err)
@@ -284,20 +276,11 @@ func TestCalcConsistencyProofNodeAddresses(t *testing.T) {
 
 func TestCalcConsistencyProofNodeAddressesBadInputs(t *testing.T) {
 	for _, testCase := range consistencyTestsBad {
-		_, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize, 64)
+		_, err := CalcConsistencyProofNodeAddresses(testCase.priorTreeSize, testCase.treeSize, testCase.treeSize)
 
 		if err == nil {
 			t.Fatalf("consistency path calculation accepted bad input: %v", testCase)
 		}
-	}
-}
-
-func TestCalcConsistencyProofNodeAddressesRejectsBadBitLen(t *testing.T) {
-	_, err := CalcConsistencyProofNodeAddresses(6, 7, 7, -1)
-	_, err2 := CalcConsistencyProofNodeAddresses(6, 7, 7, 0)
-
-	if err == nil || err2 == nil {
-		t.Fatalf("consistency path calculation accepted bad bitlen: %v %v", err, err2)
 	}
 }
 
@@ -308,7 +291,7 @@ func comparePaths(t *testing.T, desc string, got, expected []NodeFetch) {
 
 	for i := 0; i < len(expected); i++ {
 		if !expected[i].Equivalent(got[i]) {
-			t.Fatalf("%s: expected node %v (%v) at position %d but got %v (%v)", desc, expected[i], expected[i].NodeID.CoordString(), i, got[i], got[i].NodeID.CoordString())
+			t.Fatalf("%s: expected node %+v at position %d but got %+v", desc, expected[i], i, got[i])
 		}
 	}
 }
@@ -333,7 +316,7 @@ func TestLastNodeWritten(t *testing.T) {
 func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
 	for ts := 1; ts < testUpToTreeSize; ts++ {
 		for i := ts; i < ts; i++ {
-			if _, err := CalcInclusionProofNodeAddresses(int64(ts), int64(i), int64(ts), 64); err != nil {
+			if _, err := CalcInclusionProofNodeAddresses(int64(ts), int64(i), int64(ts)); err != nil {
 				t.Errorf("CalcInclusionProofNodeAddresses(ts:%d, i:%d) = %v", ts, i, err)
 			}
 		}
@@ -343,17 +326,14 @@ func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
 func TestConsistencySucceedsUpToTreeSize(t *testing.T) {
 	for s1 := 1; s1 < testUpToTreeSize; s1++ {
 		for s2 := s1 + 1; s2 < testUpToTreeSize; s2++ {
-			if _, err := CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), int64(s2), 64); err != nil {
+			if _, err := CalcConsistencyProofNodeAddresses(int64(s1), int64(s2), int64(s2)); err != nil {
 				t.Errorf("CalcConsistencyProofNodeAddresses(%d, %d) = %v", s1, s2, err)
 			}
 		}
 	}
 }
 
-func MustCreateNodeFetchForTreeCoords(depth, index int64, maxPathBits int, rehash bool) NodeFetch {
-	n, err := storage.NewNodeIDForTreeCoords(depth, index, maxPathBits)
-	if err != nil {
-		panic(err)
-	}
-	return NodeFetch{NodeID: n, Rehash: rehash}
+func NodeFetchForTreeCoords(depth, index int64, rehash bool) NodeFetch {
+	n := compact.NewNodeID(uint(depth), uint64(index))
+	return NodeFetch{ID: n, Rehash: rehash}
 }

--- a/merkle/merkle_path_test.go
+++ b/merkle/merkle_path_test.go
@@ -290,7 +290,7 @@ func comparePaths(t *testing.T, desc string, got, expected []NodeFetch) {
 	}
 
 	for i := 0; i < len(expected); i++ {
-		if !expected[i].Equivalent(got[i]) {
+		if expected[i] != got[i] {
 			t.Fatalf("%s: expected node %+v at position %d but got %+v", desc, expected[i], i, got[i])
 		}
 	}

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -35,11 +35,7 @@ import (
 // TODO: There is no access control in the server yet and clients could easily modify
 // any tree.
 
-// Pass this as a fixed value to proof calculations. It's used as the max depth of the tree
-const (
-	proofMaxBitLen = 64
-	traceSpanRoot  = "/trillian"
-)
+const traceSpanRoot = "/trillian"
 
 var (
 	optsLogInit            = trees.NewGetOpts(trees.Admin, trillian.TreeType_LOG, trillian.TreeType_PREORDERED_LOG)
@@ -438,7 +434,7 @@ func (t *TrillianLogRPCServer) GetLatestSignedLogRoot(ctx context.Context, req *
 }
 
 func tryGetConsistencyProof(ctx context.Context, firstTreeSize, secondTreeSize, rootTreeSize int64, tx storage.ReadOnlyLogTreeTX, hasher hashers.LogHasher) (*trillian.Proof, error) {
-	nodeFetches, err := merkle.CalcConsistencyProofNodeAddresses(firstTreeSize, secondTreeSize, rootTreeSize, proofMaxBitLen)
+	nodeFetches, err := merkle.CalcConsistencyProofNodeAddresses(firstTreeSize, secondTreeSize, rootTreeSize)
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +703,7 @@ func (t *TrillianLogRPCServer) closeAndLog(ctx context.Context, logID int64, tx 
 // an RPC response
 func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTreeTX, hasher hashers.LogHasher, snapshot, leafIndex, treeSize int64) (*trillian.Proof, error) {
 	// We have the tree size and leaf index so we know the nodes that we need to serve the proof
-	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize, proofMaxBitLen)
+	proofNodeIDs, err := merkle.CalcInclusionProofNodeAddresses(snapshot, leafIndex, treeSize)
 	if err != nil {
 		return nil, err
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1614,7 +1614,7 @@ func TestGetConsistencyProof(t *testing.T) {
 		{
 			// Storage doesn't return the requested node, should result in an error.
 			req:        &getConsistencyProofRequest7,
-			errStr:     "expected node {{[0 0 0 0 0 0 0 4] 62}",
+			errStr:     "expected node {[0 0 0 0 0 0 0 4] 62}",
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
 			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -140,7 +140,7 @@ func TestTree813FetchAll(t *testing.T) {
 	})
 
 	for l := int64(271); l < ts; l++ {
-		fetches, err := merkle.CalcInclusionProofNodeAddresses(ts, l, ts, 64)
+		fetches, err := merkle.CalcInclusionProofNodeAddresses(ts, l, ts)
 
 		if err != nil {
 			t.Fatal(err)
@@ -156,7 +156,7 @@ func TestTree813FetchAll(t *testing.T) {
 
 		if got, want := len(proof.Hashes), len(refProof); got != want {
 			for i, f := range fetches {
-				t.Errorf("Fetch: %d => %s", i, f.NodeID.CoordString())
+				t.Errorf("Fetch: %d => %+v", i, f.ID)
 			}
 			t.Fatalf("(%d, %d): got proof len: %d, want: %d: %v\n%v", ts, l, got, want, fetches, refProof)
 		}
@@ -180,7 +180,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 
 		for s := int64(2); s <= int64(ts); s++ {
 			for l := int64(0); l < s; l++ {
-				fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, int64(ts), 64)
+				fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, int64(ts))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -222,7 +222,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 
 	for s := int64(2); s <= 32; s++ {
 		for l := int64(0); l < s; l++ {
-			fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, 32, 64)
+			fetches, err := merkle.CalcInclusionProofNodeAddresses(s, l, 32)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -260,7 +260,7 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 
 		for s1 := int64(2); s1 < int64(ts); s1++ {
 			for s2 := int64(s1 + 1); s2 < int64(ts); s2++ {
-				fetches, err := merkle.CalcConsistencyProofNodeAddresses(s1, s2, int64(ts), 64)
+				fetches, err := merkle.CalcConsistencyProofNodeAddresses(s1, s2, int64(ts))
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
This change pushes `storage.NodeID` usage for logs up the stack. As a
result, the log-specific subset of `merkle` package no longer depends on
`storage`, and uses its own lightweight `compact.NodeID` type.