### PR TITLE
Run all the tests in the presubmit scripts

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -87,7 +87,7 @@ main() {
     echo 'running go build'
     go build ./...
 
-    export TEST_FLAGS="-short -timeout=${GO_TEST_TIMEOUT:-5m}"
+    export TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT:-5m}"
 
     if [[ ${coverage} -eq 1 ]]; then
       TEST_FLAGS+=" -covermode=atomic -coverprofile=coverage.txt"


### PR DESCRIPTION
This script is invoked by Travis and by good developers that want to ensure their changes work properly. Only running those tests that don't self identify as not short doesn't work well for either of these use cases. This fixes #1850 .