### PR TITLE
Move storage providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ SetAndVerifyMapLeaves method was deleted.
 The StorageProvider type and helpers have been moved from the server package to
 storage. Aliases for the old types/functions are created for backward
 compatibility, but the new code should not use them as we will remove them with
-the next major version bump.
+the next major version bump. The individual storage providers have been moved to
+the corresponding packages, and are now required to be imported explicitly by
+the main file in order to be registered. We are including only MySQL and
+cloudspanner providers by default, since these are the ones that we support.
 
 ## v1.3.2 - Module fixes
 

--- a/server/mysql_quota_provider.go
+++ b/server/mysql_quota_provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/mysqlqm"
+	"github.com/google/trillian/storage/mysql"
 )
 
 // QuotaMySQL represents the MySQL quota implementation.
@@ -37,7 +38,7 @@ func init() {
 }
 
 func newMySQLQuotaManager() (quota.Manager, error) {
-	db, err := getMySQLDatabase()
+	db, err := mysql.GetDatabase()
 	if err != nil {
 		return nil, err
 	}

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -48,6 +48,10 @@ import (
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
 	_ "github.com/google/trillian/crypto/keys/pkcs11/proto"
 
+	// Register supported storage providers.
+	_ "github.com/google/trillian/storage/cloudspanner"
+	_ "github.com/google/trillian/storage/mysql"
+
 	// Load hashers
 	_ "github.com/google/trillian/merkle/rfc6962"
 )

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -48,6 +48,10 @@ import (
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
 	_ "github.com/google/trillian/crypto/keys/pkcs11/proto"
 
+	// Register supported storage providers.
+	_ "github.com/google/trillian/storage/cloudspanner"
+	_ "github.com/google/trillian/storage/mysql"
+
 	// Load hashers
 	_ "github.com/google/trillian/merkle/rfc6962"
 )

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -45,6 +45,10 @@ import (
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
 	_ "github.com/google/trillian/crypto/keys/pkcs11/proto"
 
+	// Register supported storage providers.
+	_ "github.com/google/trillian/storage/cloudspanner"
+	_ "github.com/google/trillian/storage/mysql"
+
 	// Load hashers
 	_ "github.com/google/trillian/merkle/coniks"
 	_ "github.com/google/trillian/merkle/maphasher"

--- a/storage/cloudspanner/storage_provider.go
+++ b/storage/cloudspanner/storage_provider.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package cloudspanner
 
 import (
 	"bytes"
@@ -28,7 +28,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/storage/cloudspanner"
 )
 
 var (
@@ -50,7 +49,7 @@ var (
 )
 
 func init() {
-	if err := RegisterStorageProvider("cloud_spanner", newCloudSpannerStorageProvider); err != nil {
+	if err := storage.RegisterProvider("cloud_spanner", newCloudSpannerStorageProvider); err != nil {
 		panic(err)
 	}
 }
@@ -88,7 +87,7 @@ func configFromFlags() spanner.ClientConfig {
 	return r
 }
 
-func newCloudSpannerStorageProvider(_ monitoring.MetricFactory) (StorageProvider, error) {
+func newCloudSpannerStorageProvider(_ monitoring.MetricFactory) (storage.Provider, error) {
 	csMu.Lock()
 	defer csMu.Unlock()
 
@@ -109,7 +108,7 @@ func newCloudSpannerStorageProvider(_ monitoring.MetricFactory) (StorageProvider
 // LogStorage builds and returns a new storage.LogStorage using CloudSpanner.
 func (s *cloudSpannerProvider) LogStorage() storage.LogStorage {
 	warn()
-	opts := cloudspanner.LogStorageOptions{}
+	opts := LogStorageOptions{}
 	frac := *csDequeueAcrossMerkleBucketsFraction
 	if frac > 1.0 {
 		frac = 1.0
@@ -121,23 +120,23 @@ func (s *cloudSpannerProvider) LogStorage() storage.LogStorage {
 	if *csReadOnlyStaleness > 0 {
 		opts.ReadOnlyStaleness = *csReadOnlyStaleness
 	}
-	return cloudspanner.NewLogStorageWithOpts(s.client, opts)
+	return NewLogStorageWithOpts(s.client, opts)
 }
 
 // MapStorage builds and returns a new storage.MapStorage using CloudSpanner.
 func (s *cloudSpannerProvider) MapStorage() storage.MapStorage {
 	warn()
-	opts := cloudspanner.MapStorageOptions{}
+	opts := MapStorageOptions{}
 	if *csReadOnlyStaleness > 0 {
 		opts.ReadOnlyStaleness = *csReadOnlyStaleness
 	}
-	return cloudspanner.NewMapStorageWithOpts(s.client, opts)
+	return NewMapStorageWithOpts(s.client, opts)
 }
 
 // AdminStorage builds and returns a new storage.AdminStorage using CloudSpanner.
 func (s *cloudSpannerProvider) AdminStorage() storage.AdminStorage {
 	warn()
-	return cloudspanner.NewAdminStorage(s.client)
+	return NewAdminStorage(s.client)
 }
 
 // Close shuts down this provider. Calls to the other methods will fail

--- a/storage/memory/provider.go
+++ b/storage/memory/provider.go
@@ -12,35 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package memory
 
 import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/storage/memory"
 )
 
 func init() {
-	if err := RegisterStorageProvider("memory", newMemoryStorageProvider); err != nil {
+	if err := storage.RegisterProvider("memory", newMemoryStorageProvider); err != nil {
 		glog.Fatalf("Failed to register storage provider memory: %v", err)
 	}
 }
 
 type memProvider struct {
 	mf monitoring.MetricFactory
-	ts *memory.TreeStorage
+	ts *TreeStorage
 }
 
-func newMemoryStorageProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
+func newMemoryStorageProvider(mf monitoring.MetricFactory) (storage.Provider, error) {
 	return &memProvider{
 		mf: mf,
-		ts: memory.NewTreeStorage(),
+		ts: NewTreeStorage(),
 	}, nil
 }
 
 func (s *memProvider) LogStorage() storage.LogStorage {
-	return memory.NewLogStorage(s.ts, s.mf)
+	return NewLogStorage(s.ts, s.mf)
 }
 
 func (s *memProvider) MapStorage() storage.MapStorage {
@@ -48,7 +47,7 @@ func (s *memProvider) MapStorage() storage.MapStorage {
 }
 
 func (s *memProvider) AdminStorage() storage.AdminStorage {
-	return memory.NewAdminStorage(s.ts)
+	return NewAdminStorage(s.ts)
 }
 
 func (s *memProvider) Close() error {

--- a/storage/memory/provider_test.go
+++ b/storage/memory/provider_test.go
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package memory
 
 import (
 	"testing"
+
+	"github.com/google/trillian/storage"
 )
 
 func TestMemoryStorageProvider(t *testing.T) {
-	sp, err := NewStorageProvider("memory", nil)
+	sp, err := storage.NewProvider("memory", nil)
 	if err != nil {
 		t.Fatalf("Got an unexpected error: %v", err)
 	}
@@ -29,7 +31,7 @@ func TestMemoryStorageProvider(t *testing.T) {
 }
 
 func TestMemoryStorageProviderLogStorage(t *testing.T) {
-	sp, err := NewStorageProvider("memory", nil)
+	sp, err := storage.NewProvider("memory", nil)
 	if err != nil {
 		t.Fatalf("Got an unexpected error: %v", err)
 	}
@@ -41,7 +43,7 @@ func TestMemoryStorageProviderLogStorage(t *testing.T) {
 }
 
 func TestMemoryStorageProviderMapStorage(t *testing.T) {
-	sp, err := NewStorageProvider("memory", nil)
+	sp, err := storage.NewProvider("memory", nil)
 	if err != nil {
 		t.Fatalf("Got an unexpected error: %v", err)
 	}
@@ -53,7 +55,7 @@ func TestMemoryStorageProviderMapStorage(t *testing.T) {
 }
 
 func TestMemoryStorageProviderAdminStorage(t *testing.T) {
-	sp, err := NewStorageProvider("memory", nil)
+	sp, err := storage.NewProvider("memory", nil)
 	if err != nil {
 		t.Fatalf("Got an unexpected error: %v", err)
 	}
@@ -65,7 +67,7 @@ func TestMemoryStorageProviderAdminStorage(t *testing.T) {
 }
 
 func TestMemoryStorageProviderClose(t *testing.T) {
-	sp, err := NewStorageProvider("memory", nil)
+	sp, err := storage.NewProvider("memory", nil)
 	if err != nil {
 		t.Fatalf("Got an unexpected error: %v", err)
 	}

--- a/storage/mysql/provider_test.go
+++ b/storage/mysql/provider_test.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package mysql
 
 import (
 	"flag"
 	"testing"
 
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly/flagsaver"
 )
 
@@ -28,18 +29,18 @@ func TestMySQLStorageProviderErrorPersistence(t *testing.T) {
 	}
 
 	// First call: This should fail due to the Database URL being garbage.
-	_, err1 := NewStorageProvider("mysql", nil)
+	_, err1 := storage.NewProvider("mysql", nil)
 	if err1 == nil {
-		t.Fatalf("Expected 'server.NewStorageProvider' to fail")
+		t.Fatalf("Expected 'storage.NewProvider' to fail")
 	}
 
 	// Second call: This should fail with the same error.
-	_, err2 := NewStorageProvider("mysql", nil)
+	_, err2 := storage.NewProvider("mysql", nil)
 	if err2 == nil {
-		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail")
+		t.Fatalf("Expected second call to 'storage.NewProvider' to fail")
 	}
 
 	if err2 != err1 {
-		t.Fatalf("Expected second call to 'server.NewStorageProvider' to fail with %q, instead got: %q", err1, err2)
+		t.Fatalf("Expected second call to 'storage.NewProvider' to fail with %q, instead got: %q", err1, err2)
 	}
 }

--- a/storage/postgres/provider.go
+++ b/storage/postgres/provider.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package postgres
 
 import (
 	"database/sql"
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/storage/postgres"
 
 	// Load PG driver
 	_ "github.com/lib/pq"
@@ -36,7 +35,7 @@ var (
 )
 
 func init() {
-	if err := RegisterStorageProvider("postgres", newPGProvider); err != nil {
+	if err := storage.RegisterProvider("postgres", newPGProvider); err != nil {
 		glog.Fatalf("Failed to register storage provider postgres: %v", err)
 	}
 }
@@ -46,10 +45,10 @@ type pgProvider struct {
 	mf monitoring.MetricFactory
 }
 
-func newPGProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
+func newPGProvider(mf monitoring.MetricFactory) (storage.Provider, error) {
 	pgOnce.Do(func() {
 		var db *sql.DB
-		db, pgOnceErr = postgres.OpenDB(*pgConnStr)
+		db, pgOnceErr = OpenDB(*pgConnStr)
 		if pgOnceErr != nil {
 			return
 		}
@@ -68,7 +67,7 @@ func newPGProvider(mf monitoring.MetricFactory) (StorageProvider, error) {
 func (s *pgProvider) LogStorage() storage.LogStorage {
 
 	glog.Warningf("Support for the PostgreSQL log is experimental.  Please use at your own risk!!!")
-	return postgres.NewLogStorage(s.db, s.mf)
+	return NewLogStorage(s.db, s.mf)
 }
 
 func (s *pgProvider) MapStorage() storage.MapStorage {
@@ -76,7 +75,7 @@ func (s *pgProvider) MapStorage() storage.MapStorage {
 }
 
 func (s *pgProvider) AdminStorage() storage.AdminStorage {
-	return postgres.NewAdminStorage(s.db)
+	return NewAdminStorage(s.db)
 }
 
 func (s *pgProvider) Close() error {


### PR DESCRIPTION
This change moves the individual storage providers to the corresponding implementation packages. This makes the `server` package agnostic of storage implementations, and makes it the responsibility of `main.go` files to import them.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
