### PR TITLE
Fix data race by passing wanted config by value

### DIFF
--- a/quota/etcd/quotaapi/quota_server_test.go
+++ b/quota/etcd/quotaapi/quota_server_test.go
@@ -372,7 +372,7 @@ func TestServer_UpdateConfig_ResetQuota(t *testing.T) {
 	}
 }
 
-func TestServer_UpdateConfig_Race(t *testing.T) {
+func TestServer_UpdateConfig_ConcurrentUpdates(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping race test due to short mode")
 		return

--- a/quota/etcd/quotaapi/quota_server_test.go
+++ b/quota/etcd/quotaapi/quota_server_test.go
@@ -374,7 +374,7 @@ func TestServer_UpdateConfig_ResetQuota(t *testing.T) {
 
 func TestServer_UpdateConfig_ConcurrentUpdates(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping race test due to short mode")
+		t.Skip("Skipping concurrency test due to short mode")
 		return
 	}
 

--- a/quota/etcd/quotaapi/quota_server_test.go
+++ b/quota/etcd/quotaapi/quota_server_test.go
@@ -417,7 +417,7 @@ func TestServer_UpdateConfig_Race(t *testing.T) {
 	for _, cfg := range configs {
 		for num := 0; num < routinesPerConfig; num++ {
 			wg.Add(1)
-			go func(num int, want *quotapb.Config) {
+			go func(num int, want quotapb.Config) {
 				defer wg.Done()
 				baseTokens := 1 + rand.Intn(routinesPerConfig*100)
 				reset := num%2 == 0
@@ -436,12 +436,12 @@ func TestServer_UpdateConfig_Race(t *testing.T) {
 
 					want.CurrentTokens = got.CurrentTokens // Not important for this test
 					want.MaxTokens = tokens
-					if !proto.Equal(got, want) {
-						diff := cmp.Diff(got, want, cmp.Comparer(proto.Equal))
+					if !proto.Equal(got, &want) {
+						diff := cmp.Diff(got, &want, cmp.Comparer(proto.Equal))
 						t.Errorf("%v: post-UpdateConfig() diff (-got +want):\n%v", want.Name, diff)
 					}
 				}
-			}(num, cfg)
+			}(num, *cfg)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
This means that this test now passes, which unblocks running it in Travis - #1850.