### PR TITLE
Factored test coverage generation into a Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,9 @@ cache:
     - "$HOME/gopath/pkg/mod"
 
 env: #TODO: Merge the test matrix into individual jobs
-  - PRESUB_TESTS=true                                      PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"
-  - INTEG_TESTS=true                                       PRESUBMIT_OPTS="--coverage --no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race'                       PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race --tags=batched_queue'  PRESUBMIT_OPTS="--no-linters --no-generate"
   - INTEG_TESTS=true GOFLAGS='-race' WITH_ETCD=true        PRESUBMIT_OPTS="--no-linters --no-generate"
@@ -38,6 +36,12 @@ jobs:
       install: true
       before_script: true
       script: go build ./...
+    - name: "coverage"
+      before_install: true
+      install: true
+      before_script: true
+      script: go test -covermode=atomic -coverprofile=coverage.txt ./...
+      after_success: bash <(curl -s https://codecov.io/bash)
     - name: "generate"
       before_install: true
       install:
@@ -161,6 +165,3 @@ script:
       HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
     fi
   - set +e
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
     - "$HOME/gopath/pkg/mod"
 
 env: #TODO: Merge the test matrix into individual jobs
+  - DO_NOTHING_SPECIAL=true # The first line of env will be used for everything in jobs, below.
   - PRESUB_TESTS=true GOFLAGS='-race'                      PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=batched_queue' PRESUBMIT_OPTS="--no-linters --no-generate"
   - PRESUB_TESTS=true GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters --no-generate"


### PR DESCRIPTION
The integration tests weren't actually generating a coverage report anyway. The presubmit checks were, but the new job is equivalent to that. The two entries have been removed from the env configuration because they are now equivalent to the line under each of them, modulo the race flag. If we're going to run the tests with the race flag anyway, then there is no advantage to running the tests without it too; it's just a waste of compute time.

This PR tidies up the after_success which was running after all of our 16 tests, but only doing something for one of them. That's an unneccessary load on the codecov website, which I have observed timeouts in the travis logs for. Let's be good citizens.