### PR TITLE
examples/deployment: define default for $NAMESPACE

### DIFF
--- a/examples/deployment/kubernetes/example-config.sh
+++ b/examples/deployment/kubernetes/example-config.sh
@@ -8,6 +8,7 @@ export REGION=us-east4
 export MASTER_ZONE="${REGION}-a"
 export NODE_LOCATIONS="${REGION}-a,${REGION}-b,${REGION}-c"
 export CONFIGMAP=${DIR}/trillian-cloudspanner.yaml
+export NAMESPACE=default
 
 export POOLSIZE=2
 export MACHINE_TYPE="n1-standard-2"


### PR DESCRIPTION
Commit 8a50790 requires the definition of a default namespace for
deploy.sh to succeed. This was added to the ci-config but not to
the example one.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
