### PR TITLE
Hstar3: Implement a faster Prepare algorithm

### DIFF
--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -78,12 +78,12 @@ func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HSta
 //
 // TODO(pavelkalinnikov): Return only tile IDs.
 func (h HStar3) Prepare() []tree.NodeID2 {
-	empty := tree.NodeID2{}
-
 	// Start with a single "sentinel" empty ID, which helps maintaining the loop
 	// invariants below. Preallocate enough memory to store all the node IDs.
 	ids := make([]tree.NodeID2, 1, len(h.upd)*int(h.depth-h.top)+1)
 	pos := make([]int, h.depth-h.top)
+	// Note: This variable compares equal to ids[0].
+	empty := tree.NodeID2{}
 
 	// For each node, add all its ancestors' siblings, down to the given depth.
 	// Avoid duplicate IDs, and possibly remove already added ones if they become
@@ -91,8 +91,8 @@ func (h HStar3) Prepare() []tree.NodeID2 {
 	//
 	// Loop invariants:
 	// 1. pos[idx] < len(ids), for each idx.
-	// 2. ids[pos[idx]] is the ID of the rightmost sibling at depth idx+h.top+1,
-	//    or an empty ID if there is none at this depth yet.
+	// 2. ids[pos[idx]] is the ID of the rightmost sibling at depth idx+h.top+1
+	//    added so far, or an empty ID if there is none at this depth yet.
 	//
 	// Note: The algorithm works because the list of updates is sorted.
 	for _, upd := range h.upd {

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -78,7 +78,8 @@ func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HSta
 // TODO(pavelkalinnikov): Return only tile IDs.
 func (h HStar3) Prepare() []tree.NodeID2 {
 	empty := tree.NodeID2{}
-	ids := []tree.NodeID2{empty} // Start with a dummy sentinel value.
+	// Start with a dummy sentinel value.
+	ids := make([]tree.NodeID2, 1, len(h.upd)*int(h.depth-h.top)+1)
 	pos := make([]int, h.depth-h.top)
 
 	// For each node, add all its ancestors' siblings, down to the given depth.

--- a/merkle/smt/hstar3.go
+++ b/merkle/smt/hstar3.go
@@ -72,8 +72,9 @@ func NewHStar3(updates []NodeUpdate, hash HashChildrenFn, depth, top uint) (HSta
 
 // Prepare returns the list of all the node IDs that the Update method will
 // load in order to compute node hash updates from the initial tree depth up to
-// the top level specified in the constructor. It may be useful for creating a
-// a NodeAccessor, e.g. by batch-reading the nodes from elsewhere.
+// the top level specified in the constructor. The ordering of the returned IDs
+// is arbitrary. This method may be useful for creating a NodeAccessor, e.g.
+// by batch-reading the nodes from elsewhere.
 //
 // TODO(pavelkalinnikov): Return only tile IDs.
 func (h HStar3) Prepare() []tree.NodeID2 {

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -31,15 +31,15 @@ import (
 type emptyNodes struct {
 	treeID int64
 	hasher hashers.MapHasher
-	hashes map[tree.NodeID2][]byte
+	ids    map[tree.NodeID2]bool
 }
 
 func (e *emptyNodes) Get(id tree.NodeID2) ([]byte, error) {
-	if e.hashes != nil {
-		if _, ok := e.hashes[id]; !ok {
+	if e.ids != nil {
+		if !e.ids[id] {
 			return nil, fmt.Errorf("not found or read twice: %v", id)
 		}
-		delete(e.hashes, id) // Allow getting this ID only once.
+		delete(e.ids, id) // Allow getting this ID only once.
 	}
 	index := make([]byte, e.hasher.Size())
 	copy(index, id.FullBytes())
@@ -144,14 +144,55 @@ func TestHStar3Prepare(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHStar3: %v", err)
 	}
-	rs := hs.Prepare()
+	rs := idsToMap(t, hs.Prepare())
 
-	nodes := &emptyNodes{treeID: 42, hasher: hasher, hashes: rs}
+	nodes := &emptyNodes{treeID: 42, hasher: hasher, ids: rs}
 	if _, err = hs.Update(nodes); err != nil {
 		t.Errorf("Update: %v", err)
 	}
-	if got := len(nodes.hashes); got != 0 {
-		t.Errorf("%d hashes were not read", got)
+	if got := len(nodes.ids); got != 0 {
+		t.Errorf("%d ids were not read", got)
+	}
+}
+
+func TestHStar3PrepareAlternative(t *testing.T) {
+	// This is the intuitively simpler alternative Prepare implementation.
+	prepare := func(updates []NodeUpdate, depth, top uint) map[tree.NodeID2]bool {
+		ids := make(map[tree.NodeID2]bool)
+		// For each node, add all its ancestors' siblings, down to the given depth.
+		for _, upd := range updates {
+			for id, d := upd.ID, depth; d > top; d-- {
+				pref := id.Prefix(d)
+				if _, ok := ids[pref]; ok {
+					// Delete the prefix node because its original hash does not contribute
+					// to the updates, so should not be read.
+					delete(ids, pref)
+					// All the upper siblings have been added already, so skip them.
+					break
+				}
+				ids[pref.Sibling()] = true
+			}
+		}
+		return ids
+	}
+
+	for n := 0; n <= 32; n++ {
+		upd := leafUpdates(t, n)
+		hs, err := NewHStar3(upd, nil, 256, 8)
+		if err != nil {
+			t.Fatalf("NewHStar3: %v", err)
+		}
+		ids := prepare(upd, 256, 8)
+		got := hs.Prepare()
+		for _, id := range got {
+			if !ids[id] {
+				t.Fatalf("not found: %v", id)
+			}
+			delete(ids, id)
+		}
+		if ln := len(ids); ln != 0 {
+			t.Fatalf("%d IDs left", ln)
+		}
 	}
 }
 
@@ -187,4 +228,16 @@ func leafUpdates(t testing.TB, n int) []NodeUpdate {
 	}
 
 	return updates
+}
+
+func idsToMap(t testing.TB, ids []tree.NodeID2) map[tree.NodeID2]bool {
+	t.Helper()
+	res := make(map[tree.NodeID2]bool, len(ids))
+	for _, id := range ids {
+		if res[id] {
+			t.Errorf("ID duplicate: %v", id)
+		}
+		res[id] = true
+	}
+	return res
 }

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -177,22 +177,18 @@ func TestHStar3PrepareAlternative(t *testing.T) {
 	}
 
 	for n := 0; n <= 32; n++ {
-		upd := leafUpdates(t, n)
-		hs, err := NewHStar3(upd, nil, 256, 8)
-		if err != nil {
-			t.Fatalf("NewHStar3: %v", err)
-		}
-		ids := prepare(upd, 256, 8)
-		got := hs.Prepare()
-		for _, id := range got {
-			if !ids[id] {
-				t.Fatalf("not found: %v", id)
+		t.Run(fmt.Sprintf("n:%d", n), func(t *testing.T) {
+			upd := leafUpdates(t, n)
+			hs, err := NewHStar3(upd, nil, 256, 8)
+			if err != nil {
+				t.Fatalf("NewHStar3: %v", err)
 			}
-			delete(ids, id)
-		}
-		if ln := len(ids); ln != 0 {
-			t.Fatalf("%d IDs left", ln)
-		}
+			ids := prepare(upd, 256, 8)
+			got := idsToMap(t, hs.Prepare())
+			if !reflect.DeepEqual(got, ids) {
+				t.Error("IDs mismatch")
+			}
+		})
 	}
 }
 

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -155,6 +155,17 @@ func TestHStar3Prepare(t *testing.T) {
 	}
 }
 
+func BenchmarkHStar3Prepare(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		updates := leafUpdates(b, 512)
+		hs, err := NewHStar3(updates, nil, 256, 0)
+		if err != nil {
+			b.Fatalf("NewHStar3: %v", err)
+		}
+		_ = hs.Prepare()
+	}
+}
+
 // leafUpdates generates n leaf updates at depth 256. The function is
 // pseudo-random, and the returned data depends only on n. The algorithm is the
 // same as in HStar2 tests, which allows cross-checking their results.


### PR DESCRIPTION
This change implements a faster `Prepare` algorithm that generates the slice of nodes straight away without using a Golang `map`.

The benchmark introduced in this PR shows a 10x speedup of `Prepare`:

```
Before:	BenchmarkHStar3Prepare-12    	      19	  59717482 ns/op
After:	BenchmarkHStar3Prepare-12    	     189	   5793267 ns/op
```