### PR TITLE
MapHasher: Define index parameter of HashEmpty

### DIFF
--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -35,9 +35,18 @@ type LogHasher interface {
 
 // MapHasher provides the hash functions needed to compute sparse merkle trees.
 type MapHasher interface {
-	// HashEmpty returns the hash of an empty branch at a given depth.
-	// A height of 0 indicates an empty leaf. The maximum height is Size*8.
-	// TODO(gbelvin) fully define index.
+	// HashEmpty returns the hash of an empty subtree of the given height. The
+	// location of the subtree root is defined by the index parameter, which
+	// encodes the path from the tree root to the node as a bit sequence of
+	// length BitLen()-height. Note that a height of 0 indicates a leaf.
+	//
+	// Each byte of index is considered from MSB to LSB. The last byte might be
+	// used partially, but the unused bits must be zero. If index contains more
+	// bytes than necessary then the remaining bytes are ignored. May panic if
+	// the index is too short for the specified height.
+	//
+	// TODO(pavelkalinnikov): Pass in NodeID2 which type-safely defines index and
+	// height/depth simultaneously.
 	HashEmpty(treeID int64, index []byte, height int) []byte
 	// HashLeaf computes the hash of a leaf that exists.  This method
 	// is *not* used for computing the hash of a leaf that does not exist

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -57,15 +57,16 @@ func (m *MapHasher) String() string {
 	return fmt.Sprintf("MapHasher{%v}", m.Hash)
 }
 
-// HashEmpty returns the hash of an empty branch at a given depth.
-// A depth of 0 indicates the hash of an empty leaf.
-// Empty branches within the tree are plain interior nodes e1 = H(e0, e0) etc.
+// HashEmpty returns the hash of an empty subtree of the given height, e.g. the
+// height of 0 indicates an empty leaf. For this hasher, the result depends
+// only on height. The treeID and index, i.e. the precise position of this
+// subtree, are ignored.
 func (m *MapHasher) HashEmpty(treeID int64, index []byte, height int) []byte {
 	if height < 0 || height >= len(m.nullHashes) {
 		panic(fmt.Sprintf("HashEmpty(%v) out of bounds", height))
 	}
-	depth := m.BitLen() - height
 	if glog.V(5) {
+		depth := m.BitLen() - height
 		glog.Infof("HashEmpty(%x, %d): %x", index, depth, m.nullHashes[height])
 	}
 	return m.nullHashes[height]


### PR DESCRIPTION
This PR precisely defines the semantic of `HashEmpty` method of `MapHasher` interface.

It also makes CONIKS method a bit laxer, as it doesn't make sense to force `index` parameter being the same length always regardless of the tree level.