### PR TITLE
Added operation on MapClient to get root by revision

### DIFF
--- a/client/map_client.go
+++ b/client/map_client.go
@@ -52,6 +52,16 @@ func (c *MapClient) GetAndVerifyLatestMapRoot(ctx context.Context) (*types.MapRo
 	return c.VerifySignedMapRoot(rootResp.GetMapRoot())
 }
 
+// GetAndVerifyMapRootByRevision verifies and returns the map root with the given revision.
+func (c *MapClient) GetAndVerifyMapRootByRevision(ctx context.Context, revision int64) (*types.MapRootV1, error) {
+	rootResp, err := c.Conn.GetSignedMapRootByRevision(ctx, &trillian.GetSignedMapRootByRevisionRequest{MapId: c.MapID, Revision: revision})
+	if err != nil {
+		s := status.Convert(err)
+		return nil, status.Errorf(s.Code(), "GetSignedMapRootByRevision(%v): %v", c.MapID, s.Message())
+	}
+	return c.VerifySignedMapRoot(rootResp.GetMapRoot())
+}
+
 // GetAndVerifyMapLeaves verifies and returns the requested map leaves.
 // indexes may not contain duplicates.
 func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte) ([]*trillian.MapLeaf, error) {

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -88,6 +88,35 @@ func TestGetLatestMapRoot(t *testing.T) {
 	}
 }
 
+func TestGetMapRootByRevision(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	env, err := integration.NewMapEnv(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+	tree, err := CreateAndInitTree(ctx,
+		&trillian.CreateTreeRequest{Tree: testonly.MapTree},
+		env.Admin, env.Map, nil)
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	client, err := NewMapClientFromTree(env.Map, tree)
+	if err != nil {
+		t.Fatalf("NewMapClientFromTree(): %v", err)
+	}
+
+	root, err := client.GetAndVerifyMapRootByRevision(ctx, 0)
+	if err != nil {
+		t.Fatalf("GetAndVerifyLatestMapRoot(): %v", err)
+	}
+	if got, want := root.Revision, uint64(0); got != want {
+		t.Errorf("root.Revision: %v, want %v", got, want)
+	}
+}
+
 func TestGetLeavesAtRevision(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()


### PR DESCRIPTION
This operation is unused in this PR, but a follow up PR will make use of it. This operation is likely to be used heavily in the real world.
