### PR TITLE
Fix MySQL quota provider initialization bug

### DIFF
--- a/server/mysql_quota_provider.go
+++ b/server/mysql_quota_provider.go
@@ -37,8 +37,12 @@ func init() {
 }
 
 func newMySQLQuotaManager() (quota.Manager, error) {
+	db, err := getMySQLDatabase()
+	if err != nil {
+		return nil, err
+	}
 	qm := &mysqlqm.QuotaManager{
-		DB:                 mySQLstorageInstance.db,
+		DB:                 db,
 		MaxUnsequencedRows: *maxUnsequencedRows,
 	}
 	glog.Info("Using MySQL QuotaManager")


### PR DESCRIPTION
The order in which MySQL storage and quota providers are created is undefined. MySQL quota provider previously relied on the database field having been created by the storage provider. Now it's not required.