### PR TITLE
Factor out treeLayout type from SubtreeCache

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -426,7 +426,13 @@ func (s *SubtreeCache) Flush(ctx context.Context, setSubtrees SetSubtreesFunc) e
 	return err
 }
 
+// newEmptySubtree creates an empty subtree for the passed-in root node ID,
+// which must be at a stratum boundary.
 func (s *SubtreeCache) newEmptySubtree(id storage.NodeID) *storagepb.SubtreeProto {
+	// TODO(pavelkalinnikov): Migrate this check to constructing SubtreeID.
+	if bl := id.PrefixLenBits; bl%8 != 0 {
+		panic(fmt.Errorf("invalid subtree ID: not a multiple of 8: %d", bl))
+	}
 	height := s.layout.GetSubtreeHeight(id)
 	if glog.V(2) {
 		glog.Infof("Creating new empty subtree for %x, with height %d", id.Path, height)

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -157,7 +157,7 @@ func TestCacheFlush(t *testing.T) {
 	m.EXPECT().SetSubtrees(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, trees []*storagepb.SubtreeProto) {
 		for _, s := range trees {
 			subID := storage.NewNodeIDFromHash(s.Prefix)
-			if got, want := s.Depth, c.layout.GetSubtreeHeight(subID); got != int32(want) {
+			if got, want := s.Depth, c.layout.getSubtreeHeight(subID); got != int32(want) {
 				t.Errorf("Got subtree with depth %d, expected %d for prefixLen %d", got, want, subID.PrefixLenBits)
 			}
 			state, ok := expectedSetIDs[subID.String()]
@@ -237,7 +237,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
-				_, sfx := c.layout.Split(n)
+				_, sfx := c.layout.split(n)
 				cmtStorage.InternalNodes[sfx.String()] = hash
 			}
 		}

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -40,49 +40,6 @@ var (
 
 const treeID = int64(0)
 
-func TestSplitNodeID(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
-	for _, tc := range []struct {
-		inPath        []byte
-		inPathLenBits int
-		outPrefix     []byte
-		outSuffixBits int
-		outSuffix     []byte
-	}{
-		{[]byte{0x12, 0x34, 0x56, 0x7f}, 32, []byte{0x12, 0x34, 0x56}, 8, []byte{0x7f}},
-		{[]byte{0x12, 0x34, 0x56, 0xff}, 29, []byte{0x12, 0x34, 0x56}, 5, []byte{0xf8}},
-		{[]byte{0x12, 0x34, 0x56, 0xff}, 25, []byte{0x12, 0x34, 0x56}, 1, []byte{0x80}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 16, []byte{0x12}, 8, []byte{0x34}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 9, []byte{0x12}, 1, []byte{0x00}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 8, []byte{}, 8, []byte{0x12}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 7, []byte{}, 7, []byte{0x12}},
-		{[]byte{0x12, 0x34, 0x56, 0x78}, 0, []byte{}, 0, []byte{0}},
-		{[]byte{0x70}, 2, []byte{}, 2, []byte{0x40}},
-		{[]byte{0x70}, 3, []byte{}, 3, []byte{0x60}},
-		{[]byte{0x70}, 4, []byte{}, 4, []byte{0x70}},
-		{[]byte{0x70}, 5, []byte{}, 5, []byte{0x70}},
-		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
-		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
-	} {
-		n := storage.NewNodeIDFromHash(tc.inPath)
-		n.PrefixLenBits = tc.inPathLenBits
-
-		sInfo := c.stratumInfoForNodeID(n)
-		p, s := n.Split(sInfo.prefixBytes, sInfo.depth)
-		if got, want := p, tc.outPrefix; !bytes.Equal(got, want) {
-			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
-			continue
-		}
-		if got, want := int(s.Bits()), tc.outSuffixBits; got != want {
-			t.Errorf("splitNodeID(%v): suffix.Bits %v, want %v", n, got, want)
-			continue
-		}
-		if got, want := s.Path(), tc.outSuffix; !bytes.Equal(got, want) {
-			t.Errorf("splitNodeID(%v): suffix.Path %x, want %x", n, got, want)
-		}
-	}
-}
-
 func TestCacheFillOnlyReadsSubtrees(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -200,7 +157,7 @@ func TestCacheFlush(t *testing.T) {
 	m.EXPECT().SetSubtrees(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, trees []*storagepb.SubtreeProto) {
 		for _, s := range trees {
 			subID := storage.NewNodeIDFromHash(s.Prefix)
-			if got, want := s.Depth, c.stratumInfoForPrefixLength(subID.PrefixLenBits).depth; got != int32(want) {
+			if got, want := s.Depth, c.layout.GetSubtreeHeight(subID); got != int32(want) {
 				t.Errorf("Got subtree with depth %d, expected %d for prefixLen %d", got, want, subID.PrefixLenBits)
 			}
 			state, ok := expectedSetIDs[subID.String()]
@@ -280,8 +237,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
-				sInfo := c.stratumInfoForNodeID(n)
-				sfx := n.Suffix(sInfo.prefixBytes, sInfo.depth)
+				_, sfx := c.layout.Split(n)
 				cmtStorage.InternalNodes[sfx.String()] = hash
 			}
 		}
@@ -342,40 +298,6 @@ func BenchmarkRepopulateLogSubtree(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		if err := populate(&s); err != nil {
 			b.Fatalf("failed populate subtree: %v", err)
-		}
-	}
-}
-
-func TestPrefixLengths(t *testing.T) {
-	strata := []int{8, 8, 16, 32, 64, 128}
-	stratumInfo := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
-
-	c := NewSubtreeCache(strata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
-
-	if diff := pretty.Compare(c.stratumInfo, stratumInfo); diff != "" {
-		t.Fatalf("prefixLengths diff:\n%v", diff)
-	}
-}
-
-func TestGetStratumInfo(t *testing.T) {
-	c := NewSubtreeCache(defaultMapStrata, populateMapSubtreeNodes(treeID, maphasher.Default), prepareMapSubtreeWrite())
-	testVec := []struct {
-		depth int
-		info  stratumInfo
-	}{
-		{0, stratumInfo{0, 8}},
-		{1, stratumInfo{0, 8}},
-		{7, stratumInfo{0, 8}},
-		{8, stratumInfo{1, 8}},
-		{15, stratumInfo{1, 8}},
-		{79, stratumInfo{9, 8}},
-		{80, stratumInfo{10, 176}},
-		{81, stratumInfo{10, 176}},
-		{156, stratumInfo{10, 176}},
-	}
-	for i, tv := range testVec {
-		if diff := pretty.Compare(c.stratumInfoForPrefixLength(tv.depth), tv.info); diff != "" {
-			t.Errorf("(test %d for depth %d) diff:\n%v", i, tv.depth, diff)
 		}
 	}
 }

--- a/storage/cache/tree_layout.go
+++ b/storage/cache/tree_layout.go
@@ -45,12 +45,6 @@ type TreeLayout struct {
 func NewTreeLayout(heights []int) *TreeLayout {
 	// Compute the total tree height.
 	height := 0
-	for _, h := range heights {
-		height += h
-	}
-
-	// Build the strata information index.
-	sIndex := make([]stratumInfo, 0, height/depthQuantum)
 	for i, h := range heights {
 		// Verify the stratum height is valid.
 		if h <= 0 {
@@ -59,6 +53,12 @@ func NewTreeLayout(heights []int) *TreeLayout {
 		if h%depthQuantum != 0 {
 			panic(fmt.Errorf("invalid stratum height[%d]: %d; must be a multiple of %d", i, h, depthQuantum))
 		}
+		height += h
+	}
+
+	// Build the strata information index.
+	sIndex := make([]stratumInfo, 0, height/depthQuantum)
+	for _, h := range heights {
 		// Assign the same stratum info to depth quants that this stratum spans.
 		info := stratumInfo{idBytes: len(sIndex), height: h}
 		for d := 0; d < h; d += depthQuantum {

--- a/storage/cache/tree_layout.go
+++ b/storage/cache/tree_layout.go
@@ -25,7 +25,7 @@ const (
 	// subtree heights must also be a multiple of.
 	//
 	// WARNING: The code below breaks if this value is not a multiple of 8,
-	// because it use the NodeID byte representation directly.
+	// because it uses storage.NodeID byte representation directly.
 	depthQuantum = 8
 )
 

--- a/storage/cache/tree_layout.go
+++ b/storage/cache/tree_layout.go
@@ -24,8 +24,8 @@ const (
 	// depthQuantum defines the smallest supported subtree height, which all
 	// subtree heights must also be a multiple of.
 	//
-	// WARNING: The code below breaks if this value is not a multiple of 8,
-	// because it uses storage.NodeID byte representation directly.
+	// WARNING: TreeLayout breaks if this value is not a multiple of 8, because
+	// it uses storage.NodeID byte representation directly.
 	depthQuantum = 8
 )
 

--- a/storage/cache/tree_layout.go
+++ b/storage/cache/tree_layout.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/google/trillian/storage"
+)
+
+const (
+	// depthQuantum defines the smallest supported subtree height, which all
+	// subtree heights must also be a multiple of.
+	//
+	// WARNING: The code below breaks if this value is not a multiple of 8,
+	// because it use the NodeID byte representation directly.
+	depthQuantum = 8
+)
+
+// TreeLayout defines the mapping between tree node IDs and subtree IDs.
+type TreeLayout struct {
+	// sIndex contains stratum info for each multiple-of-depthQuantum node depth.
+	// Note that if a stratum spans multiple depthQuantum heights then it will be
+	// present in this slice the corresponding number of times.
+	// This index is used for fast mapping from node IDs to strata IDs.
+	sIndex []stratumInfo
+	// height is the height of the tree. It defines the maximal bit-length of a
+	// node ID that the tree can contain.
+	height int
+}
+
+// NewTreeLayout creates a tree layout based on the passed-in strata heights.
+func NewTreeLayout(heights []int) *TreeLayout {
+	// Compute the total tree height.
+	height := 0
+	for _, h := range heights {
+		height += h
+	}
+
+	// Build the strata information index.
+	sIndex := make([]stratumInfo, 0, (height+depthQuantum-1)/depthQuantum)
+	for i, h := range heights {
+		// Verify the stratum height is valid.
+		if h <= 0 {
+			panic(fmt.Errorf("invalid stratum height[%d]: %d; must be > 0", i, h))
+		}
+		if h%depthQuantum != 0 {
+			panic(fmt.Errorf("invalid stratum height[%d]: %d; must be a multiple of %d", i, h, depthQuantum))
+		}
+		// Assign the same stratum info to depth quants that this stratum spans.
+		info := stratumInfo{idBytes: len(sIndex), height: h}
+		for d := 0; d < h; d += depthQuantum {
+			sIndex = append(sIndex, info)
+		}
+	}
+
+	return &TreeLayout{sIndex: sIndex, height: height}
+}
+
+// GetSubtreeRoot returns the root node ID for the stratum that the passed-in
+// node belongs to.
+//
+// Note that nodes located at multiples of depthQuantum normally belong to
+// subtrees rooted above them. However, the topmost node (with an empty NodeID)
+// is the root for its own subtree since there is nothing above it.
+func (t *TreeLayout) GetSubtreeRoot(id storage.NodeID) storage.NodeID {
+	if depth := id.PrefixLenBits; depth > 0 {
+		info := t.getStratumAt(depth - 1)
+		// TODO(pavelkalinnikov): Use Prefix method once it no longer copies Path.
+		// TODO(pavelkalinnikov): Rename *FromHash to something sensible.
+		return storage.NewNodeIDFromHash(id.Path[:info.idBytes])
+	}
+	return id
+}
+
+// Split returns the ID of the root of the subtree that the passed-in node
+// belongs to, and the corresponding local address within this subree.
+func (t *TreeLayout) Split(id storage.NodeID) (storage.NodeID, *storage.Suffix) {
+	if depth := id.PrefixLenBits; depth > 0 {
+		info := t.getStratumAt(depth - 1)
+		prefixID := storage.NewNodeIDFromHash(id.Path[:info.idBytes])
+		return prefixID, id.Suffix(info.idBytes, info.height)
+	}
+	// TODO(pavelkalinnikov): Leave Path == nil once it is safe.
+	return storage.NodeID{Path: []byte{}}, storage.EmptySuffix
+}
+
+// GetSubtreeHeight returns the height of the subtree with the passed-in ID.
+func (t *TreeLayout) GetSubtreeHeight(id storage.NodeID) int {
+	return t.getStratumAt(id.PrefixLenBits).height
+}
+
+func (t *TreeLayout) getStratumAt(depth int) stratumInfo {
+	return t.sIndex[depth/depthQuantum]
+}
+
+// stratumInfo describes a single stratum across the tree.
+type stratumInfo struct {
+	// idBytes is the byte length of IDs for this stratum.
+	idBytes int
+	// height is the number of levels in this stratum.
+	height int
+}

--- a/storage/cache/tree_layout.go
+++ b/storage/cache/tree_layout.go
@@ -50,7 +50,7 @@ func NewTreeLayout(heights []int) *TreeLayout {
 	}
 
 	// Build the strata information index.
-	sIndex := make([]stratumInfo, 0, (height+depthQuantum-1)/depthQuantum)
+	sIndex := make([]stratumInfo, 0, height/depthQuantum)
 	for i, h := range heights {
 		// Verify the stratum height is valid.
 		if h <= 0 {
@@ -72,9 +72,11 @@ func NewTreeLayout(heights []int) *TreeLayout {
 // GetSubtreeRoot returns the root node ID for the stratum that the passed-in
 // node belongs to.
 //
-// Note that nodes located at multiples of depthQuantum normally belong to
-// subtrees rooted above them. However, the topmost node (with an empty NodeID)
-// is the root for its own subtree since there is nothing above it.
+// Note that nodes located at strata boundaries normally belong to subtrees
+// rooted above them. However, the topmost node (with an empty NodeID) is the
+// root for its own subtree since there is nothing above it.
+//
+// TODO(pavelkalinnikov): Introduce a "type-safe" SubtreeID type.
 func (t *TreeLayout) GetSubtreeRoot(id storage.NodeID) storage.NodeID {
 	if depth := id.PrefixLenBits; depth > 0 {
 		info := t.getStratumAt(depth - 1)
@@ -110,6 +112,6 @@ func (t *TreeLayout) getStratumAt(depth int) stratumInfo {
 type stratumInfo struct {
 	// idBytes is the byte length of IDs for this stratum.
 	idBytes int
-	// height is the number of levels in this stratum.
+	// height is the number of tree levels in this stratum.
 	height int
 }

--- a/storage/cache/tree_layout_test.go
+++ b/storage/cache/tree_layout_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSplitNodeID(t *testing.T) {
-	layout := NewTreeLayout(defaultMapStrata)
+	layout := newTreeLayout(defaultMapStrata)
 	for _, tc := range []struct {
 		inPath        []byte
 		inPathLenBits int
@@ -50,7 +50,7 @@ func TestSplitNodeID(t *testing.T) {
 		n := storage.NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
-		p, s := layout.Split(n)
+		p, s := layout.split(n)
 		if got, want := p.Path, tc.outPrefix; !bytes.Equal(got, want) {
 			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
 			continue
@@ -69,14 +69,14 @@ func TestStrataIndex(t *testing.T) {
 	heights := []int{8, 8, 16, 32, 64, 128}
 	want := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
-	layout := NewTreeLayout(heights)
+	layout := newTreeLayout(heights)
 	if diff := pretty.Compare(layout.sIndex, want); diff != "" {
 		t.Fatalf("sIndex diff:\n%v", diff)
 	}
 }
 
 func TestDefaultMapStrataIndex(t *testing.T) {
-	layout := NewTreeLayout(defaultMapStrata)
+	layout := newTreeLayout(defaultMapStrata)
 	for _, tc := range []struct {
 		depth int
 		want  stratumInfo

--- a/storage/cache/tree_layout_test.go
+++ b/storage/cache/tree_layout_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/google/trillian/storage"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestSplitNodeID(t *testing.T) {
+	layout := NewTreeLayout(defaultMapStrata)
+	for _, tc := range []struct {
+		inPath        []byte
+		inPathLenBits int
+		outPrefix     []byte
+		outSuffixBits int
+		outSuffix     []byte
+	}{
+		{[]byte{0x12, 0x34, 0x56, 0x7f}, 32, []byte{0x12, 0x34, 0x56}, 8, []byte{0x7f}},
+		{[]byte{0x12, 0x34, 0x56, 0xff}, 29, []byte{0x12, 0x34, 0x56}, 5, []byte{0xf8}},
+		{[]byte{0x12, 0x34, 0x56, 0xff}, 25, []byte{0x12, 0x34, 0x56}, 1, []byte{0x80}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 16, []byte{0x12}, 8, []byte{0x34}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 9, []byte{0x12}, 1, []byte{0x00}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 8, []byte{}, 8, []byte{0x12}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 7, []byte{}, 7, []byte{0x12}},
+		{[]byte{0x12, 0x34, 0x56, 0x78}, 0, []byte{}, 0, []byte{0}},
+		{[]byte{0x70}, 2, []byte{}, 2, []byte{0x40}},
+		{[]byte{0x70}, 3, []byte{}, 3, []byte{0x60}},
+		{[]byte{0x70}, 4, []byte{}, 4, []byte{0x70}},
+		{[]byte{0x70}, 5, []byte{}, 5, []byte{0x70}},
+		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
+		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
+	} {
+		n := storage.NewNodeIDFromHash(tc.inPath)
+		n.PrefixLenBits = tc.inPathLenBits
+
+		p, s := layout.Split(n)
+		if got, want := p.Path, tc.outPrefix; !bytes.Equal(got, want) {
+			t.Errorf("splitNodeID(%v): prefix %x, want %x", n, got, want)
+			continue
+		}
+		if got, want := int(s.Bits()), tc.outSuffixBits; got != want {
+			t.Errorf("splitNodeID(%v): suffix.Bits %v, want %v", n, got, want)
+			continue
+		}
+		if got, want := s.Path(), tc.outSuffix; !bytes.Equal(got, want) {
+			t.Errorf("splitNodeID(%v): suffix.Path %x, want %x", n, got, want)
+		}
+	}
+}
+
+func TestStrataIndex(t *testing.T) {
+	heights := []int{8, 8, 16, 32, 64, 128}
+	want := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
+
+	layout := NewTreeLayout(heights)
+	if diff := pretty.Compare(layout.sIndex, want); diff != "" {
+		t.Fatalf("sIndex diff:\n%v", diff)
+	}
+}
+
+func TestDefaultMapStrataIndex(t *testing.T) {
+	layout := NewTreeLayout(defaultMapStrata)
+	for _, tc := range []struct {
+		depth int
+		want  stratumInfo
+	}{
+		{0, stratumInfo{0, 8}},
+		{1, stratumInfo{0, 8}},
+		{7, stratumInfo{0, 8}},
+		{8, stratumInfo{1, 8}},
+		{15, stratumInfo{1, 8}},
+		{79, stratumInfo{9, 8}},
+		{80, stratumInfo{10, 176}},
+		{81, stratumInfo{10, 176}},
+		{156, stratumInfo{10, 176}},
+	} {
+		t.Run(fmt.Sprintf("depth:%d", tc.depth), func(t *testing.T) {
+			got := layout.getStratumAt(tc.depth)
+			if want := tc.want; got != want {
+				t.Errorf("got %+v; want %+v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change moves the subtree strata calculus into a separate `treeLayout` type. This is the first step towards having cleaner abstraction levels around `SubtreeCache`. As an extra small optimization, this type can have 2 global instances (for log and for map), and be reused everywhere instead of being instantiated whenever a new transaction is started.