### PR TITLE
Move StorageProvider interfaces to storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ leaves were fetched. Without this callers of GetAndVerifyMapLeaves in particular
 were unable to reason about which map revision they were seeing. The
 SetAndVerifyMapLeaves method was deleted.
 
+### Storage
+
+The StorageProvider type and helpers have been moved from the server package to
+storage. Aliases for the old types/functions are created for backward
+compatibility, but the new code should not use them as we will remove them with
+the next major version bump.
+
 ## v1.3.2 - Module fixes
 
 Published 2019-09-05 17:30:00 +0000 UTC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-Not yet released; provisionally v1.3.3 (may change).
+Not yet released; provisionally v1.4.0 (may change).
 
 ### Map Changes
 

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -22,28 +22,28 @@ import "github.com/google/trillian/storage"
 // NewStorageProviderFunc is the signature of a function which can be
 // registered to provide instances of storage providers.
 //
-// Deprecated: storage.NewProviderFunc must be used directly.
+// Deprecated: storage.NewProviderFunc should be used directly.
 type NewStorageProviderFunc = storage.NewProviderFunc
 
 // StorageProvider is an interface which allows Trillian binaries to use
 // different storage implementations.
 //
-// Deprecated: storage.Provider must be used directly.
+// Deprecated: storage.Provider should be used directly.
 type StorageProvider = storage.Provider
 
 // RegisterStorageProvider registers the provided StorageProvider.
 //
-// Deprecated: storage.RegisterProvider must be used directly.
+// Deprecated: storage.RegisterProvider should be used directly.
 var RegisterStorageProvider = storage.RegisterProvider
 
 // NewStorageProviderFromFlags returns a new StorageProvider instance of the
 // type specified by flag.
 //
-// Deprecated: storage.NewProviderFromFlags must be used directly.
+// Deprecated: storage.NewProviderFromFlags should be used directly.
 var NewStorageProviderFromFlags = storage.NewProviderFromFlags
 
 // NewStorageProvider returns a new StorageProvider instance of the type
 // specified by name.
 //
-// Deprecated: storage.NewProvider must be used directly.
+// Deprecated: storage.NewProvider should be used directly.
 var NewStorageProvider = storage.NewProvider

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -21,19 +21,29 @@ import "github.com/google/trillian/storage"
 
 // NewStorageProviderFunc is the signature of a function which can be
 // registered to provide instances of storage providers.
+//
+// Deprecated: storage.NewProviderFunc must be used directly.
 type NewStorageProviderFunc = storage.NewProviderFunc
 
 // StorageProvider is an interface which allows Trillian binaries to use
 // different storage implementations.
+//
+// Deprecated: storage.Provider must be used directly.
 type StorageProvider = storage.Provider
 
 // RegisterStorageProvider registers the provided StorageProvider.
+//
+// Deprecated: storage.RegisterProvider must be used directly.
 var RegisterStorageProvider = storage.RegisterProvider
 
 // NewStorageProviderFromFlags returns a new StorageProvider instance of the
 // type specified by flag.
+//
+// Deprecated: storage.NewProviderFromFlags must be used directly.
 var NewStorageProviderFromFlags = storage.NewProviderFromFlags
 
 // NewStorageProvider returns a new StorageProvider instance of the type
 // specified by name.
+//
+// Deprecated: storage.NewProvider must be used directly.
 var NewStorageProvider = storage.NewProvider

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc. All Rights Reserved.
+// Copyright 2019 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,87 +14,23 @@
 
 package server
 
-import (
-	"flag"
-	"fmt"
-	"sync"
+import "github.com/google/trillian/storage"
 
-	"github.com/google/trillian/monitoring"
-	"github.com/google/trillian/storage"
-)
+// NewStorageProviderFunc is the signature of a function which can be
+// registered to provide instances of storage providers.
+type NewStorageProviderFunc = storage.NewProviderFunc
 
-// NewStorageProviderFunc is the signature of a function which can be registered
-// to provide instances of storage providers.
-type NewStorageProviderFunc func(monitoring.MetricFactory) (StorageProvider, error)
-
-var (
-	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", storageProviders()))
-
-	spMu     sync.RWMutex
-	spOnce   sync.Once
-	spByName map[string]NewStorageProviderFunc
-)
+// StorageProvider is an interface which allows Trillian binaries to use
+// different storage implementations.
+type StorageProvider = storage.Provider
 
 // RegisterStorageProvider registers the provided StorageProvider.
-func RegisterStorageProvider(name string, sp NewStorageProviderFunc) error {
-	spMu.Lock()
-	defer spMu.Unlock()
+var RegisterStorageProvider = storage.RegisterProvider
 
-	spOnce.Do(func() {
-		spByName = make(map[string]NewStorageProviderFunc)
-	})
-
-	_, exists := spByName[name]
-	if exists {
-		return fmt.Errorf("storage provider %v already registered", name)
-	}
-	spByName[name] = sp
-	return nil
-}
-
-// NewStorageProviderFromFlags returns a new StorageProvider instance of the type
-// specified by flag.
-func NewStorageProviderFromFlags(mf monitoring.MetricFactory) (StorageProvider, error) {
-	return NewStorageProvider(*storageSystem, mf)
-}
+// NewStorageProviderFromFlags returns a new StorageProvider instance of the
+// type specified by flag.
+var NewStorageProviderFromFlags = storage.NewProviderFromFlags
 
 // NewStorageProvider returns a new StorageProvider instance of the type
 // specified by name.
-func NewStorageProvider(name string, mf monitoring.MetricFactory) (StorageProvider, error) {
-	spMu.RLock()
-	defer spMu.RUnlock()
-
-	sp := spByName[name]
-	if sp == nil {
-		return nil, fmt.Errorf("no such storage provider %v", name)
-	}
-
-	return sp(mf)
-}
-
-// storageProviders returns a slice of all registered storage provider names.
-func storageProviders() []string {
-	spMu.RLock()
-	defer spMu.RUnlock()
-
-	r := []string{}
-	for k := range spByName {
-		r = append(r, k)
-	}
-
-	return r
-}
-
-// StorageProvider is an interface which allows trillian binaries to use
-// different storage implementations.
-type StorageProvider interface {
-	// LogStorage creates and returns a LogStorage implementation.
-	LogStorage() storage.LogStorage
-	// MapStorage creates and returns a MapStorage implementation.
-	MapStorage() storage.MapStorage
-	// AdminStorage creates and returns a AdminStorage implementation.
-	AdminStorage() storage.AdminStorage
-
-	// Close closes the underlying storage.
-	Close() error
-}
+var NewStorageProvider = storage.NewProvider

--- a/server/storage_provider.go
+++ b/server/storage_provider.go
@@ -16,6 +16,9 @@ package server
 
 import "github.com/google/trillian/storage"
 
+// TODO(pavelkalinnikov): This file contains type/function aliases for backward
+// compatibility purposes. It will be removed with the next major version bump.
+
 // NewStorageProviderFunc is the signature of a function which can be
 // registered to provide instances of storage providers.
 type NewStorageProviderFunc = storage.NewProviderFunc

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util/clock"
 	"github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -102,7 +103,7 @@ func main() {
 		options = append(options, opts...)
 	}
 
-	sp, err := server.NewStorageProviderFromFlags(mf)
+	sp, err := storage.NewProviderFromFlags(mf)
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}

--- a/server/trillian_log_signer/main.go
+++ b/server/trillian_log_signer/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/server"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/clock"
 	"github.com/google/trillian/util/election"
@@ -96,7 +97,7 @@ func main() {
 	mf := prometheus.MetricFactory{}
 	monitoring.SetStartSpan(opencensus.StartSpan)
 
-	sp, err := server.NewStorageProviderFromFlags(mf)
+	sp, err := storage.NewProviderFromFlags(mf)
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}

--- a/server/trillian_map_server/main.go
+++ b/server/trillian_map_server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
@@ -98,7 +99,7 @@ func main() {
 		options = append(options, opts...)
 	}
 
-	sp, err := server.NewStorageProviderFromFlags(mf)
+	sp, err := storage.NewProviderFromFlags(mf)
 	if err != nil {
 		glog.Exitf("Failed to get storage provider: %v", err)
 	}

--- a/storage/provider.go
+++ b/storage/provider.go
@@ -31,18 +31,13 @@ var (
 	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", providers()))
 
 	spMu     sync.RWMutex
-	spOnce   sync.Once
-	spByName map[string]NewProviderFunc
+	spByName = make(map[string]NewProviderFunc)
 )
 
 // RegisterProvider registers the given storage Provider.
 func RegisterProvider(name string, sp NewProviderFunc) error {
 	spMu.Lock()
 	defer spMu.Unlock()
-
-	spOnce.Do(func() {
-		spByName = make(map[string]NewProviderFunc)
-	})
 
 	_, exists := spByName[name]
 	if exists {

--- a/storage/provider_test.go
+++ b/storage/provider_test.go
@@ -12,24 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package storage
 
 import (
 	"testing"
 
 	"github.com/google/trillian/monitoring"
-	"github.com/google/trillian/storage"
 )
 
 type provider struct {
 }
 
-func (p *provider) LogStorage() storage.LogStorage     { return nil }
-func (p *provider) MapStorage() storage.MapStorage     { return nil }
-func (p *provider) AdminStorage() storage.AdminStorage { return nil }
-func (p *provider) Close() error                       { return nil }
+func (p *provider) LogStorage() LogStorage     { return nil }
+func (p *provider) MapStorage() MapStorage     { return nil }
+func (p *provider) AdminStorage() AdminStorage { return nil }
+func (p *provider) Close() error               { return nil }
 
-func TestStorageProviderRegistration(t *testing.T) {
+func TestProviderRegistration(t *testing.T) {
 	for _, test := range []struct {
 		desc    string
 		reg     bool
@@ -51,18 +50,18 @@ func TestStorageProviderRegistration(t *testing.T) {
 			name := test.desc
 
 			if test.reg {
-				RegisterStorageProvider(name, func(_ monitoring.MetricFactory) (StorageProvider, error) {
+				RegisterProvider(name, func(_ monitoring.MetricFactory) (Provider, error) {
 					called = true
 					return &provider{}, nil
 				})
 			}
 
-			_, err := NewStorageProvider(name, nil)
+			_, err := NewProvider(name, nil)
 			if err != nil && !test.wantErr {
-				t.Fatalf("NewStorageProvider = %v, want no error", err)
+				t.Fatalf("NewProvider = %v, want no error", err)
 			}
 			if err == nil && test.wantErr {
-				t.Fatalf("NewStorageProvider = no error, want error")
+				t.Fatalf("NewProvider = no error, want error")
 			}
 			if !called && !test.wantErr {
 				t.Fatal("Registered storage provider was not called")
@@ -71,14 +70,14 @@ func TestStorageProviderRegistration(t *testing.T) {
 	}
 }
 
-func TestStorageProviders(t *testing.T) {
-	RegisterStorageProvider("a", func(_ monitoring.MetricFactory) (StorageProvider, error) {
+func TestProviders(t *testing.T) {
+	RegisterProvider("a", func(_ monitoring.MetricFactory) (Provider, error) {
 		return &provider{}, nil
 	})
-	RegisterStorageProvider("b", func(_ monitoring.MetricFactory) (StorageProvider, error) {
+	RegisterProvider("b", func(_ monitoring.MetricFactory) (Provider, error) {
 		return &provider{}, nil
 	})
-	sp := storageProviders()
+	sp := providers()
 
 	if got, want := len(sp), 2; got < want {
 		t.Fatalf("Got %d names, want at least %d", got, want)
@@ -95,9 +94,9 @@ func TestStorageProviders(t *testing.T) {
 		}
 	}
 	if a != 1 {
-		t.Errorf("StorageProviders() gave %d 'a', want 1", a)
+		t.Errorf("Providers() gave %d 'a', want 1", a)
 	}
 	if b != 1 {
-		t.Errorf("StorageProviders() gave %d 'b', want 1", b)
+		t.Errorf("Providers() gave %d 'b', want 1", b)
 	}
 }


### PR DESCRIPTION
This change moves `StorageProvider` interfaces/functions to `storage` package, and adds aliases in `server` package for backward compatibility.

This is the first step of #1919. What follows is the move of the existing providers to the corresponding packages.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
