### PR TITLE
NodeID: Remove the empty ID constructor

### DIFF
--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -385,8 +385,8 @@ func (s SparseMerkleTreeReader) RootAtRevision(ctx context.Context, rev int64) (
 	ctx, spanEnd := spanFor(ctx, "RootAtRevision")
 	defer spanEnd()
 
-	rootNodeID := storage.NewEmptyNodeID(256)
-	nodes, err := s.tx.GetMerkleNodes(ctx, rev, []storage.NodeID{*rootNodeID})
+	rootNodeID := storage.NodeID{}
+	nodes, err := s.tx.GetMerkleNodes(ctx, rev, []storage.NodeID{rootNodeID})
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (s SparseMerkleTreeReader) RootAtRevision(ctx context.Context, rev int64) (
 		return nil, fmt.Errorf("expected 1 node, but got %d", len(nodes))
 	}
 	// Sanity check the nodeID
-	if !nodes[0].NodeID.Equivalent(*rootNodeID) {
+	if !nodes[0].NodeID.Equivalent(rootNodeID) {
 		return nil, fmt.Errorf("unexpected node returned with ID: %v", nodes[0].NodeID)
 	}
 	// Sanity check the revision

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -113,7 +113,6 @@ func randomBytes(t *testing.T, n int) []byte {
 
 func getRandomRootNode(t *testing.T, rev int64) storage.Node {
 	return storage.Node{
-		NodeID:       *storage.NewEmptyNodeID(0),
 		Hash:         randomBytes(t, 32),
 		NodeRevision: rev,
 	}

--- a/storage/memory/tree_debug.go
+++ b/storage/memory/tree_debug.go
@@ -38,7 +38,7 @@ func Dump(t *btree.BTree) {
 func DumpSubtrees(ls storage.LogStorage, treeID int64, callback func(string, *storagepb.SubtreeProto)) {
 	m := ls.(*memoryLogStorage)
 	tree := m.trees[treeID]
-	pi := subtreeKey(treeID, 0, *storage.NewEmptyNodeID(64))
+	pi := subtreeKey(treeID, 0, storage.NodeID{})
 
 	tree.store.AscendGreaterOrEqual(pi, func(bi btree.Item) bool {
 		i := bi.(*kv)

--- a/storage/node.go
+++ b/storage/node.go
@@ -37,8 +37,9 @@ type Node struct {
 	NodeRevision int64
 }
 
-// NodeID is an immutable identifier of a Merkle tree Node. A default
-// constructed NodeID is an empty ID representing the root of a (sub-)tree.
+// NodeID is an identifier of a Merkle tree Node. A default constructed NodeID
+// is an empty ID representing the root of a (sub-)tree. The type is designed
+// to be immutable, so the public fields should not be modified.
 //
 // Reading paths right to left is the natural order when traversing from
 // leaves towards the root. However, for internal nodes the rightmost bits

--- a/storage/node.go
+++ b/storage/node.go
@@ -223,7 +223,7 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 	// This node is effectively a prefix of the subtree underneath (for non-leaf
 	// depths), so we shift the index accordingly.
 	uidx := uint64(index) << uint(depth)
-	r := &NodeID{Path: make([]byte, (maxPathBits+7)/8)}
+	r := NodeID{Path: make([]byte, maxPathBits/8)} // Note: maxPathBits % 8 == 0.
 	for i := len(r.Path) - 1; uidx > 0 && i >= 0; i-- {
 		r.Path[i] = byte(uidx & 0xff)
 		uidx >>= 8
@@ -231,7 +231,7 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 	// In the storage model nodes closer to the leaves have longer nodeIDs, so
 	// we "reverse" depth here:
 	r.PrefixLenBits = int(maxPathBits - int(depth))
-	return *r, nil
+	return r, nil
 }
 
 // Bit returns 1 if the zero indexed ith bit from the right (of the whole path

--- a/storage/node_test.go
+++ b/storage/node_test.go
@@ -57,23 +57,6 @@ func TestMaskLeft(t *testing.T) {
 	}
 }
 
-func TestNewEmptyNodeIDPanic(t *testing.T) {
-	for b := 0; b < 64; b++ {
-		t.Run(fmt.Sprintf("%dbits", b), func(t *testing.T) {
-			// Only multiples of 8 bits should be accepted.
-			want := b%8 != 0
-			// Unfortunately we have to test for panics.
-			defer func() {
-				got := recover()
-				if (got != nil && !want) || (got == nil && want) {
-					t.Errorf("Incorrect panic behaviour got: %v, want: %v", got, want)
-				}
-			}()
-			_ = NewEmptyNodeID(b)
-		})
-	}
-}
-
 // TestNewNodeIDFromPrefixPanic tests the cases where this will panic. To
 // succeed these must all be true:
 // 1.) totalDepth must be a multiple of 8 and not negative.
@@ -616,7 +599,7 @@ func TestString(t *testing.T) {
 		wantKey string
 	}{
 		{
-			n:       *NewEmptyNodeID(32),
+			n:       NodeID{},
 			want:    "",
 			wantKey: "0:",
 		},


### PR DESCRIPTION
Since `NodeID` is now immutable, there is no point to have a constructor which pre-allocates a zeroed byte slice (presumably the idea was that it can later be filled in).