### PR TITLE
Fix improper gomock comparisons

### DIFF
--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -322,7 +322,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 	}
 
 	if params.updatedLeaves != nil {
-		mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), *params.updatedLeaves).Return(params.updatedLeavesError)
+		mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), cmpMatcher{*params.updatedLeaves}).Return(params.updatedLeavesError)
 	}
 
 	if params.merkleNodesSet != nil {
@@ -331,7 +331,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 
 	if !params.skipStoreSignedRoot {
 		if params.storeSignedRoot != nil {
-			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), params.storeSignedRoot).Return(params.storeSignedRootError)
+			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), cmpMatcher{params.storeSignedRoot}).Return(params.storeSignedRootError)
 		} else {
 			// At the moment if we're going to fail the operation we accept any root
 			mockTx.EXPECT().StoreSignedLogRoot(gomock.Any(), gomock.Any()).Return(params.storeSignedRootError)


### PR DESCRIPTION
The gomock framework uses reflect.DeepEqual by default unless the
test passes an object that implements gomock.Matcher.
Use of reflect.DeepEqual on protocol buffer messages is problematic
because generated messages contain unexported fields, mutexes,
and other internal data structures that reflect.DeepEqual does not
know how to handle. Fix the tests by defining a custom gomock.Matcher
to properly compare the inputs.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
