### PR TITLE
Be less permissive of multiple trees in the scope of a context.

### DIFF
--- a/trees/trees.go
+++ b/trees/trees.go
@@ -165,9 +165,11 @@ func GetTree(ctx context.Context, s storage.AdminStorage, treeID int64, opts Get
 		if err != nil {
 			return nil, err
 		}
-	} else if tree.TreeId != treeID {
+	}
+	if tree.TreeId != treeID {
 		// No operations should span multiple trees. If a tree is already in the context
-		// it better had be the one that we want.
+		// it had better be the one that we want. If the tree comes back from the DB with
+		// the wrong ID then this checks that too.
 		return nil, status.Errorf(codes.Internal, "got tree %v, want %v", tree.TreeId, treeID)
 	}
 

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -166,7 +166,7 @@ func TestGetTree(t *testing.T) {
 		},
 		{
 			desc:        "adminFrozen",
-			treeID:      logTree.TreeId,
+			treeID:      frozenTree.TreeId,
 			opts:        NewGetOpts(Admin, trillian.TreeType_LOG),
 			storageTree: frozenTree,
 			wantTree:    frozenTree,

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -269,6 +269,8 @@ func TestGetTree(t *testing.T) {
 			ctxTree:     mapTree,
 			storageTree: logTree,
 			wantTree:    logTree,
+			wantErr:     true,
+			code:        codes.Internal,
 		},
 		{
 			desc:     "beginErr",


### PR DESCRIPTION
No operations should span multiple trees so we shouldn't be tolerant of this case. This change makes it clearer what one can expect of the tree being set in the context.
