### PR TITLE
smt: Factor out NodeUpdate slice preparation

### DIFF
--- a/merkle/smt/updates.go
+++ b/merkle/smt/updates.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/trillian/storage/tree"
+)
+
+// NodeUpdate represents an update of a node hash in a sparse Merkle tree.
+type NodeUpdate struct {
+	ID   tree.NodeID2
+	Hash []byte
+}
+
+// Prepare sorts the updates slice for it to be usable by HStar3 algorithm and
+// the sparse Merkle tree Writer. It also verifies that the nodes are placed at
+// the required depth, and there are no duplicate IDs.
+//
+// TODO(pavelkalinnikov): Make this algorithm independent of NodeUpdate type.
+func Prepare(updates []NodeUpdate, depth uint) error {
+	for i := range updates {
+		if d, want := updates[i].ID.BitLen(), depth; d != want {
+			return fmt.Errorf("upd #%d: invalid depth %d, want %d", i, d, want)
+		}
+	}
+	sort.Slice(updates, func(i, j int) bool {
+		return compareHorizontal(updates[i].ID, updates[j].ID)
+	})
+	for i, last := 0, len(updates)-1; i < last; i++ {
+		if id := updates[i].ID; id == updates[i+1].ID {
+			return fmt.Errorf("duplicate ID: %v", id)
+		}
+	}
+	return nil
+}
+
+// compareHorizontal returns whether the first node ID is to the left from the
+// second one. The result only makes sense for IDs at the same tree level.
+func compareHorizontal(a, b tree.NodeID2) bool {
+	if res := strings.Compare(a.FullBytes(), b.FullBytes()); res != 0 {
+		return res < 0
+	}
+	aLast, _ := a.LastByte()
+	bLast, _ := b.LastByte()
+	return aLast < bLast
+}

--- a/merkle/smt/updates_test.go
+++ b/merkle/smt/updates_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/trillian/storage/tree"
+)
+
+func TestPrepare(t *testing.T) {
+	id1 := tree.NewNodeID2("01234567890000000000000000000001", 256)
+	id2 := tree.NewNodeID2("01234567890000000000000000000002", 256)
+	id3 := tree.NewNodeID2("01234567890000000000000000000003", 256)
+	id4 := tree.NewNodeID2("01234567890000000000000001111111", 256)
+
+	for _, tc := range []struct {
+		desc    string
+		upd     []NodeUpdate
+		want    []NodeUpdate
+		wantErr string
+	}{
+		{desc: "depth-err", upd: []NodeUpdate{{ID: id1.Prefix(10)}}, wantErr: "invalid depth"},
+		{desc: "dup-err1", upd: []NodeUpdate{{ID: id1}, {ID: id1}}, wantErr: "duplicate ID"},
+		{desc: "dup-err2", upd: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id1}}, wantErr: "duplicate ID"},
+		{
+			desc: "ok1",
+			upd:  []NodeUpdate{{ID: id2}, {ID: id1}, {ID: id4}, {ID: id3}},
+			want: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id3}, {ID: id4}},
+		},
+		{
+			desc: "ok2",
+			upd:  []NodeUpdate{{ID: id4}, {ID: id3}, {ID: id2}, {ID: id1}},
+			want: []NodeUpdate{{ID: id1}, {ID: id2}, {ID: id3}, {ID: id4}},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			upd := tc.upd // No need to copy it here.
+			err := Prepare(upd, 256)
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if want := tc.wantErr; !strings.Contains(got, want) {
+				t.Errorf("NewHStar3: want error containing %q, got %v", want, err)
+			}
+			if want := tc.want; want != nil && !reflect.DeepEqual(upd, want) {
+				t.Errorf("NewHStar3: want updates:\n%v\ngot:\n%v", upd, want)
+			}
+		})
+	}
+}

--- a/merkle/smt/writer.go
+++ b/merkle/smt/writer.go
@@ -59,7 +59,7 @@ func NewWriter(treeID int64, hasher hashers.MapHasher, height, split uint) *Writ
 // the subsets belonging to different subtrees. The updates must belong to the
 // same tree level which is equal to the tree height.
 func (w *Writer) Split(upd []NodeUpdate) ([][]NodeUpdate, error) {
-	if err := sortUpdates(upd, w.height); err != nil {
+	if err := Prepare(upd, w.height); err != nil {
 		return nil, err
 	}
 	// TODO(pavelkalinnikov): Try estimating the capacity for this slice.


### PR DESCRIPTION
This change separates `[]NodeUpdate` preparation function, because it is used by both `HStar3` and `Writer`. This function will be also used by the application layer to prepare updates and validate input (i.e. detect duplicates and incorrect `NodeID2` sizes), instead of [`validateIndices`](https://github.com/google/trillian/blob/4fc084db765583589b771b094955ec6ff958754c/server/map_rpc_server.go#L592).

This change also allows unexporting `HStar3` and using only the `Prepare` function in #1902.