### PR TITLE
Hammer allows SMRs from the past to be checked

### DIFF
--- a/testonly/hammer/reader.go
+++ b/testonly/hammer/reader.go
@@ -113,6 +113,10 @@ func (o *validReadOps) doGetLeaves(ctx context.Context, prng *rand.Rand, latest 
 		return fmt.Errorf("incorrect contents of leaves: %v", err)
 	}
 	glog.V(2).Infof("%d: got %d leaves", o.mc.MapID, len(leaves))
+
+	if err = o.sharedState.advertiseSMR(*root); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/testonly/hammer/record.go
+++ b/testonly/hammer/record.go
@@ -84,7 +84,8 @@ func (g *sharedState) advertiseSMR(smr types.MapRootV1) error {
 		if g.smrs[0] == nil || g.smrs[0].Revision < smr.Revision {
 			return true, nil
 		}
-		pos := sort.Search(smrCount, func(i int) bool {
+		// Search to smrCount-1 so that pos will always be a valid index into the array.
+		pos := sort.Search(smrCount-1, func(i int) bool {
 			return g.smrs[i] == nil || g.smrs[i].Revision <= smr.Revision
 		})
 		if known := g.smrs[pos]; known != nil && known.Revision == smr.Revision && !reflect.DeepEqual(known, &smr) {

--- a/testonly/hammer/record.go
+++ b/testonly/hammer/record.go
@@ -75,44 +75,62 @@ func (g *sharedState) proposeLeaves(rev uint64, leaves []*trillian.MapLeaf) erro
 	return nil
 }
 
-// TODO(mhutchinson): Make this way more tolerant so it accepts older SMRs and
-// checks they are equivalent to previously seen versions if applicable.
 func (g *sharedState) advertiseSMR(smr types.MapRootV1) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	update, err := func() (bool, error) {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
 
-	var prevRev uint64 // The last revision committed to contents.
-	if g.smrs[0] != nil {
-		if g.smrs[0].Revision > smr.Revision {
-			return fmt.Errorf("stale root: got revision %d, already had %d", smr.Revision, g.smrs[0].Revision)
-		} else if g.smrs[0].Revision == smr.Revision {
-			if !reflect.DeepEqual(g.smrs[0], &smr) {
-				return fmt.Errorf("SMR mismatch at revision %d: had %+v, got %+v", smr.Revision, g.smrs[0], smr)
+		if g.smrs[0] == nil || g.smrs[0].Revision < smr.Revision {
+			return true, nil
+		}
+
+		for i := 0; i < smrCount && g.smrs[i] != nil && g.smrs[i].Revision >= smr.Revision; i++ {
+			if g.smrs[0].Revision == smr.Revision {
+				if !reflect.DeepEqual(g.smrs[i], &smr) {
+					return false, fmt.Errorf("SMR mismatch at revision %d: had %+v, got %+v", smr.Revision, g.smrs[0], smr)
+				}
 			}
-			// Roots are equal, so no need to push on the same root twice
+		}
+		return false, nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	if update {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+
+		// update is a suggestion. We need to confirm the condition holds now we have write lock.
+		if g.smrs[0] != nil && g.smrs[0].Revision >= smr.Revision {
 			return nil
 		}
-		prevRev = g.smrs[0].Revision
-	}
 
-	glog.V(2).Infof("adding new SMR: %+v", smr)
-	// Shuffle earlier SMRs along.
-	for i := smrCount - 1; i > 0; i-- {
-		g.smrs[i] = g.smrs[i-1]
-	}
+		var prevRev uint64 // The last revision committed to contents.
+		if g.smrs[0] != nil {
+			prevRev = g.smrs[0].Revision
+		}
 
-	g.smrs[0] = &smr
+		glog.V(2).Infof("adding new SMR: %+v", smr)
+		// Shuffle earlier SMRs along.
+		for i := smrCount - 1; i > 0; i-- {
+			g.smrs[i] = g.smrs[i-1]
+		}
 
-	for i := prevRev + 1; i <= smr.Revision; i++ {
-		if leaves, ok := g.pendingWrites[i]; ok {
-			if _, err := g.contents.UpdateContentsWith(i, leaves); err != nil {
-				return err
+		g.smrs[0] = &smr
+
+		for i := prevRev + 1; i <= smr.Revision; i++ {
+			if leaves, ok := g.pendingWrites[i]; ok {
+				if _, err := g.contents.UpdateContentsWith(i, leaves); err != nil {
+					return err
+				}
+				delete(g.pendingWrites, i)
+			} else {
+				return fmt.Errorf("found SMR(r=%d), but failed to find pending write for r=%d", smr.Revision, i)
 			}
-			delete(g.pendingWrites, i)
-		} else {
-			return fmt.Errorf("found SMR(r=%d), but failed to find pending write for r=%d", smr.Revision, i)
 		}
 	}
+
 	return nil
 }
 

--- a/testonly/hammer/record_test.go
+++ b/testonly/hammer/record_test.go
@@ -53,7 +53,7 @@ func TestSharedState_advertiseSMR(t *testing.T) {
 			desc:      "roots out of order",
 			seq:       []types.MapRootV1{r2, r1},
 			writeRevs: 2,
-			wantErr:   true,
+			wantErr:   false,
 		},
 		{
 			desc: "same revision with same contents",
@@ -61,7 +61,7 @@ func TestSharedState_advertiseSMR(t *testing.T) {
 		},
 		{
 			desc:    "same revision but different contents",
-			seq:     []types.MapRootV1{r0, {Revision: 0, RootHash: testonly.MustHexDecode("FFFF")}},
+			seq:     []types.MapRootV1{r0, r1, r2, {Revision: 1, RootHash: testonly.MustHexDecode("FFFF")}},
 			wantErr: true,
 		},
 	} {

--- a/testonly/hammer/record_test.go
+++ b/testonly/hammer/record_test.go
@@ -60,9 +60,10 @@ func TestSharedState_advertiseSMR(t *testing.T) {
 			seq:  []types.MapRootV1{r0, r0},
 		},
 		{
-			desc:    "same revision but different contents",
-			seq:     []types.MapRootV1{r0, r1, r2, {Revision: 1, RootHash: testonly.MustHexDecode("FFFF")}},
-			wantErr: true,
+			desc:      "same revision but different contents",
+			seq:       []types.MapRootV1{r0, r1, r2, {Revision: 1, RootHash: testonly.MustHexDecode("FFFF")}},
+			writeRevs: 2,
+			wantErr:   true,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
This prevents things blowing up if there are race conditions where two workers find new SMRs and advertize them slightly out of order.

This is more comprehensive, because old SMRs will be checked whenver we find them to make sure history isn't being switched around.

This is faster because more operations in advertiseSMR are done with read locks instead of write locks.