### PR TITLE
Disable go build caching in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ go_import_path: github.com/google/trillian
 
 cache:
   directories:
-    - "$HOME/.cache/go-build"
-    - "$HOME/.cache/go-build-race"
     - "$HOME/google-cloud-sdk/"
     - "$HOME/gopath/pkg/mod"
 
@@ -142,7 +140,3 @@ before_script:
   - ./scripts/resetdb.sh --force
   - ./scripts/mysqlconnlimit.sh --force
   - ./scripts/postgres_resetdb.sh --force
-  - |
-    if [[ "${GOFLAGS}" == *-race* ]]; then
-      export GOCACHE="$(go env GOCACHE)-race"
-    fi


### PR DESCRIPTION
TBD if this makes it faster or slower. It was taking ~20s after each build target to update the cache, and as all the builds for a revision happen in parallel and with different build tags, there are a lot of good reasons this might cost more to move bytes than it saves us in compile time.
