### PR TITLE
Make faster Map effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ have become stricter: now it always requires the caller to specify the write
 revision. These changes will not affect the Trillian module semantic version due
 to the experimental status of the Map.
 
+Map API has been extended with Layout, GetTiles and SetTiles calls which allow
+for more direct processing of sparse Merkle tree tiles in the application layer.
+Map storage implementations are simpler, and no longer use the SubtreeCache.
+
 The map client has been updated so that GetAndVerifyMapLeaves and
 GetAndVerifyMapLeavesByRevision return the MapRoot for the revision at which the
 leaves were fetched. Without this callers of GetAndVerifyMapLeaves in particular
@@ -39,6 +43,10 @@ the next major version bump. The individual storage providers have been moved to
 the corresponding packages, and are now required to be imported explicitly by
 the main file in order to be registered. We are including only MySQL and
 cloudspanner providers by default, since these are the ones that we support.
+
+The cloudspanner storage is supported for logs only, while the Map storage API
+is being polished and decoupled from the log storage API. We may return the
+support when the new API is tested.
 
 ### Quota
 

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -345,8 +345,13 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		})
 	}
 
+	layout, err := t.registry.MapStorage.Layout(tree)
+	if err != nil {
+		return nil, err
+	}
 	updater := &mapTreeUpdater{
 		tree:     tree,
+		layout:   layout,
 		hasher:   hasher,
 		ms:       t.registry.MapStorage,
 		singleTX: t.opts.UseSingleTransaction,

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -354,6 +354,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		layout:   layout,
 		hasher:   hasher,
 		ms:       t.registry.MapStorage,
+		writeRev: req.Revision,
 		singleTX: t.opts.UseSingleTransaction,
 		preload:  t.opts.UseLargePreload,
 	}
@@ -369,7 +370,7 @@ func (t *TrillianMapServer) SetLeaves(ctx context.Context, req *trillian.SetMapL
 		if err := t.writeLeaves(ctx, tx, req.Leaves); err != nil {
 			return err
 		}
-		hash, err := updater.update(ctx, tx, nodes, writeRev)
+		hash, err := updater.update(ctx, tx, nodes)
 		if err != nil {
 			return err
 		}

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -33,20 +33,21 @@ type mapTreeUpdater struct {
 	layout   *tree.Layout
 	hasher   hashers.MapHasher
 	ms       storage.MapStorage
+	writeRev int64
 	singleTX bool
 	preload  bool
 }
 
-// update updates the sparse Merkle tree at the passed-in revision with the
+// update updates the sparse Merkle tree at the current write revision with the
 // given leaf node updates, and writes it to the storage. Returns the new root
 // hash. Requires nodes slice to be non-empty.
-func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node, writeRev int64) ([]byte, error) {
+func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node) ([]byte, error) {
 	// Work around a performance issue when using the map in single-transaction
 	// mode by preloading all the tiles we know the Writer is going to need.
 	var preloaded *smt.TileSet
 	if t.singleTX && t.preload {
 		var err error
-		if preloaded, err = t.doPreload(ctx, tx, nodes, writeRev-1); err != nil {
+		if preloaded, err = t.doPreload(ctx, tx, nodes); err != nil {
 			return nil, err
 		}
 	}
@@ -66,7 +67,7 @@ func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes
 		err = runTX(ctx, func(ctx context.Context, tx storage.MapTreeTX) error {
 			nodesCopy := make([]smt.Node, len(nodes))
 			copy(nodesCopy, nodes) // Protect from TX restarts.
-			acc := &txAccessor{updater: t, tiles: preloaded, tx: tx, rev: writeRev}
+			acc := &txAccessor{updater: t, tiles: preloaded, tx: tx}
 			var err error
 			root, err = w.Write(ctx, nodesCopy, acc)
 			return err
@@ -116,7 +117,6 @@ type txAccessor struct {
 	// (and the only) Get call occurs. A missing tile is interpreted as empty.
 	tiles *smt.TileSet
 	tx    storage.MapTreeTX
-	rev   int64
 }
 
 // TODO(pavelkalinnikov): Get should take a list of tile IDs.
@@ -124,7 +124,7 @@ func (t *txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.Node
 	// TODO(pavelkalinnikov): Factor out preload into another accessor.
 	if t.tiles == nil {
 		var err error
-		if t.tiles, err = t.updater.load(ctx, t.tx, ids, t.rev-1); err != nil {
+		if t.tiles, err = t.updater.load(ctx, t.tx, ids); err != nil {
 			return nil, err
 		}
 	}
@@ -166,7 +166,7 @@ func (t *mapTreeUpdater) newTXFunc(tx storage.MapTreeTX) txFunc {
 
 // doPreload loads all Merkle tree tiles that will be involved when updating
 // the given set of nodes at the specified revision.
-func (t *mapTreeUpdater) doPreload(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node, rev int64) (*smt.TileSet, error) {
+func (t *mapTreeUpdater) doPreload(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node) (*smt.TileSet, error) {
 	ctx, spanEnd := spanFor(ctx, "doPreload")
 	defer spanEnd()
 	// TODO(pavelkalinnikov): Avoid using HStar3 directly.
@@ -175,13 +175,13 @@ func (t *mapTreeUpdater) doPreload(ctx context.Context, tx storage.MapTreeTX, no
 	if err != nil {
 		return nil, err
 	}
-	return t.load(ctx, tx, hs.Prepare(), rev)
+	return t.load(ctx, tx, hs.Prepare())
 }
 
 // load fetches Merkle tree tiles containing the given node IDs.
-func (t *mapTreeUpdater) load(ctx context.Context, tx storage.MapTreeTX, ids []tree.NodeID2, rev int64) (*smt.TileSet, error) {
+func (t *mapTreeUpdater) load(ctx context.Context, tx storage.MapTreeTX, ids []tree.NodeID2) (*smt.TileSet, error) {
 	tileIDs := toTileIDs(ids, t.layout)
-	tiles, err := tx.GetTiles(ctx, rev, tileIDs)
+	tiles, err := tx.GetTiles(ctx, t.writeRev-1, tileIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -130,11 +130,11 @@ func (t *txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.Node
 }
 
 func (t *txAccessor) Set(ctx context.Context, nodes []smt.Node) error {
-	mut := smt.NewTileSetMutation(t.read)
+	m := smt.NewTileSetMutation(t.read)
 	for _, n := range nodes {
-		mut.Set(n.ID, n.Hash)
+		m.Set(n.ID, n.Hash)
 	}
-	tiles, err := mut.Build()
+	tiles, err := m.Build()
 	if err != nil {
 		return err
 	}

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -131,6 +131,9 @@ func (t *txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.Node
 	return t.tiles.Hashes(), nil
 }
 
+// Set puts the updates of the given tree nodes to the transaction. It accepts
+// all nodes updated in the tree. However, only "leaf" nodes of tiles are used
+// to build the updated tiles, before they are passed in to the storage layer.
 func (t *txAccessor) Set(ctx context.Context, nodes []smt.Node) error {
 	m := smt.NewTileSetMutation(t.tiles)
 	for _, n := range nodes {

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -30,6 +30,7 @@ import (
 // map tree transactions.
 type mapTreeUpdater struct {
 	tree     *trillian.Tree
+	layout   *tree.Layout
 	hasher   hashers.MapHasher
 	ms       storage.MapStorage
 	singleTX bool
@@ -38,16 +39,14 @@ type mapTreeUpdater struct {
 
 // update updates the sparse Merkle tree at the passed-in revision with the
 // given leaf node updates, and writes it to the storage. Returns the new root
-// hash. Requires nodes to be non-empty.
+// hash. Requires nodes slice to be non-empty.
 func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node, writeRev int64) ([]byte, error) {
 	// Work around a performance issue when using the map in single-transaction
-	// mode by preloading all the nodes we know the Writers are going to need.
-	var hashes map[tree.NodeID2][]byte
-	preload := t.singleTX && t.preload
-	// Note: It's fine if hashes == nil, it only happens if preload == false.
-	if preload {
+	// mode by preloading all the tiles we know the Writer is going to need.
+	var preload *smt.TileSet
+	if t.singleTX && t.preload {
 		var err error
-		if hashes, err = doPreload(ctx, tx, uint(t.hasher.BitLen()), nodes, writeRev-1); err != nil {
+		if preload, err = t.doPreload(ctx, tx, nodes, writeRev-1); err != nil {
 			return nil, err
 		}
 	}
@@ -67,7 +66,7 @@ func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes
 		err = runTX(ctx, func(ctx context.Context, tx storage.MapTreeTX) error {
 			nodesCopy := make([]smt.Node, len(nodes))
 			copy(nodesCopy, nodes) // Protect from TX restarts.
-			acc := &txAccessor{hashes: hashes, preload: preload, tx: tx, rev: writeRev}
+			acc := &txAccessor{mtu: t, read: preload, tx: tx, rev: writeRev}
 			var err error
 			root, err = w.Write(ctx, nodesCopy, acc)
 			return err
@@ -110,44 +109,36 @@ func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes
 }
 
 type txAccessor struct {
-	// hashes is a cache of node hashes that Get returns directly instead of
-	// calling GetMerkleNodes. Used only if preload is true.
-	hashes  map[tree.NodeID2][]byte
-	preload bool
-
-	tx  storage.MapTreeTX
-	rev int64
+	mtu *mapTreeUpdater
+	// read is a cache of tree tiles that Get returns directly instead of calling
+	// GetTiles. It is initialized by the first Get call if not specified.
+	read *smt.TileSet
+	tx   storage.MapTreeTX
+	rev  int64
 }
 
-func (t txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.NodeID2][]byte, error) {
+// TODO(pavelkalinnikov): Get should take a list of tile IDs.
+func (t *txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.NodeID2][]byte, error) {
 	// TODO(pavelkalinnikov): Factor out preload into another accessor.
-	if t.preload {
-		return t.hashes, nil
+	if t.read == nil {
+		var err error
+		if t.read, err = t.mtu.load(ctx, t.tx, ids, t.rev-1); err != nil {
+			return nil, err
+		}
 	}
-
-	// TODO(pavelkalinnikov): Pass NodeID2 directly to storage.
-	convIDs := make([]tree.NodeID, 0, len(ids))
-	for _, id := range ids {
-		convIDs = append(convIDs, tree.NewNodeIDFromID2(id))
-	}
-	nodes, err := t.tx.GetMerkleNodes(ctx, t.rev-1, convIDs)
-	if err != nil {
-		return nil, err
-	}
-	res := make(map[tree.NodeID2][]byte, len(nodes))
-	for _, node := range nodes {
-		res[node.NodeID.ToNodeID2()] = node.Hash
-	}
-	return res, nil
+	return t.read.Hashes(), nil
 }
 
-func (t txAccessor) Set(ctx context.Context, nodes []smt.Node) error {
-	stNodes := make([]tree.Node, 0, len(nodes))
+func (t *txAccessor) Set(ctx context.Context, nodes []smt.Node) error {
+	mut := smt.NewTileSetMutation(t.read)
 	for _, n := range nodes {
-		id := tree.NewNodeIDFromID2(n.ID)
-		stNodes = append(stNodes, tree.Node{NodeID: id, Hash: n.Hash, NodeRevision: t.rev})
+		mut.Set(n.ID, n.Hash)
 	}
-	return t.tx.SetMerkleNodes(ctx, stNodes)
+	tiles, err := mut.Build()
+	if err != nil {
+		return err
+	}
+	return t.tx.SetTiles(ctx, tiles)
 }
 
 type txFunc func(context.Context, func(context.Context, storage.MapTreeTX) error) error
@@ -168,20 +159,49 @@ func (t *mapTreeUpdater) newTXFunc(tx storage.MapTreeTX) txFunc {
 	}
 }
 
-// doPreload causes the subtreeCache in tx to become populated with all
-// subtrees on the Merkle path for the indices specified in upd.
-// This is a performance workaround for locking issues which occur when the
-// sparse Merkle tree code is used with a single transaction (and therefore a
-// single subtreeCache too).
-func doPreload(ctx context.Context, tx storage.MapTreeTX, depth uint, upd []smt.Node, rev int64) (map[tree.NodeID2][]byte, error) {
+// doPreload loads all Merkle tree tiles that will be involved when updating
+// the given set of nodes at the specified revision.
+func (t *mapTreeUpdater) doPreload(ctx context.Context, tx storage.MapTreeTX, nodes []smt.Node, rev int64) (*smt.TileSet, error) {
 	ctx, spanEnd := spanFor(ctx, "doPreload")
 	defer spanEnd()
-
 	// TODO(pavelkalinnikov): Avoid using HStar3 directly.
-	hs, err := smt.NewHStar3(upd, nil, depth, 0)
+	hs, err := smt.NewHStar3(nodes, nil, uint(t.hasher.BitLen()), 0)
 	if err != nil {
 		return nil, err
 	}
-	acc := txAccessor{tx: tx, rev: rev + 1}
-	return acc.Get(ctx, hs.Prepare())
+	return t.load(ctx, tx, hs.Prepare(), rev)
+}
+
+// load fetches Merkle tree tiles containing the given node IDs.
+func (t *mapTreeUpdater) load(ctx context.Context, tx storage.MapTreeTX, ids []tree.NodeID2, rev int64) (*smt.TileSet, error) {
+	tileIDs := toTileIDs(ids, t.layout)
+	tiles, err := tx.GetTiles(ctx, rev, tileIDs)
+	if err != nil {
+		return nil, err
+	}
+	ts := smt.NewTileSet(t.tree.TreeId, t.hasher, t.layout)
+	for _, tile := range tiles {
+		// TODO(pavelkalinnikov): Check tile against the layout.
+		if err := ts.Add(tile); err != nil {
+			return nil, err
+		}
+	}
+	return ts, nil
+}
+
+// toTileIDs returns the list of tile IDs that the given nodes belong to, in
+// accordance with the layout.
+func toTileIDs(ids []tree.NodeID2, layout *tree.Layout) []tree.NodeID2 {
+	// Note: The capacity estimate assumes that most of the tile heights are 8.
+	// It's not a strong requirement, as the map grows when necessary. The real
+	// size also depends on IDs, so can differ even if all tile heights are 8.
+	roots := make(map[tree.NodeID2]bool, len(ids)/8)
+	for _, id := range ids {
+		roots[layout.GetTileRootID(id)] = true
+	}
+	tileIDs := make([]tree.NodeID2, 0, len(roots))
+	for id := range roots {
+		tileIDs = append(tileIDs, id)
+	}
+	return tileIDs
 }

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -170,6 +170,7 @@ func (t *mapTreeUpdater) doPreload(ctx context.Context, tx storage.MapTreeTX, no
 	ctx, spanEnd := spanFor(ctx, "doPreload")
 	defer spanEnd()
 	// TODO(pavelkalinnikov): Avoid using HStar3 directly.
+	// TODO(pavelkalinnikov): Introduce layout "height" method and use it here.
 	hs, err := smt.NewHStar3(nodes, nil, uint(t.hasher.BitLen()), 0)
 	if err != nil {
 		return nil, err

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -110,10 +110,10 @@ func (t *mapTreeUpdater) update(ctx context.Context, tx storage.MapTreeTX, nodes
 
 type txAccessor struct {
 	updater *mapTreeUpdater
-	// tiles is a cache of tree tiles that Get uses to fetch node hashes from. It
-	// is either specified when this accessor is created (i.e. the hashes were
-	// preloaded), or otherwise set when the first (and the only) Get call
-	// occurs. A missing tile is interpreted as empty.
+	// tiles is a cache of tree tiles that Get uses to fetch node hashes from,
+	// and Set mutates tiles from. It is either specified when this accessor is
+	// created (i.e. the hashes were preloaded), or otherwise set when the first
+	// (and the only) Get call occurs. A missing tile is interpreted as empty.
 	tiles *smt.TileSet
 	tx    storage.MapTreeTX
 	rev   int64
@@ -131,7 +131,7 @@ func (t *txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.Node
 	return t.tiles.Hashes(), nil
 }
 
-// Set puts the updates of the given tree nodes to the transaction. It accepts
+// Set applies the updates of the given nodes to the transaction. It accepts
 // all nodes updated in the tree. However, only "leaf" nodes of tiles are used
 // to build the updated tiles, before they are passed in to the storage layer.
 func (t *txAccessor) Set(ctx context.Context, nodes []smt.Node) error {

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -24,9 +24,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/smt"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/cloudspanner/spannerpb"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -110,6 +112,11 @@ func (ms *mapStorage) SnapshotForTree(ctx context.Context, tree *trillian.Tree) 
 	return ms.begin(ctx, tree, true, ms.ts.client.ReadOnlyTransaction())
 }
 
+// Layout is not implemented.
+func (ms *mapStorage) Layout(tree *trillian.Tree) (*tree.Layout, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (ms *mapStorage) ReadWriteTransaction(ctx context.Context, tree *trillian.Tree, f storage.MapTXFunc) error {
 	_, err := ms.ts.client.ReadWriteTransaction(ctx, func(ctx context.Context, stx *spanner.ReadWriteTransaction) error {
 		tx, err := ms.begin(ctx, tree, false /* readonly */, stx)
@@ -134,7 +141,6 @@ func (ms *mapStorage) ReadWriteTransaction(ctx context.Context, tree *trillian.T
 type mapTX struct {
 	// treeTX embeds the merkle-tree level transactional actions.
 	*treeTX
-
 	// ms is the MapStorage which begat this mapTX.
 	ms *mapStorage
 }
@@ -261,6 +267,16 @@ func (tx *mapTX) Set(ctx context.Context, index []byte, value *trillian.MapLeaf)
 		[]interface{}{tx.treeID, index, writeRev, value.LeafHash, leafValue, value.ExtraData})
 
 	return stx.BufferWrite([]*spanner.Mutation{m})
+}
+
+// GetTiles is not implemented.
+func (tx *mapTX) GetTiles(ctx context.Context, rev int64, ids []tree.NodeID2) ([]smt.Tile, error) {
+	return nil, errors.New("not implemented")
+}
+
+// SetTiles is not implemented.
+func (tx *mapTX) SetTiles(ctx context.Context, tiles []smt.Tile) error {
+	return errors.New("not implemented")
 }
 
 // getMapLeaf fetches and returns the MapLeaf stored at the specified index and

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	trillian "github.com/google/trillian"
+	smt "github.com/google/trillian/merkle/smt"
 	tree "github.com/google/trillian/storage/tree"
 	reflect "reflect"
 	time "time"
@@ -711,6 +712,21 @@ func (mr *MockMapStorageMockRecorder) CheckDatabaseAccessible(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDatabaseAccessible", reflect.TypeOf((*MockMapStorage)(nil).CheckDatabaseAccessible), arg0)
 }
 
+// Layout mocks base method
+func (m *MockMapStorage) Layout(arg0 *trillian.Tree) (*tree.Layout, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Layout", arg0)
+	ret0, _ := ret[0].(*tree.Layout)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Layout indicates an expected call of Layout
+func (mr *MockMapStorageMockRecorder) Layout(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Layout", reflect.TypeOf((*MockMapStorage)(nil).Layout), arg0)
+}
+
 // ReadWriteTransaction mocks base method
 func (m *MockMapStorage) ReadWriteTransaction(arg0 context.Context, arg1 *trillian.Tree, arg2 MapTXFunc) error {
 	m.ctrl.T.Helper()
@@ -836,6 +852,21 @@ func (mr *MockMapTreeTXMockRecorder) GetSignedMapRoot(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSignedMapRoot", reflect.TypeOf((*MockMapTreeTX)(nil).GetSignedMapRoot), arg0, arg1)
 }
 
+// GetTiles mocks base method
+func (m *MockMapTreeTX) GetTiles(arg0 context.Context, arg1 int64, arg2 []tree.NodeID2) ([]smt.Tile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTiles", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]smt.Tile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTiles indicates an expected call of GetTiles
+func (mr *MockMapTreeTXMockRecorder) GetTiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTiles", reflect.TypeOf((*MockMapTreeTX)(nil).GetTiles), arg0, arg1, arg2)
+}
+
 // IsOpen mocks base method
 func (m *MockMapTreeTX) IsOpen() bool {
 	m.ctrl.T.Helper()
@@ -920,6 +951,20 @@ func (m *MockMapTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []tree.Node) e
 func (mr *MockMapTreeTXMockRecorder) SetMerkleNodes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMerkleNodes", reflect.TypeOf((*MockMapTreeTX)(nil).SetMerkleNodes), arg0, arg1)
+}
+
+// SetTiles mocks base method
+func (m *MockMapTreeTX) SetTiles(arg0 context.Context, arg1 []smt.Tile) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTiles", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetTiles indicates an expected call of SetTiles
+func (mr *MockMapTreeTXMockRecorder) SetTiles(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTiles", reflect.TypeOf((*MockMapTreeTX)(nil).SetTiles), arg0, arg1)
 }
 
 // StoreSignedMapRoot mocks base method
@@ -1433,6 +1478,21 @@ func (m *MockReadOnlyMapTreeTX) GetSignedMapRoot(arg0 context.Context, arg1 int6
 func (mr *MockReadOnlyMapTreeTXMockRecorder) GetSignedMapRoot(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSignedMapRoot", reflect.TypeOf((*MockReadOnlyMapTreeTX)(nil).GetSignedMapRoot), arg0, arg1)
+}
+
+// GetTiles mocks base method
+func (m *MockReadOnlyMapTreeTX) GetTiles(arg0 context.Context, arg1 int64, arg2 []tree.NodeID2) ([]smt.Tile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTiles", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]smt.Tile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTiles indicates an expected call of GetTiles
+func (mr *MockReadOnlyMapTreeTXMockRecorder) GetTiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTiles", reflect.TypeOf((*MockReadOnlyMapTreeTX)(nil).GetTiles), arg0, arg1, arg2)
 }
 
 // IsOpen mocks base method

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/merkle/smt"
@@ -27,11 +29,9 @@ import (
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/storage/storagepb/convert"
-	stree "github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+	stree "github.com/google/trillian/storage/tree"
 )
 
 const (

--- a/storage/testonly/transaction.go
+++ b/storage/testonly/transaction.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/tree"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -129,6 +130,11 @@ func (f *FakeMapStorage) Snapshot(ctx context.Context) (storage.ReadOnlyMapTX, e
 // SnapshotForTree implements MapStorage.SnapshotForTree
 func (f *FakeMapStorage) SnapshotForTree(ctx context.Context, _ *trillian.Tree) (storage.ReadOnlyMapTreeTX, error) {
 	return f.ReadOnlyTX, f.SnapshotErr
+}
+
+// Layout is not implemented.
+func (f *FakeMapStorage) Layout(*trillian.Tree) (*tree.Layout, error) {
+	return nil, errors.New("not implemented")
 }
 
 // ReadWriteTransaction implements MapStorage.ReadWriteTransaction


### PR DESCRIPTION
This change makes the new Map writer design effective.

The tiling structure of Map is now explicit in `storage` API. The new `Layout`
method of `MapStorage` interface returns the layout, and `MapTX`'s `GetTiles` and
`SetTiles` methods allow reading and writing tiles. Most of the tile processing
logic, e.g. computing intermediate hashes, now resides in the application layer.

The new code supports both single- and multi- transaction writes, and is fully
compatible with the previous implementation (true only for MySQL storage).

`SubtreeCache` is no longer used by the Map, and so there are no longer hidden
races/locking between parallel `GetTiles`/`SetTiles` calls.

As a result, MySQL map integration tests running time is reduced by 20%.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
