### PR TITLE
Switch the map hammer to use WriteLeaves instead of SetLeaves

### DIFF
--- a/client/map_client.go
+++ b/client/map_client.go
@@ -82,6 +82,7 @@ func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revisio
 }
 
 // SetAndVerifyMapLeaves calls SetLeaves and verifies the signature of the returned map root.
+// Deprecated: Use WriteLeaves on the TrillianMapWriteClient instead.
 func (c *MapClient) SetAndVerifyMapLeaves(ctx context.Context, leaves []*trillian.MapLeaf, metadata []byte) (*types.MapRootV1, error) {
 	// Set new leaf values.
 	req := &trillian.SetMapLeavesRequest{

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -674,7 +674,12 @@ leafloop:
 
 	writeRev := uint64(rev + 1)
 
-	req := trillian.WriteMapLeavesRequest{MapId: s.cfg.MapID, Leaves: leaves, ExpectRevision: int64(writeRev)}
+	req := trillian.WriteMapLeavesRequest{
+		MapId:          s.cfg.MapID,
+		Leaves:         leaves,
+		Metadata:       metadataForRev(writeRev),
+		ExpectRevision: int64(writeRev),
+	}
 	_, err := s.cfg.Write.WriteLeaves(ctx, &req)
 	if err != nil {
 		return fmt.Errorf("failed to set-leaves(count=%d): %v", len(leaves), err)

--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -65,6 +65,7 @@ func TestRetryExposesDeadlineError(t *testing.T) {
 	cfg := MapConfig{
 		MapID:         0, // ephemeral tree
 		Client:        env.Map,
+		Write:         env.Write,
 		Admin:         env.Admin,
 		MetricFactory: monitoring.InertMetricFactory{},
 		RandSource:    rand.NewSource(seed),
@@ -115,6 +116,7 @@ func TestInProcessMapHammer(t *testing.T) {
 	cfg := MapConfig{
 		MapID:         0, // ephemeral tree
 		Client:        env.Map,
+		Write:         env.Write,
 		Admin:         env.Admin,
 		MetricFactory: monitoring.InertMetricFactory{},
 		RandSource:    rand.NewSource(seed),

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -180,6 +180,7 @@ func main() {
 		cfg := hammer.MapConfig{
 			MapID:             mapid,
 			Client:            trillian.NewTrillianMapClient(c),
+			Write:             trillian.NewTrillianMapWriteClient(c),
 			Admin:             trillian.NewTrillianAdminClient(ac),
 			MetricFactory:     mf,
 			RandSource:        randSrc,

--- a/testonly/hammer/mapreplay/main.go
+++ b/testonly/hammer/mapreplay/main.go
@@ -49,12 +49,14 @@ func main() {
 	}
 
 	var cl trillian.TrillianMapClient
+	var write trillian.TrillianMapWriteClient
 	if *rpcServer != "" {
 		c, err := grpc.Dial(*rpcServer, grpc.WithInsecure())
 		if err != nil {
 			glog.Exitf("Failed to create map client conn: %v", err)
 		}
 		cl = trillian.NewTrillianMapClient(c)
+		write = trillian.NewTrillianMapWriteClient(c)
 	}
 
 	pairRE := regexp.MustCompile(`(\d+):(\d+)`)
@@ -78,7 +80,7 @@ func main() {
 		}
 		mapmap[from] = to
 	}
-	if err := hammer.ReplayFile(ctx, f, cl, mapmap); err != nil {
+	if err := hammer.ReplayFile(ctx, f, cl, write, mapmap); err != nil {
 		glog.Exitf("Error replaying messages: %v", err)
 	}
 }


### PR DESCRIPTION
This will allow #1842 to be submitted without needing to disable linter checks for using deprecated methods.

This is based on top of #1872, which is required so that the missing SMR in WriteLeaves (compared to SetLeaves response) is not an issue.