### PR TITLE
Made the tests more deterministic

### DIFF
--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -61,7 +61,7 @@ func TestRetryExposesDeadlineError(t *testing.T) {
 		},
 	}
 
-	seed := time.Now().UTC().UnixNano() & 0xFFFFFFFF
+	seed := int64(99)
 	cfg := MapConfig{
 		MapID:         0, // ephemeral tree
 		Client:        env.Map,
@@ -112,7 +112,7 @@ func TestInProcessMapHammer(t *testing.T) {
 		},
 	}
 
-	seed := time.Now().UTC().UnixNano() & 0xFFFFFFFF
+	seed := int64(99)
 	cfg := MapConfig{
 		MapID:         0, // ephemeral tree
 		Client:        env.Map,


### PR DESCRIPTION
Using a random seed is great for the proper integration tests, and that property is maintained in maphammer/main.go. These tests are really checking that the hammer doesn't fail catastrophically when running briefly, and these should be as deterministic as possible (within the constraints of multi-threading).