### PR TITLE
Hammer supports writer getting ahead of published SMR

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -473,12 +473,10 @@ type hammerState struct {
 	cfg            *MapConfig
 	validReadOps   *validReadOps
 	invalidReadOps *invalidReadOps
+	gossipHub      *gossipHub
+	head           *testonly.MapContents // TODO(mhutchinson): This should move to writeWorker.
 
 	start time.Time
-
-	// copies of earlier contents of the map
-	prevContents *testonly.VersionedMapContents
-	smrs         *smrStash
 
 	mu sync.RWMutex // Protects everything below
 
@@ -519,28 +517,26 @@ func newHammerState(ctx context.Context, cfg *MapConfig) (*hammerState, error) {
 		cfg.OperationDeadline = 60 * time.Second
 	}
 
-	var prevContents testonly.VersionedMapContents
-	var smrs smrStash
+	gossipHub := newGossipHub()
 	validReadOps := validReadOps{
 		mc:           mc,
 		extraSize:    cfg.ExtraSize,
 		minLeaves:    cfg.MinLeaves,
 		maxLeaves:    cfg.MaxLeaves,
-		prevContents: &prevContents,
-		smrs:         &smrs,
+		prevContents: gossipHub.contents,
+		gossipHub:    gossipHub,
 	}
 	invalidReadOps := invalidReadOps{
 		mapID:        cfg.MapID,
 		client:       cfg.Client,
-		prevContents: &prevContents,
-		smrs:         &smrs,
+		prevContents: gossipHub.contents,
+		gossipHub:    gossipHub,
 	}
 
 	return &hammerState{
 		cfg:            cfg,
 		start:          time.Now(),
-		prevContents:   &prevContents,
-		smrs:           &smrs,
+		gossipHub:      gossipHub,
 		validReadOps:   &validReadOps,
 		invalidReadOps: &invalidReadOps,
 	}, nil
@@ -581,11 +577,13 @@ func (s *hammerState) String() string {
 		totalInvalidReqs += int(invalidReqs.Value(s.label(), string(ep)))
 		totalErrs += int(errs.Value(s.label(), string(ep)))
 	}
-	var latestRev int64 = -1
-	if smr := s.smrs.previousSMR(0); smr != nil {
-		latestRev = int64(smr.Revision)
+	var revStr string
+	if latestRev, found := s.gossipHub.getLastReadRev(); found {
+		revStr = strconv.FormatUint(latestRev, 10)
+	} else {
+		revStr = "N/A"
 	}
-	return fmt.Sprintf("%d: lastSMR.rev=%d ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, latestRev, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
+	return fmt.Sprintf("%d: lastSMR.rev=%v ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, revStr, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
 }
 
 func pickIntInRange(min, max int, prng *rand.Rand) int {
@@ -628,15 +626,14 @@ func (s *hammerState) setLeaves(ctx context.Context, prng *rand.Rand) error {
 		n = 1
 	}
 	leaves := make([]*trillian.MapLeaf, 0, n)
-	contents := s.prevContents.LastCopy()
 	rev := int64(0)
-	if contents != nil {
-		rev = contents.Rev
+	if s.head != nil {
+		rev = s.head.Rev
 	}
 leafloop:
 	for i := 0; i < n; i++ {
 		choice := choices[prng.Intn(len(choices))]
-		if contents.Empty() {
+		if s.head.Empty() {
 			choice = CreateLeaf
 		}
 		switch choice {
@@ -650,7 +647,7 @@ leafloop:
 			})
 			glog.V(3).Infof("%d: %v: data[%q]=%q", s.cfg.MapID, choice, key, string(value))
 		case UpdateLeaf, DeleteLeaf:
-			key := contents.PickKey(prng)
+			key := s.head.PickKey(prng)
 			// Not allowed to have the same key more than once in the same request
 			for _, leaf := range leaves {
 				if bytes.Equal(leaf.Index, key) {
@@ -677,16 +674,18 @@ leafloop:
 		Metadata:       metadataForRev(writeRev),
 		ExpectRevision: int64(writeRev),
 	}
-	_, err := s.cfg.Write.WriteLeaves(ctx, &req)
+
+	err := s.gossipHub.proposeLeaves(writeRev, leaves)
+	if err != nil {
+		return err
+	}
+	_, err = s.cfg.Write.WriteLeaves(ctx, &req)
 	if err != nil {
 		return fmt.Errorf("failed to set-leaves(count=%d): %v", len(leaves), err)
 	}
 
-	_, err = s.prevContents.UpdateContentsWith(writeRev, leaves)
-	if err != nil {
-		return err
-	}
 	glog.V(2).Infof("%d: set %d leaves, rev=%d", s.cfg.MapID, len(leaves), writeRev)
+	s.head = s.head.UpdatedWith(writeRev, leaves)
 	return nil
 }
 
@@ -697,8 +696,7 @@ func (s *hammerState) setLeavesInvalid(ctx context.Context, prng *rand.Rand) err
 	value := []byte("value-for-invalid-req")
 
 	choice := choices[prng.Intn(len(choices))]
-	contents := s.prevContents.LastCopy()
-	if contents.Empty() {
+	if s.head.Empty() {
 		choice = MalformedKey
 	}
 	switch choice {
@@ -706,7 +704,7 @@ func (s *hammerState) setLeavesInvalid(ctx context.Context, prng *rand.Rand) err
 		key := testonly.TransparentHash("..invalid-size")
 		leaves = append(leaves, &trillian.MapLeaf{Index: key[2:], LeafValue: value})
 	case DuplicateKey:
-		key := contents.PickKey(prng)
+		key := s.head.PickKey(prng)
 		leaves = append(leaves, &trillian.MapLeaf{Index: key, LeafValue: value})
 		leaves = append(leaves, &trillian.MapLeaf{Index: key, LeafValue: value})
 	}

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -675,12 +675,10 @@ leafloop:
 		ExpectRevision: int64(writeRev),
 	}
 
-	err := s.gossipHub.proposeLeaves(writeRev, leaves)
-	if err != nil {
+	if err := s.gossipHub.proposeLeaves(writeRev, leaves); err != nil {
 		return err
 	}
-	_, err = s.cfg.Write.WriteLeaves(ctx, &req)
-	if err != nil {
+	if _, err := s.cfg.Write.WriteLeaves(ctx, &req); err != nil {
 		return fmt.Errorf("failed to set-leaves(count=%d): %v", len(leaves), err)
 	}
 

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -577,11 +577,9 @@ func (s *hammerState) String() string {
 		totalInvalidReqs += int(invalidReqs.Value(s.label(), string(ep)))
 		totalErrs += int(errs.Value(s.label(), string(ep)))
 	}
-	var revStr string
+	revStr := "N/A"
 	if latestRev, found := s.sharedState.getLastReadRev(); found {
 		revStr = strconv.FormatUint(latestRev, 10)
-	} else {
-		revStr = "N/A"
 	}
 	return fmt.Sprintf("%d: lastSMR.rev=%v ops: total=%d (%f ops/sec) invalid=%d errs=%v%s", s.cfg.MapID, revStr, totalReqs, float64(totalReqs)/interval.Seconds(), totalInvalidReqs, totalErrs, details)
 }
@@ -679,7 +677,7 @@ leafloop:
 		return err
 	}
 	if _, err := s.cfg.Write.WriteLeaves(ctx, &req); err != nil {
-		return fmt.Errorf("failed to set-leaves(count=%d): %v", len(leaves), err)
+		return fmt.Errorf("failed to WriteLeaves(count=%d): %v", len(leaves), err)
 	}
 
 	glog.V(2).Infof("%d: set %d leaves, rev=%d", s.cfg.MapID, len(leaves), writeRev)

--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -88,17 +88,14 @@ func (o *validReadOps) doGetLeaves(ctx context.Context, prng *rand.Rand, latest 
 	var leaves []*trillian.MapLeaf
 	var root *types.MapRootV1
 	if latest {
-		leaves, root, err = o.mc.GetAndVerifyMapLeaves(ctx, indices)
-		if err != nil {
+		if leaves, root, err = o.mc.GetAndVerifyMapLeaves(ctx, indices); err != nil {
 			return fmt.Errorf("failed to GetAndVerifyMapLeaves: %v", err)
 		}
-		err = o.sharedState.advertiseSMR(*root)
-		if err != nil {
+		if err := o.sharedState.advertiseSMR(*root); err != nil {
 			return err
 		}
 	} else {
-		leaves, root, err = o.mc.GetAndVerifyMapLeavesByRevision(ctx, contents.Rev, indices)
-		if err != nil {
+		if leaves, root, err = o.mc.GetAndVerifyMapLeavesByRevision(ctx, contents.Rev, indices); err != nil {
 			return fmt.Errorf("failed to GetAndVerifyMapLeavesByRevision(%d): %v", contents.Rev, err)
 		}
 	}
@@ -126,8 +123,7 @@ func (o *validReadOps) getSMR(ctx context.Context, prng *rand.Rand) error {
 		return fmt.Errorf("failed to get-smr: %v", err)
 	}
 
-	err = o.sharedState.advertiseSMR(*root)
-	if err != nil {
+	if err := o.sharedState.advertiseSMR(*root); err != nil {
 		return fmt.Errorf("got bad SMR in get-smr: %v", err)
 	}
 	glog.V(2).Infof("%d: got SMR(time=%q, rev=%d)", o.mc.MapID, time.Unix(0, int64(root.TimestampNanos)), root.Revision)

--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -36,7 +36,7 @@ type validReadOps struct {
 	extraSize            uint
 	minLeaves, maxLeaves int
 	prevContents         *testonly.VersionedMapContents // copies of earlier contents of the map
-	gossipHub            *gossipHub
+	sharedState          *sharedState
 }
 
 func (o *validReadOps) getLeaves(ctx context.Context, prng *rand.Rand) error {
@@ -92,7 +92,7 @@ func (o *validReadOps) doGetLeaves(ctx context.Context, prng *rand.Rand, latest 
 		if err != nil {
 			return fmt.Errorf("failed to GetAndVerifyMapLeaves: %v", err)
 		}
-		err = o.gossipHub.advertiseSMR(*root)
+		err = o.sharedState.advertiseSMR(*root)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (o *validReadOps) getSMR(ctx context.Context, prng *rand.Rand) error {
 		return fmt.Errorf("failed to get-smr: %v", err)
 	}
 
-	err = o.gossipHub.advertiseSMR(*root)
+	err = o.sharedState.advertiseSMR(*root)
 	if err != nil {
 		return fmt.Errorf("got bad SMR in get-smr: %v", err)
 	}
@@ -139,7 +139,7 @@ func (o *validReadOps) getSMR(ctx context.Context, prng *rand.Rand) error {
 // the map still returns the same SMR for this revision.
 func (o *validReadOps) getSMRRev(ctx context.Context, prng *rand.Rand) error {
 	which := prng.Intn(smrCount)
-	smrRoot := o.gossipHub.previousSMR(which)
+	smrRoot := o.sharedState.previousSMR(which)
 	if smrRoot == nil {
 		glog.V(3).Infof("%d: skipping get-smr-rev as no earlier SMR", o.mc.MapID)
 		return errSkip{}
@@ -179,7 +179,7 @@ type invalidReadOps struct {
 	mapID        int64
 	client       trillian.TrillianMapClient
 	prevContents *testonly.VersionedMapContents // copies of earlier contents of the map
-	gossipHub    *gossipHub
+	sharedState  *sharedState
 }
 
 func (o *invalidReadOps) getLeaves(ctx context.Context, prng *rand.Rand) error {

--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -92,6 +92,10 @@ func (o *validReadOps) doGetLeaves(ctx context.Context, prng *rand.Rand, latest 
 		if err != nil {
 			return fmt.Errorf("failed to GetAndVerifyMapLeaves: %v", err)
 		}
+		err = o.gossipHub.advertiseSMR(*root)
+		if err != nil {
+			return err
+		}
 	} else {
 		leaves, root, err = o.mc.GetAndVerifyMapLeavesByRevision(ctx, contents.Rev, indices)
 		if err != nil {

--- a/testonly/hammer/record.go
+++ b/testonly/hammer/record.go
@@ -34,7 +34,7 @@ const (
 // to be shared between different workers running in the same process. The same
 // interface could be implemented by something which shared these details with
 // a remote process via gRPC if that was desirable.
-// The goal is thatVersionedMapContents can be subsumed into this class - there
+// The goal is that VersionedMapContents can be subsumed into this class - there
 // should be no reason to address it directly. For now, this class coordinates
 // writes, reads, and local state such that VersionedMapContents always contains
 // revisions which are no further ahead than the most recent SMR published by the
@@ -69,10 +69,6 @@ func (g *gossipHub) getLastReadRev() (rev uint64, found bool) {
 // will be available to readers only once advertiseSMR has been called with a root
 // that is >= the revision of this write.
 func (g *gossipHub) proposeLeaves(rev uint64, leaves []*trillian.MapLeaf) error {
-	if head, found := g.getLastReadRev(); found && rev <= head {
-		return fmt.Errorf("Cannot create revision %d, latest SMR is %d", rev, head)
-	}
-
 	g.mu.Lock()
 	defer g.mu.Unlock()
 

--- a/testonly/hammer/record.go
+++ b/testonly/hammer/record.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 )
 
@@ -28,48 +30,99 @@ const (
 	smrCount = 30
 )
 
-// smrStash provides thread-safe access to an ordered, bounded queue of previously
-// witnessed SMRs
-type smrStash struct {
-	mu sync.RWMutex
+// gossipHub allows details of what has been written to and read from the Map
+// to be shared between different workers running in the same process. The same
+// interface could be implemented by something which shared these details with
+// a remote process via gRPC if that was desirable.
+// The goal is thatVersionedMapContents can be subsumed into this class - there
+// should be no reason to address it directly. For now, this class coordinates
+// writes, reads, and local state such that VersionedMapContents always contains
+// revisions which are no further ahead than the most recent SMR published by the
+// Map.
+type gossipHub struct {
+	contents *testonly.VersionedMapContents
+
+	mu            sync.RWMutex
+	pendingWrites map[uint64][]*trillian.MapLeaf
 
 	// SMRs are arranged from later to earlier (so [0] is the most recent), and the
 	// discovery of new SMRs will push older ones off the end. No SMR for a revision
 	// will be stored more than once.
-	smr [smrCount]*types.MapRootV1
+	smrs [smrCount]*types.MapRootV1
 }
 
-// pushSMR ensures that the SMR is the latest revision and adds it to the queue of
-// seen SMRs. If this SMR is the same as a previously pushed version, then it is
-// equality checked and an error is returned if there is a difference.
-func (s *smrStash) pushSMR(smr types.MapRootV1) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func newGossipHub() *gossipHub {
+	return &gossipHub{
+		contents:      &testonly.VersionedMapContents{},
+		pendingWrites: make(map[uint64][]*trillian.MapLeaf),
+	}
+}
 
-	if s.smr[0] != nil {
-		if s.smr[0].Revision > smr.Revision {
-			return fmt.Errorf("pushSMR called with stale root. Received revision %d, already had revision %d", smr.Revision, s.smr[0].Revision)
-		} else if s.smr[0].Revision == smr.Revision {
-			if !reflect.DeepEqual(s.smr[0], &smr) {
-				return fmt.Errorf("pushSMR witnessed different SMRs for revision=%d. Had %+v, received %+v", smr.Revision, s.smr[0], smr)
+func (g *gossipHub) getLastReadRev() (rev uint64, found bool) {
+	if lastRoot := g.previousSMR(0); lastRoot != nil {
+		return lastRoot.Revision, true
+	}
+	return 0, false
+}
+
+// proposeLeaves should be called *before* writing a new map revision. The revision
+// will be available to readers only once advertiseSMR has been called with a root
+// that is >= the revision of this write.
+func (g *gossipHub) proposeLeaves(rev uint64, leaves []*trillian.MapLeaf) error {
+	if head, found := g.getLastReadRev(); found && rev <= head {
+		return fmt.Errorf("Cannot create revision %d, latest SMR is %d", rev, head)
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.pendingWrites[rev] = leaves
+	return nil
+}
+
+// TODO(mhutchinson): Make this way more tolerant so it accepts older SMRs and
+// checks they are equivalent to previously seen versions if applicable.
+func (g *gossipHub) advertiseSMR(smr types.MapRootV1) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var prevRev uint64 // The last revision committed to contents.
+	if g.smrs[0] != nil {
+		if g.smrs[0].Revision > smr.Revision {
+			return fmt.Errorf("pushSMR called with stale root. Received revision %d, already had revision %d", smr.Revision, g.smrs[0].Revision)
+		} else if g.smrs[0].Revision == smr.Revision {
+			if !reflect.DeepEqual(g.smrs[0], &smr) {
+				return fmt.Errorf("pushSMR witnessed different SMRs for revision=%d. Had %+v, received %+v", smr.Revision, g.smrs[0], smr)
 			}
 			// Roots are equal, so no need to push on the same root twice
 			return nil
 		}
+		prevRev = g.smrs[0].Revision
 	}
 
 	glog.V(2).Infof("adding new SMR: %+v", smr)
 	// Shuffle earlier SMRs along.
 	for i := smrCount - 1; i > 0; i-- {
-		s.smr[i] = s.smr[i-1]
+		g.smrs[i] = g.smrs[i-1]
 	}
 
-	s.smr[0] = &smr
+	g.smrs[0] = &smr
+
+	for i := prevRev + 1; i <= smr.Revision; i++ {
+		if leaves, ok := g.pendingWrites[i]; ok {
+			if _, err := g.contents.UpdateContentsWith(i, leaves); err != nil {
+				return err
+			}
+			delete(g.pendingWrites, i)
+		} else {
+			return fmt.Errorf("Found SMR(r=%d), but failed to find pending write for r=%d", smr.Revision, i)
+		}
+	}
 	return nil
 }
 
-func (s *smrStash) previousSMR(which int) *types.MapRootV1 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.smr[which]
+func (g *gossipHub) previousSMR(which int) *types.MapRootV1 {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.smrs[which]
 }

--- a/testonly/hammer/record_test.go
+++ b/testonly/hammer/record_test.go
@@ -15,34 +15,45 @@
 package hammer
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/google/trillian"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 )
 
-func TestSmrStash_PushSMR(t *testing.T) {
+func TestGossipHub_advertiseSMR(t *testing.T) {
 	r0 := types.MapRootV1{Revision: 0, RootHash: testonly.MustHexDecode("AAAA")}
 	r1 := types.MapRootV1{Revision: 1, RootHash: testonly.MustHexDecode("BBBB")}
 	r2 := types.MapRootV1{Revision: 2, RootHash: testonly.MustHexDecode("CCCC")}
 
 	for _, test := range []struct {
-		desc    string
-		seq     []types.MapRootV1
-		wantErr bool
+		desc      string
+		seq       []types.MapRootV1
+		writeRevs uint64
+		wantErr   bool
 	}{
 		{
 			desc: "single root",
 			seq:  []types.MapRootV1{r0},
 		},
 		{
-			desc: "all the roots in order",
-			seq:  []types.MapRootV1{r0, r1, r2},
+			desc:      "all the roots in order",
+			seq:       []types.MapRootV1{r0, r1, r2},
+			writeRevs: 2,
 		},
 		{
-			desc:    "roots out of order",
-			seq:     []types.MapRootV1{r2, r1},
-			wantErr: true,
+			desc:      "read ahead of writes",
+			seq:       []types.MapRootV1{r0, r1, r2},
+			writeRevs: 1,
+			wantErr:   true,
+		},
+		{
+			desc:      "roots out of order",
+			seq:       []types.MapRootV1{r2, r1},
+			writeRevs: 2,
+			wantErr:   true,
 		},
 		{
 			desc: "same revision with same contents",
@@ -55,17 +66,77 @@ func TestSmrStash_PushSMR(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			var stash smrStash
+			g := newGossipHub()
+
+			for i := uint64(1); i <= test.writeRevs; i++ {
+				leaves := []*trillian.MapLeaf{}
+				g.proposeLeaves(i, leaves)
+			}
 
 			var gotErr error
 			for _, r := range test.seq {
-				err := stash.pushSMR(r)
+				err := g.advertiseSMR(r)
 				if err != nil {
 					gotErr = err
 				}
 			}
 			if (gotErr != nil) != test.wantErr {
 				t.Errorf("Unexpected error state: %v, wantErr: %v", gotErr, test.wantErr)
+			}
+		})
+	}
+
+}
+
+func TestGossipHub_keepsReadableRevisions(t *testing.T) {
+	g := newGossipHub()
+
+	for _, test := range []struct {
+		writeRevs   uint64
+		readSMRs    uint64
+		lookupRev   uint64
+		expectFound bool
+	}{
+		{
+			writeRevs:   0,
+			readSMRs:    0,
+			lookupRev:   0,
+			expectFound: false,
+		},
+		{
+			writeRevs:   1,
+			readSMRs:    1,
+			lookupRev:   1,
+			expectFound: true,
+		},
+		{
+			writeRevs:   30,
+			readSMRs:    10,
+			lookupRev:   5,
+			expectFound: true,
+		},
+		{
+			writeRevs:   30,
+			readSMRs:    25,
+			lookupRev:   5,
+			expectFound: false,
+		},
+	} {
+		t.Run(fmt.Sprintf("write=%d,read=%d,lookup=%d", test.writeRevs, test.readSMRs, test.lookupRev), func(t *testing.T) {
+			for i := uint64(1); i <= test.writeRevs; i++ {
+				leaves := []*trillian.MapLeaf{}
+				g.proposeLeaves(i, leaves)
+			}
+			for i := uint64(1); i <= test.readSMRs; i++ {
+				g.advertiseSMR(types.MapRootV1{Revision: i, RootHash: testonly.MustHexDecode("AAAA")})
+			}
+
+			got := g.contents.PickRevision(test.lookupRev)
+			if (got != nil) != test.expectFound {
+				t.Errorf("Unexpected found status: got %v, want: %v", (got != nil), test.expectFound)
+			}
+			if got != nil && got.Rev != int64(test.lookupRev) {
+				t.Errorf("Unexpected rev: got %d, want: %d", got.Rev, test.lookupRev)
 			}
 		})
 	}

--- a/testonly/hammer/record_test.go
+++ b/testonly/hammer/record_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/trillian/types"
 )
 
-func TestGossipHub_advertiseSMR(t *testing.T) {
+func TestSharedState_advertiseSMR(t *testing.T) {
 	r0 := types.MapRootV1{Revision: 0, RootHash: testonly.MustHexDecode("AAAA")}
 	r1 := types.MapRootV1{Revision: 1, RootHash: testonly.MustHexDecode("BBBB")}
 	r2 := types.MapRootV1{Revision: 2, RootHash: testonly.MustHexDecode("CCCC")}
@@ -66,7 +66,7 @@ func TestGossipHub_advertiseSMR(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			g := newGossipHub()
+			g := newSharedState()
 
 			for i := uint64(1); i <= test.writeRevs; i++ {
 				leaves := []*trillian.MapLeaf{}
@@ -88,8 +88,8 @@ func TestGossipHub_advertiseSMR(t *testing.T) {
 
 }
 
-func TestGossipHub_keepsReadableRevisions(t *testing.T) {
-	g := newGossipHub()
+func TestSharedState_keepsReadableRevisions(t *testing.T) {
+	g := newSharedState()
 
 	for _, test := range []struct {
 		writeRevs   uint64


### PR DESCRIPTION
This will be required when WriteLeaves publishes SMRs asynchronously to writing the leaf values. This change makes VersionedMapContents updated with a revision X only when an SMR for a revision >= X is found. This allows the readers to keep using VersionedMapContents as they did before, without risking the writer getting so far ahead of the latest SMR that we push out all 10 of the revisions stored in memory that could be used to validate what the readers are getting from the map.