### PR TITLE
map_rpc_server: Cover preload and split TX with tests

### DIFF
--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -455,14 +455,15 @@ func TestSetLeaves(t *testing.T) {
 					// One Set call per leaf.
 					mockTX.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(count)
 					if !tc.splitTX {
-						// One shard per leaf (note that they are random), plus the root shard.
+						// Leaves are in different shards because the leaf indices are
+						// random. We query one shard per leaf, plus the root shard.
 						merkleGets := count + 1
-						// Plus, possibly, the preloading phase.
+						// Plus, possibly, there is a "global" preloading query.
 						if tc.preload {
 							merkleGets++
 						}
 						mockTX.EXPECT().GetMerkleNodes(gomock.Any(), gomock.Any(), gomock.Any()).Times(merkleGets)
-						// Storing each shard and the common root.
+						// Store each leave's shard, and the root shard.
 						mockTX.EXPECT().SetMerkleNodes(gomock.Any(), gomock.Any()).Times(count + 1)
 					}
 					mockTX.EXPECT().StoreSignedMapRoot(gomock.Any(), gomock.Any())

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -463,7 +463,7 @@ func TestSetLeaves(t *testing.T) {
 							merkleGets++
 						}
 						mockTX.EXPECT().GetMerkleNodes(gomock.Any(), gomock.Any(), gomock.Any()).Times(merkleGets)
-						// Store each leave's shard, and the root shard.
+						// Store each leaf's shard, and the root shard.
 						mockTX.EXPECT().SetMerkleNodes(gomock.Any(), gomock.Any()).Times(count + 1)
 					}
 					mockTX.EXPECT().StoreSignedMapRoot(gomock.Any(), gomock.Any())

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -422,6 +422,8 @@ func TestSetLeaves(t *testing.T) {
 		{Index: b64("sQJTdkyLIz+zdULiNAHHtFDlpvl1HztaAU9vZ+i8mZ0="), LeafValue: []byte("value2")},
 		{Index: b64("9XYQTuvqsJZR2DrP/HfIuMbqpLdnrqsk19qA+D9R2GU="), LeafValue: []byte("value3")},
 	}
+	// The root hash of the sparse Merkle when the leaves above are inserted.
+	rootHash := b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ=")
 
 	for _, tc := range []struct {
 		desc    string
@@ -431,9 +433,10 @@ func TestSetLeaves(t *testing.T) {
 		want    []byte
 	}{
 		{desc: "one-leaf", leaves: leaves[:1], want: b64("PPI818D5CiUQQMZulH58LikjxeOFWw2FbnGM0AdVHWA=")},
-		{desc: "multi-leaves", leaves: leaves, want: b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ=")},
-		{desc: "preload", preload: true, leaves: leaves, want: b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ=")},
-		{desc: "split-tx", splitTX: true, leaves: leaves, want: b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ=")},
+		{desc: "multi-leaves", leaves: leaves, want: rootHash},
+		{desc: "preload", preload: true, leaves: leaves, want: rootHash},
+		{desc: "split-tx", splitTX: true, leaves: leaves, want: rootHash},
+		{desc: "split-tx-preload-ignored", preload: true, splitTX: true, leaves: leaves, want: rootHash},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			fakeStorage := storage.NewMockMapStorage(ctrl)

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -423,6 +423,7 @@ func TestSetLeaves(t *testing.T) {
 		{Index: b64("9XYQTuvqsJZR2DrP/HfIuMbqpLdnrqsk19qA+D9R2GU="), LeafValue: []byte("value3")},
 	}
 	// The root hash of the sparse Merkle when the leaves above are inserted.
+	// Copied from other tests in order to catch regressions.
 	rootHash := b64("Ms8A+VeDImofprfgq7Hoqh9cw+YrD/P/qibTmCm5JvQ=")
 
 	for _, tc := range []struct {


### PR DESCRIPTION
This change further improves test coverage for `mapTreeUpdater` by including the "single transaction" and "preload" modes. Another prereq for #1902.