### PR TITLE
subtree_cache: Make GetNodes read sync.Map only once

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -242,7 +242,7 @@ func (s *SubtreeCache) GetNodes(ids []storage.NodeID, getSubtrees GetSubtreesFun
 	}
 
 	// Get node hashes from the subtrees.
-	ret := make([]storage.Node, len(ids))
+	ret := make([]storage.Node, 0, len(ids))
 	for i, id := range ids {
 		sInfo := s.stratumInfoForNodeID(id)
 		suf := id.Suffix(sInfo.prefixBytes, sInfo.depth)

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -147,7 +147,7 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	}
 
 	// Now request the nodes:
-	_, err := c.GetNodes(
+	nodes, err := c.GetNodes(
 		nodeIDs,
 		// Glue function to convert a call requesting multiple subtrees into a
 		// sequence of calls to our mock storage:
@@ -165,7 +165,10 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 			return ret, nil
 		})
 	if err != nil {
-		t.Errorf("getNodeHash(_, _) = _, %v", err)
+		t.Fatalf("getNodeHash(_, _) = _, %v", err)
+	}
+	if got, mx := len(nodes), len(nodeIDs); got > mx {
+		t.Errorf("getNodeHash returned %d nodes, want <= %d", got, mx)
 	}
 }
 


### PR DESCRIPTION
Previously: `GetNodes` fills up the cache map with all the missing subtrees; then it tries to read from this map as if it didn't know what it had just written to it.

Now: `GetNodes` returns the results using all the available information about the subtrees that previously the `preload` function was hiding. As a result, it reads from the cached map only once.