### PR TITLE
Reduce the min/max leaves in the hammer test

### DIFF
--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -71,10 +71,11 @@ func TestRetryExposesDeadlineError(t *testing.T) {
 		EPBias:        bias,
 		LeafSize:      1000,
 		ExtraSize:     100,
-		MinLeaves:     800,
-		MaxLeaves:     1200,
-		Operations:    *operations,
-		NumCheckers:   1,
+		// TODO(mhutchinson): Increase these when #1845 is understood & fixed.
+		MinLeaves:   100,
+		MaxLeaves:   150,
+		Operations:  *operations,
+		NumCheckers: 1,
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
@@ -120,10 +121,11 @@ func TestInProcessMapHammer(t *testing.T) {
 		EPBias:        bias,
 		LeafSize:      1000,
 		ExtraSize:     100,
-		MinLeaves:     800,
-		MaxLeaves:     1200,
-		Operations:    *operations,
-		NumCheckers:   1,
+		// TODO(mhutchinson): Increase these when #1845 is understood & fixed.
+		MinLeaves:   100,
+		MaxLeaves:   150,
+		Operations:  *operations,
+		NumCheckers: 1,
 	}
 	if err := HitMap(ctx, cfg); err != nil {
 		t.Fatalf("hammer failure: %v", err)


### PR DESCRIPTION
This load causes failures on multiple versions of MySQL. This has been going on for a while and doesn't seem to be the result of any recent changes, but has come to light due to mariadb being force upgraded on our dev machines.

This is a temporary workaround while we determine:
a) what versions of MySQL we want to support; and
b) what loads are reasonable to hit it with

This puts the fire out for #1845 while we determine the next steps.