### PR TITLE
NodeID: Do not copy bytes in Prefix method

### DIFF
--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	reflect "reflect"
 	"testing"
 
 	"github.com/google/trillian/merkle/compact"
@@ -56,7 +57,7 @@ func TestSplitNodeID(t *testing.T) {
 		{[]byte{0x12, 0x34, 0x56, 0x78}, 9, []byte{0x12}, 1, []byte{0x00}},
 		{[]byte{0x12, 0x34, 0x56, 0x78}, 8, []byte{}, 8, []byte{0x12}},
 		{[]byte{0x12, 0x34, 0x56, 0x78}, 7, []byte{}, 7, []byte{0x12}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 0, []byte{}, 0, []byte{0}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 0, nil, 0, []byte{0}},
 		{[]byte{0x70}, 2, []byte{}, 2, []byte{0x40}},
 		{[]byte{0x70}, 3, []byte{}, 3, []byte{0x60}},
 		{[]byte{0x70}, 4, []byte{}, 4, []byte{0x70}},
@@ -69,8 +70,10 @@ func TestSplitNodeID(t *testing.T) {
 
 		sInfo := c.stratumInfoForNodeID(n)
 		p, s := n.Split(sInfo.prefixBytes, sInfo.depth)
-		if got, want := p, tc.outPrefix; !bytes.Equal(got, want) {
-			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
+		wantP := storage.NewNodeIDFromHash(tc.outPrefix)
+
+		if got, want := p, wantP; !reflect.DeepEqual(got, want) {
+			t.Errorf("splitNodeID(%v): prefix %v, want %v", n, got, want)
 			continue
 		}
 		if got, want := int(s.Bits()), tc.outSuffixBits; got != want {

--- a/storage/node.go
+++ b/storage/node.go
@@ -409,16 +409,6 @@ func (n NodeID) Prefix(bytes int) NodeID {
 	return NodeID{Path: n.Path[:bytes], PrefixLenBits: bytes * 8}
 }
 
-// PrefixAsKey returns a NodeID's prefix in a format suitable for use as a map key.
-// This is the same value that would be returned from Split, but without the
-// overhead of calculating the suffix too.
-func (n NodeID) PrefixAsKey(prefixBytes int) string {
-	if n.PrefixLenBits == 0 {
-		return ""
-	}
-	return string(n.Path[:prefixBytes])
-}
-
 // Split splits a NodeID into a prefix of the specified byte length, and and a
 // suffix of the specified bit length. Equivalent to calling Prefix and Suffix.
 func (n NodeID) Split(prefixBytes, suffixBits int) (NodeID, *Suffix) {

--- a/storage/node.go
+++ b/storage/node.go
@@ -398,17 +398,15 @@ func (n NodeID) Suffix(prefixBytes, suffixBits int) *Suffix {
 	return NewSuffix(byte(b), sfxPath)
 }
 
-// Prefix returns a copy of NodeID's prefix.
-// This is the same value that would be returned from Split, but without the
-// overhead of calculating the suffix too.
-func (n NodeID) Prefix(prefixBytes int) []byte {
+// Prefix returns a NodeID's prefix of the specified byte length, as another
+// NodeID. Panics if the byte length is out of bound for this ID.
+func (n NodeID) Prefix(bytes int) NodeID {
+	// TODO(pavelkalinnikov): This check doesn't eliminate panics, so we should
+	// either delete it, or cover all other panics.
 	if n.PrefixLenBits == 0 {
-		return []byte{}
+		return NodeID{}
 	}
-	a := make([]byte, prefixBytes)
-	copy(a, n.Path[:prefixBytes])
-
-	return a
+	return NodeID{Path: n.Path[:bytes], PrefixLenBits: bytes * 8}
 }
 
 // PrefixAsKey returns a NodeID's prefix in a format suitable for use as a map key.
@@ -421,11 +419,11 @@ func (n NodeID) PrefixAsKey(prefixBytes int) string {
 	return string(n.Path[:prefixBytes])
 }
 
-// Split splits a NodeID into a prefix and a suffix at prefixBytes.
-// The returned prefix is a copy of the underlying bytes.
-func (n NodeID) Split(prefixBytes, suffixBits int) ([]byte, *Suffix) {
+// Split splits a NodeID into a prefix of the specified byte length, and and a
+// suffix of the specified bit length. Equivalent to calling Prefix and Suffix.
+func (n NodeID) Split(prefixBytes, suffixBits int) (NodeID, *Suffix) {
 	if n.PrefixLenBits == 0 {
-		return []byte{}, EmptySuffix
+		return NodeID{}, EmptySuffix
 	}
 	return n.Prefix(prefixBytes), n.Suffix(prefixBytes, suffixBits)
 }

--- a/storage/node_test.go
+++ b/storage/node_test.go
@@ -224,20 +224,6 @@ func TestPrefix(t *testing.T) {
 	}
 }
 
-func TestPrefixAsKey(t *testing.T) {
-	for _, tc := range goldenSplitData {
-		n := NewNodeIDFromHash(tc.inPath)
-		n.PrefixLenBits = tc.inPathLenBits
-
-		p := n.PrefixAsKey(tc.splitBytes)
-		if got, want := p, string(tc.outPrefix); got != want {
-			t.Errorf("%d, %x.PrefixAsKey(%v): prefix %x, want %x",
-				tc.inPathLenBits, tc.inPath, tc.splitBytes, got, want)
-			continue
-		}
-	}
-}
-
 func TestSplit(t *testing.T) {
 	for _, tc := range goldenSplitData {
 		n := NewNodeIDFromHash(tc.inPath)


### PR DESCRIPTION
This change makes `NodeID.Prefix` method return a new `NodeID` which represents a prefix of the passed-in ID. This allows both using the returned `Path` slice as an in-memory map key, and reusing it for querying subtrees. As a result, the `PrefixAsKey` method is redundant, and is being removed.