### PR TITLE
Add and use NodeID/NodeID2 conversion

### DIFF
--- a/merkle/smt/writer.go
+++ b/merkle/smt/writer.go
@@ -165,11 +165,7 @@ func (s *shardAccessor) Set(id tree.NodeID2, hash []byte) {
 
 // TODO(pavelkalinnikov): Make MapHasher.HashEmpty method take the id directly.
 func hashEmpty(hasher hashers.MapHasher, treeID int64, id tree.NodeID2) []byte {
-	index := make([]byte, hasher.Size())
-	copy(index, id.FullBytes())
-	if last, bits := id.LastByte(); bits != 0 {
-		index[len(id.FullBytes())] = last
-	}
-	height := hasher.BitLen() - int(id.BitLen())
-	return hasher.HashEmpty(treeID, index, height)
+	oldID := tree.NewNodeIDFromID2(id)
+	height := hasher.BitLen() - oldID.PrefixLenBits
+	return hasher.HashEmpty(treeID, oldID.Path, height)
 }

--- a/storage/tree/node.go
+++ b/storage/tree/node.go
@@ -201,6 +201,23 @@ loop:
 	}
 }
 
+// NewNodeIDFromID2 constructs a NodeID from a NodeID2.
+func NewNodeIDFromID2(id NodeID2) NodeID {
+	bytes := id.FullBytes()
+	last, bits := id.LastByte()
+	path := make([]byte, len(bytes)+int(bits+7)/8)
+	copy(path, bytes)
+	if bits != 0 {
+		path[len(bytes)] = last
+	}
+	return NodeID{Path: path, PrefixLenBits: int(id.BitLen())}
+}
+
+// ToNodeID2 converts the ID to NodeID2.
+func (n NodeID) ToNodeID2() NodeID2 {
+	return NewNodeID2(string(n.Path), uint(n.PrefixLenBits))
+}
+
 // BigInt returns the big.Int for this node.
 func (n NodeID) BigInt() *big.Int {
 	return new(big.Int).SetBytes(n.Path)

--- a/storage/tree/node.go
+++ b/storage/tree/node.go
@@ -203,12 +203,10 @@ loop:
 
 // NewNodeIDFromID2 constructs a NodeID from a NodeID2.
 func NewNodeIDFromID2(id NodeID2) NodeID {
-	bytes := id.FullBytes()
-	last, bits := id.LastByte()
-	path := make([]byte, len(bytes)+int(bits+7)/8)
-	copy(path, bytes)
-	if bits != 0 {
-		path[len(bytes)] = last
+	path := make([]byte, bytesForBits(int(id.BitLen())))
+	copy(path, id.FullBytes())
+	if last, bits := id.LastByte(); bits != 0 {
+		path[len(path)-1] = last
 	}
 	return NodeID{Path: path, PrefixLenBits: int(id.BitLen())}
 }

--- a/storage/tree/node_test.go
+++ b/storage/tree/node_test.go
@@ -772,6 +772,30 @@ func TestCoordString(t *testing.T) {
 	}
 }
 
+func TestNodeIDFromAndToNodeID2(t *testing.T) {
+	const bytes = "\x0A\xBC\x5D\x00\x11"
+	for bits := 0; bits <= len(bytes)*8; bits++ {
+		t.Run(fmt.Sprintf("bits:%d", bits), func(t *testing.T) {
+			id := NewNodeID2(bytes, uint(bits))
+			wantBytes := id.FullBytes()
+			if last, bits := id.LastByte(); bits != 0 {
+				wantBytes += string([]byte{last})
+			}
+
+			oldID := NewNodeIDFromID2(id)
+			if got, want := string(oldID.Path), wantBytes; got != want {
+				t.Errorf("NewNodeIDFromID2: got bytes %x, want %x", got, want)
+			}
+			if got, want := uint(oldID.PrefixLenBits), id.BitLen(); got != want {
+				t.Errorf("NewNodeIDFromID2: got %d bits, want %d", got, want)
+			}
+			if got, want := oldID.ToNodeID2(), id; got != want {
+				t.Errorf("ToNodeID2: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func h2b(h string) []byte {
 	b, err := hex.DecodeString(h)
 	if err != nil {


### PR DESCRIPTION
This PR adds conversion between `NodeID` and `NodeID2`. It is necessary to integrate new sparse Merkle tree `Writer` on `HStar3` without breaking `storage` API (yet).