### PR TITLE
Fixed flakiness introduced in #1872

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,8 @@ jobs:
       env: GOFLAGS='-race --tags=pkcs11' GO_TEST_TIMEOUT=20m
       script: ./scripts/presubmit.sh --no-linters --no-generate
     - name: "integration"
-      env: GOFLAGS='-race' GO_TEST_TIMEOUT=20m
-      script: ./integration/integration_test.sh && HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
+      env: GO_TEST_TIMEOUT=20m
+      script: ./integration/integration_test.sh && HAMMER_OPTS="--operations=150" ./integration/maphammer.sh 3
     - name: "integration (etcd)"
       env: GOFLAGS='-race' ETCD_DIR="${GOPATH}/bin" GO_TEST_TIMEOUT=20m
       install: go install go.etcd.io/etcd go.etcd.io/etcd/etcdctl

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -759,10 +759,6 @@ func (s *hammerState) getSMRRev(ctx context.Context, prng *rand.Rand) error {
 		return fmt.Errorf("get-smr-rev(@%d)=%+v, want %+v", rev, root, smrRoot)
 	}
 
-	if err := s.verify(root); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -773,7 +769,7 @@ func (s *hammerState) verify(root *types.MapRootV1) error {
 		return err
 	}
 	if !bytes.Equal(root.RootHash, want) {
-		return fmt.Errorf("unexpected root hash: got %x, want %x", root.RootHash, want)
+		return fmt.Errorf("unexpected root hash for revision %d: got %x, want %x", root.Revision, root.RootHash, want)
 	}
 	return nil
 }


### PR DESCRIPTION
Verifying root correctness at old revisions isn't guaranteed to work because we only keep a finite cache of committed state. Trying to check SMRs for revisions > 10 in the past would fail. The previous code only checked this immediately on write, where #1872 performed the check on both a) examining the latest SMR; and b) examining historic SMRs. This change only keeps a) and drops the check in b), because the old state may have been purged. This gives less coverage, but is closer to what we had before. As work progresses on this hammer, I intend to increase coverage over historic roots. The priority for now is removing the flake though.

This caused flakiness because of the randomness of the hammer and the number of iterations. This change also increases the number of operations performed in Travis, which would turn this from a flakey failure to a persistent failure, if this PR didn't also include the medicine.
