### PR TITLE
HStar3: A faster non-recursive HStar2

### DIFF
--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -239,7 +239,7 @@ func TestHStar2RootGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Root: %v", err)
 	}
-	want := "d01bd540dc8b4a3ca3ac8deb485b431e9ce1290becb36838c4463a811d15c7f6"
+	want := "daf17dc2c83f37962bae8a65d294ef7fca4ffa02c10bdc4ca5c4dec408001c98"
 	if got := hex.EncodeToString(hash); got != want {
 		t.Errorf("Root: got %x, want %v", hash, want)
 	}
@@ -255,10 +255,12 @@ func BenchmarkHStar2Root(b *testing.B) {
 	}
 }
 
+// leafHashes generates n leaf updates at depth 256. The function is
+// pseudo-random, and the returned data depends only on n.
 func leafHashes(t testing.TB, n int) []*HStar2LeafHash {
 	t.Helper()
-	// Use a fixed sequence to ensure runs are comparable
-	r := rand.New(rand.NewSource(42424242))
+	// Use a random sequence that depends on n.
+	r := rand.New(rand.NewSource(int64(n)))
 	lh := make([]*HStar2LeafHash, 0, n)
 
 	for l := 0; l < n; l++ {

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -17,6 +17,7 @@ package merkle
 import (
 	"bytes"
 	"crypto"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -232,6 +233,18 @@ func TestHStar2NegativeTreeLevelOffset(t *testing.T) {
 	}
 }
 
+func TestHStar2RootGolden(t *testing.T) {
+	hs2 := NewHStar2(42, coniks.New(crypto.SHA256))
+	hash, err := hs2.HStar2Root(256, leafHashes(t, 500))
+	if err != nil {
+		t.Fatalf("Root: %v", err)
+	}
+	want := "d01bd540dc8b4a3ca3ac8deb485b431e9ce1290becb36838c4463a811d15c7f6"
+	if got := hex.EncodeToString(hash); got != want {
+		t.Errorf("Root: got %x, want %v", hash, want)
+	}
+}
+
 func BenchmarkHStar2Root(b *testing.B) {
 	hs2 := NewHStar2(42, coniks.New(crypto.SHA256))
 	for i := 0; i < b.N; i++ {
@@ -242,8 +255,8 @@ func BenchmarkHStar2Root(b *testing.B) {
 	}
 }
 
-func leafHashes(b *testing.B, n int) []*HStar2LeafHash {
-	b.Helper()
+func leafHashes(t testing.TB, n int) []*HStar2LeafHash {
+	t.Helper()
 	// Use a fixed sequence to ensure runs are comparable
 	r := rand.New(rand.NewSource(42424242))
 	lh := make([]*HStar2LeafHash, 0, n)
@@ -251,11 +264,11 @@ func leafHashes(b *testing.B, n int) []*HStar2LeafHash {
 	for l := 0; l < n; l++ {
 		h := make([]byte, 32)
 		if _, err := r.Read(h); err != nil {
-			b.Fatalf("Failed to make random leaf hashes: %v", err)
+			t.Fatalf("Failed to make random leaf hashes: %v", err)
 		}
 		path := make([]byte, 32)
 		if _, err := r.Read(path); err != nil {
-			b.Fatalf("Failed to make random path: %v", err)
+			t.Fatalf("Failed to make random path: %v", err)
 		}
 		lh = append(lh, &HStar2LeafHash{
 			LeafHash: h,

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -95,7 +95,8 @@ func (h HStar3) GetReadSet(updates []NodeUpdate, top uint) map[tree.NodeID2][]by
 			ids[sib] = nil
 		}
 	}
-	// Delete the nodes that don't contribute to the updated hashes because
+	// Delete the sibling nodes that are both in the set. Their original hashes
+	// don't contribute to the updated hashes because they are both changed.
 	for id := range ids {
 		sib := id.Sibling()
 		if _, ok := ids[sib]; ok {
@@ -147,7 +148,7 @@ func (h HStar3) updateAt(updates []NodeUpdate, depth uint, ns NodeStorage) ([]No
 	newLen := 0
 	for i, ln := 0, len(updates); i < ln; i, newLen = i+1, newLen+1 {
 		sib := updates[i].ID.Sibling()
-		left, right := updates[i].Hash, []byte{}
+		left, right := updates[i].Hash, []byte(nil)
 		if next := i + 1; next < ln && updates[next].ID == sib {
 			// The sibling is the right child here, as updates are sorted.
 			right = updates[next].Hash

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -148,7 +148,8 @@ func (h HStar3) updateAt(updates []NodeUpdate, depth uint, ns NodeStorage) ([]No
 	newLen := 0
 	for i, ln := 0, len(updates); i < ln; i, newLen = i+1, newLen+1 {
 		sib := updates[i].ID.Sibling()
-		left, right := updates[i].Hash, []byte(nil)
+		left := updates[i].Hash
+		var right []byte
 		if next := i + 1; next < ln && updates[next].ID == sib {
 			// The sibling is the right child here, as updates are sorted.
 			right = updates[next].Hash

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -143,18 +143,18 @@ func (h HStar3) updateAt(updates []NodeUpdate, depth uint, ns NodeStorage) ([]No
 	newLen := 0
 	for i, ln := 0, len(updates); i < ln; i, newLen = i+1, newLen+1 {
 		sib := updates[i].ID.Sibling()
-		left := updates[i].Hash
-		var right []byte
+		var left, right []byte
 		if next := i + 1; next < ln && updates[next].ID == sib {
 			// The sibling is the right child here, as updates are sorted.
-			right = updates[next].Hash
+			left, right = updates[i].Hash, updates[next].Hash
 			i = next // Skip the next update in the outer loop.
 		} else {
 			// The sibling is not updated, so fetch the original from NodeStorage.
-			var err error
-			if right, err = ns.Get(sib); err != nil {
+			hash, err := ns.Get(sib)
+			if err != nil {
 				return nil, err
 			}
+			left, right = updates[i].Hash, hash
 			if isLeftChild(sib) {
 				left, right = right, left
 			}

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -1,0 +1,186 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package smt contains the implementation of the sparse Merkle tree logic.
+package smt
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/trillian/storage/tree"
+)
+
+// NodeStorage reads and writes sparse Merkle tree node hashes.
+type NodeStorage interface {
+	// Get returns the hash of the given node.
+	Get(id tree.NodeID2) ([]byte, error)
+	// Set sets the hash of the given node.
+	Set(id tree.NodeID2, hash []byte)
+}
+
+// HashChildrenFn computes a node hash based on its child nodes' hashes.
+type HashChildrenFn func(left, right []byte) []byte
+
+// NodeUpdate represents an update of a node hash in HStar3 algorithm.
+type NodeUpdate struct {
+	ID   tree.NodeID2
+	Hash []byte
+}
+
+// HStar3 is a faster non-recursive HStar2.
+//
+// TODO(pavelkalinnikov): Swap in the code, and document it properly.
+type HStar3 struct {
+	hash  HashChildrenFn
+	depth uint
+}
+
+// NewHStar3 returns a new instance of HStar3.
+func NewHStar3(hash HashChildrenFn, depth uint) HStar3 {
+	return HStar3{hash: hash, depth: depth}
+}
+
+// Prepare sorts the updates slice for it to be usable by HStar3. It also
+// verifies that the nodes are placed at the required depth, and there are no
+// ID duplicates amongh them.
+func (h HStar3) Prepare(updates []NodeUpdate) error {
+	for i := range updates {
+		if d, want := updates[i].ID.BitLen(), h.depth; d != want {
+			return fmt.Errorf("upd #%d: invalid depth %d, want %d", i, d, want)
+		}
+	}
+	sort.Slice(updates, func(i, j int) bool {
+		return compareHorizontal(updates[i].ID, updates[j].ID)
+	})
+	for i, last := 0, len(updates)-1; i < last; i++ {
+		if id := updates[i].ID; id == updates[i+1].ID {
+			return fmt.Errorf("duplicate ID: %v", id)
+		}
+	}
+	return nil
+}
+
+// GetReadSet returns the set of all the node IDs that HStar3 requires to read
+// in order to apply the passed-in updates and propagate node hash changes up
+// to the root(top) node(s) at the specified depth. The updates must have been
+// processed by Prepare.
+//
+// Note: The returned map could have bool value type, but []byte allows the
+// caller to reuse this map for filling in the hashes for the Update method.
+//
+// TODO(pavelkalinnikov): Return only tile IDs.
+func (h HStar3) GetReadSet(updates []NodeUpdate, top uint) map[tree.NodeID2][]byte {
+	ids := make(map[tree.NodeID2][]byte)
+	// For each node, add all its ancestors' siblings, down to the given depth.
+	for _, upd := range updates {
+		for id, d := upd.ID, h.depth; d > top; d-- {
+			sib := id.Prefix(d).Sibling()
+			if _, ok := ids[sib]; ok {
+				// All the upper siblings have been added already, so skip them.
+				break
+			}
+			ids[sib] = nil
+		}
+	}
+	// Delete the nodes that don't contribute to the updated hashes because
+	for id := range ids {
+		sib := id.Sibling()
+		if _, ok := ids[sib]; ok {
+			delete(ids, id)
+			delete(ids, sib)
+		}
+	}
+	return ids
+}
+
+// Update applies the given updates to a sparse Merkle tree. Requires a
+// previous Prepare invocation on the same updates slice. Returns an error if
+// any of the NodeStorage.Get calls does so, for example if a node is missing.
+//
+// Returns the slice of updates at the top level of the sparse Merkle tree
+// induced by the provided lower level updates. Typically it will contain only
+// one item for the root hash of a tile or a (sub)tree, but the caller may
+// arrange multiple subtrees in one call, in which case the corresponding
+// returned top-level updates will be sorted lexicographically by node ID.
+//
+// Note that Update invocations can be chained. For example, a bunch of HStar3
+// instances at depth 256 can return updates for depth 8 (in parallel), which
+// are then merged together and passed into another HStar3 at depth 8 which
+// computes the overall tree root update.
+//
+// For that reason, Update doesn't invoke NodeStorage.Set for the topmost level
+// nodes. If it did then chained Updates would Set the borderline nodes twice.
+//
+// Warning: This call modifies the updates slice in-place, so the caller must
+// ensure to not reuse it.
+func (h HStar3) Update(updates []NodeUpdate, top uint, ns NodeStorage) ([]NodeUpdate, error) {
+	for d := h.depth; d > top; d-- {
+		var err error
+		if updates, err = h.updateAt(updates, d, ns); err != nil {
+			return nil, fmt.Errorf("depth %d: %v", d, err)
+		}
+	}
+	return updates, nil
+}
+
+// updateAt applies the given node updates at the specified tree level.
+// Returns the updates that propagated to the level above.
+func (h HStar3) updateAt(updates []NodeUpdate, depth uint, ns NodeStorage) ([]NodeUpdate, error) {
+	// Apply the updates.
+	for _, upd := range updates {
+		ns.Set(upd.ID, upd.Hash)
+	}
+	// Calculate the updates that propagate to one level above.
+	newLen := 0
+	for i, ln := 0, len(updates); i < ln; i, newLen = i+1, newLen+1 {
+		sib := updates[i].ID.Sibling()
+		left, right := updates[i].Hash, []byte{}
+		if next := i + 1; next < ln && updates[next].ID == sib {
+			// The sibling is the right child here, as updates are sorted.
+			right = updates[next].Hash
+			i = next // Skip the next update in the outer loop.
+		} else {
+			// The sibling is not updated, so fetch the original from NodeStorage.
+			var err error
+			if right, err = ns.Get(sib); err != nil {
+				return nil, err
+			}
+			if isLeftChild(sib) {
+				left, right = right, left
+			}
+		}
+		hash := h.hash(left, right)
+		updates[newLen] = NodeUpdate{ID: sib.Prefix(depth - 1), Hash: hash}
+	}
+	return updates[:newLen], nil
+}
+
+// isLeftChild returns whether the the given node is a left child.
+func isLeftChild(id tree.NodeID2) bool {
+	last, bits := id.LastByte()
+	return last&(1<<(8-bits)) == 0
+}
+
+// compareHorizontal returns whether the first node ID is to the left from the
+// second one. The result only makes sense for IDs at the same tree level.
+func compareHorizontal(a, b tree.NodeID2) bool {
+	if res := strings.Compare(a.FullBytes(), b.FullBytes()); res != 0 {
+		return res < 0
+	}
+	aLast, _ := a.LastByte()
+	bLast, _ := b.LastByte()
+	return aLast < bLast
+}

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -87,21 +87,16 @@ func (h HStar3) GetReadSet(updates []NodeUpdate, top uint) map[tree.NodeID2][]by
 	// For each node, add all its ancestors' siblings, down to the given depth.
 	for _, upd := range updates {
 		for id, d := upd.ID, h.depth; d > top; d-- {
-			sib := id.Prefix(d).Sibling()
-			if _, ok := ids[sib]; ok {
+			pref := id.Prefix(d)
+			if _, ok := ids[pref]; ok {
+				// Delete the prefix node because its original hash does not contribute
+				// to the updates, so should not be read.
+				delete(ids, pref)
 				// All the upper siblings have been added already, so skip them.
 				break
 			}
+			sib := pref.Sibling()
 			ids[sib] = nil
-		}
-	}
-	// Delete the sibling nodes that are both in the set. Their original hashes
-	// don't contribute to the updated hashes because they are both changed.
-	for id := range ids {
-		sib := id.Sibling()
-		if _, ok := ids[sib]; ok {
-			delete(ids, id)
-			delete(ids, sib)
 		}
 	}
 	return ids

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -70,7 +70,7 @@ func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HSta
 	return HStar3{upd: updates, hash: hash, depth: depth, top: top}, nil
 }
 
-// Preload returns the set of all the node IDs that the Update method will load
+// Prepare returns the set of all the node IDs that the Update method will load
 // in order to compute node hash updates from the initial tree depth up to the
 // top level specified in the constructor. It may be useful for constructing a
 // NodeAccessor, e.g. by batch-reading the nodes from elsewhere.
@@ -79,7 +79,7 @@ func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HSta
 // caller to reuse this map for filling in the hashes for the Update method.
 //
 // TODO(pavelkalinnikov): Return only tile IDs.
-func (h HStar3) Preload() map[tree.NodeID2][]byte {
+func (h HStar3) Prepare() map[tree.NodeID2][]byte {
 	ids := make(map[tree.NodeID2][]byte)
 	// For each node, add all its ancestors' siblings, down to the given depth.
 	for _, upd := range h.upd {

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -64,6 +64,8 @@ type HStar3 struct {
 func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HStar3, error) {
 	if err := sortUpdates(updates, depth); err != nil {
 		return HStar3{}, err
+	} else if top > depth {
+		return HStar3{}, fmt.Errorf("top > depth: %d vs. %d", top, depth)
 	}
 	return HStar3{upd: updates, hash: hash, depth: depth, top: top}, nil
 }
@@ -178,7 +180,7 @@ func compareHorizontal(a, b tree.NodeID2) bool {
 
 // sortUpdates sorts the updates slice for it to be usable by HStar3. It also
 // verifies that the nodes are placed at the required depth, and there are no
-// ID duplicates amongh them.
+// duplicate IDs.
 func sortUpdates(updates []NodeUpdate, depth uint) error {
 	for i := range updates {
 		if d, want := updates[i].ID.BitLen(), depth; d != want {

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -84,7 +84,7 @@ func TestHStar3Golden(t *testing.T) {
 		t.Fatalf("Update returned %d updates, want 1", ln)
 	}
 
-	want := "d01bd540dc8b4a3ca3ac8deb485b431e9ce1290becb36838c4463a811d15c7f6"
+	want := "daf17dc2c83f37962bae8a65d294ef7fca4ffa02c10bdc4ca5c4dec408001c98"
 	if got := hex.EncodeToString(upd[0].Hash); got != want {
 		t.Errorf("Root: got %x, want %v", upd[0].Hash, want)
 	}
@@ -155,12 +155,14 @@ func TestHStar3GetReadSet(t *testing.T) {
 	}
 }
 
+// leafUpdates generates n leaf updates at depth 256. The function is
+// pseudo-random, and the returned data depends only on n. The algorithm is the
+// same as in HStar2 tests, which allows cross-checking their results.
 func leafUpdates(t testing.TB, n int) []NodeUpdate {
 	t.Helper()
+	// Use a random sequence that depends on n.
+	r := rand.New(rand.NewSource(int64(n)))
 	updates := make([]NodeUpdate, n)
-
-	// Use a fixed sequence to ensure runs are comparable.
-	r := rand.New(rand.NewSource(42424242))
 	for i := range updates {
 		updates[i].Hash = make([]byte, 32)
 		if _, err := r.Read(updates[i].Hash); err != nil {

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -100,12 +100,14 @@ func TestNewHStar3(t *testing.T) {
 	for _, tc := range []struct {
 		desc    string
 		upd     []NodeUpdate
+		top     uint
 		want    []NodeUpdate
 		wantErr string
 	}{
 		{desc: "depth-err", upd: []NodeUpdate{{ID: id1.Prefix(10)}}, wantErr: "invalid depth"},
 		{desc: "dup-err1", upd: []NodeUpdate{{ID: id1}, {ID: id1}}, wantErr: "duplicate ID"},
 		{desc: "dup-err2", upd: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id1}}, wantErr: "duplicate ID"},
+		{desc: "top-vs-depth-err", upd: []NodeUpdate{{ID: id1}}, top: 300, wantErr: "top > depth"},
 		{
 			desc: "ok1",
 			upd:  []NodeUpdate{{ID: id2}, {ID: id1}, {ID: id4}, {ID: id3}},
@@ -118,8 +120,9 @@ func TestNewHStar3(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			upd := tc.upd                                            // No need to copy it here.
-			_, err := NewHStar3(tc.upd, hasher.HashChildren, 256, 0) // Potentially shuffles upd.
+			upd := tc.upd // No need to copy it here.
+			// Note: NewHStar3 potentially shuffles upd.
+			_, err := NewHStar3(tc.upd, hasher.HashChildren, 256, tc.top)
 			got := ""
 			if err != nil {
 				got = err.Error()

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -137,14 +137,14 @@ func TestNewHStar3(t *testing.T) {
 	}
 }
 
-func TestHStar3Preload(t *testing.T) {
+func TestHStar3Prepare(t *testing.T) {
 	hasher := coniks.Default
 	updates := leafUpdates(t, 512)
 	hs, err := NewHStar3(updates, hasher.HashChildren, 256, 0)
 	if err != nil {
 		t.Fatalf("NewHStar3: %v", err)
 	}
-	rs := hs.Preload()
+	rs := hs.Prepare()
 
 	nodes := &emptyNodes{treeID: 42, hasher: hasher, hashes: rs}
 	if _, err = hs.Update(nodes); err != nil {

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -1,0 +1,177 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"crypto"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/trillian/merkle/coniks"
+	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage/tree"
+)
+
+type emptyNodes struct {
+	treeID int64
+	hasher hashers.MapHasher
+	hashes map[tree.NodeID2][]byte
+}
+
+func (e *emptyNodes) Get(id tree.NodeID2) ([]byte, error) {
+	if e.hashes != nil {
+		if _, ok := e.hashes[id]; !ok {
+			return nil, fmt.Errorf("not found or read twice: %v", id)
+		}
+		delete(e.hashes, id) // Allow getting this ID only once.
+	}
+	index := make([]byte, e.hasher.Size())
+	copy(index, id.FullBytes())
+	if last, bits := id.LastByte(); bits != 0 {
+		index[len(id.FullBytes())] = last
+	}
+	// TODO(pavelkalinnikov): Make HashEmpty method take the id directly.
+	return e.hasher.HashEmpty(e.treeID, index, e.hasher.BitLen()-int(id.BitLen())), nil
+}
+
+func (e *emptyNodes) Set(id tree.NodeID2, hash []byte) {}
+
+func BenchmarkHStar3Root(b *testing.B) {
+	hasher := coniks.New(crypto.SHA256)
+	for i := 0; i < b.N; i++ {
+		updates := leafUpdates(b, 512)
+		hs := NewHStar3(hasher.HashChildren, 256)
+		if err := hs.Prepare(updates); err != nil {
+			b.Fatalf("Prepare: %v", err)
+		}
+		nodes := &emptyNodes{treeID: 42, hasher: hasher}
+		if _, err := hs.Update(updates, 0, nodes); err != nil {
+			b.Fatalf("Update: %v", err)
+		}
+	}
+}
+
+// This test checks HStar3 implementation against HStar2-generated result.
+func TestHStar3Golden(t *testing.T) {
+	hasher := coniks.New(crypto.SHA256)
+	hs := NewHStar3(hasher.HashChildren, 256)
+	updates := leafUpdates(t, 500)
+	if err := hs.Prepare(updates); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	nodes := &emptyNodes{treeID: 42, hasher: hasher}
+	upd, err := hs.Update(updates, 0, nodes)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if ln := len(upd); ln != 1 {
+		t.Fatalf("Update returned %d updates, want 1", ln)
+	}
+
+	want := "d01bd540dc8b4a3ca3ac8deb485b431e9ce1290becb36838c4463a811d15c7f6"
+	if got := hex.EncodeToString(upd[0].Hash); got != want {
+		t.Errorf("Root: got %x, want %v", upd[0].Hash, want)
+	}
+}
+
+func TestHStar3Prepare(t *testing.T) {
+	id1 := tree.NewNodeID2("01234567890000000000000000000001", 256)
+	id2 := tree.NewNodeID2("01234567890000000000000000000002", 256)
+	id3 := tree.NewNodeID2("01234567890000000000000000000003", 256)
+	id4 := tree.NewNodeID2("01234567890000000000000001111111", 256)
+	hasher := coniks.Default
+	hs := NewHStar3(hasher.HashChildren, 256)
+
+	for _, tc := range []struct {
+		desc    string
+		upd     []NodeUpdate
+		want    []NodeUpdate
+		wantErr string
+	}{
+		{desc: "depth-err", upd: []NodeUpdate{{ID: id1.Prefix(10)}}, wantErr: "invalid depth"},
+		{desc: "dup-err1", upd: []NodeUpdate{{ID: id1}, {ID: id1}}, wantErr: "duplicate ID"},
+		{desc: "dup-err2", upd: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id1}}, wantErr: "duplicate ID"},
+		{
+			desc: "ok1",
+			upd:  []NodeUpdate{{ID: id2}, {ID: id1}, {ID: id4}, {ID: id3}},
+			want: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id3}, {ID: id4}},
+		},
+		{
+			desc: "ok2",
+			upd:  []NodeUpdate{{ID: id4}, {ID: id3}, {ID: id2}, {ID: id1}},
+			want: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id3}, {ID: id4}},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			upd := tc.upd          // No need to copy it here.
+			err := hs.Prepare(upd) // Potentially shuffles upd.
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if want := tc.wantErr; !strings.Contains(got, want) {
+				t.Errorf("Prepare: want error containing %q, got %v", want, err)
+			}
+			if want := tc.want; want != nil && !reflect.DeepEqual(upd, want) {
+				t.Errorf("Prepare: want updates:\n%v\ngot:\n%v", upd, want)
+			}
+		})
+	}
+}
+
+func TestHStar3GetReadSet(t *testing.T) {
+	hasher := coniks.Default
+	hs := NewHStar3(hasher.HashChildren, 256)
+
+	updates := leafUpdates(t, 512)
+	if err := hs.Prepare(updates); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	rs := hs.GetReadSet(updates, 0)
+
+	nodes := &emptyNodes{treeID: 42, hasher: hasher, hashes: rs}
+	_, err := hs.Update(updates, 0, nodes)
+	if err != nil {
+		t.Errorf("Update: %v", err)
+	}
+	if got := len(nodes.hashes); got != 0 {
+		t.Errorf("%d hashes were not read", got)
+	}
+}
+
+func leafUpdates(t testing.TB, n int) []NodeUpdate {
+	t.Helper()
+	updates := make([]NodeUpdate, n)
+
+	// Use a fixed sequence to ensure runs are comparable.
+	r := rand.New(rand.NewSource(42424242))
+	for i := range updates {
+		updates[i].Hash = make([]byte, 32)
+		if _, err := r.Read(updates[i].Hash); err != nil {
+			t.Fatalf("Failed to make random leaf hash: %v", err)
+		}
+		path := make([]byte, 32)
+		if _, err := r.Read(path); err != nil {
+			t.Fatalf("Failed to make random path: %v", err)
+		}
+		updates[i].ID = tree.NewNodeID2(string(path), 256)
+	}
+
+	return updates
+}

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -48,6 +48,19 @@ func (n NodeID2) BitLen() uint {
 	return uint(len(n.path))*8 + uint(n.bits)
 }
 
+// FullBytes returns the ID bytes that are complete. Note that there might
+// still be up to 8 extra bits, which can be obtained with the LastByte method.
+func (n NodeID2) FullBytes() string {
+	return n.path
+}
+
+// LastByte returns the terminating byte of the ID, with the number of upper
+// bits that it uses (between 1 and 8, and 0 if the ID is empty). The remaining
+// unused lower bits are always unset.
+func (n NodeID2) LastByte() (byte, uint8) {
+	return n.last, n.bits
+}
+
 // Prefix returns the prefix of NodeID2 with the given number of bits.
 func (n NodeID2) Prefix(bits uint) NodeID2 {
 	// Note: This code is very similar to NewNodeID2, and it's tempting to return


### PR DESCRIPTION
This change introduces the new `HStar3` algorithm, a future replacement for `HStar2`. It takes advantage of the faster `NodeID2` type operations like `Prefix` and `Sibling`, and doesn't use the heavy `big.Int` calculations.

Benchmarks compare with a 10-15% speed-up on the same dataset:

```
BenchmarkHStar2Root-12    	       2	 517407218 ns/op
BenchmarkHStar3Root-12    	       3	 443897809 ns/op
```

`HStar3` code also claims to be more readable, as it is not recursive.

It is also more generic. For example, it doesn't depend on `MapHasher` interface and has no "empty hash" notion. The idea is that the caller is the one who provides empty hashes. It allows more flexibility: for example, the caller can error if some hash is not present (e.g. they used the `GetReadSet` method to prefetch all hashes, but `HStar3` tries to read something different), or return an empty hash (e.g. if they did not use the prefetching option).

The lack of empty hash notion allows (in principle) using `HStar3` even with logs. If `HashChildrenFn` returns `nil` unless both children are non-`nil`, and otherwise returns a "log" `HashChildren` then we can basically get similar functionality as `compact.Range` provides.