### PR TITLE
NodeID2: Introduce a low-level constructor

### DIFF
--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -44,7 +44,7 @@ import "fmt"
 type NodeID2 struct {
 	path string
 	last byte  // Invariant: Lowest (8-bits) bits of the last byte are unset.
-	bits uint8 // Invariant: 1 <= bits <= 8, or bits == 0 if len(path) == 0.
+	bits uint8 // Invariant: 1 <= bits <= 8, or bits == 0 for the empty ID.
 }
 
 // NewNodeID2 creates a NodeID2 from the given path bytes truncated to the

--- a/storage/tree/node_id2.go
+++ b/storage/tree/node_id2.go
@@ -17,8 +17,8 @@ package tree
 import "fmt"
 
 // NodeID2 identifies a node of a Merkle tree. It is a bit string that counts
-// the node down from the tree root, i.e. 0 and 1 bits correspond to going to
-// the left or right child correspondingly.
+// the node down from the tree root, i.e. 0 and 1 bits represent going to the
+// left or right child correspondingly.
 //
 // NodeID2 is immutable, comparable, and can be used as a Golang map key. It
 // also incurs zero memory allocations in transforming methods like Prefix and

--- a/storage/tree/node_id2_test.go
+++ b/storage/tree/node_id2_test.go
@@ -20,6 +20,40 @@ import (
 	"testing"
 )
 
+func TestNewNodeID2WithLast(t *testing.T) {
+	const bytes = "\x0A\x0B\x0C\xFA"
+	for _, tc := range []struct {
+		length uint
+		path   string
+		last   byte
+		bits   uint8
+	}{
+		{length: 0, last: 0, bits: 0},
+		{length: 0, last: 123, bits: 0},
+		{length: 1, last: 0, bits: 1},
+		{length: 1, last: 123, bits: 1},
+		{length: 4, last: 0, bits: 4},
+		{length: 5, last: 0xA, bits: 5},
+		{length: 5, last: 0xF, bits: 5},
+		{length: 7, last: 0xB, bits: 7},
+		{length: 8, last: 0xA, bits: 8},
+		{length: 9, path: bytes[:1], last: 0, bits: 1},
+		{length: 13, path: bytes[:1], last: 0xA, bits: 5},
+		{length: 24, path: bytes[:2], last: 0xC, bits: 8},
+		{length: 31, path: bytes[:3], last: 0xFB, bits: 7},
+		{length: 31, path: bytes[:3], last: 0xFA, bits: 7},
+		{length: 32, path: bytes[:3], last: 0xFA, bits: 8},
+	} {
+		id := NewNodeID2(bytes, tc.length)
+		t.Run(id.String(), func(t *testing.T) {
+			got := NewNodeID2WithLast(tc.path, tc.last, tc.bits)
+			if want := id; got != want {
+				t.Errorf("NewNodeID2WithLast: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestNodeID2String(t *testing.T) {
 	bytes := string([]byte{5, 1, 127})
 	for _, tc := range []struct {


### PR DESCRIPTION
This change adds a `NodeID2` constructor that allows the caller to take advantage of `NodeID2` internal structure. For example, `storage` implementations that have their tree tiles aligned to 8-bit heights will be able to construct node IDs of small tiles without any additional memory allocations except for the root.

This change also improves documentation of `NodeID2` in general.

Example of future usage in #1932.