### PR TITLE
Removed misleading verbose log and made range more idiomatic

### DIFF
--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -245,11 +245,8 @@ func (t *TrillianMapServer) getLeavesByRevision(ctx context.Context, mapID int64
 			errCh <- fmt.Errorf("could not fetch leaves: %v", err)
 			return
 		}
-		for i, l := range leaves {
-			leavesByIndex[string(l.Index)] = leaves[i]
-		}
-		if len(indices) != len(leavesByIndex) {
-			glog.V(1).Infof("%v: request had %v indices, %v of these are unique", mapID, len(indices), len(leavesByIndex))
+		for _, l := range leaves {
+			leavesByIndex[string(l.Index)] = l
 		}
 		glog.V(1).Infof("%v: wanted %v leaves, found %v", mapID, len(indices), len(leaves))
 


### PR DESCRIPTION
There can be no duplicate indices as this is enforced at the beginning of this method. Any missing indices is because they were not found, which the next line gives a better clue about.

Also made the for loop more consistent with how we range over arrays elsewhere.
