### PR TITLE
Moved content checking from setLeaves to getSMR methods

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -773,7 +773,7 @@ func (s *hammerState) validateSMRMatchesWrittenContents(root *types.MapRootV1) e
 		return err
 	}
 	if !bytes.Equal(root.RootHash, wantRootHash) {
-		return fmt.Errorf("failed to check root hash: got %x, want %x", root.RootHash, wantRootHash)
+		return fmt.Errorf("unexpected root hash: got %x, want %x", root.RootHash, wantRootHash)
 	}
 	return nil
 }

--- a/testonly/mapcontents.go
+++ b/testonly/mapcontents.go
@@ -278,6 +278,20 @@ func (p *VersionedMapContents) PickCopy(prng *rand.Rand) *MapContents {
 	return p.contents[choice]
 }
 
+// PickRevision returns the previous copy of the map's contents that match
+// the given revision, or nil if there are no matching copies.
+func (p *VersionedMapContents) PickRevision(rev uint64) *MapContents {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	for i := 0; i < copyCount && p.contents[i] != nil; i++ {
+		if p.contents[i].Rev == int64(rev) {
+			return p.contents[i]
+		}
+	}
+	return nil
+}
+
 // UpdateContentsWith stores a new copy of the Map's contents, updating the
 // most recent copy with the given leaves.  Returns the updated contents.
 func (p *VersionedMapContents) UpdateContentsWith(rev uint64, leaves []*trillian.MapLeaf) (*MapContents, error) {

--- a/testonly/mapcontents.go
+++ b/testonly/mapcontents.go
@@ -284,7 +284,7 @@ func (p *VersionedMapContents) PickRevision(rev uint64) *MapContents {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	for i := 0; i < copyCount && p.contents[i] != nil; i++ {
+	for i := 0; i < copyCount && p.contents[i] != nil && p.contents[i].Rev >= int64(rev); i++ {
 		if p.contents[i].Rev == int64(rev) {
 			return p.contents[i]
 		}

--- a/testonly/mapcontents_test.go
+++ b/testonly/mapcontents_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/maphasher"
 )
 
@@ -154,5 +155,100 @@ func TestRootHash(t *testing.T) {
 				t.Fatalf("RootHash()=%x, want %x", got, want)
 			}
 		})
+	}
+}
+
+func TestVersionedMapContents_UpdateContents(t *testing.T) {
+	type update struct {
+		rev    uint64
+		leaves []*trillian.MapLeaf
+	}
+	tests := []struct {
+		desc    string
+		updates []update
+		wantErr bool
+	}{
+		{
+			desc: "single revision",
+			updates: []update{
+				{
+					rev:    1,
+					leaves: []*trillian.MapLeaf{},
+				},
+			},
+		}, {
+			desc: "duplicate revision is error",
+			updates: []update{
+				{
+					rev:    1,
+					leaves: []*trillian.MapLeaf{},
+				}, {
+					rev:    1,
+					leaves: []*trillian.MapLeaf{},
+				},
+			},
+			wantErr: true,
+		}, {
+			desc: "unordered revisions is error",
+			updates: []update{
+				{
+					rev:    2,
+					leaves: []*trillian.MapLeaf{},
+				}, {
+					rev:    1,
+					leaves: []*trillian.MapLeaf{},
+				},
+			},
+			wantErr: true,
+		}, {
+			desc: "consecutive revision",
+			updates: []update{
+				{
+					rev:    1,
+					leaves: []*trillian.MapLeaf{},
+				}, {
+					rev:    2,
+					leaves: []*trillian.MapLeaf{},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var vmc VersionedMapContents
+			var gotErr error
+			for _, u := range test.updates {
+				_, e := vmc.UpdateContentsWith(u.rev, u.leaves)
+				if e != nil {
+					gotErr = e
+				}
+			}
+			if (gotErr != nil) != test.wantErr {
+				t.Errorf("Unexpected error state: %v, wantErr: %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestPickRevision(t *testing.T) {
+	var vmc VersionedMapContents
+	for rev := 1; rev < 5; rev++ {
+		_, err := vmc.UpdateContentsWith(uint64(rev), []*trillian.MapLeaf{})
+		if err != nil {
+			t.Fatalf("Error adding revision %d", rev)
+		}
+	}
+
+	for want := 1; want < 5; want++ {
+		if got := vmc.PickRevision(uint64(want)).Rev; got != int64(want) {
+			t.Fatalf("PickRevision()=%x, want %x", got, want)
+		}
+	}
+
+	if got := vmc.PickRevision(0); got != nil {
+		t.Fatalf("PickRevision(0) should be nil, was %v", got)
+	}
+	if got := vmc.PickRevision(5); got != nil {
+		t.Fatalf("PickRevision(5) should be nil, was %v", got)
 	}
 }

--- a/testonly/mapcontents_test.go
+++ b/testonly/mapcontents_test.go
@@ -218,8 +218,7 @@ func TestVersionedMapContents_UpdateContents(t *testing.T) {
 			var vmc VersionedMapContents
 			var gotErr error
 			for _, u := range test.updates {
-				_, e := vmc.UpdateContentsWith(u.rev, u.leaves)
-				if e != nil {
+				if _, e := vmc.UpdateContentsWith(u.rev, u.leaves); e != nil {
 					gotErr = e
 				}
 			}


### PR DESCRIPTION
SetLeaves is being deprecated in #1842 and replaced with WriteLeaves, which does not return an SMR upon writing. This PR moves the checks that were performed on the map contents being applied properly from the write to the reader. This adds a PickRevision method and tests it.