### PR TITLE
Add NodeID2, the fast NodeID with zero allocations

### DIFF
--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -65,19 +65,6 @@ func (n NodeID2) Prefix(bits uint) NodeID2 {
 	return NodeID2{path: n.path[:bytes], last: last, bits: tail}
 }
 
-// Suffix returns the suffix of NodeID2 after the given number of bits.
-func (n NodeID2) Suffix(bits uint) NodeID2 {
-	if mx := n.BitLen(); bits > mx {
-		panic(fmt.Sprintf("Suffix: bits %d > %d", bits, mx))
-	} else if bits == mx {
-		return NodeID2{}
-	} else if bits%8 == 0 {
-		return NewNodeID2(n.path[bits/8:], mx-bits)
-	}
-	// TODO(pavelkalinnikov): Support arbitrary lengths.
-	panic("Suffix: only multiples of 8 are supported")
-}
-
 // Sibling returns the NodeID2 of the nodes's sibling in a binary tree. If the
 // node is the root then the returned ID is the same.
 func (n NodeID2) Sibling() NodeID2 {

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -23,7 +23,7 @@ import "fmt"
 type NodeID2 struct {
 	path string
 	last byte
-	bits byte
+	bits uint8
 }
 
 // NewNodeID2 creates a NodeID2 from the given path bytes truncated to the
@@ -37,7 +37,7 @@ func NewNodeID2(path string, bits int) NodeID2 {
 	}
 	bytes, tail, mask := split(bits)
 	last := path[bytes] & mask
-	return NodeID2{path: path[:bytes], last: last, bits: byte(tail)}
+	return NodeID2{path: path[:bytes], last: last, bits: uint8(tail)}
 }
 
 // BitLen returns the length of the NodeID2 in bits.
@@ -58,7 +58,7 @@ func (n NodeID2) Prefix(bits int) NodeID2 {
 		last = n.path[bytes]
 	}
 	last &= mask
-	return NodeID2{path: n.path[:bytes], last: last, bits: byte(tail)}
+	return NodeID2{path: n.path[:bytes], last: last, bits: uint8(tail)}
 }
 
 // Suffix returns the suffix of NodeID2 after the given number of bits.

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -65,8 +65,9 @@ func (n NodeID2) Prefix(bits uint) NodeID2 {
 	return NodeID2{path: n.path[:bytes], last: last, bits: tail}
 }
 
-// Sibling returns the NodeID2 of the nodes's sibling in a binary tree. If the
-// node is the root then the returned ID is the same.
+// Sibling returns the NodeID2 of the nodes's sibling in a binary tree, i.e.
+// the ID of the parent node's other child. If the node is the root then the
+// returned ID is the same.
 func (n NodeID2) Sibling() NodeID2 {
 	last := n.last ^ byte(1<<(8-n.bits))
 	return NodeID2{path: n.path, last: last, bits: n.bits}

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -37,6 +37,7 @@ func NewNodeID2(path string, bits uint) NodeID2 {
 	}
 	bytes, tail, mask := split(bits)
 	last := path[bytes] & mask
+	// Note: Getting the substring is cheap because strings are immutable in Go.
 	return NodeID2{path: path[:bytes], last: last, bits: tail}
 }
 
@@ -47,6 +48,9 @@ func (n NodeID2) BitLen() uint {
 
 // Prefix returns the prefix of NodeID2 with the given number of bits.
 func (n NodeID2) Prefix(bits uint) NodeID2 {
+	// Note: This code is very similar to NewNodeID2, and it's tempting to return
+	// NewNodeID2(n.path, bits). But there is a difference: NewNodeID2 expects
+	// all the bytes to be in the path string, while here the last byte is not.
 	if bits == 0 {
 		return NodeID2{}
 	} else if mx := n.BitLen(); bits > mx {

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -109,6 +109,6 @@ func (n NodeID2) String() string {
 func decompose(bits int) (int, int, byte) {
 	bytes := (bits - 1) / 8
 	tailBits := 1 + (bits-1)%8
-	mask := ^byte(1<<(8-tailBits) - 1)
+	mask := ^byte(1<<uint(8-tailBits) - 1)
 	return bytes, tailBits, mask
 }

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import "fmt"
+
+// NodeID2 is a faster NodeID that does zero memory allocations.
+//
+// TODO(pavelkalinnikov): Rename to NodeID and document it properly when the
+// code has migrated.
+type NodeID2 struct {
+	path string
+	last byte
+	bits byte
+}
+
+// NewNodeID2 creates a NodeID2 from the given path bytes truncated to the
+// specified number of bits if necessary. Panics if the number of bits is
+// negative, or is more than the byte string contains.
+func NewNodeID2(path string, bits int) NodeID2 {
+	if bits == 0 {
+		return NodeID2{}
+	} else if mx := len(path) * 8; bits > mx {
+		panic(fmt.Sprintf("NewNodeID2: bits %d > %d", bits, mx))
+	}
+	bytes, tail, mask := decompose(bits)
+	last := path[bytes] & mask
+	return NodeID2{path: path[:bytes], last: last, bits: byte(tail)}
+}
+
+// BitLen returns the length of the NodeID2 in bits.
+func (n NodeID2) BitLen() int {
+	return len(n.path)*8 + int(n.bits)
+}
+
+// Prefix returns the prefix of NodeID2 with the given number of bits.
+func (n NodeID2) Prefix(bits int) NodeID2 {
+	if bits == 0 {
+		return NodeID2{}
+	} else if mx := n.BitLen(); bits > mx {
+		panic(fmt.Sprintf("Prefix: bits %d > %d", bits, mx))
+	}
+	last := n.last
+	bytes, tail, mask := decompose(bits)
+	if bytes != len(n.path) {
+		last = n.path[bytes]
+	}
+	last &= mask
+	return NodeID2{path: n.path[:bytes], last: last, bits: byte(tail)}
+}
+
+// Suffix returns the suffix of NodeID2 after the given number of bits.
+func (n NodeID2) Suffix(bits int) NodeID2 {
+	if mx := n.BitLen(); bits > mx {
+		panic(fmt.Sprintf("Suffix: bits %d > %d", bits, mx))
+	} else if bits == mx {
+		return NodeID2{}
+	} else if bits%8 == 0 {
+		return NewNodeID2(n.path[bits/8:], mx-bits)
+	}
+	// TODO(pavelkalinnikov): Support arbitrary lengths.
+	panic("Suffix: only multiples of 8 are supported")
+}
+
+// PrefixBytes returns a prefix of bytes*8 bits, as bytes. Must always be
+// called with a prefix shorter than BitLen().
+func (n NodeID2) PrefixBytes(bytes int) string {
+	return n.path[:bytes]
+}
+
+// Sibling returns the NodeID2 of the nodes's sibling in a binary tree. If the
+// node is the root then the returned ID is the same.
+func (n NodeID2) Sibling() NodeID2 {
+	last := n.last ^ byte(1<<(8-n.bits))
+	return NodeID2{path: n.path, last: last, bits: n.bits}
+}
+
+// String returns a human-readable bit string.
+func (n NodeID2) String() string {
+	if n.BitLen() == 0 {
+		return "[]"
+	}
+	path := fmt.Sprintf("%08b", []byte(n.path))
+	path = path[1 : len(path)-1] // Trim the brackets.
+	if len(path) > 0 {
+		path += " "
+	}
+	return fmt.Sprintf("[%s%0*b]", path, n.bits, n.last>>(8-n.bits))
+}
+
+// decompose returns decomposition of a NodeID2 with the given number of bits.
+//
+// The first int of the returned triple is the number of full bytes stored in
+// the dynamically allocated part. The second one is the number of bits in the
+// tail byte (between 1 and 8). The third value is a mask with the
+// corresponding number of higher bits set.
+func decompose(bits int) (int, int, byte) {
+	bytes := (bits - 1) / 8
+	tailBits := 1 + (bits-1)%8
+	mask := ^byte(1<<(8-tailBits) - 1)
+	return bytes, tailBits, mask
+}

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -27,8 +27,8 @@ type NodeID2 struct {
 }
 
 // NewNodeID2 creates a NodeID2 from the given path bytes truncated to the
-// specified number of bits if necessary. Panics if the number of bits is
-// negative, or is more than the byte string contains.
+// specified number of bits if necessary. Panics if the number of bits is more
+// than the byte string contains.
 func NewNodeID2(path string, bits uint) NodeID2 {
 	if bits == 0 {
 		return NodeID2{}

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -29,24 +29,24 @@ type NodeID2 struct {
 // NewNodeID2 creates a NodeID2 from the given path bytes truncated to the
 // specified number of bits if necessary. Panics if the number of bits is
 // negative, or is more than the byte string contains.
-func NewNodeID2(path string, bits int) NodeID2 {
+func NewNodeID2(path string, bits uint) NodeID2 {
 	if bits == 0 {
 		return NodeID2{}
-	} else if mx := len(path) * 8; bits > mx {
+	} else if mx := uint(len(path)) * 8; bits > mx {
 		panic(fmt.Sprintf("NewNodeID2: bits %d > %d", bits, mx))
 	}
 	bytes, tail, mask := split(bits)
 	last := path[bytes] & mask
-	return NodeID2{path: path[:bytes], last: last, bits: uint8(tail)}
+	return NodeID2{path: path[:bytes], last: last, bits: tail}
 }
 
 // BitLen returns the length of the NodeID2 in bits.
-func (n NodeID2) BitLen() int {
-	return len(n.path)*8 + int(n.bits)
+func (n NodeID2) BitLen() uint {
+	return uint(len(n.path))*8 + uint(n.bits)
 }
 
 // Prefix returns the prefix of NodeID2 with the given number of bits.
-func (n NodeID2) Prefix(bits int) NodeID2 {
+func (n NodeID2) Prefix(bits uint) NodeID2 {
 	if bits == 0 {
 		return NodeID2{}
 	} else if mx := n.BitLen(); bits > mx {
@@ -54,15 +54,15 @@ func (n NodeID2) Prefix(bits int) NodeID2 {
 	}
 	last := n.last
 	bytes, tail, mask := split(bits)
-	if bytes != len(n.path) {
+	if bytes != uint(len(n.path)) {
 		last = n.path[bytes]
 	}
 	last &= mask
-	return NodeID2{path: n.path[:bytes], last: last, bits: uint8(tail)}
+	return NodeID2{path: n.path[:bytes], last: last, bits: tail}
 }
 
 // Suffix returns the suffix of NodeID2 after the given number of bits.
-func (n NodeID2) Suffix(bits int) NodeID2 {
+func (n NodeID2) Suffix(bits uint) NodeID2 {
 	if mx := n.BitLen(); bits > mx {
 		panic(fmt.Sprintf("Suffix: bits %d > %d", bits, mx))
 	} else if bits == mx {
@@ -100,9 +100,9 @@ func (n NodeID2) String() string {
 // the dynamically allocated part. The second one is the number of bits in the
 // tail byte (between 1 and 8). The third value is a mask with the
 // corresponding number of higher bits set.
-func split(bits int) (int, int, byte) {
+func split(bits uint) (uint, uint8, byte) {
 	bytes := (bits - 1) / 8
-	tailBits := 1 + (bits-1)%8
-	mask := ^byte(1<<uint(8-tailBits) - 1)
+	tailBits := uint8(1 + (bits-1)%8)
+	mask := ^byte(1<<(8-tailBits) - 1)
 	return bytes, tailBits, mask
 }

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -16,7 +16,9 @@ package tree
 
 import "fmt"
 
-// NodeID2 is a faster NodeID that does zero memory allocations.
+// NodeID2 is a faster NodeID that does zero memory allocations in transforming
+// methods like Prefix and Sibling. NodeID2 can be used as a key in Golang maps
+// directly, as well as compared equal.
 //
 // TODO(pavelkalinnikov): Rename to NodeID and document it properly when the
 // code has migrated.

--- a/storage/tree/node_id2_test.go
+++ b/storage/tree/node_id2_test.go
@@ -23,7 +23,7 @@ import (
 func TestNodeID2String(t *testing.T) {
 	bytes := string([]byte{5, 1, 127})
 	for _, tc := range []struct {
-		bits int
+		bits uint
 		want string
 	}{
 		{bits: 0, want: "[]"},
@@ -73,7 +73,7 @@ func TestNodeID2Prefix(t *testing.T) {
 	const bytes = "\x0A\x0B\x0C"
 	for i, tc := range []struct {
 		id   NodeID2
-		bits int
+		bits uint
 		want NodeID2
 	}{
 		{id: NewNodeID2(bytes, 24), bits: 0, want: NodeID2{}},
@@ -137,7 +137,7 @@ func BenchmarkNodeID2Siblings(b *testing.B) {
 		ln := id.BitLen()
 		sibs := make([]NodeID2, ln)
 		for height := range sibs {
-			depth := ln - height
+			depth := ln - uint(height)
 			sibs[height] = id.Prefix(depth).Sibling()
 		}
 		return sibs
@@ -147,7 +147,7 @@ func BenchmarkNodeID2Siblings(b *testing.B) {
 	ids := make([]NodeID2, batch)
 	for i := range ids {
 		bytes := "0123456789012345678901234567" + string(i&255) + string((i>>8)&255)
-		ids[i] = NewNodeID2(bytes, len(bytes)*8)
+		ids[i] = NewNodeID2(bytes, uint(len(bytes))*8)
 	}
 	for i, n := 0, b.N; i < n; i++ {
 		for _, id := range ids {

--- a/storage/tree/node_id2_test.go
+++ b/storage/tree/node_id2_test.go
@@ -1,0 +1,177 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestNodeID2String(t *testing.T) {
+	bytes := string([]byte{5, 1, 127})
+	for _, tc := range []struct {
+		bits int
+		want string
+	}{
+		{bits: 0, want: "[]"},
+		{bits: 1, want: "[0]"},
+		{bits: 4, want: "[0000]"},
+		{bits: 6, want: "[000001]"},
+		{bits: 8, want: "[00000101]"},
+		{bits: 16, want: "[00000101 00000001]"},
+		{bits: 21, want: "[00000101 00000001 01111]"},
+		{bits: 24, want: "[00000101 00000001 01111111]"},
+	} {
+		t.Run(fmt.Sprintf("bits:%d", tc.bits), func(t *testing.T) {
+			id := NewNodeID2(bytes, tc.bits)
+			if got, want := id.String(), tc.want; got != want {
+				t.Errorf("String: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestNodeID2Comparison(t *testing.T) {
+	const bytes = "\x0A\x0B\x0C\x0A\x0B\x0C\x01"
+	for _, tc := range []struct {
+		desc string
+		id1  NodeID2
+		id2  NodeID2
+		want bool
+	}{
+		{desc: "all-same", id1: NewNodeID2(bytes, 56), id2: NewNodeID2(bytes, 56), want: true},
+		{desc: "same-bytes", id1: NewNodeID2(bytes[:3], 24), id2: NewNodeID2(bytes[3:6], 24), want: true},
+		{desc: "same-bits1", id1: NewNodeID2(bytes[:4], 25), id2: NewNodeID2(bytes[3:], 25), want: true},
+		{desc: "same-bits2", id1: NewNodeID2(bytes[:4], 28), id2: NewNodeID2(bytes[3:], 28), want: true},
+		{desc: "diff-bits", id1: NewNodeID2(bytes[:4], 29), id2: NewNodeID2(bytes[3:], 29)},
+		{desc: "diff-len", id1: NewNodeID2(bytes, 56), id2: NewNodeID2(bytes, 55)},
+		{desc: "diff-bytes", id1: NewNodeID2(bytes, 56), id2: NewNodeID2(bytes, 48)},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			eq := tc.id1 == tc.id2
+			if want := tc.want; eq != want {
+				t.Errorf("(id1==id2) is %v, want %v", eq, want)
+			}
+		})
+	}
+}
+
+func TestNodeID2Prefix(t *testing.T) {
+	const bytes = "\x0A\x0B\x0C"
+	for i, tc := range []struct {
+		id   NodeID2
+		bits int
+		want NodeID2
+	}{
+		{id: NewNodeID2(bytes, 24), bits: 0, want: NodeID2{}},
+		{id: NewNodeID2(bytes, 24), bits: 1, want: NewNodeID2(bytes, 1)},
+		{id: NewNodeID2(bytes, 24), bits: 2, want: NewNodeID2(bytes, 2)},
+		{id: NewNodeID2(bytes, 24), bits: 5, want: NewNodeID2(bytes, 5)},
+		{id: NewNodeID2(bytes, 24), bits: 8, want: NewNodeID2(bytes, 8)},
+		{id: NewNodeID2(bytes, 24), bits: 15, want: NewNodeID2(bytes, 15)},
+		{id: NewNodeID2(bytes, 24), bits: 24, want: NewNodeID2(bytes, 24)},
+		{id: NewNodeID2(bytes, 21), bits: 15, want: NewNodeID2(bytes, 15)},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if got, want := tc.id.Prefix(tc.bits), tc.want; got != want {
+				t.Errorf("Prefix: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestNodeID2PrefixBytes(t *testing.T) {
+	const bytes = "\x0A\x0B\x0C"
+	for i, tc := range []struct {
+		id    NodeID2
+		bytes int
+		want  string
+	}{
+		{id: NewNodeID2(bytes, 24), bytes: 0},
+		{id: NewNodeID2(bytes, 24), bytes: 1, want: bytes[:1]},
+		{id: NewNodeID2(bytes, 24), bytes: 2, want: bytes[:2]},
+		{id: NewNodeID2(bytes, 21), bytes: 2, want: bytes[:2]},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if got, want := tc.id.PrefixBytes(tc.bytes), tc.want; got != want {
+				t.Errorf("PrefixBytes: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestNodeID2Sibling(t *testing.T) {
+	const bytes = "\x0A\x0B\x0C"
+	for _, tc := range []struct {
+		id   NodeID2
+		want NodeID2
+	}{
+		{id: NewNodeID2(bytes, 0), want: NodeID2{}},
+		{id: NewNodeID2(bytes, 1), want: NewNodeID2("\xA0", 1)},
+		{id: NewNodeID2(bytes, 2), want: NewNodeID2("\x40", 2)},
+		{id: NewNodeID2(bytes, 8), want: NewNodeID2("\x0B", 8)},
+		{id: NewNodeID2(bytes, 24), want: NewNodeID2("\x0A\x0B\x0D", 24)},
+	} {
+		t.Run(tc.id.String(), func(t *testing.T) {
+			sib := tc.id.Sibling()
+			if got, want := sib, tc.want; got != want {
+				t.Errorf("Sibling: got %v, want %v", got, want)
+			}
+			// The sibling's sibling is the original node.
+			if got, want := sib.Sibling(), tc.id; got != want {
+				t.Errorf("Sibling: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func BenchmarkNodeIDSiblings(b *testing.B) {
+	const batch = 512
+	ids := make([]NodeID, batch)
+	for i := range ids {
+		bytes := append([]byte("0123456789012345678901234567"), byte(i&255), byte((i>>8)&255))
+		ids[i] = NewNodeIDFromHash(bytes)
+	}
+	for i, n := 0, b.N; i < n; i++ {
+		for _, id := range ids {
+			_ = id.Siblings()
+		}
+	}
+}
+
+func BenchmarkNodeID2Siblings(b *testing.B) {
+	siblings := func(id NodeID2) []NodeID2 {
+		ln := id.BitLen()
+		sibs := make([]NodeID2, ln)
+		for height := range sibs {
+			depth := ln - height
+			sibs[height] = id.Prefix(depth).Sibling()
+		}
+		return sibs
+	}
+
+	const batch = 512
+	ids := make([]NodeID2, batch)
+	for i := range ids {
+		bytes := "0123456789012345678901234567" + string(i&255) + string((i>>8)&255)
+		ids[i] = NewNodeID2(bytes, len(bytes)*8)
+	}
+	for i, n := 0, b.N; i < n; i++ {
+		for _, id := range ids {
+			_ = siblings(id)
+		}
+	}
+}

--- a/storage/tree/node_id2_test.go
+++ b/storage/tree/node_id2_test.go
@@ -93,26 +93,6 @@ func TestNodeID2Prefix(t *testing.T) {
 	}
 }
 
-func TestNodeID2PrefixBytes(t *testing.T) {
-	const bytes = "\x0A\x0B\x0C"
-	for i, tc := range []struct {
-		id    NodeID2
-		bytes int
-		want  string
-	}{
-		{id: NewNodeID2(bytes, 24), bytes: 0},
-		{id: NewNodeID2(bytes, 24), bytes: 1, want: bytes[:1]},
-		{id: NewNodeID2(bytes, 24), bytes: 2, want: bytes[:2]},
-		{id: NewNodeID2(bytes, 21), bytes: 2, want: bytes[:2]},
-	} {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if got, want := tc.id.PrefixBytes(tc.bytes), tc.want; got != want {
-				t.Errorf("PrefixBytes: %v, want %v", got, want)
-			}
-		})
-	}
-}
-
 func TestNodeID2Sibling(t *testing.T) {
 	const bytes = "\x0A\x0B\x0C"
 	for _, tc := range []struct {


### PR DESCRIPTION
This change introduces a new experimental `NodeID2` type.

The new type has multiple advantages over the old `NodeID`:

- Immutability is enforced by design.
- It doesn't require multiple-of-8 prefixes.
- It can be used as a Go map key directly.
- The `Sibling` method is cheap.
- It takes less space than the current `[]byte + int` implementation.
- Client code never sees the internal structure of this type.

Benchmarks show a 3x speedup of the `Siblings` function (runs `Siblings` for 512 x 32byte IDs):

```
BenchmarkNodeIDSiblings-12     	     100	  11361849 ns/op
BenchmarkNodeID2Siblings-12    	     338	   3428912 ns/op
```

Addresses #1855