### PR TITLE
Add check command to licenses command.

### DIFF
--- a/scripts/licenses/README.md
+++ b/scripts/licenses/README.md
@@ -28,6 +28,19 @@ $ licenses save "github.com/google/trillian/server/trillian_log_server" --save_d
 
 This command analyzes a binary/package's dependencies and determines what needs to be redistributed alongside that binary/package in order to comply with the license terms. This typically includes the license itself and a copyright notice, but may also include the dependency's source code. All of the required artifacts will be saved in the directory indicated by `--save_dir`.
 
+## Checking for forbidden licenses.
+
+```shell
+$ licenses check github.com/logrusorgru/aurora
+Forbidden license type WTFPL for library github.com/logrusorgru/auroraexit status 1
+```
+
+This command analyzes a package's dependencies and determines if any are
+considered forbidden by the license classifer. See
+[github.com/google/licenseclassifier](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323)
+
+for licenses considered forbidden.
+
 ## Warnings and errors
 
 The tool will log warnings and errors in some scenarios. This section provides guidance on addressing them.

--- a/scripts/licenses/check.go
+++ b/scripts/licenses/check.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/trillian/scripts/licenses/licenses"
+	"github.com/spf13/cobra"
+)
+
+var (
+	checkCmd = &cobra.Command{
+		Use:   "check <package>",
+		Short: "Checks whether licenses for a package are not Forbidden.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  checkMain,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}
+
+func checkMain(_ *cobra.Command, args []string) error {
+	classifier, err := licenses.NewClassifier(confidenceThreshold)
+	if err != nil {
+		return err
+	}
+
+	importPath := args[0]
+	libs, err := licenses.Libraries(context.Background(), importPath)
+	if err != nil {
+		return err
+	}
+	for _, lib := range libs {
+		licenseName, licenseType, err := classifier.Identify(lib.LicensePath)
+		if err != nil {
+			return err
+		}
+		if licenseType == licenses.Forbidden {
+			fmt.Fprintf(os.Stderr, "Forbidden license type %s for library %v", licenseName, lib)
+			os.Exit(1)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds functionality similar to [`dep-collector
-check`](https://github.com/knative/test-infra/tree/master/tools/dep-collector) but with go module support.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

(not sure if CHANGELOG is appropriate here since this only affects `scripts/licences`).

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).


