### PR TITLE
Implement sparse Merkle tree writer on HStar3

### DIFF
--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/trillian/storage/tree"
 )
 
+// TODO(pavelkalinnikov): Unexport this file, as it is used only by Writer.
+
 // NodeAccessor provides read and write access to Merkle tree node hashes.
 //
 // The Update algorithm uses it to read the existing nodes of the tree and

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -41,13 +41,7 @@ func (e *emptyNodes) Get(id tree.NodeID2) ([]byte, error) {
 		}
 		delete(e.ids, id) // Allow getting this ID only once.
 	}
-	index := make([]byte, e.hasher.Size())
-	copy(index, id.FullBytes())
-	if last, bits := id.LastByte(); bits != 0 {
-		index[len(id.FullBytes())] = last
-	}
-	// TODO(pavelkalinnikov): Make HashEmpty method take the id directly.
-	return e.hasher.HashEmpty(e.treeID, index, e.hasher.BitLen()-int(id.BitLen())), nil
+	return hashEmpty(e.hasher, e.treeID, id), nil
 }
 
 func (e *emptyNodes) Set(id tree.NodeID2, hash []byte) {}

--- a/merkle/smt/writer.go
+++ b/merkle/smt/writer.go
@@ -1,0 +1,162 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage/tree"
+)
+
+// NodeBatchAccessor reads and writes batches of Merkle tree node hashes.
+type NodeBatchAccessor interface {
+	// Get returns the hashes of the given nodes, as a map keyed by their IDs.
+	// The returned hashes may be missing or be nil for empty subtrees.
+	Get(ids []tree.NodeID2) (map[tree.NodeID2][]byte, error)
+	// Set applies the given node hash updates.
+	Set(upd []NodeUpdate) error
+}
+
+// Writer handles sharded writes to a sparse Merkle tree.
+type Writer struct {
+	treeID int64
+	hasher hashers.MapHasher
+	// depths maps the depth of "leaf" nodes of a shard to its root depth.
+	depths map[uint]uint
+}
+
+// NewWriter creates a new Writer for the specified tree of the given height,
+// with 2 levels of sharding. One shard spans the the upper levels down to
+// split point, and all the other shards span the levels below.
+func NewWriter(treeID int64, hasher hashers.MapHasher, height, split uint) *Writer {
+	if split > height {
+		panic(fmt.Errorf("NewWriter: split(%d) > height(%d)", split, height))
+	}
+	depths := map[uint]uint{height: split, split: 0}
+	return &Writer{treeID: treeID, hasher: hasher, depths: depths}
+}
+
+// Split sorts and splits the given list of node hash updates into shards, i.e.
+// the subsets belonging to different subtrees. The updates must belong to the
+// same tree level, one of the sharding split points. For example, with a
+// 2-level sharding it only makes sense to Split leaf updates.
+func (w *Writer) Split(upd []NodeUpdate) ([][]NodeUpdate, error) {
+	if len(upd) == 0 { // Nothing to split.
+		return nil, nil
+	}
+	depth := upd[0].ID.BitLen()
+	if err := sortUpdates(upd, depth); err != nil {
+		return nil, err
+	}
+	top, found := w.depths[depth]
+	if !found {
+		return nil, fmt.Errorf("unexpected depth %d", depth)
+	}
+	// TODO(pavelkalinnikov): Try estimating the capacity for this slice.
+	var shards [][]NodeUpdate
+	// The updates are sorted, so we can split them by prefix.
+	for begin, i := 0, 0; i < len(upd); i++ {
+		pref := upd[i].ID.Prefix(top)
+		next := i + 1
+		// Check if this ID ends the shard.
+		if next == len(upd) || upd[next].ID.Prefix(top) != pref {
+			shards = append(shards, upd[begin:next])
+			begin = next
+		}
+	}
+	return shards, nil
+}
+
+// Write applies the given list of updates to a single shard, and returns the
+// resulting update of the shard root. It uses the given node accessor for
+// reading and writing tree nodes. Typically, the input updates have been
+// obtained from Split method.
+func (w *Writer) Write(upd []NodeUpdate, acc NodeBatchAccessor) (NodeUpdate, error) {
+	if len(upd) == 0 {
+		return NodeUpdate{}, errors.New("nothing to write")
+	}
+	depth := upd[0].ID.BitLen()
+	top, found := w.depths[depth]
+	if !found {
+		return NodeUpdate{}, fmt.Errorf("unexpected depth %d", depth)
+	}
+
+	hs, err := NewHStar3(upd, w.hasher.HashChildren, depth, top)
+	if err != nil {
+		return NodeUpdate{}, err
+	}
+	ids := hs.Prepare()
+	nodes, err := acc.Get(ids)
+	if err != nil {
+		return NodeUpdate{}, err
+	}
+	sa := w.newAccessor(nodes)
+	topUpd, err := hs.Update(sa)
+	if err != nil {
+		return NodeUpdate{}, err
+	} else if ln := len(topUpd); ln != 1 {
+		return NodeUpdate{}, fmt.Errorf("writing across %d shards, want 1", ln)
+	}
+	if err := acc.Set(sa.writes); err != nil {
+		return NodeUpdate{}, err
+	}
+
+	return topUpd[0], nil
+}
+
+// newAccessor returns a NodeAccessor for HStar3 algorithm based on the set of
+// preloaded node hashes.
+func (w *Writer) newAccessor(nodes map[tree.NodeID2][]byte) *shardAccessor {
+	// For any node that HStar3 reads, it also writes its sibling. Therefore we
+	// can pre-allocate this many items for the writes slice.
+	// TODO(pavelkalinnikov): The actual number of written nodes will be slightly
+	// bigger by at most the number of written leaves. Try allocating precisely.
+	writes := make([]NodeUpdate, 0, len(nodes))
+	return &shardAccessor{w: w, reads: nodes, writes: writes}
+}
+
+// shardAccessor provides read and write access to nodes used by HStar3.
+type shardAccessor struct {
+	w      *Writer
+	reads  map[tree.NodeID2][]byte
+	writes []NodeUpdate
+}
+
+// Get returns the hash of the given node from the preloaded map, or a hash of
+// an empty subtree at this position if such node is not found.
+func (s *shardAccessor) Get(id tree.NodeID2) ([]byte, error) {
+	if hash, ok := s.reads[id]; ok && hash != nil {
+		return hash, nil
+	}
+	return hashEmpty(s.w.hasher, s.w.treeID, id), nil
+}
+
+// Set adds the given node hash update to the list of writes.
+func (s *shardAccessor) Set(id tree.NodeID2, hash []byte) {
+	s.writes = append(s.writes, NodeUpdate{ID: id, Hash: hash})
+}
+
+// TODO(pavelkalinnikov): Make MapHasher.HashEmpty method take the id directly.
+func hashEmpty(hasher hashers.MapHasher, treeID int64, id tree.NodeID2) []byte {
+	index := make([]byte, hasher.Size())
+	copy(index, id.FullBytes())
+	if last, bits := id.LastByte(); bits != 0 {
+		index[len(id.FullBytes())] = last
+	}
+	height := hasher.BitLen() - int(id.BitLen())
+	return hasher.HashEmpty(treeID, index, height)
+}

--- a/merkle/smt/writer.go
+++ b/merkle/smt/writer.go
@@ -22,7 +22,10 @@ import (
 	"github.com/google/trillian/storage/tree"
 )
 
-// NodeBatchAccessor reads and writes batches of Merkle tree node hashes.
+// NodeBatchAccessor reads and writes batches of Merkle tree node hashes. It is
+// a batch interface for efficiency reasons, as it is designed to guard tree
+// storage / database access. The Writer type operates on a per-shard basis,
+// i.e. it calls Get and Set method exactly once for each shard.
 type NodeBatchAccessor interface {
 	// Get returns the hashes of the given nodes, as a map keyed by their IDs.
 	// The returned hashes may be missing or be nil for empty subtrees.
@@ -31,49 +34,41 @@ type NodeBatchAccessor interface {
 	Set(upd []NodeUpdate) error
 }
 
-// Writer handles sharded writes to a sparse Merkle tree.
+// Writer handles sharded writes to a sparse Merkle tree. The tree has two
+// levels of shards: the single topmost shard spanning depths from 0 to split,
+// and 2^split second-level shards each spanning levels from split to height.
+// If the split height is 0 then effectively there is only one "global" shard.
 type Writer struct {
 	treeID int64
 	hasher hashers.MapHasher
-	// depths maps the depth of "leaf" nodes of a shard to its root depth.
-	depths map[uint]uint
+	height uint // The height of the tree.
+	split  uint // The height of the top shard.
 }
 
 // NewWriter creates a new Writer for the specified tree of the given height,
-// with 2 levels of sharding. One shard spans the the upper levels down to
-// split point, and all the other shards span the levels below.
+// with two levels of sharding, where the upper shard is `split` levels high.
 func NewWriter(treeID int64, hasher hashers.MapHasher, height, split uint) *Writer {
 	if split > height {
 		panic(fmt.Errorf("NewWriter: split(%d) > height(%d)", split, height))
 	}
-	depths := map[uint]uint{height: split, split: 0}
-	return &Writer{treeID: treeID, hasher: hasher, depths: depths}
+	return &Writer{treeID: treeID, hasher: hasher, height: height, split: split}
 }
 
 // Split sorts and splits the given list of node hash updates into shards, i.e.
 // the subsets belonging to different subtrees. The updates must belong to the
-// same tree level, one of the sharding split points. For example, with a
-// 2-level sharding it only makes sense to Split leaf updates.
+// same tree level which is equal to the tree height.
 func (w *Writer) Split(upd []NodeUpdate) ([][]NodeUpdate, error) {
-	if len(upd) == 0 { // Nothing to split.
-		return nil, nil
-	}
-	depth := upd[0].ID.BitLen()
-	if err := sortUpdates(upd, depth); err != nil {
+	if err := sortUpdates(upd, w.height); err != nil {
 		return nil, err
-	}
-	top, found := w.depths[depth]
-	if !found {
-		return nil, fmt.Errorf("unexpected depth %d", depth)
 	}
 	// TODO(pavelkalinnikov): Try estimating the capacity for this slice.
 	var shards [][]NodeUpdate
 	// The updates are sorted, so we can split them by prefix.
 	for begin, i := 0, 0; i < len(upd); i++ {
-		pref := upd[i].ID.Prefix(top)
+		pref := upd[i].ID.Prefix(w.split)
 		next := i + 1
 		// Check if this ID ends the shard.
-		if next == len(upd) || upd[next].ID.Prefix(top) != pref {
+		if next == len(upd) || upd[next].ID.Prefix(w.split) != pref {
 			shards = append(shards, upd[begin:next])
 			begin = next
 		}
@@ -83,24 +78,29 @@ func (w *Writer) Split(upd []NodeUpdate) ([][]NodeUpdate, error) {
 
 // Write applies the given list of updates to a single shard, and returns the
 // resulting update of the shard root. It uses the given node accessor for
-// reading and writing tree nodes. Typically, the input updates have been
-// obtained from Split method.
+// reading and writing tree nodes.
+//
+// The typical usage pattern is as follows. For the lower shards, the input is
+// the []NodeUpdate slices returned from the Split method. For the top shard,
+// the input is all the NodeUpdates from the lower shards Write calls.
+//
+// In another case, Write can be performed without Split if the shard split
+// depth is 0, which effectively means that there is only one "global" shard.
 func (w *Writer) Write(upd []NodeUpdate, acc NodeBatchAccessor) (NodeUpdate, error) {
 	if len(upd) == 0 {
 		return NodeUpdate{}, errors.New("nothing to write")
 	}
 	depth := upd[0].ID.BitLen()
-	top, found := w.depths[depth]
-	if !found {
-		return NodeUpdate{}, fmt.Errorf("unexpected depth %d", depth)
+	top, err := w.shardTop(depth)
+	if err != nil {
+		return NodeUpdate{}, err
 	}
 
 	hs, err := NewHStar3(upd, w.hasher.HashChildren, depth, top)
 	if err != nil {
 		return NodeUpdate{}, err
 	}
-	ids := hs.Prepare()
-	nodes, err := acc.Get(ids)
+	nodes, err := acc.Get(hs.Prepare())
 	if err != nil {
 		return NodeUpdate{}, err
 	}
@@ -118,6 +118,17 @@ func (w *Writer) Write(upd []NodeUpdate, acc NodeBatchAccessor) (NodeUpdate, err
 	return topUpd[0], nil
 }
 
+// shardTop returns the depth of a shard top based on its bottom depth.
+func (w *Writer) shardTop(depth uint) (uint, error) {
+	switch depth {
+	case w.height:
+		return w.split, nil
+	case w.split:
+		return 0, nil
+	}
+	return 0, fmt.Errorf("unexpected depth %d", depth)
+}
+
 // newAccessor returns a NodeAccessor for HStar3 algorithm based on the set of
 // preloaded node hashes.
 func (w *Writer) newAccessor(nodes map[tree.NodeID2][]byte) *shardAccessor {
@@ -129,7 +140,8 @@ func (w *Writer) newAccessor(nodes map[tree.NodeID2][]byte) *shardAccessor {
 	return &shardAccessor{w: w, reads: nodes, writes: writes}
 }
 
-// shardAccessor provides read and write access to nodes used by HStar3.
+// shardAccessor provides read and write access to nodes used by HStar3. It
+// operates entirely in-memory.
 type shardAccessor struct {
 	w      *Writer
 	reads  map[tree.NodeID2][]byte

--- a/merkle/smt/writer_test.go
+++ b/merkle/smt/writer_test.go
@@ -62,6 +62,16 @@ func TestWriter(t *testing.T) {
 }
 
 func TestWriterBigBatch(t *testing.T) {
+	testWriterBigBatch(t)
+}
+
+func BenchmarkWriterBigBatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testWriterBigBatch(b)
+	}
+}
+
+func testWriterBigBatch(t testing.TB) {
 	if testing.Short() {
 		t.Skip("BigBatch test is not short")
 	}

--- a/merkle/smt/writer_test.go
+++ b/merkle/smt/writer_test.go
@@ -1,0 +1,132 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/trillian/merkle/maphasher"
+	"github.com/google/trillian/storage/tree"
+	"github.com/google/trillian/testonly"
+	"golang.org/x/sync/errgroup"
+)
+
+const treeID = int64(0)
+
+var (
+	hasher = maphasher.Default
+	b64    = testonly.MustDecodeBase64
+)
+
+func TestWriter(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		upd      []NodeUpdate
+		wantRoot []byte
+	}{
+		{
+			// Taken from SparseMerkleTreeWriter tests.
+			desc:     "non-empty",
+			upd:      []NodeUpdate{genUpd("key1", "value1"), genUpd("key2", "value2"), genUpd("key3", "value3")},
+			wantRoot: b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ="),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := NewWriter(treeID, hasher, 256, 0)
+			rootUpd, err := w.Write(tc.upd, noopAccessor{})
+			if err != nil {
+				t.Fatalf("Split: %v", err)
+			}
+			if got, want := rootUpd.Hash, tc.wantRoot; !bytes.Equal(got, want) {
+				t.Errorf("root mismatch: got %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestWriterBigBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("BigBatch test is not short")
+	}
+
+	const batchSize = 1024
+	const numBatches = 4
+	upd := make([]NodeUpdate, 0, batchSize*numBatches)
+	for x := 0; x < numBatches; x++ {
+		for y := 0; y < batchSize; y++ {
+			u := genUpd(fmt.Sprintf("key-%d-%d", x, y), fmt.Sprintf("value-%d-%d", x, y))
+			upd = append(upd, u)
+		}
+	}
+
+	w := NewWriter(treeID, hasher, 256, 8)
+	shards, err := w.Split(upd)
+	if err != nil {
+		t.Fatalf("Split: %v", err)
+	}
+
+	var mu sync.Mutex
+	splitUpd := make([]NodeUpdate, 0, 256)
+
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, upd := range shards {
+		upd := upd
+		eg.Go(func() error {
+			rootUpd, err := w.Write(upd, noopAccessor{})
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			splitUpd = append(splitUpd, rootUpd)
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	rootUpd, err := w.Write(splitUpd, noopAccessor{})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Calculated using Python code.
+	want := b64("Av30xkERsepT6F/AgbZX3sp91TUmV1TKaXE6QPFfUZA=")
+	if got := rootUpd.Hash; !bytes.Equal(got, want) {
+		t.Errorf("root mismatch: got %x, want %x", got, want)
+	}
+}
+
+// genUpd returns a NodeUpdate for the given key and value. The returned node
+// ID is 256-bit map key based on SHA256 of the given key string.
+func genUpd(key, value string) NodeUpdate {
+	key256 := sha256.Sum256([]byte(key))
+	hash := hasher.HashLeaf(treeID, key256[:], []byte(value))
+	return NodeUpdate{ID: tree.NewNodeID2(string(key256[:]), 256), Hash: hash}
+}
+
+type noopAccessor struct{}
+
+func (n noopAccessor) Get([]tree.NodeID2) (map[tree.NodeID2][]byte, error) {
+	return make(map[tree.NodeID2][]byte), nil
+}
+
+func (n noopAccessor) Set([]NodeUpdate) error { return nil }

--- a/merkle/sparse_merkle_tree.go
+++ b/merkle/sparse_merkle_tree.go
@@ -43,6 +43,9 @@ type SparseMerkleTreeReader struct {
 
 // TXRunner supplies the RunTX function.
 // TXRunner can be passed as the last argument to MapStorage.ReadWriteTransaction.
+//
+// TODO(pavelkalinnikov): This interface violates layering, because it assumes
+// existence of transactions. It must be part of the storage package.
 type TXRunner interface {
 	// RunTX executes f and supplies a transaction object to operate on.
 	RunTX(ctx context.Context, f func(context.Context, storage.MapTreeTX) error) error

--- a/merkle/sparse_merkle_tree_test.go
+++ b/merkle/sparse_merkle_tree_test.go
@@ -38,7 +38,7 @@ var (
 	memprofile = flag.String("memprofile", "", "write mem profile to file")
 )
 
-func maybeProfileCPU(t *testing.T) func() {
+func maybeProfileCPU(t testing.TB) func() {
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
@@ -50,7 +50,7 @@ func maybeProfileCPU(t *testing.T) func() {
 	return func() {}
 }
 
-func maybeProfileMemory(t *testing.T) {
+func maybeProfileMemory(t testing.TB) {
 	if *memprofile != "" {
 		f, err := os.Create(*memprofile)
 		if err != nil {
@@ -421,6 +421,16 @@ func TestSparseMerkleTreeWriterFetchesMultipleLeaves(t *testing.T) {
 }
 
 func TestSparseMerkleTreeWriterBigBatch(t *testing.T) {
+	testSparseMerkleTreeWriterBigBatch(t)
+}
+
+func BenchmarkSparseMerkleTreeWriterBigBatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testSparseMerkleTreeWriterBigBatch(b)
+	}
+}
+
+func testSparseMerkleTreeWriterBigBatch(t testing.TB) {
 	if testing.Short() {
 		t.Skip("BigBatch test is not short")
 	}


### PR DESCRIPTION
This change introduces a sparse Merkle tree `Writer` that uses `HStar3` algorithm.

Key design decisions:
- Use `NodeID2` and `HStar3` because they are fast.
- Use 2-level sharding for simplicity, but allow easy extension if needed at some point.
- Throw away the transaction concept, as it belongs to `storage` / application layers.
- Shift control to the user of this type. This allows, for example, writing different tree shards in different transactions or even machines. See `TestWriterBigBatch` for instance.

In-memory benchmarks show almost a 2x speedup compared to the old `SparseMerkleTreeWriter`:

```
Before:	BenchmarkSparseMerkleTreeWriterBigBatch-12	2	569661060 ns/op
After:	BenchmarkWriterBigBatch-12			4	312185125 ns/op
```