### PR TITLE
Refactor invalid ops into separate class

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -498,9 +498,9 @@ type readOps interface {
 	getSMRRev(context.Context, *rand.Rand) error
 }
 
-type setLeaves func(context.Context, *rand.Rand) error
+type setLeavesFn func(context.Context, *rand.Rand) error
 
-func performOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand, read readOps, write setLeaves) error {
+func performOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand, read readOps, write setLeavesFn) error {
 	switch ep {
 	case GetLeavesName:
 		return read.getLeaves(ctx, prng)
@@ -514,7 +514,7 @@ func performOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand, read 
 		// TODO(mhutchinson): This mutation method needs to be removed from here.
 		return write(ctx, prng)
 	default:
-		return fmt.Errorf("internal error: unknown entrypoint %s selected for operation", ep)
+		return fmt.Errorf("internal error: unknown operation %s", ep)
 	}
 }
 

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -511,13 +511,13 @@ func (s *hammerState) performOp(ctx context.Context, ep MapEntrypointName, prng 
 func (s *hammerState) performInvalidOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand) error {
 	switch ep {
 	case GetLeavesName:
-		return s.invalidReadOps.getLeavesInvalid(ctx, prng)
+		return s.invalidReadOps.getLeaves(ctx, prng)
 	case GetLeavesRevName:
-		return s.invalidReadOps.getLeavesRevInvalid(ctx, prng)
+		return s.invalidReadOps.getLeavesRev(ctx, prng)
 	case GetSMRName:
-		return s.invalidReadOps.getSMRInvalid(ctx, prng)
+		return s.invalidReadOps.getSMR(ctx, prng)
 	case GetSMRRevName:
-		return s.invalidReadOps.getSMRRevInvalid(ctx, prng)
+		return s.invalidReadOps.getSMRRev(ctx, prng)
 	case SetLeavesName:
 		return s.setLeavesInvalid(ctx, prng)
 	default:

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -514,7 +514,7 @@ func performOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand, read 
 		// TODO(mhutchinson): This mutation method needs to be removed from here.
 		return write(ctx, prng)
 	default:
-		return fmt.Errorf("internal error: unknown entrypoint %s selected for valid request", ep)
+		return fmt.Errorf("internal error: unknown entrypoint %s selected for operation", ep)
 	}
 }
 

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -254,8 +254,9 @@ func HitMap(ctx context.Context, cfg MapConfig) error {
 
 // hammerState tracks the operations that have been performed during a test run.
 type hammerState struct {
-	cfg          *MapConfig
-	validReadOps *validReadOps
+	cfg            *MapConfig
+	validReadOps   *validReadOps
+	invalidReadOps *invalidReadOps
 
 	start time.Time
 
@@ -316,14 +317,21 @@ func newHammerState(ctx context.Context, cfg *MapConfig) (*hammerState, error) {
 		prevContents: &prevContents,
 		smrs:         &smrs,
 	}
-
-	return &hammerState{
-		cfg:          cfg,
-		start:        time.Now(),
-		prng:         rand.New(cfg.RandSource),
+	invalidReadOps := invalidReadOps{
+		mapID:        cfg.MapID,
+		client:       cfg.Client,
 		prevContents: &prevContents,
 		smrs:         &smrs,
-		validReadOps: &validReadOps,
+	}
+
+	return &hammerState{
+		cfg:            cfg,
+		start:          time.Now(),
+		prng:           rand.New(cfg.RandSource),
+		prevContents:   &prevContents,
+		smrs:           &smrs,
+		validReadOps:   &validReadOps,
+		invalidReadOps: &invalidReadOps,
 	}, nil
 }
 
@@ -503,68 +511,18 @@ func (s *hammerState) performOp(ctx context.Context, ep MapEntrypointName, prng 
 func (s *hammerState) performInvalidOp(ctx context.Context, ep MapEntrypointName, prng *rand.Rand) error {
 	switch ep {
 	case GetLeavesName:
-		return s.getLeavesInvalid(ctx, prng)
+		return s.invalidReadOps.getLeavesInvalid(ctx, prng)
 	case GetLeavesRevName:
-		return s.getLeavesRevInvalid(ctx, prng)
+		return s.invalidReadOps.getLeavesRevInvalid(ctx, prng)
+	case GetSMRName:
+		return s.invalidReadOps.getSMRInvalid(ctx, prng)
+	case GetSMRRevName:
+		return s.invalidReadOps.getSMRRevInvalid(ctx, prng)
 	case SetLeavesName:
 		return s.setLeavesInvalid(ctx, prng)
-	case GetSMRRevName:
-		return s.getSMRRevInvalid(ctx, prng)
-	case GetSMRName:
-		return fmt.Errorf("no invalid request possible for entrypoint %s", ep)
 	default:
 		return fmt.Errorf("internal error: unknown entrypoint %s selected for invalid request", ep)
 	}
-}
-
-func (s *hammerState) getLeavesInvalid(ctx context.Context, prng *rand.Rand) error {
-	key := testonly.TransparentHash("..invalid-size")
-	req := trillian.GetMapLeavesRequest{
-		MapId: s.cfg.MapID,
-		Index: [][]byte{key[2:]},
-	}
-	rsp, err := s.cfg.Client.GetLeaves(ctx, &req)
-	if err == nil {
-		return fmt.Errorf("unexpected success: get-leaves(MalformedKey: %+v): %+v", req, rsp.MapRoot)
-	}
-	glog.V(2).Infof("%d: expected failure: get-leaves(MalformedKey: %+v): %+v", s.cfg.MapID, req, rsp)
-	return nil
-}
-
-func (s *hammerState) getLeavesRevInvalid(ctx context.Context, prng *rand.Rand) error {
-	choices := []Choice{MalformedKey, RevTooBig, RevIsNegative}
-
-	req := trillian.GetMapLeavesByRevisionRequest{MapId: s.cfg.MapID}
-	contents := s.prevContents.LastCopy()
-	choice := choices[prng.Intn(len(choices))]
-
-	rev := int64(0)
-	var index []byte
-	if contents.Empty() {
-		// No contents so we can't choose a key
-		choice = MalformedKey
-	} else {
-		rev = contents.Rev
-		index = contents.PickKey(prng)
-	}
-	switch choice {
-	case MalformedKey:
-		key := testonly.TransparentHash("..invalid-size")
-		req.Index = [][]byte{key[2:]}
-		req.Revision = rev
-	case RevTooBig:
-		req.Index = [][]byte{index}
-		req.Revision = rev + invalidStretch
-	case RevIsNegative:
-		req.Index = [][]byte{index}
-		req.Revision = -rev - invalidStretch
-	}
-	rsp, err := s.cfg.Client.GetLeavesByRevision(ctx, &req)
-	if err == nil {
-		return fmt.Errorf("unexpected success: get-leaves-rev(%v: %+v): %+v", choice, req, rsp.MapRoot)
-	}
-	glog.V(2).Infof("%d: expected failure: get-leaves-rev(%v: %+v): %+v", s.cfg.MapID, choice, req, rsp)
-	return nil
 }
 
 func (s *hammerState) setLeaves(ctx context.Context, prng *rand.Rand) error {
@@ -663,32 +621,6 @@ func (s *hammerState) setLeavesInvalid(ctx context.Context, prng *rand.Rand) err
 		return fmt.Errorf("unexpected success: set-leaves(%v: %+v): %+v", choice, req, rsp.Revision)
 	}
 	glog.V(2).Infof("%d: expected failure: set-leaves(%v: %+v): %+v", s.cfg.MapID, choice, req, rsp)
-	return nil
-}
-
-func (s *hammerState) getSMRRevInvalid(ctx context.Context, prng *rand.Rand) error {
-	choices := []Choice{RevTooBig, RevIsNegative}
-
-	rev := latestRevision
-	contents := s.prevContents.LastCopy()
-	if contents != nil {
-		rev = contents.Rev
-	}
-
-	choice := choices[prng.Intn(len(choices))]
-
-	switch choice {
-	case RevTooBig:
-		rev += invalidStretch
-	case RevIsNegative:
-		rev = -invalidStretch
-	}
-	req := trillian.GetSignedMapRootByRevisionRequest{MapId: s.cfg.MapID, Revision: rev}
-	rsp, err := s.cfg.Client.GetSignedMapRootByRevision(ctx, &req)
-	if err == nil {
-		return fmt.Errorf("unexpected success: get-smr-rev(%v: @%d): %+v", choice, rev, rsp.MapRoot)
-	}
-	glog.V(2).Infof("%d: expected failure: get-smr-rev(%v: @%d): %+v", s.cfg.MapID, choice, rev, rsp)
 	return nil
 }
 

--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -165,7 +165,7 @@ type invalidReadOps struct {
 	smrs         *smrStash
 }
 
-func (o *invalidReadOps) getLeavesInvalid(ctx context.Context, prng *rand.Rand) error {
+func (o *invalidReadOps) getLeaves(ctx context.Context, prng *rand.Rand) error {
 	key := testonly.TransparentHash("..invalid-size")
 	req := trillian.GetMapLeavesRequest{
 		MapId: o.mapID,
@@ -179,7 +179,7 @@ func (o *invalidReadOps) getLeavesInvalid(ctx context.Context, prng *rand.Rand) 
 	return nil
 }
 
-func (o *invalidReadOps) getLeavesRevInvalid(ctx context.Context, prng *rand.Rand) error {
+func (o *invalidReadOps) getLeavesRev(ctx context.Context, prng *rand.Rand) error {
 	choices := []Choice{MalformedKey, RevTooBig, RevIsNegative}
 
 	req := trillian.GetMapLeavesByRevisionRequest{MapId: o.mapID}
@@ -215,7 +215,7 @@ func (o *invalidReadOps) getLeavesRevInvalid(ctx context.Context, prng *rand.Ran
 	return nil
 }
 
-func (o *invalidReadOps) getSMRRevInvalid(ctx context.Context, prng *rand.Rand) error {
+func (o *invalidReadOps) getSMRRev(ctx context.Context, prng *rand.Rand) error {
 	choices := []Choice{RevTooBig, RevIsNegative}
 
 	rev := latestRevision
@@ -241,6 +241,6 @@ func (o *invalidReadOps) getSMRRevInvalid(ctx context.Context, prng *rand.Rand) 
 	return nil
 }
 
-func (o *invalidReadOps) getSMRInvalid(ctx context.Context, prng *rand.Rand) error {
+func (o *invalidReadOps) getSMR(ctx context.Context, prng *rand.Rand) error {
 	return errors.New("no invalid request possible for getSMR")
 }


### PR DESCRIPTION
This finishes off what was hinted at by the work started in #1886. This removes logic from the hammer class, and removes duplication of switching.

The next stage will be to break out the write functionality so that it is only called by the main thread, and the read methods will only be used by the checkers threads. This heads towards the design in #1880.