### PR TITLE
Read and write batch sizes are configured separately

### DIFF
--- a/testonly/hammer/hammer_test.go
+++ b/testonly/hammer/hammer_test.go
@@ -73,8 +73,10 @@ func TestRetryExposesDeadlineError(t *testing.T) {
 		LeafSize:      1000,
 		ExtraSize:     100,
 		// TODO(mhutchinson): Increase these when #1845 is understood & fixed.
-		MinLeaves:   100,
-		MaxLeaves:   150,
+		MinLeavesR:  100,
+		MaxLeavesR:  150,
+		MinLeavesW:  100,
+		MaxLeavesW:  150,
 		Operations:  *operations,
 		NumCheckers: 1,
 	}
@@ -124,8 +126,10 @@ func TestInProcessMapHammer(t *testing.T) {
 		LeafSize:      1000,
 		ExtraSize:     100,
 		// TODO(mhutchinson): Increase these when #1845 is understood & fixed.
-		MinLeaves:   100,
-		MaxLeaves:   150,
+		MinLeavesR:  100,
+		MaxLeavesR:  150,
+		MinLeavesW:  100,
+		MaxLeavesW:  150,
 		Operations:  *operations,
 		NumCheckers: 1,
 	}

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -53,8 +53,10 @@ var (
 	outLog          = flag.String("log_to", "", "File to record operations in")
 	seed            = flag.Int64("seed", -1, "Seed for random number generation")
 	operations      = flag.Uint64("operations", ^uint64(0), "Number of operations to perform")
-	minLeaves       = flag.Int("min_leaves", 0, "Minimum count of leaves to affect per-operation")
-	maxLeaves       = flag.Int("max_leaves", 10, "Maximum count of leaves to affect per-operation")
+	minLeaves       = flag.Int("min_leaves", 0, "Minimum count of leaves to read per-operation")
+	maxLeaves       = flag.Int("max_leaves", 10, "Maximum count of leaves to read per-operation")
+	minLeavesWrite  = flag.Int("min_leaves_write", 0, "Minimum count of leaves to write per-operation")
+	maxLeavesWrite  = flag.Int("max_leaves_write", 10, "Maximum count of leaves to write per-operation")
 	leafSize        = flag.Uint("leaf_size", 100, "Size of leaf values")
 	extraSize       = flag.Uint("extra_size", 100, "Size of leaf extra data")
 	checkers        = flag.Int("checkers", 1, "Number of checker goroutines to run")
@@ -187,8 +189,10 @@ func main() {
 			EPBias:            bias,
 			LeafSize:          *leafSize,
 			ExtraSize:         *extraSize,
-			MinLeaves:         *minLeaves,
-			MaxLeaves:         *maxLeaves,
+			MinLeavesR:        *minLeaves,
+			MaxLeavesR:        *maxLeaves,
+			MinLeavesW:        *minLeavesWrite,
+			MaxLeavesW:        *maxLeavesWrite,
 			Operations:        *operations,
 			EmitInterval:      *emitInterval,
 			NumCheckers:       *checkers,

--- a/testonly/hammer/maphammer/main.go
+++ b/testonly/hammer/maphammer/main.go
@@ -53,8 +53,8 @@ var (
 	outLog          = flag.String("log_to", "", "File to record operations in")
 	seed            = flag.Int64("seed", -1, "Seed for random number generation")
 	operations      = flag.Uint64("operations", ^uint64(0), "Number of operations to perform")
-	minLeaves       = flag.Int("min_leaves", 0, "Minimum count of leaves to read per-operation")
-	maxLeaves       = flag.Int("max_leaves", 10, "Maximum count of leaves to read per-operation")
+	minLeavesRead   = flag.Int("min_leaves_read", 0, "Minimum count of leaves to read per-operation")
+	maxLeavesRead   = flag.Int("max_leaves_read", 10, "Maximum count of leaves to read per-operation")
 	minLeavesWrite  = flag.Int("min_leaves_write", 0, "Minimum count of leaves to write per-operation")
 	maxLeavesWrite  = flag.Int("max_leaves_write", 10, "Maximum count of leaves to write per-operation")
 	leafSize        = flag.Uint("leaf_size", 100, "Size of leaf values")
@@ -189,8 +189,8 @@ func main() {
 			EPBias:            bias,
 			LeafSize:          *leafSize,
 			ExtraSize:         *extraSize,
-			MinLeavesR:        *minLeaves,
-			MaxLeavesR:        *maxLeaves,
+			MinLeavesR:        *minLeavesRead,
+			MaxLeavesR:        *maxLeavesRead,
 			MinLeavesW:        *minLeavesWrite,
 			MaxLeavesW:        *maxLeavesWrite,
 			Operations:        *operations,


### PR DESCRIPTION
There is no reason in the real world that the number of leaves fetched by clients in a batch would have any relationship to the number of leaves written at a time. The single parameter was an artefact of the way the hammer was written. Allowing these to be configured separately better approximates the real world and allows the hammer to hit the map more flexibly.

Making either of the read or write flags be above 100 triggers the issue in #1845, though it does so differently for each of the batch sizes.
