### PR TITLE
Move irrelevant types from storage/tree

### DIFF
--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -14,16 +14,25 @@
 
 package storage
 
-import tree "github.com/google/trillian/storage/tree"
+import (
+	"github.com/google/trillian/storage/storagepb"
+	"github.com/google/trillian/storage/tree"
+)
 
-// TODO(pavelkalinnikov): These aliases were created to not break the code that
-// depended on these types. We should delete this file eventually.
+// TODO(pavelkalinnikov, v2): These aliases were created to not break the code
+// that depended on these types. We should delete this.
 
 type NodeID = tree.NodeID
 type Node = tree.Node
 type Suffix = tree.Suffix
-type PopulateSubtreeFunc = tree.PopulateSubtreeFunc
-type PrepareSubtreeWriteFunc = tree.PrepareSubtreeWriteFunc
+
+// PopulateSubtreeFunc is a function which knows how to re-populate a subtree
+// from just its leaf nodes.
+type PopulateSubtreeFunc func(*storagepb.SubtreeProto) error
+
+// PrepareSubtreeWriteFunc is a function that carries out any required tree
+// type specific manipulation of a subtree before it's written to storage
+type PrepareSubtreeWriteFunc func(*storagepb.SubtreeProto) error
 
 var (
 	NewNodeIDFromHash         = tree.NewNodeIDFromHash

--- a/storage/cache/log_subtree_cache.go
+++ b/storage/cache/log_subtree_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/storage/tree"
 )
@@ -38,7 +39,7 @@ func NewLogSubtreeCache(logStrata []int, hasher hashers.LogHasher) *SubtreeCache
 
 // LogPopulateFunc obtains a log storage population function based on a supplied LogHasher.
 // This is intended for use by storage utilities.
-func LogPopulateFunc(hasher hashers.LogHasher) tree.PopulateSubtreeFunc {
+func LogPopulateFunc(hasher hashers.LogHasher) storage.PopulateSubtreeFunc {
 	return populateLogSubtreeNodes(hasher)
 }
 
@@ -49,7 +50,7 @@ func LogPopulateFunc(hasher hashers.LogHasher) tree.PopulateSubtreeFunc {
 // handle imperfect (but left-hand dense) subtrees. Note that we only rebuild internal
 // nodes when the subtree is fully populated. For an explanation of why see the comments
 // below for PrepareLogSubtreeWrite.
-func populateLogSubtreeNodes(hasher hashers.LogHasher) tree.PopulateSubtreeFunc {
+func populateLogSubtreeNodes(hasher hashers.LogHasher) storage.PopulateSubtreeFunc {
 	return func(st *storagepb.SubtreeProto) error {
 		if st.Depth < 1 {
 			return fmt.Errorf("populate log subtree with invalid depth: %d", st.Depth)
@@ -136,7 +137,7 @@ func populateLogSubtreeNodes(hasher hashers.LogHasher) tree.PopulateSubtreeFunc 
 //
 // Fully populated subtrees don't have this problem because by definition they can only
 // contain internal nodes built from their own contents.
-func prepareLogSubtreeWrite() tree.PrepareSubtreeWriteFunc {
+func prepareLogSubtreeWrite() storage.PrepareSubtreeWriteFunc {
 	return func(st *storagepb.SubtreeProto) error {
 		st.InternalNodeCount = uint32(len(st.InternalNodes))
 		if st.Depth < 1 {

--- a/storage/cache/map_subtree_cache.go
+++ b/storage/cache/map_subtree_cache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/storage/tree"
 )
@@ -36,12 +37,12 @@ func NewMapSubtreeCache(mapStrata []int, treeID int64, hasher hashers.MapHasher)
 // subtree Leaves map.
 //
 // This uses HStar2 to repopulate internal nodes.
-func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) tree.PopulateSubtreeFunc {
+func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) storage.PopulateSubtreeFunc {
 	return func(st *storagepb.SubtreeProto) error {
 		st.InternalNodes = make(map[string][]byte)
 		leaves := make([]*merkle.HStar2LeafHash, 0, len(st.Leaves))
 		for k64, v := range st.Leaves {
-			sfx, err := tree.ParseSuffix(k64)
+			sfx, err := storage.ParseSuffix(k64)
 			if err != nil {
 				return err
 			}
@@ -85,7 +86,7 @@ func populateMapSubtreeNodes(treeID int64, hasher hashers.MapHasher) tree.Popula
 
 // prepareMapSubtreeWrite prepares a map subtree for writing. For maps the internal
 // nodes are never written to storage and are thus always cleared.
-func prepareMapSubtreeWrite() tree.PrepareSubtreeWriteFunc {
+func prepareMapSubtreeWrite() storage.PrepareSubtreeWriteFunc {
 	return func(st *storagepb.SubtreeProto) error {
 		st.InternalNodes = nil
 		// We don't check the node count for map subtrees but ensure it's zero for consistency

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/storage/tree"
 )
@@ -66,18 +67,18 @@ type SubtreeCache struct {
 	dirtyPrefixes sync.Map
 
 	// populate is used to rebuild internal nodes when subtrees are loaded from storage.
-	populate tree.PopulateSubtreeFunc
+	populate storage.PopulateSubtreeFunc
 	// populateConcurrency sets the amount of concurrency when repopulating subtrees.
 	populateConcurrency int
 	// prepare is used for preparation work when subtrees are about to be written to storage.
-	prepare tree.PrepareSubtreeWriteFunc
+	prepare storage.PrepareSubtreeWriteFunc
 }
 
 // NewSubtreeCache returns a newly intialised cache ready for use.
 // populateSubtree is a function which knows how to populate a subtree's
 // internal nodes given its leaves, and will be called for each subtree loaded
 // from storage.
-func NewSubtreeCache(strataDepths []int, populateSubtree tree.PopulateSubtreeFunc, prepareSubtreeWrite tree.PrepareSubtreeWriteFunc) *SubtreeCache {
+func NewSubtreeCache(strataDepths []int, populateSubtree storage.PopulateSubtreeFunc, prepareSubtreeWrite storage.PrepareSubtreeWriteFunc) *SubtreeCache {
 	// TODO(al): pass this in
 	maxTreeDepth := maxSupportedTreeDepth
 	glog.V(1).Infof("Creating new subtree cache maxDepth=%d strataDepths=%v", maxTreeDepth, strataDepths)

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -313,7 +313,7 @@ func Main(args Options) string {
 	return allRevisions(ls, tree.TreeId, repopFunc, formatter, args.Rebuild, args.HexKeys)
 }
 
-func allRevisions(ls storage.LogStorage, treeID int64, repopFunc tree.PopulateSubtreeFunc, of func(*storagepb.SubtreeProto) string, rebuildInternal, hexKeysFlag bool) string {
+func allRevisions(ls storage.LogStorage, treeID int64, repopFunc storage.PopulateSubtreeFunc, of func(*storagepb.SubtreeProto) string, rebuildInternal, hexKeysFlag bool) string {
 	out := new(bytes.Buffer)
 	memory.DumpSubtrees(ls, treeID, func(k string, v *storagepb.SubtreeProto) {
 		if rebuildInternal {
@@ -327,7 +327,7 @@ func allRevisions(ls storage.LogStorage, treeID int64, repopFunc tree.PopulateSu
 	return out.String()
 }
 
-func latestRevisions(ls storage.LogStorage, treeID int64, repopFunc tree.PopulateSubtreeFunc, of func(*storagepb.SubtreeProto) string, rebuildInternal, hexKeysFlag bool) string {
+func latestRevisions(ls storage.LogStorage, treeID int64, repopFunc storage.PopulateSubtreeFunc, of func(*storagepb.SubtreeProto) string, rebuildInternal, hexKeysFlag bool) string {
 	out := new(bytes.Buffer)
 	// vMap maps subtree prefixes (as strings) to the corresponding subtree proto and its revision
 	vMap := make(map[string]treeAndRev)

--- a/storage/tree/node.go
+++ b/storage/tree/node.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian/storage/storagepb"
 )
 
 const hexChars = "0123456789abcdef"
@@ -470,11 +469,3 @@ func (n NodeID) Equivalent(other NodeID) bool {
 	mask := leftmask[n.PrefixLenBits%8]
 	return (n.Path[depthBytes] & mask) == (other.Path[depthBytes] & mask)
 }
-
-// PopulateSubtreeFunc is a function which knows how to re-populate a subtree
-// from just its leaf nodes.
-type PopulateSubtreeFunc func(*storagepb.SubtreeProto) error
-
-// PrepareSubtreeWriteFunc is a function that carries out any required tree type specific
-// manipulation of a subtree before it's written to storage
-type PrepareSubtreeWriteFunc func(*storagepb.SubtreeProto) error


### PR DESCRIPTION
The callback types are being moved to their original place in `storage` package. This a) helps eliminating circular dependencies in #1932, and b) makes `tree` package agnostic of `SubtreeCache` machinery.