### PR TITLE
Add error checks in handful mysql getLeaves methods

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -796,9 +796,9 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 		ret = append(ret, leaf)
 	}
 	if err := rows.Err(); err != nil {
-                glog.Warningf("Failed to read returned leaves: %s", err)
-                return nil, err
-        }
+		glog.Warningf("Failed to read returned leaves: %s", err)
+		return nil, err
+	}
 
 	return ret, nil
 }
@@ -947,9 +947,9 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		ret = append(ret, leaf)
 	}
 	if err := rows.Err(); err != nil {
-                glog.Warningf("Failed to read returned leaves: %s", err)
-                return nil, err
-        }
+		glog.Warningf("Failed to read returned leaves: %s", err)
+		return nil, err
+	}
 
 	return ret, nil
 }

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -716,6 +716,10 @@ func (t *logTreeTX) GetLeavesByIndex(ctx context.Context, leaves []int64) ([]*tr
 		}
 		ret = append(ret, leaf)
 	}
+	if err := rows.Err(); err != nil {
+		glog.Warningf("Failed to read returned leaves: %s", err)
+		return nil, err
+	}
 
 	if got, want := len(ret), len(leaves); got != want {
 		return nil, status.Errorf(codes.Internal, "len(ret): %d, want %d", got, want)
@@ -791,6 +795,10 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 		}
 		ret = append(ret, leaf)
 	}
+	if err := rows.Err(); err != nil {
+                glog.Warningf("Failed to read returned leaves: %s", err)
+                return nil, err
+        }
 
 	return ret, nil
 }
@@ -938,6 +946,10 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 
 		ret = append(ret, leaf)
 	}
+	if err := rows.Err(); err != nil {
+                glog.Warningf("Failed to read returned leaves: %s", err)
+                return nil, err
+        }
 
 	return ret, nil
 }


### PR DESCRIPTION
Adds the missing row error checks to `GetLeavesByIndex`, `getLeavesByRangeInternal`, and `getLeavesByHashInternal` which prevents returning incomplete result sets.

Fixes #1917.