### PR TITLE
Allow proto generation to happen outside of gosrc directory

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -14,10 +14,10 @@
 
 package trillian
 
-//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis --go_out=plugins=grpc:$GOPATH/src trillian_log_api.proto trillian_log_sequencer_api.proto trillian_map_api.proto trillian_admin_api.proto trillian.proto --doc_out=markdown,api.md:./docs/
-//go:generate protoc -I=. --go_out=:$GOPATH/src crypto/sigpb/sigpb.proto
-//go:generate protoc -I=. --go_out=:$GOPATH/src crypto/keyspb/keyspb.proto
-//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis --grpc-gateway_out=logtostderr=true:$GOPATH/src trillian_log_api.proto trillian_map_api.proto trillian_admin_api.proto trillian.proto
+//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis --go_out=plugins=grpc,paths=source_relative:. trillian_log_api.proto trillian_log_sequencer_api.proto trillian_map_api.proto trillian_admin_api.proto trillian.proto --doc_out=markdown,api.md:./docs/
+//go:generate protoc -I=. --go_out=paths=source_relative:. crypto/sigpb/sigpb.proto
+//go:generate protoc -I=. --go_out=paths=source_relative:. crypto/keyspb/keyspb.proto
+//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis --grpc-gateway_out=logtostderr=true,paths=source_relative:. trillian_log_api.proto trillian_map_api.proto trillian_admin_api.proto trillian.proto
 
 //go:generate mockgen -package tmock -destination testonly/tmock/mock_log_server.go  github.com/google/trillian TrillianLogServer
 //go:generate mockgen -package tmock -destination testonly/tmock/mock_map_server.go  github.com/google/trillian TrillianMapServer

--- a/skylog/storage/gcp/gcppb/gen.go
+++ b/skylog/storage/gcp/gcppb/gen.go
@@ -15,4 +15,4 @@
 // Package gcppb contains proto messages for GCP-based Skylog storage.
 package gcppb
 
-//go:generate protoc -I=. --go_out=$GOPATH/src gcp.proto
+//go:generate protoc -I=. --go_out=paths=source_relative:. gcp.proto

--- a/storage/cloudspanner/spannerpb/gen.go
+++ b/storage/cloudspanner/spannerpb/gen.go
@@ -14,4 +14,4 @@
 
 package spannerpb
 
-//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis/ --go_out=$GOPATH/src spanner.proto
+//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/googleapis/googleapis/ --go_out=paths=source_relative:. spanner.proto


### PR DESCRIPTION
This makes life happier for people developing in other locations, which is increasingly common in the module-aware world. Tested this works by deleting all *pb.go files and regenerating them in a non-gosrc checkout.
