### PR TITLE
Removed redundant test for ETCD in presubmit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
   - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
-  - PRESUB_TESTS=true GOFLAGS='-race' WITH_ETCD=true       PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true                                       PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race'                       PRESUBMIT_OPTS="--no-linters --no-generate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,7 @@ cache:
     - "$HOME/google-cloud-sdk/"
     - "$HOME/gopath/pkg/mod"
 
-env:
-  global:
-  - GO111MODULE=on
-  - GOPROXY=https://proxy.golang.org
-  matrix: #TODO: Merge the test matrix into individual jobs
+env: #TODO: Merge the test matrix into individual jobs
   - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"


### PR DESCRIPTION
Setting WITH_ETCD causes ETCD_DIR to be set, which is used in the integration tests. This env variable is not read in the presubmit tests though, which collapses the row to be equivalent to one of the existing flagsets. This will save Travis from running the presubmit tests with race detection twice per run, which is ~7m30s of execution time.