### PR TITLE
The Map Client now returns the SMR when fetching leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The verifiable map is still experimental. APIs have been deprecated and will be
 deleted in the near future. These changes will not affect the Trillian module
 semantic version due to the experimental status of the Map.
 
+The map client has been updated so that GetAndVerifyMapLeaves and
+GetAndVerifyMapLeavesByRevision return the MapRoot for the revision at which the
+leaves were fetched. Without this callers of GetAndVerifyMapLeaves in particular
+were unable to reason about which map revision they were seeing.
+
 ## v1.3.2 - Module fixes
 
 Published 2019-09-05 17:30:00 +0000 UTC

--- a/client/map_client.go
+++ b/client/map_client.go
@@ -72,21 +72,21 @@ func (c *MapClient) GetAndVerifyMapRootByRevision(ctx context.Context, revision 
 
 // GetAndVerifyMapLeaves verifies and returns the requested map leaves.
 // indexes may not contain duplicates.
-func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte) ([]*trillian.MapLeaf, error) {
+func (c *MapClient) GetAndVerifyMapLeaves(ctx context.Context, indexes [][]byte) ([]*trillian.MapLeaf, *types.MapRootV1, error) {
 	getResp, err := c.Conn.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
 		MapId: c.MapID,
 		Index: indexes,
 	})
 	if err != nil {
 		s := status.Convert(err)
-		return nil, status.Errorf(s.Code(), "map.GetLeaves(): %v", s.Message())
+		return nil, nil, status.Errorf(s.Code(), "map.GetLeaves(): %v", s.Message())
 	}
 	return c.VerifyMapLeavesResponse(indexes, -1, getResp)
 }
 
 // GetAndVerifyMapLeavesByRevision verifies and returns the requested map leaves at a specific revision.
 // indexes may not contain duplicates.
-func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, error) {
+func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revision int64, indexes [][]byte) ([]*trillian.MapLeaf, *types.MapRootV1, error) {
 	getResp, err := c.Conn.GetLeavesByRevision(ctx, &trillian.GetMapLeavesByRevisionRequest{
 		MapId:    c.MapID,
 		Index:    indexes,
@@ -94,7 +94,7 @@ func (c *MapClient) GetAndVerifyMapLeavesByRevision(ctx context.Context, revisio
 	})
 	if err != nil {
 		s := status.Convert(err)
-		return nil, status.Errorf(s.Code(), "map.GetLeaves(): %v", s.Message())
+		return nil, nil, status.Errorf(s.Code(), "map.GetLeaves(): %v", s.Message())
 	}
 	return c.VerifyMapLeavesResponse(indexes, revision, getResp)
 }

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -159,7 +159,7 @@ func TestGetLeavesAtRevision(t *testing.T) {
 		{desc: "2", indexes: [][]byte{index, index}, wantCode: codes.InvalidArgument},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			leaves, err := client.GetAndVerifyMapLeaves(ctx, tc.indexes)
+			leaves, _, err := client.GetAndVerifyMapLeaves(ctx, tc.indexes)
 			if status.Code(err) != tc.wantCode {
 				t.Fatalf("GetAndVerifyMapLeavesAtRevision(): %v, wantErr %v", err, tc.wantCode)
 			}


### PR DESCRIPTION
This allows clients to be sure which version of the map they are seeing. This is known in the case of GetAndVerifyMapLeavesByRevision, but for GetAndVerifyMapLeaves the caller was completely blind to this. It was causing problems in the Hammer, and it seems likely other clients will want this. If they don't, it can be easily ignored.

This is a breaking API change, but the Map is experimental and the CHANGELOG has been updated.

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
