### PR TITLE
Layout: Get tile height independently of NodeID

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -431,7 +431,7 @@ func (s *SubtreeCache) Flush(ctx context.Context, setSubtrees SetSubtreesFunc) e
 
 // newEmptySubtree creates an empty subtree for the passed-in ID.
 func (s *SubtreeCache) newEmptySubtree(id tree.TileID) *storagepb.SubtreeProto {
-	height := s.layout.GetTileHeight(id)
+	height := s.layout.TileHeight(id.Root.PrefixLenBits)
 	if glog.V(2) {
 		glog.Infof("Creating new empty subtree for %x, with height %d", id.AsBytes(), height)
 	}

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -156,8 +156,7 @@ func TestCacheFlush(t *testing.T) {
 	m.EXPECT().SetSubtrees(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, trees []*storagepb.SubtreeProto) {
 		for _, s := range trees {
 			rootID := tree.NewNodeIDFromHash(s.Prefix)
-			subID := tree.TileID{Root: rootID}
-			if got, want := s.Depth, c.layout.GetTileHeight(subID); got != int32(want) {
+			if got, want := s.Depth, c.layout.TileHeight(rootID.PrefixLenBits); got != int32(want) {
 				t.Errorf("Got subtree with depth %d, expected %d for prefixLen %d", got, want, rootID.PrefixLenBits)
 			}
 			state, ok := expectedSetIDs[rootID.String()]

--- a/storage/tree/layout.go
+++ b/storage/tree/layout.go
@@ -14,9 +14,7 @@
 
 package tree
 
-import (
-	"fmt"
-)
+import "fmt"
 
 const (
 	// depthQuantum defines the smallest supported tile height, which all tile
@@ -97,9 +95,11 @@ func (l *Layout) Split(id NodeID) (TileID, *Suffix) {
 	return TileID{Root: NodeID{Path: []byte{}}}, EmptySuffix
 }
 
-// GetTileHeight returns the height of the tile with the passed-in ID.
-func (l *Layout) GetTileHeight(id TileID) int {
-	return l.getStratumAt(id.Root.PrefixLenBits).height
+// TileHeight returns the height of a tile with its root located at the
+// specified depth from the tree root. The result is not defined if rootDepth
+// is not a tile boundary.
+func (l *Layout) TileHeight(rootDepth int) int {
+	return l.getStratumAt(rootDepth).height
 }
 
 func (l *Layout) getStratumAt(depth int) stratumInfo {

--- a/storage/tree/layout.go
+++ b/storage/tree/layout.go
@@ -98,6 +98,8 @@ func (l *Layout) Split(id NodeID) (TileID, *Suffix) {
 // TileHeight returns the height of a tile with its root located at the
 // specified depth from the tree root. The result is not defined if rootDepth
 // is not a tile boundary.
+//
+// TODO(pavelkalinnikov, v2): Use "type-safe" structured argument like NodeID2.
 func (l *Layout) TileHeight(rootDepth int) int {
 	return l.getStratumAt(rootDepth).height
 }

--- a/storage/tree/layout_test.go
+++ b/storage/tree/layout_test.go
@@ -100,3 +100,26 @@ func TestDefaultMapStrataIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestLayoutTileHeight(t *testing.T) {
+	layout := NewLayout(defaultMapStrata)
+	for _, tc := range []struct {
+		depth  int
+		height int
+	}{
+		{depth: 0, height: 8},
+		{depth: 5, height: 8},
+		{depth: 8, height: 8},
+		{depth: 16, height: 8},
+		{depth: 79, height: 8},
+		{depth: 80, height: 176},
+		{depth: 81, height: 176},
+		{depth: 255, height: 176},
+	} {
+		t.Run(fmt.Sprintf("depth:%d", tc.depth), func(t *testing.T) {
+			if got, want := layout.TileHeight(tc.depth), tc.height; got != want {
+				t.Errorf("TileHeight: got %d, want %d", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change makes `Layout.TileHeight` method more generic, in order for it to be usable with `NodeID2`. A prereq for #1932.