### PR TITLE
Move primitives from storage to tree package

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
 
@@ -141,9 +142,9 @@ func (s Sequencer) initCompactRangeFromStorage(ctx context.Context, root *types.
 	}
 
 	ids := compact.RangeNodes(0, root.TreeSize)
-	storIDs := make([]storage.NodeID, len(ids))
+	storIDs := make([]tree.NodeID, len(ids))
 	for i, id := range ids {
-		nodeID, err := storage.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)
+		nodeID, err := tree.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create nodeID: %v", err)
 		}
@@ -183,14 +184,14 @@ func (s Sequencer) initCompactRangeFromStorage(ctx context.Context, root *types.
 	return cr, nil
 }
 
-func (s Sequencer) buildNodesFromNodeMap(nodeMap map[compact.NodeID][]byte, newVersion int64) ([]storage.Node, error) {
-	nodes := make([]storage.Node, 0, len(nodeMap))
+func (s Sequencer) buildNodesFromNodeMap(nodeMap map[compact.NodeID][]byte, newVersion int64) ([]tree.Node, error) {
+	nodes := make([]tree.Node, 0, len(nodeMap))
 	for id, hash := range nodeMap {
-		nodeID, err := storage.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)
+		nodeID, err := tree.NewNodeIDForTreeCoords(int64(id.Level), int64(id.Index), maxTreeDepth)
 		if err != nil {
 			return nil, err
 		}
-		nodes = append(nodes, storage.Node{NodeID: nodeID, Hash: hash, NodeRevision: newVersion})
+		nodes = append(nodes, tree.Node{NodeID: nodeID, Hash: hash, NodeRevision: newVersion})
 	}
 	return nodes, nil
 }

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -37,6 +37,7 @@ import (
 
 	tcrypto "github.com/google/trillian/crypto"
 	stestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 )
 
 // Arbitrary time for use in tests
@@ -68,7 +69,7 @@ var (
 	}
 	testSignedRoot0, _ = fixedLog1Signer.SignLogRoot(testRoot0)
 
-	updatedNodes0 = []storage.Node{{NodeID: storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 64}, Hash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), NodeRevision: 1}}
+	updatedNodes0 = []tree.Node{{NodeID: tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 64}, Hash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), NodeRevision: 1}}
 	updatedRoot   = &types.LogRootV1{
 		TimestampNanos: uint64(fakeTime.UnixNano()),
 		RootHash:       []byte{110, 52, 11, 156, 255, 179, 122, 152, 156, 165, 68, 230, 187, 120, 10, 44, 120, 144, 29, 63, 179, 55, 56, 118, 133, 17, 163, 6, 23, 175, 160, 29},

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -35,6 +35,7 @@ import (
 
 	tcrypto "github.com/google/trillian/crypto"
 	stestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 )
 
 var (
@@ -66,8 +67,8 @@ var (
 		RootHash:       []byte{},
 		TimestampNanos: uint64(fakeTime.Add(-10 * time.Millisecond).UnixNano()),
 	}
-	compactTree16 = []storage.Node{{
-		NodeID: storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
+	compactTree16 = []tree.Node{{
+		NodeID: tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
 		// TODO(pavelkalinnikov): Put a well-formed hash here. The current one is
 		// taken from testRoot16 and retained for regression purposes.
 		Hash:         []byte{},
@@ -107,14 +108,14 @@ var (
 	testSignedRoot18, _ = tcrypto.NewSigner(0, fixedGoSigner, crypto.SHA256).SignLogRoot(testRoot18)
 
 	// These will be accepted in either order because of custom sorting in the mock
-	updatedNodes = []storage.Node{
+	updatedNodes = []tree.Node{
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 64},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 64},
 			Hash:         testonly.MustDecodeBase64("L5Iyd7aFOVewxiRm29xD+EU+jvEo4RfufBijKdflWMk="),
 			NodeRevision: 6,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 59},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 59},
 			Hash:         testonly.MustDecodeBase64("R57DrKTGuZdjCNXjv6InGrm4rABLOn9yWpdHmYOoLwU="),
 			NodeRevision: 6,
 		},
@@ -138,42 +139,42 @@ var (
 	}
 	testSignedRoot21, _ = tcrypto.NewSigner(0, fixedGoSigner, crypto.SHA256).SignLogRoot(testRoot21)
 	// Nodes that will be loaded when updating the tree of size 21.
-	compactTree21 = []storage.Node{
+	compactTree21 = []tree.Node{
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 60},
 			Hash:         testonly.MustDecodeBase64("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="),
 			NodeRevision: 5,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 62},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 62},
 			Hash:         testonly.MustDecodeBase64("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="),
 			NodeRevision: 5,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 64},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 64},
 			Hash:         testonly.MustDecodeBase64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
 			NodeRevision: 5,
 		},
 	}
 	// Nodes that will be stored after updating the tree of size 21.
-	updatedNodes21 = []storage.Node{
+	updatedNodes21 = []tree.Node{
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 59},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 59},
 			Hash:         testonly.MustDecodeBase64("1oUtLDlyOWXLHLAvL3NvWaO4D9kr0oQYScylDlgjey4="),
 			NodeRevision: 6,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 61},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}, PrefixLenBits: 61},
 			Hash:         testonly.MustDecodeBase64("1yCvo/9xbNIileBAEjc+c00GxVQQV7h54Tdmkc48uRU="),
 			NodeRevision: 6,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 63},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14}, PrefixLenBits: 63},
 			Hash:         testonly.MustDecodeBase64("S55qEsQMx90/eq1fSb87pYCB9WIYL7hBgiTY+B9LmPw="),
 			NodeRevision: 6,
 		},
 		{
-			NodeID:       storage.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15}, PrefixLenBits: 64},
+			NodeID:       tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15}, PrefixLenBits: 64},
 			Hash:         testonly.MustDecodeBase64("L5Iyd7aFOVewxiRm29xD+EU+jvEo4RfufBijKdflWMk="),
 			NodeRevision: 6,
 		},
@@ -221,13 +222,13 @@ type testParameters struct {
 	latestSignedRootError error
 	latestSignedRoot      *trillian.SignedLogRoot
 
-	merkleNodesGet      *[]storage.Node
+	merkleNodesGet      *[]tree.Node
 	merkleNodesGetError error
 
 	updatedLeaves      *[]*trillian.LogLeaf
 	updatedLeavesError error
 
-	merkleNodesSet      *[]storage.Node
+	merkleNodesSet      *[]tree.Node
 	merkleNodesSetError error
 
 	skipStoreSignedRoot  bool
@@ -313,7 +314,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	}
 
 	if params.merkleNodesGet != nil {
-		ids := make([]storage.NodeID, 0, len(*params.merkleNodesGet))
+		ids := make([]tree.NodeID, 0, len(*params.merkleNodesGet))
 		for _, node := range *params.merkleNodesGet {
 			ids = append(ids, node.NodeID)
 		}
@@ -358,7 +359,7 @@ func TestIntegrateBatch(t *testing.T) {
 	guardWindow := time.Second * 10
 	expectedCutoffTime := fakeTime.Add(-guardWindow)
 	noLeaves := []*trillian.LogLeaf{}
-	noNodes := []storage.Node{}
+	noNodes := []tree.Node{}
 	specs := []quota.Spec{
 		{Group: quota.Tree, Kind: quota.Read, TreeID: 154035},
 		{Group: quota.Tree, Kind: quota.Write, TreeID: 154035},

--- a/merkle/hstar2.go
+++ b/merkle/hstar2.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle/hashers"
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 )
 
 var (
@@ -132,7 +132,7 @@ func (s *HStar2) run(prefix []byte, subtreeDepth int, values []*HStar2LeafHash,
 		return nil, ErrSubtreeOverrun
 	}
 	sort.Sort(ByIndex{values})
-	offset := storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, s.hasher.BitLen()).BigInt()
+	offset := tree.NewNodeIDFromPrefixSuffix(prefix, tree.EmptySuffix, s.hasher.BitLen()).BigInt()
 	return s.hStar2b(depth, totalDepth, values, offset, get, combine)
 }
 
@@ -184,7 +184,7 @@ func (s *HStar2) get(index *big.Int, depth int, getter SparseGetNodeFunc) ([]byt
 	}
 	// TODO(gdbelvin): Hashers should accept depth as their main argument.
 	height := s.hasher.BitLen() - depth
-	nodeID := storage.NewNodeIDFromBigInt(index.BitLen(), index, s.hasher.BitLen())
+	nodeID := tree.NewNodeIDFromBigInt(index.BitLen(), index, s.hasher.BitLen())
 	return s.hasher.HashEmpty(s.treeID, nodeID.Path, height), nil
 }
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/trillian/merkle/coniks"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/merkle/maphasher"
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 )
 
@@ -185,7 +185,7 @@ func rootsForTrimmedKeys(t *testing.T, prefixSize int, lh []*HStar2LeafHash) []*
 		}
 
 		ret = append(ret, &HStar2LeafHash{
-			Index:    storage.NewNodeIDFromPrefixSuffix(prefix, storage.EmptySuffix, hasher.BitLen()).BigInt(),
+			Index:    tree.NewNodeIDFromPrefixSuffix(prefix, tree.EmptySuffix, hasher.BitLen()).BigInt(),
 			LeafHash: root,
 		})
 	}

--- a/merkle/map_verifier.go
+++ b/merkle/map_verifier.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 )
 
 // VerifyMapInclusionProof verifies that the passed in expectedRoot can be
@@ -51,7 +51,7 @@ func VerifyMapInclusionProof(treeID int64, leaf *trillian.MapLeaf, expectedRoot 
 	}
 
 	runningHash := leafHash
-	nID := storage.NewNodeIDFromHash(leaf.Index)
+	nID := tree.NewNodeIDFromHash(leaf.Index)
 	for height, sib := range nID.Siblings() {
 		pElement := proof[height]
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -42,6 +42,7 @@ import (
 
 	tcrypto "github.com/google/trillian/crypto"
 	stestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 )
 
 func newTestLeaf(data []byte, extra []byte, index int64) *trillian.LogLeaf {
@@ -105,12 +106,12 @@ var (
 	getConsistencyProofRequest44 = trillian.GetConsistencyProofRequest{LogId: logID1, FirstTreeSize: 4, SecondTreeSize: 4}
 	getConsistencyProofRequest48 = trillian.GetConsistencyProofRequest{LogId: logID1, FirstTreeSize: 4, SecondTreeSize: 8}
 
-	nodeIdsInclusionSize7Index2 = []storage.NodeID{
+	nodeIdsInclusionSize7Index2 = []tree.NodeID{
 		stestonly.MustCreateNodeIDForTreeCoords(0, 3, 64),
 		stestonly.MustCreateNodeIDForTreeCoords(1, 0, 64),
 		stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64)}
 
-	nodeIdsConsistencySize4ToSize7 = []storage.NodeID{stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64)}
+	nodeIdsConsistencySize4ToSize7 = []tree.NodeID{stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64)}
 	corruptLogRoot                 = &trillian.SignedLogRoot{LogRoot: []byte("this is not tls encoded data")}
 )
 
@@ -881,7 +882,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("STORAGE"))
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -896,7 +897,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// The server expects three nodes from storage but we return only two
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -911,7 +912,7 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// We set this up so one of the returned nodes has the wrong ID
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -1014,7 +1015,7 @@ func TestGetProofByHash(t *testing.T) {
 			mockTX.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			mockTX.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(tc.leavesByHashVal, nil)
 			mockTX.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil).AnyTimes()
-			mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+			mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 				{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 				{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 				{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil).AnyTimes()
@@ -1114,7 +1115,7 @@ func TestGetProofByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{}, errors.New("STORAGE"))
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1128,7 +1129,7 @@ func TestGetProofByIndex(t *testing.T) {
 				// The server expects three nodes from storage but we return only two
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1142,7 +1143,7 @@ func TestGetProofByIndex(t *testing.T) {
 				// We set this up so one of the returned nodes has the wrong ID
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1155,7 +1156,7 @@ func TestGetProofByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
@@ -1193,7 +1194,7 @@ func TestGetProofByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1303,7 +1304,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1320,7 +1321,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1362,7 +1363,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1380,7 +1381,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1423,7 +1424,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), tree1).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil) // nolint: megacheck
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]storage.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")}}, nil)
@@ -1557,8 +1558,8 @@ type consistProofTest struct {
 	noRoot      bool
 	rootErr     error
 	noRev       bool
-	nodeIDs     []storage.NodeID
-	nodes       []storage.Node
+	nodeIDs     []tree.NodeID
+	nodes       []tree.Node
 	getNodesErr error
 	noCommit    bool
 	commitErr   error
@@ -1598,7 +1599,7 @@ func TestGetConsistencyProof(t *testing.T) {
 			errStr:      "getMerkle",
 			nodeIDs:     nodeIdsConsistencySize4ToSize7,
 			wantHashes:  [][]byte{[]byte("nodehash")},
-			nodes:       []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
+			nodes:       []tree.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
 			getNodesErr: errors.New("getMerkleNodes() failed"),
 			noCommit:    true,
 		},
@@ -1608,7 +1609,7 @@ func TestGetConsistencyProof(t *testing.T) {
 			errStr:     "commit",
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
-			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
+			nodes:      []tree.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
 			commitErr:  errors.New("commit() failed"),
 		},
 		{
@@ -1617,7 +1618,7 @@ func TestGetConsistencyProof(t *testing.T) {
 			errStr:     "expected node 00000000000000000000000000000000000000000000000000000000000001 at",
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
-			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
+			nodes:      []tree.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
 			noCommit:   true,
 		},
 		{
@@ -1626,7 +1627,7 @@ func TestGetConsistencyProof(t *testing.T) {
 			errStr:     "expected 1 nodes",
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
-			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 10, 64), NodeRevision: 37, Hash: []byte("nodehash2")}},
+			nodes:      []tree.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(3, 10, 64), NodeRevision: 37, Hash: []byte("nodehash2")}},
 			noCommit:   true,
 		},
 		{
@@ -1642,14 +1643,14 @@ func TestGetConsistencyProof(t *testing.T) {
 			req:        &getConsistencyProofRequest7,
 			wantHashes: [][]byte{[]byte("nodehash")},
 			nodeIDs:    nodeIdsConsistencySize4ToSize7,
-			nodes:      []storage.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
+			nodes:      []tree.Node{{NodeID: stestonly.MustCreateNodeIDForTreeCoords(2, 1, 64), NodeRevision: 3, Hash: []byte("nodehash")}},
 		},
 		{
 			// Tests first==second edge case, which should succeed but is an empty proof.
 			req:        &getConsistencyProofRequest44,
 			wantHashes: [][]byte{},
-			nodeIDs:    []storage.NodeID{},
-			nodes:      []storage.Node{},
+			nodeIDs:    []tree.NodeID{},
+			nodes:      []tree.Node{},
 		},
 	}
 

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 )
 
 // rehashTest encapsulates one test case for the rehasher in isolation. Input data like the storage
@@ -33,7 +33,7 @@ import (
 type rehashTest struct {
 	desc    string
 	index   int64
-	nodes   []storage.Node
+	nodes   []tree.Node
 	fetches []merkle.NodeFetch
 	output  *trillian.Proof
 }
@@ -49,11 +49,11 @@ var h4 = th.HashLeaf([]byte("Hash 4"))
 var h5 = th.HashLeaf([]byte("Hash 5"))
 
 // And the dummy nodes themselves.
-var sn1 = storage.Node{NodeID: storage.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
-var sn2 = storage.Node{NodeID: storage.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
-var sn3 = storage.Node{NodeID: storage.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
-var sn4 = storage.Node{NodeID: storage.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
-var sn5 = storage.Node{NodeID: storage.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
+var sn1 = tree.Node{NodeID: tree.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
+var sn2 = tree.Node{NodeID: tree.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
+var sn3 = tree.Node{NodeID: tree.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
+var sn4 = tree.Node{NodeID: tree.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
+var sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 
 func TestRehasher(t *testing.T) {
 	hasher := rfc6962.DefaultHasher
@@ -61,7 +61,7 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "no rehash",
 			index:   126,
-			nodes:   []storage.Node{sn1, sn2, sn3},
+			nodes:   []tree.Node{sn1, sn2, sn3},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: false}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 126,
@@ -71,7 +71,7 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "single rehash",
 			index:   999,
-			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 999,
@@ -81,7 +81,7 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "single rehash at end",
 			index:   11,
-			nodes:   []storage.Node{sn1, sn2, sn3},
+			nodes:   []tree.Node{sn1, sn2, sn3},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}},
 			output: &trillian.Proof{
 				LeafIndex: 11,
@@ -91,7 +91,7 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "single rehash multiple nodes",
 			index:   23,
-			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: true}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 23,
@@ -101,7 +101,7 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "multiple rehash",
 			index:   45,
-			nodes:   []storage.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
 			fetches: []merkle.NodeFetch{{Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: true}, {Rehash: true}},
 			output: &trillian.Proof{
 				LeafIndex: 45,

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -14,10 +14,11 @@
 
 package storage
 
+import tree "github.com/google/trillian/storage/tree"
+
 // TODO(pavelkalinnikov): These aliases were created to not break the code that
 // depended on these type. We should delete this file eventually.
 
-/*
 type NodeID = tree.NodeID
 type Node = tree.Node
 type Suffix = tree.Suffix
@@ -34,4 +35,3 @@ var (
 	EmptySuffix = tree.EmptySuffix
 	ParseSuffix = tree.ParseSuffix
 )
-*/

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -14,11 +14,10 @@
 
 package storage
 
-import "github.com/google/trillian/storage/tree"
-
 // TODO(pavelkalinnikov): These aliases were created to not break the code that
 // depended on these type. We should delete this file eventually.
 
+/*
 type NodeID = tree.NodeID
 type Node = tree.Node
 type Suffix = tree.Suffix
@@ -35,3 +34,4 @@ var (
 	EmptySuffix = tree.EmptySuffix
 	ParseSuffix = tree.ParseSuffix
 )
+*/

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -17,7 +17,7 @@ package storage
 import tree "github.com/google/trillian/storage/tree"
 
 // TODO(pavelkalinnikov): These aliases were created to not break the code that
-// depended on these type. We should delete this file eventually.
+// depended on these types. We should delete this file eventually.
 
 type NodeID = tree.NodeID
 type Node = tree.Node

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "github.com/google/trillian/storage/tree"
+
+// TODO(pavelkalinnikov): These aliases were created to not break the code that
+// depended on these type. We should delete this file eventually.
+
+type NodeID = tree.NodeID
+type Node = tree.Node
+type Suffix = tree.Suffix
+type PopulateSubtreeFunc = tree.PopulateSubtreeFunc
+type PrepareSubtreeWriteFunc = tree.PrepareSubtreeWriteFunc
+
+var (
+	NewNodeIDFromHash         = tree.NewNodeIDFromHash
+	NewNodeIDFromPrefix       = tree.NewNodeIDFromPrefix
+	NewNodeIDFromBigInt       = tree.NewNodeIDFromBigInt
+	NewNodeIDForTreeCoords    = tree.NewNodeIDForTreeCoords
+	NewNodeIDFromPrefixSuffix = tree.NewNodeIDFromPrefixSuffix
+
+	EmptySuffix = tree.EmptySuffix
+	ParseSuffix = tree.ParseSuffix
+)

--- a/storage/cache/gen.go
+++ b/storage/cache/gen.go
@@ -20,12 +20,12 @@ package cache
 import (
 	"context"
 
-	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
+	"github.com/google/trillian/storage/tree"
 )
 
 // NodeStorage provides an interface for storing and retrieving subtrees.
 type NodeStorage interface {
-	GetSubtree(n storage.NodeID) (*storagepb.SubtreeProto, error)
+	GetSubtree(n tree.NodeID) (*storagepb.SubtreeProto, error)
 	SetSubtrees(ctx context.Context, s []*storagepb.SubtreeProto) error
 }

--- a/storage/cache/mock_node_storage.go
+++ b/storage/cache/mock_node_storage.go
@@ -7,8 +7,8 @@ package cache
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	storage "github.com/google/trillian/storage"
 	storagepb "github.com/google/trillian/storage/storagepb"
+	tree "github.com/google/trillian/storage/tree"
 	reflect "reflect"
 )
 
@@ -36,7 +36,7 @@ func (m *MockNodeStorage) EXPECT() *MockNodeStorageMockRecorder {
 }
 
 // GetSubtree mocks base method
-func (m *MockNodeStorage) GetSubtree(arg0 storage.NodeID) (*storagepb.SubtreeProto, error) {
+func (m *MockNodeStorage) GetSubtree(arg0 tree.NodeID) (*storagepb.SubtreeProto, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubtree", arg0)
 	ret0, _ := ret[0].(*storagepb.SubtreeProto)

--- a/storage/cache/tree_layout_test.go
+++ b/storage/cache/tree_layout_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -47,7 +47,7 @@ func TestSplitNodeID(t *testing.T) {
 		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
 		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
 	} {
-		n := storage.NewNodeIDFromHash(tc.inPath)
+		n := tree.NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
 		t.Run(fmt.Sprintf("%v", n), func(t *testing.T) {

--- a/storage/memory/tree_debug.go
+++ b/storage/memory/tree_debug.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/btree"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
+	stree "github.com/google/trillian/storage/tree"
 )
 
 // This file contains utilities that are not part of the Storage API contracts but may
@@ -38,7 +39,7 @@ func Dump(t *btree.BTree) {
 func DumpSubtrees(ls storage.LogStorage, treeID int64, callback func(string, *storagepb.SubtreeProto)) {
 	m := ls.(*memoryLogStorage)
 	tree := m.trees[treeID]
-	pi := subtreeKey(treeID, 0, storage.NodeID{})
+	pi := subtreeKey(treeID, 0, stree.NodeID{})
 
 	tree.store.AscendGreaterOrEqual(pi, func(bi btree.Item) bool {
 		i := bi.(*kv)

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	trillian "github.com/google/trillian"
+	tree "github.com/google/trillian/storage/tree"
 	reflect "reflect"
 	time "time"
 )
@@ -514,10 +515,10 @@ func (mr *MockLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 interface
 }
 
 // GetMerkleNodes mocks base method
-func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []NodeID) ([]Node, error) {
+func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]Node)
+	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -617,7 +618,7 @@ func (mr *MockLogTreeTXMockRecorder) Rollback() *gomock.Call {
 }
 
 // SetMerkleNodes mocks base method
-func (m *MockLogTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []Node) error {
+func (m *MockLogTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []tree.Node) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -806,10 +807,10 @@ func (mr *MockMapTreeTXMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // GetMerkleNodes mocks base method
-func (m *MockMapTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []NodeID) ([]Node, error) {
+func (m *MockMapTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]Node)
+	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -908,7 +909,7 @@ func (mr *MockMapTreeTXMockRecorder) Set(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // SetMerkleNodes mocks base method
-func (m *MockMapTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []Node) error {
+func (m *MockMapTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []tree.Node) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1251,10 +1252,10 @@ func (mr *MockReadOnlyLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 i
 }
 
 // GetMerkleNodes mocks base method
-func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []NodeID) ([]Node, error) {
+func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]Node)
+	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1405,10 +1406,10 @@ func (mr *MockReadOnlyMapTreeTXMockRecorder) Get(arg0, arg1, arg2 interface{}) *
 }
 
 // GetMerkleNodes mocks base method
-func (m *MockReadOnlyMapTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []NodeID) ([]Node, error) {
+func (m *MockReadOnlyMapTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]Node)
+	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/postgres/testdb"
 	storageto "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
+	stree "github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 )
@@ -42,7 +44,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	const writeRevision = int64(100)
 	nodesToStore := createSomeNodes()
-	nodeIDsToRead := make([]storage.NodeID, len(nodesToStore))
+	nodeIDsToRead := make([]stree.NodeID, len(nodesToStore))
 	for i := range nodesToStore {
 		nodeIDsToRead[i] = nodesToStore[i].NodeID
 	}
@@ -83,10 +85,10 @@ func forceWriteRevision(rev int64, tx storage.TreeTX) {
 	mtx.treeTX.writeRevision = rev
 }
 
-func createSomeNodes() []storage.Node {
-	r := make([]storage.Node, 4)
+func createSomeNodes() []stree.Node {
+	r := make([]stree.Node, 4)
 	for i := range r {
-		r[i].NodeID = storage.NewNodeIDFromPrefix([]byte{byte(i)}, 0, 8, 8, 8)
+		r[i].NodeID = tree.NewNodeIDFromPrefix([]byte{byte(i)}, 0, 8, 8, 8)
 		h := sha256.Sum256([]byte{byte(i)})
 		r[i].Hash = h[:]
 		glog.Infof("Node to store: %v\n", r[i].NodeID)
@@ -94,7 +96,7 @@ func createSomeNodes() []storage.Node {
 	return r
 }
 
-func nodesAreEqual(lhs []storage.Node, rhs []storage.Node) error {
+func nodesAreEqual(lhs []stree.Node, rhs []stree.Node) error {
 	if ls, rs := len(lhs), len(rhs); ls != rs {
 		return fmt.Errorf("different number of nodes, %d vs %d", ls, rs)
 	}

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -27,9 +27,9 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
-	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/storagepb"
+	"github.com/google/trillian/storage/tree"
 )
 
 const (
@@ -219,8 +219,8 @@ type treeTX struct {
 	writeRevision int64
 }
 
-func (t *treeTX) getSubtree(ctx context.Context, treeRevision int64, nodeID storage.NodeID) (*storagepb.SubtreeProto, error) {
-	s, err := t.getSubtrees(ctx, treeRevision, []storage.NodeID{nodeID})
+func (t *treeTX) getSubtree(ctx context.Context, treeRevision int64, nodeID tree.NodeID) (*storagepb.SubtreeProto, error) {
+	s, err := t.getSubtrees(ctx, treeRevision, []tree.NodeID{nodeID})
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (t *treeTX) getSubtree(ctx context.Context, treeRevision int64, nodeID stor
 	}
 }
 
-func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, nodeIDs []tree.NodeID) ([]*storagepb.SubtreeProto, error) {
 	glog.V(4).Infof("getSubtrees(")
 	if len(nodeIDs) == 0 {
 		return nil, nil
@@ -401,14 +401,14 @@ func (t *treeTX) Close() error {
 	return nil
 }
 
-func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []storage.NodeID) ([]storage.Node, error) {
+func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []tree.NodeID) ([]tree.Node, error) {
 	return t.subtreeCache.GetNodes(nodeIDs, t.getSubtreesAtRev(ctx, treeRevision))
 }
 
-func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []storage.Node) error {
+func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 	for _, n := range nodes {
 		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,
-			func(nID storage.NodeID) (*storagepb.SubtreeProto, error) {
+			func(nID tree.NodeID) (*storagepb.SubtreeProto, error) {
 				return t.getSubtree(ctx, t.writeRevision, nID)
 			})
 		if err != nil {
@@ -424,7 +424,7 @@ func (t *treeTX) IsOpen() bool {
 
 // getSubtreesAtRev returns a GetSubtreesFunc which reads at the passed in rev.
 func (t *treeTX) getSubtreesAtRev(ctx context.Context, rev int64) cache.GetSubtreesFunc {
-	return func(ids []storage.NodeID) ([]*storagepb.SubtreeProto, error) {
+	return func(ids []tree.NodeID) ([]*storagepb.SubtreeProto, error) {
 		return t.getSubtrees(ctx, rev, ids)
 	}
 }
@@ -453,7 +453,7 @@ func checkResultOkAndRowCountIs(res sql.Result, err error, count int64) error {
 // subtreeKey returns a non-nil []byte suitable for use as a primary key column
 // for the subtree rooted at the passed-in node ID. Returns an error if the ID
 // is not aligned to bytes.
-func subtreeKey(id storage.NodeID) ([]byte, error) {
+func subtreeKey(id tree.NodeID) ([]byte, error) {
 	// TODO(pavelkalinnikov): Extend this check to verify strata boundaries.
 	if id.PrefixLenBits%8 != 0 {
 		return nil, fmt.Errorf("invalid subtree ID - not multiple of 8: %d", id.PrefixLenBits)

--- a/storage/testonly/matchers.go
+++ b/storage/testonly/matchers.go
@@ -20,16 +20,16 @@ import (
 	"sort"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 )
 
 type nodeIDEq struct {
-	expectedID storage.NodeID
+	expectedID tree.NodeID
 }
 
 // Matches implements the gomock.Matcher API.
 func (m nodeIDEq) Matches(x interface{}) bool {
-	n, ok := x.(storage.NodeID)
+	n, ok := x.(tree.NodeID)
 	if !ok {
 		return false
 	}
@@ -41,30 +41,30 @@ func (m nodeIDEq) String() string {
 }
 
 // NodeIDEq returns a matcher that expects the specified NodeID.
-func NodeIDEq(n storage.NodeID) gomock.Matcher {
+func NodeIDEq(n tree.NodeID) gomock.Matcher {
 	return nodeIDEq{n}
 }
 
 // We need a stable order to match the mock expectations so we sort them by
 // prefix len before passing them to the mock library. Might need extending
 // if we have more complex tests.
-func prefixLen(n1, n2 *storage.Node) bool {
+func prefixLen(n1, n2 *tree.Node) bool {
 	return n1.NodeID.PrefixLenBits < n2.NodeID.PrefixLenBits
 }
 
 // NodeSet returns a matcher that expects the given set of Nodes.
-func NodeSet(nodes []storage.Node) gomock.Matcher {
+func NodeSet(nodes []tree.Node) gomock.Matcher {
 	by(prefixLen).sort(nodes)
 	return nodeSet{nodes}
 }
 
 type nodeSet struct {
-	other []storage.Node
+	other []tree.Node
 }
 
 // Matches implements the gomock.Matcher API.
 func (n nodeSet) Matches(x interface{}) bool {
-	nodes, ok := x.([]storage.Node)
+	nodes, ok := x.([]tree.Node)
 	if !ok {
 		return false
 	}
@@ -78,16 +78,16 @@ func (n nodeSet) String() string {
 
 // Node sorting boilerplate below.
 
-type by func(n1, n2 *storage.Node) bool
+type by func(n1, n2 *tree.Node) bool
 
-func (by by) sort(nodes []storage.Node) {
+func (by by) sort(nodes []tree.Node) {
 	ns := &nodeSorter{nodes: nodes, by: by}
 	sort.Sort(ns)
 }
 
 type nodeSorter struct {
-	nodes []storage.Node
-	by    func(n1, n2 *storage.Node) bool
+	nodes []tree.Node
+	by    func(n1, n2 *tree.Node) bool
 }
 
 // Len implements the sort.Interface API.

--- a/storage/testonly/nodes.go
+++ b/storage/testonly/nodes.go
@@ -15,13 +15,11 @@
 // Package testonly holds test-specific code for Trillian storage layers.
 package testonly
 
-import (
-	"github.com/google/trillian/storage"
-)
+import "github.com/google/trillian/storage/tree"
 
 // MustCreateNodeIDForTreeCoords creates a NodeID for the given position in the tree.
-func MustCreateNodeIDForTreeCoords(depth, index int64, maxPathBits int) storage.NodeID {
-	n, err := storage.NewNodeIDForTreeCoords(depth, index, maxPathBits)
+func MustCreateNodeIDForTreeCoords(depth, index int64, maxPathBits int) tree.NodeID {
+	n, err := tree.NewNodeIDForTreeCoords(depth, index, maxPathBits)
 	if err != nil {
 		panic(err)
 	}

--- a/storage/tree/node.go
+++ b/storage/tree/node.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+// Package tree defines types that help navigating a tree in storage.
+package tree
 
 import (
 	"bytes"

--- a/storage/tree/node_test.go
+++ b/storage/tree/node_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package tree
 
 import (
 	"bytes"

--- a/storage/tree/suffix.go
+++ b/storage/tree/suffix.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package tree
 
 import (
 	"encoding/base64"

--- a/storage/tree/suffix_test.go
+++ b/storage/tree/suffix_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package tree
 
 import (
 	"bytes"

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	"github.com/google/trillian/storage/tree"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -62,7 +63,7 @@ type TreeTX interface {
 // TreeWriter represents additional transaction methods that modify the tree.
 type TreeWriter interface {
 	// SetMerkleNodes stores the provided nodes, at the transaction's writeRevision.
-	SetMerkleNodes(ctx context.Context, nodes []Node) error
+	SetMerkleNodes(ctx context.Context, nodes []tree.Node) error
 
 	// WriteRevision returns the tree revision that any writes through this TreeTX will be stored at.
 	WriteRevision(ctx context.Context) (int64, error)
@@ -79,5 +80,5 @@ type DatabaseChecker interface {
 type NodeReader interface {
 	// GetMerkleNodes looks up the set of nodes identified by ids, at
 	// treeRevision, and returns them in the same order.
-	GetMerkleNodes(ctx context.Context, treeRevision int64, ids []NodeID) ([]Node, error)
+	GetMerkleNodes(ctx context.Context, treeRevision int64, ids []tree.NodeID) ([]tree.Node, error)
 }


### PR DESCRIPTION
Move all primitives that can be used without pairing up with `storage` API, to a separate package. The nice benefit that we get is that some packages no longer depend on `storage`.