### PR TITLE
Licenses tool: Derive license URLs from package name

### DIFF
--- a/scripts/licenses/csv.go
+++ b/scripts/licenses/csv.go
@@ -61,14 +61,19 @@ func csvMain(_ *cobra.Command, args []string) error {
 		if lib.LicensePath != "" {
 			// Find a URL for the license file, based on the URL of a remote for the Git repository.
 			var errs []string
-			for _, remote := range gitRemotes {
-				url, err := licenses.GitFileURL(lib.LicensePath, remote)
-				if err != nil {
-					errs = append(errs, err.Error())
-					continue
+			repo, err := licenses.FindGitRepo(lib.LicensePath)
+			if err != nil {
+				errs = append(errs, err.Error())
+			} else {
+				for _, remote := range gitRemotes {
+					url, err := repo.FileURL(lib.LicensePath, remote)
+					if err != nil {
+						errs = append(errs, err.Error())
+						continue
+					}
+					licenseURL = url.String()
+					break
 				}
-				licenseURL = url.String()
-				break
 			}
 			if licenseURL == "Unknown" {
 				glog.Errorf("Error discovering URL for %q:\n- %s", lib.LicensePath, strings.Join(errs, "\n- "))

--- a/scripts/licenses/csv.go
+++ b/scripts/licenses/csv.go
@@ -63,7 +63,13 @@ func csvMain(_ *cobra.Command, args []string) error {
 			var errs []string
 			repo, err := licenses.FindGitRepo(lib.LicensePath)
 			if err != nil {
-				errs = append(errs, err.Error())
+				// Can't find Git repo (possibly a Go Module?) - derive URL from lib name instead.
+				lURL, err := lib.FileURL(lib.LicensePath)
+				if err != nil {
+					errs = append(errs, err.Error())
+				} else {
+					licenseURL = lURL.String()
+				}
 			} else {
 				for _, remote := range gitRemotes {
 					url, err := repo.FileURL(lib.LicensePath, remote)

--- a/scripts/licenses/licenses/git_test.go
+++ b/scripts/licenses/licenses/git_test.go
@@ -61,15 +61,19 @@ func TestGitFileURL(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			url, err := GitFileURL(test.file, test.remote)
+			repo, err := FindGitRepo(test.file)
+			if err != nil {
+				t.Fatalf("FindGitRepo(%q) = (_, %q), want (_, nil)", test.file, err)
+			}
+			url, err := repo.FileURL(test.file, test.remote)
 			if err != nil {
 				if err != test.wantErr {
-					t.Fatalf("GitFileURL(%q, %q) = (_, %q), want (_, %q)", test.file, test.remote, err, test.wantErr)
+					t.Fatalf("repo.FileURL(%q, %q) = (_, %q), want (_, %q)", test.file, test.remote, err, test.wantErr)
 				}
 				return
 			}
 			if url.String() != test.wantURL {
-				t.Fatalf("GitFileURL(%q, %q) = (%q, nil), want (%q, nil)", test.file, test.remote, url, test.wantURL)
+				t.Fatalf("repo.FileURL(%q, %q) = (%q, nil), want (%q, nil)", test.file, test.remote, url, test.wantURL)
 			}
 		})
 	}

--- a/scripts/licenses/licenses/library_test.go
+++ b/scripts/licenses/licenses/library_test.go
@@ -109,3 +109,62 @@ func TestLibraryName(t *testing.T) {
 		})
 	}
 }
+
+func TestLibraryFileURL(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		lib     *Library
+		path    string
+		wantURL string
+		wantErr bool
+	}{
+		{
+			desc: "Library on github.com",
+			lib: &Library{
+				Packages: []string{
+					"github.com/google/trillian",
+					"github.com/google/trillian/crypto",
+				},
+				LicensePath: "/go/src/github.com/google/trillian/LICENSE",
+			},
+			path:    "/go/src/github.com/google/trillian/foo/README.md",
+			wantURL: "https://github.com/google/trillian/blob/master/foo/README.md",
+		},
+		{
+			desc: "Library on bitbucket.org",
+			lib: &Library{
+				Packages: []string{
+					"bitbucket.org/user/project/pkg",
+					"bitbucket.org/user/project/pkg2",
+				},
+				LicensePath: "/foo/bar/bitbucket.org/user/project/LICENSE",
+			},
+			path:    "/foo/bar/bitbucket.org/user/project/foo/README.md",
+			wantURL: "https://bitbucket.org/user/project/src/master/pkg/foo/README.md",
+		},
+		{
+			desc: "Library on example.com",
+			lib: &Library{
+				Packages: []string{
+					"example.com/user/project/pkg",
+					"example.com/user/project/pkg2",
+				},
+				LicensePath: "/foo/bar/example.com/user/project/LICENSE",
+			},
+			path:    "/foo/bar/example.com/user/project/foo/README.md",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			fileURL, err := test.lib.FileURL(test.path)
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("FileURL(%q) = (_, %q), want err? %t", test.path, err, test.wantErr)
+			} else if gotErr {
+				return
+			}
+			if got, want := fileURL.String(), test.wantURL; got != want {
+				t.Fatalf("FileURL(%q) = %q, want %q", test.path, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When Go Modules are enabled, Git repositories for dependencies are not available (the ".git" directories are stripped away). As a fallback, derive the URL from the package name for a set of known package prefixes (e.g. "github.com").

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
