### PR TITLE
Writer only performs write operations

### DIFF
--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -75,9 +75,9 @@ type MapEntrypointName string
 const (
 	GetLeavesName    = MapEntrypointName("GetLeaves")
 	GetLeavesRevName = MapEntrypointName("GetLeavesRev")
-	SetLeavesName    = MapEntrypointName("SetLeaves")
 	GetSMRName       = MapEntrypointName("GetSMR")
 	GetSMRRevName    = MapEntrypointName("GetSMRRev")
+	SetLeavesName    = MapEntrypointName("SetLeaves") // TODO(mhutchinson): rename to WriteLeaves.
 )
 
 // Read-only map entry points.
@@ -452,7 +452,7 @@ func (w *writeWorker) run(ctx context.Context, done <-chan struct{}) (uint64, er
 	return count, nil
 }
 
-func (w *writeWorker) writeOnce(ctx context.Context) (err error) {
+func (w *writeWorker) writeOnce(ctx context.Context) error {
 	ep := SetLeavesName
 	if w.bias.invalid(ep, w.prng) {
 		glog.V(3).Infof("%d: perform invalid %s operation", w.mapID, ep)
@@ -484,8 +484,7 @@ leafloop:
 		}
 		switch choice {
 		case CreateLeaf:
-			key := w.nextKey()
-			value := w.nextValue()
+			key, value := w.nextKey(), w.nextValue()
 			leaves = append(leaves, &trillian.MapLeaf{
 				Index:     testonly.TransparentHash(key),
 				LeafValue: value,

--- a/testonly/hammer/hammer.go
+++ b/testonly/hammer/hammer.go
@@ -450,24 +450,14 @@ func (w *writeWorker) run(ctx context.Context, done <-chan struct{}) (uint64, er
 }
 
 func (w *writeWorker) writeOnce(ctx context.Context) (err error) {
-	ep := w.bias.choose(w.prng)
+	ep := SetLeavesName
 	if w.bias.invalid(ep, w.prng) {
 		glog.V(3).Infof("%d: perform invalid %s operation", w.mapID, ep)
 		invalidReqs.Inc(w.label, string(ep))
-		op, err := getOp(ep, w.s.invalidReadOps, w.s.setLeavesInvalid)
-		if err != nil {
-			return err
-		}
-		return op(ctx, w.prng)
+		return w.s.setLeavesInvalid(ctx, w.prng)
 	}
-
-	op, err := getOp(ep, w.s.validReadOps, w.s.setLeaves)
-	if err != nil {
-		return err
-	}
-
 	glog.V(3).Infof("%d: perform %s operation", w.mapID, ep)
-	return w.retryOp(ctx, op, string(ep))
+	return w.retryOp(ctx, w.s.setLeaves, string(ep))
 }
 
 // hammerState tracks the operations that have been performed during a test run.

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -57,7 +57,7 @@ var (
 	maxLeaves       = flag.Int("max_leaves", 10, "Maximum count of leaves to affect per-operation")
 	leafSize        = flag.Uint("leaf_size", 100, "Size of leaf values")
 	extraSize       = flag.Uint("extra_size", 100, "Size of leaf extra data")
-	checkers        = flag.Int("checkers", 0, "Number of checker goroutines to run")
+	checkers        = flag.Int("checkers", 1, "Number of checker goroutines to run")
 	retryErrors     = flag.Bool("retry_errors", false, "Whether to retry failed operations")
 	opDeadline      = flag.Duration("op_deadline", 60*time.Second, "How long to wait for operation success")
 	emitInterval    = flag.Duration("emit_interval", 0, "How often to output the Hammer state")


### PR DESCRIPTION
Increased the number of checkers from 0 to 1 by default so that callers relying on the defaults don't see a large change in behaviour.

Also included a bunch of refactors to clean up the hammer in this PR now that the read and write workers are separated. Recommend reviewing commit-by-commit.