### PR TITLE
WriteLeaves: Always require the expected revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ Not yet released; provisionally v1.3.3 (may change).
 
 ### Map Changes
 
-The verifiable map is still experimental. APIs have been deprecated and will be
-deleted in the near future. These changes will not affect the Trillian module
-semantic version due to the experimental status of the Map.
+The verifiable map is still experimental. APIs, such as SetLeaves, have been
+deprecated and will be deleted in the near future. The semantic of WriteLeaves
+has become stricter: now it always requires the caller to specify the write
+revision. These changes will not affect the Trillian module semantic version due
+to the experimental status of the Map.
 
 The map client has been updated so that GetAndVerifyMapLeaves and
 GetAndVerifyMapLeavesByRevision return the MapRoot for the revision at which the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Not yet released; provisionally v1.3.3 (may change).
 ### Map Changes
 
 The verifiable map is still experimental. APIs, such as SetLeaves, have been
-deprecated and will be deleted in the near future. The semantic of WriteLeaves
-has become stricter: now it always requires the caller to specify the write
+deprecated and will be deleted in the near future. The semantics of WriteLeaves
+have become stricter: now it always requires the caller to specify the write
 revision. These changes will not affect the Trillian module semantic version due
 to the experimental status of the Map.
 

--- a/client/map_client_test.go
+++ b/client/map_client_test.go
@@ -146,8 +146,9 @@ func TestGetLeavesAtRevision(t *testing.T) {
 				LeafValue: []byte("A"),
 			},
 		},
+		ExpectRevision: 1,
 	}); err != nil {
-		t.Fatalf("SetLeaves(): %v", err)
+		t.Fatalf("WriteLeaves(): %v", err)
 	}
 
 	for _, tc := range []struct {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1031,7 +1031,7 @@ MapLeaf represents the data behind Map leaves.
 | map_id | [int64](#int64) |  |  |
 | leaves | [MapLeaf](#trillian.MapLeaf) | repeated | The leaves being set must have unique Index values within the request. |
 | metadata | [bytes](#bytes) |  |  |
-| revision | [int64](#int64) |  | The map revision to associate the leaves with. The request will fail if this revision already exists, does not match the current write revision, or is negative. If revision = 0 then the leaves will be written to the current write revision. |
+| revision | [int64](#int64) |  | The map revision to associate the leaves with. The request will fail if this revision already exists, does not match the current write revision, or is not positive. Note that revision = 0 is reserved for the empty tree. |
 
 
 
@@ -1064,7 +1064,7 @@ MapLeaf represents the data behind Map leaves.
 | map_id | [int64](#int64) |  |  |
 | leaves | [MapLeaf](#trillian.MapLeaf) | repeated | The leaves being set must have unique Index values within the request. |
 | metadata | [bytes](#bytes) |  | Metadata that the Map should associate with the new Map root after incorporating the leaf changes. The metadata will be reflected in the Map Root published for this revision. Map personalities should use metadata to persist any state needed later to continue mapping from an external data source. |
-| expect_revision | [int64](#int64) |  | The map revision to associate the leaves with. The request will fail if this revision already exists, does not match the current write revision, or is negative. If revision = 0 then the leaves will be written to the current write revision. |
+| expect_revision | [int64](#int64) |  | The map revision to associate the leaves with. The request will fail if this revision already exists, does not match the current write revision, or is not positive. Note that revision = 0 is reserved for the empty tree. |
 
 
 

--- a/integration/map.go
+++ b/integration/map.go
@@ -105,7 +105,8 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 	// Add a single leaf (key0=>value0) for revision 1.
 	fmt.Printf("%d: Write map[key0]=%q\n", mi.id, value0)
 	leaves := []*trillian.MapLeaf{{Index: key0, LeafValue: value0}}
-	writeRsp, err := mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: leaves})
+	writeRsp, err := mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
+		MapId: mi.id, Leaves: leaves, ExpectRevision: 1})
 	if err != nil {
 		return fmt.Errorf("failed to write-leaves: %v", err)
 	}
@@ -127,7 +128,8 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 	// Remove the single leaf by setting it to have empty contents, creating revision 2.
 	fmt.Printf("%d: Write map[key0]=''\n", mi.id)
 	emptyLeaves := []*trillian.MapLeaf{{Index: key0, LeafValue: []byte{}}}
-	writeRsp, err = mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: emptyLeaves, Metadata: []byte("metadata-2")})
+	writeRsp, err = mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
+		MapId: mi.id, Leaves: emptyLeaves, Metadata: []byte("metadata-2"), ExpectRevision: 2})
 	if err != nil {
 		return fmt.Errorf("failed to write-leaves: %v", err)
 	}
@@ -166,7 +168,8 @@ func (mi *MapInfo) RunIntegration(ctx context.Context) error {
 		{Index: key0, LeafValue: value1},
 		{Index: key1, LeafValue: value2},
 	}
-	writeRsp, err = mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{MapId: mi.id, Leaves: newLeaves, Metadata: []byte("metadata-3")})
+	writeRsp, err = mi.wcl.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
+		MapId: mi.id, Leaves: newLeaves, Metadata: []byte("metadata-3"), ExpectRevision: 3})
 	if err != nil {
 		return fmt.Errorf("failed to write-leaves: %v", err)
 	}

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -264,10 +264,11 @@ func RunMapRevisionInvalid(ctx context.Context, t *testing.T, tadmin trillian.Tr
 				if err != nil {
 					t.Fatalf("newTreeWithHasher(%v): %v", hashStrategy, err)
 				}
-				for _, batch := range tc.set {
+				for i, batch := range tc.set {
 					if _, err := twrite.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
-						MapId:  tree.TreeId,
-						Leaves: batch,
+						MapId:          tree.TreeId,
+						Leaves:         batch,
+						ExpectRevision: int64(1 + i),
 					}); err != nil {
 						t.Fatalf("WriteLeaves(): %v", err)
 					}
@@ -304,8 +305,8 @@ func RunWriteLeavesRevision(ctx context.Context, t *testing.T, tadmin trillian.T
 		{
 			desc: "no_revision",
 			sets: []batch{
-				{}, // Advance revision without changing anything.
-				{leaves: []*trillian.MapLeaf{{Index: index1, LeafValue: []byte("A")}}},
+				{rev: 1}, // Advance revision without changing anything.
+				{leaves: []*trillian.MapLeaf{{Index: index1, LeafValue: []byte("A")}}, rev: 2},
 			},
 			gets: []batch{
 				{leaves: []*trillian.MapLeaf{{Index: index1, LeafValue: nil}}, rev: 0},
@@ -341,12 +342,12 @@ func RunWriteLeavesRevision(ctx context.Context, t *testing.T, tadmin trillian.T
 			},
 		},
 		{
-			desc: "use_revision_and_no_revision",
+			desc: "use_revision_2",
 			sets: []batch{
 				{leaves: []*trillian.MapLeaf{{Index: index1, LeafValue: []byte("A")}}, rev: 1},
-				{leaves: []*trillian.MapLeaf{{Index: index2, LeafValue: []byte("B")}}},
+				{leaves: []*trillian.MapLeaf{{Index: index2, LeafValue: []byte("B")}}, rev: 2},
 				{leaves: []*trillian.MapLeaf{{Index: index3, LeafValue: []byte("C")}}, rev: 3},
-				{leaves: []*trillian.MapLeaf{{Index: index2, LeafValue: []byte("BB")}}},
+				{leaves: []*trillian.MapLeaf{{Index: index2, LeafValue: []byte("BB")}}, rev: 4},
 			},
 			gets: []batch{
 				{
@@ -467,10 +468,11 @@ func RunLeafHistory(ctx context.Context, t *testing.T, tadmin trillian.TrillianA
 					t.Fatalf("NewMapVerifierFromTree(): %v", err)
 				}
 
-				for _, batch := range tc.set {
+				for i, batch := range tc.set {
 					_, err := twrite.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
-						MapId:  tree.TreeId,
-						Leaves: batch,
+						MapId:          tree.TreeId,
+						Leaves:         batch,
+						ExpectRevision: int64(1 + i),
 					})
 					if err != nil {
 						t.Fatalf("WriteLeaves(): %v", err)
@@ -555,6 +557,7 @@ func RunInclusion(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdm
 					Metadata: testonly.MustMarshalAnyNoT(&ctmapperpb.MapperMetadata{
 						HighestFullyCompletedSeq: 0xcafe,
 					}),
+					ExpectRevision: 1,
 				}); err != nil {
 					t.Fatalf("WriteLeaves(): %v", err)
 				}
@@ -753,10 +756,11 @@ func writeBatch(ctx context.Context, t *testing.T, _ trillian.TrillianMapClient,
 	}
 
 	// Write some data in batches
-	for _, b := range leafBatch {
+	for i, b := range leafBatch {
 		if _, err := twrite.WriteLeaves(ctx, &trillian.WriteMapLeavesRequest{
-			MapId:  tree.TreeId,
-			Leaves: b,
+			MapId:          tree.TreeId,
+			Leaves:         b,
+			ExpectRevision: int64(1 + i),
 		}); err != nil {
 			t.Fatalf("WriteLeaves(): %v", err)
 		}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -381,7 +381,7 @@ func (t *TrillianMapServer) getWriteRevision(ctx context.Context, tree *trillian
 		return 0, err
 	}
 	if writeRev != assertRev {
-		return 0, status.Errorf(codes.FailedPrecondition, "can't write to revision %v: only %d", assertRev, writeRev)
+		return 0, status.Errorf(codes.FailedPrecondition, "can't write to revision %v", assertRev)
 	}
 	if readRev, err := tx.ReadRevision(ctx); err != nil {
 		return 0, err

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -369,13 +369,9 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 }
 
 // getWriteRevision returns the revision that this transaction will be written
-// at, and asserts that it correctly corresponds to the read revision and the
-// requested one. Only one transaction can be committed for a given revision,
-// thus this transaction will compete with any other transactions with the same
-// write revision.
-//
-// Returns an error if assertRev is non-zero and does not match the write
-// revision, or the read revision + 1 does not match it.
+// at, and asserts that it corresponds to assertRev and the read revision + 1.
+// Only one transaction can be committed for a given revision, so this one will
+// compete with any other transactions with the same write revision.
 //
 // TODO(pavelkalinnikov): One of Read/WriteRevision storage calls should be
 // gone really, because the +1 relation between them is fixed.
@@ -384,8 +380,8 @@ func (t *TrillianMapServer) getWriteRevision(ctx context.Context, tree *trillian
 	if err != nil {
 		return 0, err
 	}
-	if assertRev != 0 && writeRev != assertRev {
-		return 0, status.Errorf(codes.FailedPrecondition, "can't write to revision %v", assertRev)
+	if writeRev != assertRev {
+		return 0, status.Errorf(codes.FailedPrecondition, "can't write to revision %v: only %d", assertRev, writeRev)
 	}
 	if readRev, err := tx.ReadRevision(ctx); err != nil {
 		return 0, err

--- a/trillian_map_api.pb.go
+++ b/trillian_map_api.pb.go
@@ -576,8 +576,7 @@ type SetMapLeavesRequest struct {
 	Metadata []byte     `protobuf:"bytes,5,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// The map revision to associate the leaves with. The request will fail if
 	// this revision already exists, does not match the current write revision, or
-	// is negative. If revision = 0 then the leaves will be written to the current
-	// write revision.
+	// is not positive. Note that revision = 0 is reserved for the empty tree.
 	Revision             int64    `protobuf:"varint,6,opt,name=revision,proto3" json:"revision,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -688,8 +687,7 @@ type WriteMapLeavesRequest struct {
 	Metadata []byte `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// The map revision to associate the leaves with. The request will fail if
 	// this revision already exists, does not match the current write revision, or
-	// is negative. If revision = 0 then the leaves will be written to the current
-	// write revision.
+	// is not positive. Note that revision = 0 is reserved for the empty tree.
 	ExpectRevision       int64    `protobuf:"varint,4,opt,name=expect_revision,json=expectRevision,proto3" json:"expect_revision,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1103,12 +1101,12 @@ type TrillianMapClient interface {
 	GetLeafByRevision(ctx context.Context, in *GetMapLeafByRevisionRequest, opts ...grpc.CallOption) (*GetMapLeafResponse, error)
 	GetLeaves(ctx context.Context, in *GetMapLeavesRequest, opts ...grpc.CallOption) (*GetMapLeavesResponse, error)
 	GetLeavesByRevision(ctx context.Context, in *GetMapLeavesByRevisionRequest, opts ...grpc.CallOption) (*GetMapLeavesResponse, error)
-	// Deprecated: this should only be used be writers, which should migrate
+	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#GetLeavesByRevision
 	GetLeavesByRevisionNoProof(ctx context.Context, in *GetMapLeavesByRevisionRequest, opts ...grpc.CallOption) (*MapLeaves, error)
 	// GetLastInRangeByRevision returns the last leaf in a requested range.
 	GetLastInRangeByRevision(ctx context.Context, in *GetLastInRangeByRevisionRequest, opts ...grpc.CallOption) (*MapLeaf, error)
-	// Deprecated: this should only be used be writers, which should migrate
+	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#WriteLeaves
 	SetLeaves(ctx context.Context, in *SetMapLeavesRequest, opts ...grpc.CallOption) (*SetMapLeavesResponse, error)
 	GetSignedMapRoot(ctx context.Context, in *GetSignedMapRootRequest, opts ...grpc.CallOption) (*GetSignedMapRootResponse, error)
@@ -1225,12 +1223,12 @@ type TrillianMapServer interface {
 	GetLeafByRevision(context.Context, *GetMapLeafByRevisionRequest) (*GetMapLeafResponse, error)
 	GetLeaves(context.Context, *GetMapLeavesRequest) (*GetMapLeavesResponse, error)
 	GetLeavesByRevision(context.Context, *GetMapLeavesByRevisionRequest) (*GetMapLeavesResponse, error)
-	// Deprecated: this should only be used be writers, which should migrate
+	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#GetLeavesByRevision
 	GetLeavesByRevisionNoProof(context.Context, *GetMapLeavesByRevisionRequest) (*MapLeaves, error)
 	// GetLastInRangeByRevision returns the last leaf in a requested range.
 	GetLastInRangeByRevision(context.Context, *GetLastInRangeByRevisionRequest) (*MapLeaf, error)
-	// Deprecated: this should only be used be writers, which should migrate
+	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#WriteLeaves
 	SetLeaves(context.Context, *SetMapLeavesRequest) (*SetMapLeavesResponse, error)
 	GetSignedMapRoot(context.Context, *GetSignedMapRootRequest) (*GetSignedMapRootResponse, error)

--- a/trillian_map_api.proto
+++ b/trillian_map_api.proto
@@ -129,8 +129,7 @@ message SetMapLeavesRequest {
   bytes metadata = 5;
   // The map revision to associate the leaves with. The request will fail if
   // this revision already exists, does not match the current write revision, or
-  // is negative. If revision = 0 then the leaves will be written to the current
-  // write revision.
+  // is not positive. Note that revision = 0 is reserved for the empty tree.
   int64 revision = 6;
 }
 
@@ -150,8 +149,7 @@ message WriteMapLeavesRequest {
   bytes metadata = 3;
   // The map revision to associate the leaves with. The request will fail if
   // this revision already exists, does not match the current write revision, or
-  // is negative. If revision = 0 then the leaves will be written to the current
-  // write revision.
+  // is not positive. Note that revision = 0 is reserved for the empty tree.
   int64 expect_revision = 4;
 }
 


### PR DESCRIPTION
This change removes the feature of `Set/WriteLeaves` API calls, which allowed to commit leaves to a new "latest" revision rather than a fixed one. This feature is dangerous because it can cause races etc, and it was not used anyway. Additionally, the `revision == 0` meaning was overloaded (depending on the RPC being called): it could mean the "empty tree" revision, or "the latest" revision. Now it has only one meaning.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
