### PR TITLE
Added extra checks for bad states

### DIFF
--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -115,10 +115,7 @@ func (o *validReadOps) getSMR(ctx context.Context, prng *rand.Rand) error {
 	}
 	glog.V(2).Infof("%d: got SMR(time=%q, rev=%d)", o.mc.MapID, time.Unix(0, int64(root.TimestampNanos)), root.Revision)
 
-	if err := o.verify(root); err != nil {
-		return err
-	}
-	return nil
+	return o.verify(root)
 }
 
 // getSMRRev randomly chooses a previously seen SMR from the queue and checks that
@@ -147,6 +144,9 @@ func (o *validReadOps) getSMRRev(ctx context.Context, prng *rand.Rand) error {
 
 func (o *validReadOps) verify(root *types.MapRootV1) error {
 	mapContents := o.prevContents.PickRevision(root.Revision)
+	if root.Revision > 1 && mapContents == nil {
+		return fmt.Errorf("unexpected missing previous contents for revision %d", root.Revision)
+	}
 	want, err := mapContents.RootHash(o.mc.MapID, o.mc.Hasher)
 	if err != nil {
 		return err

--- a/testonly/mapcontents.go
+++ b/testonly/mapcontents.go
@@ -303,12 +303,12 @@ func (p *VersionedMapContents) UpdateContentsWith(rev uint64, leaves []*trillian
 	if rev < 1 {
 		return nil, ErrInvariant{fmt.Sprintf("got rev %d, want >=1 when trying to update hammer state with contents", rev)}
 	}
-	if p.contents[0] == nil {
-		if rev != 1 {
-			return nil, ErrInvariant{fmt.Sprintf("got rev %d, want 1 when trying to update hammer state with new contents", rev)}
-		}
-	} else if want := p.contents[0].Rev + 1; int64(rev) != want {
-		return nil, ErrInvariant{fmt.Sprintf("got rev %d, want %d when trying to update hammer state with new contents", rev, want)}
+	nextRev := uint64(1)
+	if c := p.contents[0]; c != nil {
+		nextRev = uint64(c.Rev + 1)
+	}
+	if rev != nextRev {
+		return nil, ErrInvariant{fmt.Sprintf("got rev %d, want %d when trying to update hammer state with new contents", rev, nextRev)}
 	}
 
 	// Shuffle earlier contents along.


### PR DESCRIPTION
This makes the code do what the comment implied was going to happen. Any missing revisions would be bad news given how these previous contents are used for checking map correctness.

None of this is triggered as the hammer is currently set up, but you may be surprised to learn that making the hammer properly concurrent will trigger some of these.

Also took the opportunity to simplify a little code that impaired readability.
