### PR TITLE
Use latest version of Bazel in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
     - name: "bazel"
       install:
       - |
-        BAZEL_VERSION='0.18.0'
+        BAZEL_VERSION='0.29.1'
         URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
         wget -O install.sh ${URL}
         chmod +x install.sh


### PR DESCRIPTION
No particular motivation other than 0.18 is now quite old and we don't want to get left behind.
