### PR TITLE
HStar2: Make benchmark realistic

### DIFF
--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -257,11 +257,9 @@ func leafHashes(b *testing.B, n int) []*HStar2LeafHash {
 		if _, err := r.Read(path); err != nil {
 			b.Fatalf("Failed to make random path: %v", err)
 		}
-		var index big.Int
-		index.SetBytes(path)
 		lh = append(lh, &HStar2LeafHash{
 			LeafHash: h,
-			Index:    &index,
+			Index:    new(big.Int).SetBytes(path),
 		})
 	}
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -235,7 +235,7 @@ func TestHStar2NegativeTreeLevelOffset(t *testing.T) {
 func BenchmarkHStar2Root(b *testing.B) {
 	hs2 := NewHStar2(42, coniks.New(crypto.SHA256))
 	for i := 0; i < b.N; i++ {
-		_, err := hs2.HStar2Root(256, leafHashes(b, 200))
+		_, err := hs2.HStar2Root(256, leafHashes(b, 500))
 		if err != nil {
 			b.Fatalf("hstar2 root failed: %v", err)
 		}
@@ -253,9 +253,15 @@ func leafHashes(b *testing.B, n int) []*HStar2LeafHash {
 		if _, err := r.Read(h); err != nil {
 			b.Fatalf("Failed to make random leaf hashes: %v", err)
 		}
+		path := make([]byte, 32)
+		if _, err := r.Read(path); err != nil {
+			b.Fatalf("Failed to make random path: %v", err)
+		}
+		var index big.Int
+		index.SetBytes(path)
 		lh = append(lh, &HStar2LeafHash{
 			LeafHash: h,
-			Index:    big.NewInt(r.Int63()),
+			Index:    &index,
 		})
 	}
 


### PR DESCRIPTION
Generate all 32 bytes of leaf indices randomly, rather than only the last 8 bytes. This results in a more dispersed set of nodes that `HStar2` touches, which is closer to a real world scenario.

As a result, the benchmark is now 4-5 times slower:
```
Before:	BenchmarkHStar2Root-12    	      27	  44295631 ns/op
After:	BenchmarkHStar2Root-12    	       6	 205281998 ns/op
```

Additionally, increase the number of indices from 200 to 500, to increase density in lower tree levels a bit. This further slows the benchmark down:

```
BenchmarkHStar2Root-12    	       2	 506839452 ns/op
```