### PR TITLE
storage: Ensure non-nil subtree keys

### DIFF
--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -333,7 +333,7 @@ func (t *treeTX) WriteRevision(ctx context.Context) (int64, error) {
 func subtreeKey(id storage.NodeID) ([]byte, error) {
 	// TODO(pavelkalinnikov): Extend this check to verify strata boundaries.
 	if id.PrefixLenBits%8 != 0 {
-		return nil, fmt.Errorf("invalid subtree ID: not multiple of 8: %d", id.PrefixLenBits)
+		return nil, fmt.Errorf("invalid subtree ID - not multiple of 8: %d", id.PrefixLenBits)
 	}
 	// The returned slice must not be nil, as it would correspond to NULL in SQL.
 	if bytes := id.Path; bytes != nil {

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -327,15 +327,19 @@ func (t *treeTX) WriteRevision(ctx context.Context) (int64, error) {
 	return rev, nil
 }
 
-// nodeIDToKey returns a []byte suitable for use as a primary key column for
-// the subtree which contains the id.
-// If id's prefix is not byte-aligned, an error will be returned.
+// subtreeKey returns a non-nil []byte suitable for use as a primary key column
+// for the subtree rooted at the passed-in node ID. Returns an error if the ID
+// is not aligned to bytes.
 func subtreeKey(id storage.NodeID) ([]byte, error) {
-	// TODO(al): extend this check to ensure id is at a tree stratum boundary.
+	// TODO(pavelkalinnikov): Extend this check to verify strata boundaries.
 	if id.PrefixLenBits%8 != 0 {
-		return nil, fmt.Errorf("id.PrefixLenBits (%d) is not a multiple of 8; it cannot be a subtree prefix", id.PrefixLenBits)
+		return nil, fmt.Errorf("invalid subtree ID: not multiple of 8: %d", id.PrefixLenBits)
 	}
-	return id.Path[:id.PrefixLenBits/8], nil
+	// The returned slice must not be nil, as it would correspond to NULL in SQL.
+	if bytes := id.Path; bytes != nil {
+		return bytes[:id.PrefixLenBits/8], nil
+	}
+	return []byte{}, nil
 }
 
 // getSubtree retrieves the most recent subtree specified by id at (or below)

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -434,6 +434,10 @@ func (t *treeTX) IsOpen() bool {
 // subtreeKey returns a non-nil []byte suitable for use as a primary key column
 // for the subtree rooted at the passed-in node ID. Returns an error if the ID
 // is not aligned to bytes.
+//
+// TODO(pavelkalinnikov): This function is duplicated in multiple storage
+// implementations. We should create a common "tree layout" type in the
+// top-level storage package and reuse it for ID/strata validation.
 func subtreeKey(id storage.NodeID) ([]byte, error) {
 	// TODO(pavelkalinnikov): Extend this check to verify strata boundaries.
 	if id.PrefixLenBits%8 != 0 {

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -249,16 +249,14 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []
 
 	args := make([]interface{}, 0, len(nodeIDs)+3)
 
-	// populate args with nodeIDs.
+	// Populate args with node IDs.
 	for _, nodeID := range nodeIDs {
-		if nodeID.PrefixLenBits%8 != 0 {
-			return nil, fmt.Errorf("invalid subtree ID - not multiple of 8: %d", nodeID.PrefixLenBits)
+		nodeIDBytes, err := subtreeKey(nodeID)
+		if err != nil {
+			return nil, err
 		}
-
-		nodeIDBytes := nodeID.Path[:nodeID.PrefixLenBits/8]
 		glog.V(4).Infof("  nodeID: %x", nodeIDBytes)
-
-		args = append(args, interface{}(nodeIDBytes))
+		args = append(args, nodeIDBytes)
 	}
 
 	args = append(args, interface{}(t.treeID))
@@ -450,4 +448,19 @@ func checkResultOkAndRowCountIs(res sql.Result, err error, count int64) error {
 	}
 
 	return nil
+}
+
+// subtreeKey returns a non-nil []byte suitable for use as a primary key column
+// for the subtree rooted at the passed-in node ID. Returns an error if the ID
+// is not aligned to bytes.
+func subtreeKey(id storage.NodeID) ([]byte, error) {
+	// TODO(pavelkalinnikov): Extend this check to verify strata boundaries.
+	if id.PrefixLenBits%8 != 0 {
+		return nil, fmt.Errorf("invalid subtree ID - not multiple of 8: %d", id.PrefixLenBits)
+	}
+	// The returned slice must not be nil, as it would correspond to NULL in SQL.
+	if bytes := id.Path; bytes != nil {
+		return bytes[:id.PrefixLenBits/8], nil
+	}
+	return []byte{}, nil
 }


### PR DESCRIPTION
This change makes SQL tree storages more robust by strongly ensuring that node IDs are converted to non-nil byte slices before converting to a SQL query. Follow-up to #1832.