### PR TITLE
Include full details if leaf inclusion proof fails

### DIFF
--- a/client/map_verifier.go
+++ b/client/map_verifier.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/maps"
 	"github.com/google/trillian/merkle"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gliderlabs/ssh v0.1.4 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gobuffalo/flect v0.1.5 // indirect
+	github.com/gogo/protobuf v1.2.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/mock v1.3.1


### PR DESCRIPTION
Including so much information seems a little non-standard, but this given how serious an error this is, having the relevant info seems like a must.  Useful when diagnosing #1845.