### PR TITLE
Simplify Travis setup with jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
         # TODO(RJPercival): Make docker-compose integration test work when PKCS#11
         # support is enabled. This requires running softhsm in a Docker container.
         # See https://github.com/rolandshoemaker/docker-hsm for an example.
-        ./integration/docker_compose_integration_test.sh
+      - ./integration/docker_compose_integration_test.sh
     - name: "CT Integration"
       script:
        - TRILLIAN_DIR=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,19 @@ jobs:
       install: true
       before_script: true
       script: go build ./...
+    - name: "generate"
+      before_install: true
+      install: true
+      before_script: true
+      script: 
+      - go generate ./...
+      - |
+        # Check re-generation didn't change anything. Skip protoc-generated files
+        # because protoc is not deterministic when generating file descriptors.
+        # Skip go.mod and go.sum because testing may add indirect dependencies
+        # that would be trimmed by 'go mod tidy'
+        echo "Checking that generated files are the same as checked-in versions."
+        git diff --exit-code -- ':!*.pb.go' ':!*_string.go' ':!go.*'
     - name: "lint"
       before_install: true
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,25 @@ env:
 matrix:
   fast_finish: true
 
+jobs:
+  include:
+    - name: "build"
+      before_install: true
+      install: true
+      before_script: true
+      script: go build ./...
+    - name: "lint"
+      before_install: true
+      install:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint
+      - go install github.com/uber/prototool/cmd/prototool
+      before_script: true
+      script:
+      - golangci-lint run --deadline=8m
+      - prototool lint
+      - ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
+
+
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,15 +101,13 @@ jobs:
         ./integration/docker_compose_integration_test.sh
       - name: "CT Integration"
         script:
-         - |
-           # See if we would break ct-go by checking it out and updating the trillian dep.
-           TRILLIAN_DIR=$(pwd)
-           git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
-           pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
-           echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
-           chmod +x ./trillian/integration/integration_test.sh
-           ./trillian/integration/integration_test.sh
-           popd
+         - TRILLIAN_DIR=$(pwd)
+         - git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
+         - pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
+         - echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
+         - chmod +x ./trillian/integration/integration_test.sh
+         - ./trillian/integration/integration_test.sh
+         - popd
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ jobs:
       install:
       - go install github.com/golangci/golangci-lint/cmd/golangci-lint
       - go install github.com/uber/prototool/cmd/prototool
+      - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
       before_script: true
       script:
       - golangci-lint run --deadline=8m

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ env:
   - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race' WITH_ETCD=true        PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
-  - BAZEL_TESTS=true                                       PRESUBMIT_OPTS="--no-linters --no-generate"
   - DOCKER_TESTS=true                                      PRESUBMIT_OPTS="--no-linters --no-generate"
 
 matrix:
@@ -83,6 +82,18 @@ jobs:
       - golangci-lint run --deadline=8m
       - prototool lint
       - ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
+    - name: "bazel"
+      install:
+      - |
+        BAZEL_VERSION='0.18.0'
+        URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+        wget -O install.sh ${URL}
+        chmod +x install.sh
+        ./install.sh --user
+        rm -f install.sh
+      script: bazel --batch build //:*
+
+
 
 
 services:
@@ -120,17 +131,6 @@ install:
     echo Installing ${TOOLS}...
     GOPROXY=direct go install ${TOOLS}
   # install bazel
-  - |
-    (
-    if [[ "${BAZEL_TESTS}" == "true" ]]; then
-        BAZEL_VERSION='0.18.0'
-        URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-        wget -O install.sh ${URL}
-        chmod +x install.sh
-        ./install.sh --user
-        rm -f install.sh
-      fi
-    )
 
 before_script:
   - ./scripts/resetdb.sh --force
@@ -171,10 +171,6 @@ script:
       # See https://github.com/rolandshoemaker/docker-hsm for an example.
       if [[ "${DOCKER_TESTS}" == "true" ]]; then
         ./integration/docker_compose_integration_test.sh
-      fi
-  - |
-      if [[ "${BAZEL_TESTS}" == "true" ]]; then
-        bazel --batch build //:*
       fi
   - set +e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
           unzip "protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip"
         )
       - export PATH="$(pwd)/../protoc/bin:$PATH"
+      - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
       - go install github.com/golang/protobuf/proto
       - go install github.com/golang/mock/mockgen
       - go install golang.org/x/tools/cmd/stringer
@@ -127,8 +128,6 @@ install:
     if [[ "${GOFLAGS}" == *-race* ]]; then
       export GOCACHE="$(go env GOCACHE)-race"
     fi
-  # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
-  - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
   - |
     export TOOLS=""
     if [[ "${PRESUBMIT_OPTS}" != *no-build* ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race' WITH_ETCD=true       PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
-  - CT_INTEG_TEST=true                                     PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true                                       PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race'                       PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters --no-generate"
@@ -100,6 +99,17 @@ jobs:
         # support is enabled. This requires running softhsm in a Docker container.
         # See https://github.com/rolandshoemaker/docker-hsm for an example.
         ./integration/docker_compose_integration_test.sh
+      - name: "CT Integration"
+        script:
+         - |
+           # See if we would break ct-go by checking it out and updating the trillian dep.
+           TRILLIAN_DIR=$(pwd)
+           git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
+           pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
+           echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
+           chmod +x ./trillian/integration/integration_test.sh
+           ./trillian/integration/integration_test.sh
+           popd
 
 
 
@@ -159,17 +169,6 @@ script:
     if [[ "${INTEG_TESTS}" == "true" ]]; then
       ./integration/integration_test.sh
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
-    fi
-  - |
-    if [[ "${CT_INTEG_TEST}" == "true" ]]; then
-      # See if we would break ct-go by checking it out and updating the trillian dep.
-      TRILLIAN_DIR=$(pwd)
-      git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
-      pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
-      echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
-      chmod +x ./trillian/integration/integration_test.sh
-      ./trillian/integration/integration_test.sh
-      popd
     fi
   - set +e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,9 +109,6 @@ jobs:
        - ./trillian/integration/integration_test.sh
        - popd
 
-
-
-
 services:
   - docker
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,15 +99,15 @@ jobs:
         # support is enabled. This requires running softhsm in a Docker container.
         # See https://github.com/rolandshoemaker/docker-hsm for an example.
         ./integration/docker_compose_integration_test.sh
-      - name: "CT Integration"
-        script:
-         - TRILLIAN_DIR=$(pwd)
-         - git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
-         - pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
-         - echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
-         - chmod +x ./trillian/integration/integration_test.sh
-         - ./trillian/integration/integration_test.sh
-         - popd
+    - name: "CT Integration"
+      script:
+       - TRILLIAN_DIR=$(pwd)
+       - git clone --depth=1 https://github.com/google/certificate-transparency-go.git "$GOPATH/src/github.com/google/certificate-transparency-go"
+       - pushd "$GOPATH/src/github.com/google/certificate-transparency-go"
+       - echo "replace github.com/google/trillian => $TRILLIAN_DIR" >> go.mod
+       - chmod +x ./trillian/integration/integration_test.sh
+       - ./trillian/integration/integration_test.sh
+       - popd
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ env:
   - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race' WITH_ETCD=true        PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
-  - DOCKER_TESTS=true                                      PRESUBMIT_OPTS="--no-linters --no-generate"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,21 @@ jobs:
       script: go build ./...
     - name: "generate"
       before_install: true
-      install: true
+      install:
+      - mkdir ../protoc
+      - |
+        (
+          cd ../protoc
+          wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip"
+          unzip "protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip"
+        )
+      - export PATH="$(pwd)/../protoc/bin:$PATH"
+      - go install github.com/golang/protobuf/proto
+      - go install github.com/golang/mock/mockgen
+      - go install golang.org/x/tools/cmd/stringer
+      - go install github.com/golang/protobuf/protoc-gen-go
+      - go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+      - go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       before_script: true
       script: 
       - go generate ./...
@@ -95,26 +109,10 @@ install:
     if [[ "${GOFLAGS}" == *-race* ]]; then
       export GOCACHE="$(go env GOCACHE)-race"
     fi
-  - mkdir ../protoc
-  - |
-    (
-      cd ../protoc
-      wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip"
-      unzip "protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip"
-    )
-  - export PATH="$(pwd)/../protoc/bin:$PATH"
   # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
   - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
   - |
     export TOOLS=""
-    if [[ "${PRESUBMIT_OPTS}" != *no-generate* ]]; then
-      TOOLS+=" github.com/golang/mock/mockgen"
-      TOOLS+=" github.com/golang/protobuf/proto"
-      TOOLS+=" github.com/golang/protobuf/protoc-gen-go"
-      TOOLS+=" github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
-      TOOLS+=" github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
-      TOOLS+=" golang.org/x/tools/cmd/stringer"
-    fi
     if [[ "${PRESUBMIT_OPTS}" != *no-build* ]]; then
       TOOLS+=" go.etcd.io/etcd"
       TOOLS+=" go.etcd.io/etcd/etcdctl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,13 @@ jobs:
         ./install.sh --user
         rm -f install.sh
       script: bazel --batch build //:*
+    - name: "docker"
+      script: 
+      - |
+        # TODO(RJPercival): Make docker-compose integration test work when PKCS#11
+        # support is enabled. This requires running softhsm in a Docker container.
+        # See https://github.com/rolandshoemaker/docker-hsm for an example.
+        ./integration/docker_compose_integration_test.sh
 
 
 
@@ -165,13 +172,6 @@ script:
       ./trillian/integration/integration_test.sh
       popd
     fi
-  - |
-      # TODO(RJPercival): Make docker-compose integration test work when PKCS#11
-      # support is enabled. This requires running softhsm in a Docker container.
-      # See https://github.com/rolandshoemaker/docker-hsm for an example.
-      if [[ "${DOCKER_TESTS}" == "true" ]]; then
-        ./integration/docker_compose_integration_test.sh
-      fi
   - set +e
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
   matrix:
-  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--no-build"  # only lint & generate
   - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
@@ -120,10 +119,6 @@ install:
       TOOLS+=" go.etcd.io/etcd"
       TOOLS+=" go.etcd.io/etcd/etcdctl"
     fi
-    if [[ "${PRESUBMIT_OPTS}" != *no-linters* ]]; then
-      TOOLS+=" github.com/golangci/golangci-lint/cmd/golangci-lint"
-      TOOLS+=" github.com/uber/prototool/cmd/prototool"
-    fi
     echo Installing ${TOOLS}...
     GOPROXY=direct go install ${TOOLS}
   # install bazel
@@ -151,11 +146,6 @@ script:
   - |
     if [[ "${PRESUB_TESTS}" == "true" ]]; then
       ./scripts/presubmit.sh ${PRESUBMIT_OPTS}
-      # Check re-generation didn't change anything. Skip protoc-generated files
-      # because protoc is not deterministic when generating file descriptors.
-      # Skip go.mod and go.sum because testing may add indirect dependencies that would be trimmed by 'go mod tidy'
-      echo "Checking that generated files are the same as checked-in versions."
-      git diff --exit-code -- ':!*.pb.go' ':!*_string.go' ':!go.*'
     fi
   - |
       if [[ "${WITH_ETCD}" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   global:
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
-  matrix:
+  matrix: #TODO: Merge the test matrix into individual jobs
   - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
@@ -39,7 +39,7 @@ matrix:
 jobs:
   include:
     - name: "build"
-      before_install: true
+      before_install: true # This step is empty.
       install: true
       before_script: true
       script: go build ./...


### PR DESCRIPTION
The Travis Jobs API allows us to supply different setup stages for each job.
This should 
- Reduce the massive conflagration of flags that we use.
- Make errors easier to diagnose 
- Make travis faster since each job will only need to install the dependencies that it needs

New Travis wall clock time: `Ran for 11 min 54 sec`, down from 13 min previousy
