### PR TITLE
Handle case where no SMR found yet

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -387,8 +387,11 @@ func (s *hammerState) String() string {
 		totalInvalidReqs += int(invalidReqs.Value(s.label(), string(ep)))
 		totalErrs += int(errs.Value(s.label(), string(ep)))
 	}
-	smr := s.previousSMR(0)
-	return fmt.Sprintf("%d: lastSMR.rev=%d ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, smr.Revision, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
+	var latestRev uint64
+	if smr := s.previousSMR(0); smr != nil {
+		latestRev = smr.Revision
+	}
+	return fmt.Sprintf("%d: lastSMR.rev=%d ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, latestRev, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
 }
 
 func (s *hammerState) pushSMR(smr *types.MapRootV1) error {

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -398,6 +398,7 @@ func (s *hammerState) pushSMR(smr *types.MapRootV1) error {
 	return s.smrs.pushSMR(*smr)
 }
 
+// TODO(mhutchinson): consider making this return a bool or an error to indicate missing result.
 func (s *hammerState) previousSMR(which int) *types.MapRootV1 {
 	return s.smrs.previousSMR(which)
 }

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -387,9 +387,9 @@ func (s *hammerState) String() string {
 		totalInvalidReqs += int(invalidReqs.Value(s.label(), string(ep)))
 		totalErrs += int(errs.Value(s.label(), string(ep)))
 	}
-	var latestRev uint64
+	var latestRev int64 = -1
 	if smr := s.previousSMR(0); smr != nil {
-		latestRev = smr.Revision
+		latestRev = int64(smr.Revision)
 	}
 	return fmt.Sprintf("%d: lastSMR.rev=%d ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, latestRev, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
 }


### PR DESCRIPTION
This eliminates a potential nil pointer error if String is called before any SMR has been found.
