### PR TITLE
Pass NodeID by value everywhere

### DIFF
--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -123,7 +123,7 @@ func getRandomNonRootNode(t *testing.T, rev int64) storage.Node {
 	// Make sure it's not a root node.
 	nodeID.PrefixLenBits = int(1 + randomBytes(t, 1)[0]%254)
 	return storage.Node{
-		NodeID:       *nodeID,
+		NodeID:       nodeID,
 		Hash:         randomBytes(t, 32),
 		NodeRevision: rev,
 	}
@@ -403,7 +403,7 @@ func testSparseTreeFetches(ctx context.Context, t *testing.T, vec sparseTestVect
 		// calculate the set of expected node reads.
 		for _, kv := range vec.kv {
 			keyHash := testonly.HashKey(kv.k)
-			nodeID := *storage.NewNodeIDFromHash(keyHash)
+			nodeID := storage.NewNodeIDFromHash(keyHash)
 			leafNodeIDs = append(leafNodeIDs, nodeID)
 			sibs := nodeID.Siblings()
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1614,7 +1614,7 @@ func TestGetConsistencyProof(t *testing.T) {
 		{
 			// Storage doesn't return the requested node, should result in an error.
 			req:        &getConsistencyProofRequest7,
-			errStr:     "expected node {[0 0 0 0 0 0 0 4] 62}",
+			errStr:     "expected node 00000000000000000000000000000000000000000000000000000000000001 at",
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
 			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -49,11 +49,11 @@ var h4 = th.HashLeaf([]byte("Hash 4"))
 var h5 = th.HashLeaf([]byte("Hash 5"))
 
 // And the dummy nodes themselves.
-var sn1 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
-var sn2 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
-var sn3 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
-var sn4 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
-var sn5 = storage.Node{NodeID: *storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
+var sn1 = storage.Node{NodeID: storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
+var sn2 = storage.Node{NodeID: storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
+var sn3 = storage.Node{NodeID: storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
+var sn4 = storage.Node{NodeID: storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
+var sn5 = storage.Node{NodeID: storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 
 func TestRehasher(t *testing.T) {
 	hasher := rfc6962.DefaultHasher

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -64,7 +64,7 @@ func TestSplitNodeID(t *testing.T) {
 		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
 		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
 	} {
-		n := *storage.NewNodeIDFromHash(tc.inPath)
+		n := storage.NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
 		sInfo := c.stratumInfoForNodeID(n)
@@ -90,7 +90,7 @@ func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	m := NewMockNodeStorage(mockCtrl)
 	c := NewSubtreeCache(defaultLogStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
-	nodeID := *storage.NewNodeIDFromHash([]byte("1234"))
+	nodeID := storage.NewNodeIDFromHash([]byte("1234"))
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
 	// NodeID, we should see just one "Get" request for each subtree.
 	si := 0
@@ -120,12 +120,12 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	c := NewSubtreeCache(defaultLogStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
 	nodeIDs := []storage.NodeID{
-		*storage.NewNodeIDFromHash([]byte("1234")),
-		*storage.NewNodeIDFromHash([]byte("1235")),
-		*storage.NewNodeIDFromHash([]byte("4567")),
-		*storage.NewNodeIDFromHash([]byte("89ab")),
-		*storage.NewNodeIDFromHash([]byte("89ac")),
-		*storage.NewNodeIDFromHash([]byte("89ad")),
+		storage.NewNodeIDFromHash([]byte("1234")),
+		storage.NewNodeIDFromHash([]byte("1235")),
+		storage.NewNodeIDFromHash([]byte("4567")),
+		storage.NewNodeIDFromHash([]byte("89ab")),
+		storage.NewNodeIDFromHash([]byte("89ac")),
+		storage.NewNodeIDFromHash([]byte("89ad")),
 	}
 	// Test that node IDs from one subtree are collapsed into one stratum read.
 	skips := map[int]bool{1: true, 4: true, 5: true}
@@ -182,14 +182,14 @@ func TestCacheFlush(t *testing.T) {
 	c := NewSubtreeCache(defaultMapStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
 
 	h := "0123456789abcdef0123456789abcdef"
-	nodeID := *storage.NewNodeIDFromHash([]byte(h))
+	nodeID := storage.NewNodeIDFromHash([]byte(h))
 	expectedSetIDs := make(map[string]string)
 	// When we loop around asking for all 0..32 bit prefix lengths of the above
 	// NodeID, we should see just one "Get" request for each subtree.
 	si := -1
 	for b := 0; b < nodeID.PrefixLenBits; b += defaultMapStrata[si] {
 		si++
-		e := *storage.NewNodeIDFromHash([]byte(h))
+		e := storage.NewNodeIDFromHash([]byte(h))
 		//e := nodeID
 		e.PrefixLenBits = b
 		expectedSetIDs[e.String()] = "expected"
@@ -388,7 +388,7 @@ func TestIdempotentWrites(t *testing.T) {
 	m := NewMockNodeStorage(mockCtrl)
 
 	h := "0123456789abcdef0123456789abcdef"
-	nodeID := *storage.NewNodeIDFromHash([]byte(h))
+	nodeID := storage.NewNodeIDFromHash([]byte(h))
 	nodeID.PrefixLenBits = 40
 	subtreeID := nodeID
 	subtreeID.PrefixLenBits = 32
@@ -404,7 +404,7 @@ func TestIdempotentWrites(t *testing.T) {
 	// We should only see a single write attempt
 	m.EXPECT().SetSubtrees(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, trees []*storagepb.SubtreeProto) {
 		for _, s := range trees {
-			subID := *storage.NewNodeIDFromHash(s.Prefix)
+			subID := storage.NewNodeIDFromHash(s.Prefix)
 			state, ok := expectedSetIDs[subID.String()]
 			if !ok {
 				t.Errorf("Unexpected write to subtree %s", subID.String())

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -220,7 +220,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 		if s.Prefix == nil {
 			panic(fmt.Errorf("nil prefix on %v", s))
 		}
-		k := subtreeKey(t.treeID, t.writeRevision, *storage.NewNodeIDFromHash(s.Prefix))
+		k := subtreeKey(t.treeID, t.writeRevision, storage.NewNodeIDFromHash(s.Prefix))
 		k.(*kv).v = s
 		t.tx.ReplaceOrInsert(k)
 	}

--- a/storage/node.go
+++ b/storage/node.go
@@ -111,8 +111,8 @@ func bytesForBits(numBits int) int {
 }
 
 // NewNodeIDFromHash creates a new NodeID for the given Hash.
-func NewNodeIDFromHash(h []byte) *NodeID {
-	return &NodeID{
+func NewNodeIDFromHash(h []byte) NodeID {
+	return NodeID{
 		Path:          h,
 		PrefixLenBits: len(h) * 8,
 	}
@@ -237,7 +237,7 @@ func NewNodeIDForTreeCoords(depth int64, index int64, maxPathBits int) (NodeID, 
 
 // Bit returns 1 if the zero indexed ith bit from the right (of the whole path
 // array, not just the significant portion) is true, and false otherwise.
-func (n *NodeID) Bit(i int) uint {
+func (n NodeID) Bit(i int) uint {
 	if got, want := i, n.PathLenBits()-1; got > want {
 		panic(fmt.Sprintf("storage: Bit(%v) > (PathLenBits() -1): %v", got, want))
 	}
@@ -249,7 +249,7 @@ func (n *NodeID) Bit(i int) uint {
 // The left-most bit is the MSB (i.e. nearer the root of the tree). The
 // length of the returned string will always be the same as the prefix length
 // of the node. For a string ID to use as a map key see AsKey().
-func (n *NodeID) String() string {
+func (n NodeID) String() string {
 	var r bytes.Buffer
 	limit := n.PathLenBits() - n.PrefixLenBits
 	for i := n.PathLenBits() - 1; i >= limit; i-- {
@@ -261,7 +261,7 @@ func (n *NodeID) String() string {
 // AsKey returns a string identifier for this NodeID suitable for
 // short term use e.g. as a Map key. It is more efficient to use this than
 // String() as it's not constrained to return a binary string.
-func (n *NodeID) AsKey() string {
+func (n NodeID) AsKey() string {
 	var b strings.Builder
 	fullBytes := n.PrefixLenBits / 8
 	bitsLeft := n.PrefixLenBits % 8
@@ -289,7 +289,7 @@ func (n *NodeID) AsKey() string {
 // CoordString returns a string representation assuming that the NodeID represents a
 // tree coordinate. Using this on a NodeID for a sparse Merkle tree will give incorrect
 // results. Intended for debugging purposes, the format could change.
-func (n *NodeID) CoordString() string {
+func (n NodeID) CoordString() string {
 	d := uint64(n.PathLenBits() - n.PrefixLenBits)
 	i := uint64(0)
 	for _, p := range n.Path {
@@ -300,10 +300,10 @@ func (n *NodeID) CoordString() string {
 }
 
 // Copy returns a duplicate of NodeID.
-func (n *NodeID) Copy() *NodeID {
+func (n NodeID) Copy() NodeID {
 	p := make([]byte, len(n.Path))
 	copy(p, n.Path)
-	return &NodeID{
+	return NodeID{
 		Path:          p,
 		PrefixLenBits: n.PrefixLenBits,
 	}
@@ -315,7 +315,7 @@ func (n *NodeID) Copy() *NodeID {
 var leftmask = [8]byte{0xFF, 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE}
 
 // MaskLeft returns a new copy of NodeID with only the left n bits set.
-func (n *NodeID) MaskLeft(depth int) *NodeID {
+func (n NodeID) MaskLeft(depth int) NodeID {
 	r := make([]byte, len(n.Path))
 	if depth > 0 {
 		// Copy the first depthBytes.
@@ -328,7 +328,7 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 	if depth < n.PrefixLenBits {
 		b = depth
 	}
-	return &NodeID{
+	return NodeID{
 		PrefixLenBits: b,
 		Path:          r,
 	}
@@ -338,7 +338,7 @@ func (n *NodeID) MaskLeft(depth int) *NodeID {
 // with the bit at PrefixLenBits in the copy flipped.
 // In terms of a tree traversal, this is the parent node's other child node
 // in the binary tree (often termed sibling node).
-func (n *NodeID) Neighbor(depth int) *NodeID {
+func (n NodeID) Neighbor(depth int) NodeID {
 	node := n.MaskLeft(depth)
 	height := node.PathLenBits() - node.PrefixLenBits
 	bIndex := (node.PathLenBits() - height - 1) / 8
@@ -353,11 +353,11 @@ func (n *NodeID) Neighbor(depth int) *NodeID {
 // earlier in the array.
 // These nodes are the ones that would be required for a Merkle tree inclusion
 // proof for this node.
-func (n *NodeID) Siblings() []NodeID {
+func (n NodeID) Siblings() []NodeID {
 	sibs := make([]NodeID, n.PrefixLenBits)
 	for height := range sibs {
 		depth := n.PrefixLenBits - height
-		sibs[height] = *n.Neighbor(depth)
+		sibs[height] = n.Neighbor(depth)
 	}
 	return sibs
 }
@@ -377,7 +377,7 @@ func NewNodeIDFromPrefixSuffix(prefix []byte, suffix *Suffix, maxPathBits int) N
 // Suffix returns a Node's suffix starting at prefixBytes.
 // This is the same Suffix that Split() would return, just without the overhead
 // of also creating the prefix.
-func (n *NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
+func (n NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
 	if n.PrefixLenBits == 0 {
 		return EmptySuffix
 	}
@@ -401,7 +401,7 @@ func (n *NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
 // Prefix returns a copy of NodeID's prefix.
 // This is the same value that would be returned from Split, but without the
 // overhead of calculating the suffix too.
-func (n *NodeID) Prefix(prefixBytes int) []byte {
+func (n NodeID) Prefix(prefixBytes int) []byte {
 	if n.PrefixLenBits == 0 {
 		return []byte{}
 	}
@@ -414,7 +414,7 @@ func (n *NodeID) Prefix(prefixBytes int) []byte {
 // PrefixAsKey returns a NodeID's prefix in a format suitable for use as a map key.
 // This is the same value that would be returned from Split, but without the
 // overhead of calculating the suffix too.
-func (n *NodeID) PrefixAsKey(prefixBytes int) string {
+func (n NodeID) PrefixAsKey(prefixBytes int) string {
 	if n.PrefixLenBits == 0 {
 		return ""
 	}
@@ -423,7 +423,7 @@ func (n *NodeID) PrefixAsKey(prefixBytes int) string {
 
 // Split splits a NodeID into a prefix and a suffix at prefixBytes.
 // The returned prefix is a copy of the underlying bytes.
-func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
+func (n NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 	if n.PrefixLenBits == 0 {
 		return []byte{}, EmptySuffix
 	}
@@ -431,7 +431,7 @@ func (n *NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
 }
 
 // Equivalent return true iff the other represents the same path prefix as this NodeID.
-func (n *NodeID) Equivalent(other NodeID) bool {
+func (n NodeID) Equivalent(other NodeID) bool {
 	// If they're different lengths they cannot represent the same path prefix.
 	if n.PrefixLenBits != other.PrefixLenBits {
 		return false

--- a/storage/node_test.go
+++ b/storage/node_test.go
@@ -510,8 +510,8 @@ func TestNodeEquivalentFromHash(t *testing.T) {
 		h1 := mustDecode(tc.str1)
 		h2 := mustDecode(tc.str2)
 
-		n1 := *NewNodeIDFromHash(h1)
-		n2 := *NewNodeIDFromHash(h2)
+		n1 := NewNodeIDFromHash(h1)
+		n2 := NewNodeIDFromHash(h2)
 
 		if n1.Equivalent(n2) != tc.want || n2.Equivalent(n1) != tc.want {
 			t.Errorf("TestNodeIDFromHash mismatch: %v", tc)
@@ -535,7 +535,7 @@ func TestNeighbour(t *testing.T) {
 		{index: h2b("0000000000010000"), want: h2b("0000000000010001")},
 		{index: h2b("8000000000000000"), want: h2b("8000000000000001")},
 	} {
-		nID := *NewNodeIDFromHash(tc.index)
+		nID := NewNodeIDFromHash(tc.index)
 		if got, want := nID.Neighbor(nID.PrefixLenBits).Path, tc.want; !bytes.Equal(got, want) {
 			t.Errorf("flipBit(%x): %x, want %x", tc.index, got, want)
 		}
@@ -634,7 +634,7 @@ func TestString(t *testing.T) {
 			wantKey: "16:1234",
 		},
 		{
-			n:       *NewNodeIDFromHash([]byte("this is a hash")),
+			n:       NewNodeIDFromHash([]byte("this is a hash")),
 			want:    "0111010001101000011010010111001100100000011010010111001100100000011000010010000001101000011000010111001101101000",
 			wantKey: "112:7468697320697320612068617368",
 		},


### PR DESCRIPTION
This change makes `NodeID` always passed by value. It seems that all call sites used it by value anyway. This change also encourages Go compiler to not allocate `NodeID`s in heap.