### PR TITLE
Always create a write batch of at least MinLeaves

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -663,7 +663,9 @@ leafloop:
 			// Not allowed to have the same key more than once in the same request
 			for _, leaf := range leaves {
 				if bytes.Equal(leaf.Index, key) {
-					break leafloop
+					// Go back to the beginning of the loop and choose again.
+					i--
+					continue leafloop
 				}
 			}
 			var value, extra []byte


### PR DESCRIPTION
This would often bail out of the batch generation much earlier because of a collision. It sounds like it should be unlikely but its the birthday paradox/pigeon hole principle; each time we update or delete a leaf in this loop, with (2/3) chance, then we pick from n previous keys. Once we have picked more than ~sqrt(n) leaves to update or delete, we have ~50% chance of a collision. Never tell me the odds.

This fix isn't massively efficient, but in the event we get a collision it restarts this iteration of the loop but will have different values from the prng so avoids looping forever because it would eventually creates all new leaves, even if every update/delete selection was a duplicate.
