### PR TITLE
Refactor: Choose the operation separately to invoking it

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -443,10 +443,6 @@ func (s *hammerState) retryOneOp(ctx context.Context) (err error) {
 	}
 
 	glog.V(3).Infof("%d: perform %s operation", s.cfg.MapID, ep)
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	return s.retryOp(ctx, op, string(ep))
 }
 
@@ -454,6 +450,9 @@ func (s *hammerState) retryOp(ctx context.Context, fn mapOperationFn, opName str
 	defer func(start time.Time) {
 		rspLatency.Observe(time.Since(start).Seconds(), s.label(), opName)
 	}(time.Now())
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	deadline := time.Now().Add(s.cfg.OperationDeadline)
 	seed := s.prng.Int63()


### PR DESCRIPTION
This allows the retryOp method to be more easily reused between the write and read.

The next step is to move the main thread to only perform writes and the checkers to only perform reads, according to a random selection. This requires even more refactoring though, as the hammerState.prng is only supposed to be used by the main thread, but it can be accessed from anywhere that has hammerState. If I switch this over now, the tests will stop being deterministic given a seed.