### PR TITLE
Pass SubtreeCache by pointer

### DIFF
--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -25,7 +25,7 @@ import (
 
 // NewLogSubtreeCache creates and returns a SubtreeCache appropriate for use with a log
 // tree. The caller must supply the strata depths to be used and a suitable LogHasher.
-func NewLogSubtreeCache(logStrata []int, hasher hashers.LogHasher) SubtreeCache {
+func NewLogSubtreeCache(logStrata []int, hasher hashers.LogHasher) *SubtreeCache {
 	return NewSubtreeCache(logStrata, populateLogSubtreeNodes(hasher), prepareLogSubtreeWrite())
 }
 

--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -28,7 +28,7 @@ import (
 
 // NewMapSubtreeCache creates and returns a SubtreeCache appropriate for use with a map
 // tree. The caller must supply the strata depths to be used, the treeID and a suitable MapHasher.
-func NewMapSubtreeCache(mapStrata []int, treeID int64, hasher hashers.MapHasher) SubtreeCache {
+func NewMapSubtreeCache(mapStrata []int, treeID int64, hasher hashers.MapHasher) *SubtreeCache {
 	return NewSubtreeCache(mapStrata, populateMapSubtreeNodes(treeID, hasher), prepareMapSubtreeWrite())
 }
 

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -93,7 +93,7 @@ type SubtreeCache struct {
 // internal nodes given its leaves, and will be called for each subtree loaded
 // from storage.
 // TODO(al): consider supporting different sized subtrees - for now everything's subtrees of 8 levels.
-func NewSubtreeCache(strataDepths []int, populateSubtree storage.PopulateSubtreeFunc, prepareSubtreeWrite storage.PrepareSubtreeWriteFunc) SubtreeCache {
+func NewSubtreeCache(strataDepths []int, populateSubtree storage.PopulateSubtreeFunc, prepareSubtreeWrite storage.PrepareSubtreeWriteFunc) *SubtreeCache {
 	// TODO(al): pass this in
 	maxTreeDepth := maxSupportedTreeDepth
 	glog.V(1).Infof("Creating new subtree cache maxDepth=%d strataDepths=%v", maxTreeDepth, strataDepths)
@@ -126,7 +126,7 @@ func NewSubtreeCache(strataDepths []int, populateSubtree storage.PopulateSubtree
 		panic(fmt.Errorf("populate_subtree_concurrency must be set to >= 1"))
 	}
 
-	return SubtreeCache{
+	return &SubtreeCache{
 		stratumInfo:         sInfo,
 		subtrees:            make(map[string]*storagepb.SubtreeProto),
 		dirtyPrefixes:       make(map[string]bool),

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -127,10 +127,10 @@ func (ls *logStorage) Snapshot(ctx context.Context) (storage.ReadOnlyLogTX, erro
 	return &readOnlyLogTX{snapshotTX}, nil
 }
 
-func newLogCache(tree *trillian.Tree) (cache.SubtreeCache, error) {
+func newLogCache(tree *trillian.Tree) (*cache.SubtreeCache, error) {
 	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
 	if err != nil {
-		return cache.SubtreeCache{}, err
+		return nil, err
 	}
 	return cache.NewLogSubtreeCache(defLogStrata, hasher), nil
 }

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -75,10 +75,10 @@ func (ms *mapStorage) CheckDatabaseAccessible(ctx context.Context) error {
 	return checkDatabaseAccessible(ctx, ms.ts.client)
 }
 
-func newMapCache(tree *trillian.Tree) (cache.SubtreeCache, error) {
+func newMapCache(tree *trillian.Tree) (*cache.SubtreeCache, error) {
 	hasher, err := hashers.NewMapHasher(tree.HashStrategy)
 	if err != nil {
-		return cache.SubtreeCache{}, err
+		return nil, err
 	}
 	return cache.NewMapSubtreeCache(defMapStrata, tree.TreeId, hasher), nil
 }

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -125,7 +125,7 @@ func (t *treeStorage) latestSTH(ctx context.Context, stx spanRead, treeID int64)
 	return th, nil
 }
 
-type newCacheFn func(*trillian.Tree) (cache.SubtreeCache, error)
+type newCacheFn func(*trillian.Tree) (*cache.SubtreeCache, error)
 
 func (t *treeStorage) getTreeAndConfig(ctx context.Context, tree *trillian.Tree) (*trillian.Tree, proto.Message, error) {
 	config, err := unmarshalSettings(tree)
@@ -194,7 +194,7 @@ type treeTX struct {
 	// writeRev is the tree revision at which any writes will be made.
 	_writeRev int64
 
-	cache cache.SubtreeCache
+	cache *cache.SubtreeCache
 
 	getLatestRootOnce sync.Once
 }

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -127,7 +127,7 @@ func newTree(t *trillian.Tree) *tree {
 	return ret
 }
 
-func (m *TreeStorage) beginTreeTX(ctx context.Context, treeID int64, hashSizeBytes int, cache cache.SubtreeCache, readonly bool) (treeTX, error) {
+func (m *TreeStorage) beginTreeTX(ctx context.Context, treeID int64, hashSizeBytes int, cache *cache.SubtreeCache, readonly bool) (treeTX, error) {
 	tree := m.getTree(treeID)
 	// Lock the tree for the duration of the TX.
 	// It will be unlocked by a call to Commit or Rollback.
@@ -158,7 +158,7 @@ type treeTX struct {
 	tree          *tree
 	treeID        int64
 	hashSizeBytes int
-	subtreeCache  cache.SubtreeCache
+	subtreeCache  *cache.SubtreeCache
 	writeRevision int64
 	unlock        func()
 }

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -142,7 +142,7 @@ func (m *mySQLTreeStorage) setSubtreeStmt(ctx context.Context, num int) (*sql.St
 	return m.getStmt(ctx, insertSubtreeMultiSQL, num, "VALUES(?, ?, ?, ?)", "(?, ?, ?, ?)")
 }
 
-func (m *mySQLTreeStorage) beginTreeTx(ctx context.Context, tree *trillian.Tree, hashSizeBytes int, subtreeCache cache.SubtreeCache) (treeTX, error) {
+func (m *mySQLTreeStorage) beginTreeTx(ctx context.Context, tree *trillian.Tree, hashSizeBytes int, subtreeCache *cache.SubtreeCache) (treeTX, error) {
 	t, err := m.db.BeginTx(ctx, nil /* opts */)
 	if err != nil {
 		glog.Warningf("Could not start tree TX: %s", err)
@@ -169,7 +169,7 @@ type treeTX struct {
 	treeID        int64
 	treeType      trillian.TreeType
 	hashSizeBytes int
-	subtreeCache  cache.SubtreeCache
+	subtreeCache  *cache.SubtreeCache
 	writeRevision int64
 }
 

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -191,7 +191,7 @@ func (p *pgTreeStorage) setSubtreeStmt(ctx context.Context, num int) (*sql.Stmt,
 	return p.getStmt(ctx, skeleton)
 }
 
-func (p *pgTreeStorage) beginTreeTx(ctx context.Context, tree *trillian.Tree, hashSizeBytes int, subtreeCache cache.SubtreeCache) (treeTX, error) {
+func (p *pgTreeStorage) beginTreeTx(ctx context.Context, tree *trillian.Tree, hashSizeBytes int, subtreeCache *cache.SubtreeCache) (treeTX, error) {
 	t, err := p.db.BeginTx(ctx, nil /* opts */)
 	if err != nil {
 		glog.Warningf("Could not start tree TX: %s", err)
@@ -215,7 +215,7 @@ type treeTX struct {
 	treeID        int64
 	treeType      trillian.TreeType
 	hashSizeBytes int
-	subtreeCache  cache.SubtreeCache
+	subtreeCache  *cache.SubtreeCache
 	writeRevision int64
 }
 


### PR DESCRIPTION
Stop linter complaints about an object with a `sync.Mutex` in it being copied by value.