### PR TITLE
examples/deployment: use beta gcloud version

### DIFF
--- a/examples/deployment/kubernetes/create.sh
+++ b/examples/deployment/kubernetes/create.sh
@@ -69,7 +69,7 @@ done
 
 # Create cluster
 # TODO(https://github.com/google/trillian/issues/1183): Add support for priorities and preemption when Kubernetes 1.11 is GA.
-gcloud container clusters create "${CLUSTER_NAME}" --machine-type "${MACHINE_TYPE}" --image-type "COS" --num-nodes "${POOLSIZE}" --enable-autorepair --enable-autoupgrade --node-locations="${NODE_LOCATIONS}" --addons=Istio --istio-config=auth=MTLS_PERMISSIVE
+gcloud beta container clusters create "${CLUSTER_NAME}" --machine-type "${MACHINE_TYPE}" --image-type "COS" --num-nodes "${POOLSIZE}" --enable-autorepair --enable-autoupgrade --node-locations="${NODE_LOCATIONS}" --addons=Istio --istio-config=auth=MTLS_PERMISSIVE
 gcloud container clusters get-credentials "${CLUSTER_NAME}"
 
 # Create spanner instance & DB


### PR DESCRIPTION
The use of the beta version of gcloud is required when provisioning
the Istio addons.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
