### PR TITLE
Move treeLayout to storage/tree package

### DIFF
--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -46,7 +46,7 @@ func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) tree.Popula
 				return err
 			}
 			// TODO(gdbelvin): test against subtree depth.
-			if sfx.Bits()%depthQuantum != 0 {
+			if sfx.Bits()%8 != 0 {
 				return fmt.Errorf("unexpected non-leaf suffix found: %x", sfx.Bits())
 			}
 

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -157,7 +157,7 @@ func TestCacheFlush(t *testing.T) {
 		for _, s := range trees {
 			rootID := tree.NewNodeIDFromHash(s.Prefix)
 			subID := tree.TileID{Root: rootID}
-			if got, want := s.Depth, c.layout.getTileHeight(subID); got != int32(want) {
+			if got, want := s.Depth, c.layout.GetTileHeight(subID); got != int32(want) {
 				t.Errorf("Got subtree with depth %d, expected %d for prefixLen %d", got, want, rootID.PrefixLenBits)
 			}
 			state, ok := expectedSetIDs[rootID.String()]
@@ -237,7 +237,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			n := stestonly.MustCreateNodeIDForTreeCoords(int64(id.Level), int64(id.Index), 8)
 			// Don't store leaves or the subtree root in InternalNodes
 			if id.Level > 0 && id.Level < 8 {
-				_, sfx := c.layout.split(n)
+				_, sfx := c.layout.Split(n)
 				cmtStorage.InternalNodes[sfx.String()] = hash
 			}
 		}

--- a/storage/tree/layout_test.go
+++ b/storage/tree/layout_test.go
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache
+package tree
 
 import (
 	"bytes"
 	"fmt"
 	"testing"
 
-	"github.com/google/trillian/storage/tree"
 	"github.com/kylelemons/godebug/pretty"
 )
 
+var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
+
 func TestSplitNodeID(t *testing.T) {
-	layout := newTreeLayout(defaultMapStrata)
+	layout := NewLayout(defaultMapStrata)
 	for _, tc := range []struct {
 		inPath        []byte
 		inPathLenBits int
@@ -47,11 +48,11 @@ func TestSplitNodeID(t *testing.T) {
 		{[]byte{0x00, 0x03}, 16, []byte{0x00}, 8, []byte{0x03}},
 		{[]byte{0x00, 0x03}, 15, []byte{0x00}, 7, []byte{0x02}},
 	} {
-		n := tree.NewNodeIDFromHash(tc.inPath)
+		n := NewNodeIDFromHash(tc.inPath)
 		n.PrefixLenBits = tc.inPathLenBits
 
 		t.Run(fmt.Sprintf("%v", n), func(t *testing.T) {
-			p, s := layout.split(n)
+			p, s := layout.Split(n)
 			if got, want := p.Root.Path, tc.outPrefix; !bytes.Equal(got, want) {
 				t.Errorf("prefix %x, want %x", got, want)
 			}
@@ -69,14 +70,14 @@ func TestStrataIndex(t *testing.T) {
 	heights := []int{8, 8, 16, 32, 64, 128}
 	want := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
-	layout := newTreeLayout(heights)
+	layout := NewLayout(heights)
 	if diff := pretty.Compare(layout.sIndex, want); diff != "" {
 		t.Fatalf("sIndex diff:\n%v", diff)
 	}
 }
 
 func TestDefaultMapStrataIndex(t *testing.T) {
-	layout := newTreeLayout(defaultMapStrata)
+	layout := NewLayout(defaultMapStrata)
 	for _, tc := range []struct {
 		depth int
 		want  stratumInfo


### PR DESCRIPTION
This change moves `treeLayout` from `storage/cache` package to `storage/tree`, and renames it nicely as `tree.Layout`.