### PR TITLE
smt: Add conversion between SubtreeProto and Tile

### DIFF
--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import "github.com/google/trillian/storage/tree"
+
+// Tile represents a sparse Merkle tree tile, i.e. a dense set of tree nodes
+// located under a single "root" node at a distance not exceeding the tile
+// height. A tile is identified by the ID of its root node. The Tile struct
+// contains the list of non-empty leaf nodes, which can be used to reconstruct
+// all the remaining inner nodes of the tile.
+//
+// TODO(pavelkalinnikov): Introduce invariants on the order/content of Leaves.
+// TODO(pavelkalinnikov): Rename NodeUpdate to a more generic Node or NodeHash.
+type Tile struct {
+	ID     tree.NodeID2
+	Leaves []NodeUpdate
+}

--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -22,6 +22,7 @@ import "github.com/google/trillian/storage/tree"
 // contains the list of non-empty leaf nodes, which can be used to reconstruct
 // all the remaining inner nodes of the tile.
 //
+// TODO(pavelkalinnikov): Make Tile immutable.
 // TODO(pavelkalinnikov): Introduce invariants on the order/content of Leaves.
 // TODO(pavelkalinnikov): Rename NodeUpdate to a more generic Node or NodeHash.
 type Tile struct {

--- a/storage/storagepb/convert.go
+++ b/storage/storagepb/convert.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagepb
+
+import (
+	"fmt"
+
+	"github.com/google/trillian/merkle/smt"
+	"github.com/google/trillian/storage/tree"
+)
+
+// Unmarshal converts the given SubtreeProto to a Merkle tree tile.
+func Unmarshal(sp *SubtreeProto) (smt.Tile, error) {
+	if d := sp.Depth; d <= 0 {
+		return smt.Tile{}, fmt.Errorf("wrong depth %d, want > 0", d)
+	}
+	height := uint(sp.Depth)
+	prefix := string(sp.Prefix)
+	id := tree.NewNodeID2(prefix, uint(len(sp.Prefix))*8)
+	if len(sp.Leaves) == 0 {
+		return smt.Tile{ID: id}, nil
+	}
+
+	tailBits := uint8((height-1)%8 + 1) // Bits of the last byte to use.
+	leaves := make([]smt.NodeUpdate, 0, len(sp.Leaves))
+	for idStr, hash := range sp.Leaves {
+		suf, err := tree.ParseSuffix(idStr) // Note: No allocation if height <= 8.
+		if err != nil {
+			return smt.Tile{}, fmt.Errorf("%s: ParseSuffix: %v", idStr, err)
+		} else if bits := uint(suf.Bits()); bits != height {
+			return smt.Tile{}, fmt.Errorf("%s: wrong suffix bits %d, want %d", idStr, bits, height)
+		}
+		path := suf.Path() // TODO(pavelkalinnikov): Avoid the copying here.
+		count := len(path)
+		bytes := prefix + string(path[:count-1]) // Note: No allocation if height <= 8.
+		id := tree.NewNodeID2WithLast(bytes, path[count-1], tailBits)
+		leaves = append(leaves, smt.NodeUpdate{ID: id, Hash: hash})
+	}
+	// Canonicalize the leaves list.
+	if err := smt.Prepare(leaves, id.BitLen()+height); err != nil {
+		return smt.Tile{}, fmt.Errorf("Prepare: %v", err)
+	}
+	return smt.Tile{ID: id, Leaves: leaves}, nil
+}
+
+// Marshal converts the given Merkle tree tile to SubtreeProto.
+func Marshal(t smt.Tile, height uint) (*SubtreeProto, error) {
+	if height == 0 || height > 255 {
+		return nil, fmt.Errorf("height out of [1,255] range: %d", height)
+	}
+	prefBits := t.ID.BitLen()
+	if prefBits%8 != 0 {
+		return nil, fmt.Errorf("tile root unaligned: %d", prefBits)
+	}
+	prefBytes := prefBits / 8
+	bits := prefBits + height
+
+	leaves := make(map[string][]byte, len(t.Leaves))
+	for _, upd := range t.Leaves {
+		id := upd.ID
+		// TODO(pavelkalinnikov): These must move to be part of Tile contract.
+		if bl := id.BitLen(); bl != bits {
+			return nil, fmt.Errorf("wrong ID bits %d, want %d", bl, bits)
+		}
+		if id.Prefix(prefBits) != t.ID {
+			return nil, fmt.Errorf("unrelated leaf ID: %v", id)
+		}
+		last, _ := id.LastByte()
+		// TODO(pavelkalinnikov): Avoid allocation for height <= 8.
+		path := []byte(id.FullBytes()[prefBytes:] + string([]byte{last}))
+		suf := tree.NewSuffix(uint8(height), path)
+		leaves[suf.String()] = upd.Hash
+	}
+	id := tree.NewNodeIDFromID2(t.ID)
+	return &SubtreeProto{Prefix: id.Path, Depth: int32(height), Leaves: leaves}, nil
+}

--- a/storage/storagepb/convert.go
+++ b/storage/storagepb/convert.go
@@ -23,19 +23,19 @@ import (
 
 // Unmarshal converts the given SubtreeProto to a Merkle tree tile.
 func Unmarshal(sp *SubtreeProto) (smt.Tile, error) {
-	if d := sp.Depth; d <= 0 {
+	if d := sp.GetDepth(); d <= 0 {
 		return smt.Tile{}, fmt.Errorf("wrong depth %d, want > 0", d)
 	}
-	height := uint(sp.Depth)
-	prefix := string(sp.Prefix)
-	id := tree.NewNodeID2(prefix, uint(len(sp.Prefix))*8)
-	if len(sp.Leaves) == 0 {
+	height := uint(sp.GetDepth())
+	prefix := string(sp.GetPrefix())
+	id := tree.NewNodeID2(prefix, uint(len(prefix)*8))
+	if len(sp.GetLeaves()) == 0 {
 		return smt.Tile{ID: id}, nil
 	}
 
 	tailBits := uint8((height-1)%8 + 1) // Bits of the last byte to use.
-	leaves := make([]smt.NodeUpdate, 0, len(sp.Leaves))
-	for idStr, hash := range sp.Leaves {
+	leaves := make([]smt.NodeUpdate, 0, len(sp.GetLeaves()))
+	for idStr, hash := range sp.GetLeaves() {
 		suf, err := tree.ParseSuffix(idStr) // Note: No allocation if height <= 8.
 		if err != nil {
 			return smt.Tile{}, fmt.Errorf("%s: ParseSuffix: %v", idStr, err)

--- a/storage/storagepb/convert_test.go
+++ b/storage/storagepb/convert_test.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagepb
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian/merkle/smt"
+	"github.com/google/trillian/storage/tree"
+)
+
+func TestUnmarshal(t *testing.T) {
+	type mappy map[string][]byte
+	for _, tc := range []struct {
+		sp      *SubtreeProto
+		wantErr string
+	}{
+		{sp: &SubtreeProto{}, wantErr: "wrong depth"},
+		{sp: &SubtreeProto{Depth: -1}, wantErr: "wrong depth"},
+		{sp: &SubtreeProto{Depth: 8, Leaves: mappy{"huh?": nil}}, wantErr: "base64"},
+		{sp: &SubtreeProto{Depth: 8, Leaves: mappy{"": nil}}, wantErr: "ParseSuffix: empty bytes"},
+		{sp: &SubtreeProto{Depth: 12, Leaves: mappy{"DA==": nil}}, wantErr: "ParseSuffix: unexpected length"},
+		{sp: &SubtreeProto{Depth: 12, Leaves: mappy{"DAAA": nil}}},
+		{sp: &SubtreeProto{Depth: 13, Leaves: mappy{"DAAA": nil}}, wantErr: "wrong suffix bits"},
+		{sp: &SubtreeProto{Depth: 12, Leaves: mappy{"DAAA": nil, "DAAB": nil}}, wantErr: "Prepare"},
+		{sp: &SubtreeProto{Depth: 16, Leaves: mappy{"EAAA": nil, "EAAB": nil}}},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := ""
+			if _, err := Unmarshal(tc.sp); err != nil {
+				got = err.Error()
+			}
+			if want := tc.wantErr; len(want) == 0 && len(got) != 0 {
+				t.Errorf("Unmarshal: %s, want no error", got)
+			} else if !strings.Contains(got, want) {
+				t.Errorf("Unmarshal: %s, want error containing %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMarshalErrors(t *testing.T) {
+	for _, tc := range []struct {
+		tile    smt.Tile
+		height  uint
+		wantErr string
+	}{
+		{tile: smt.Tile{}, height: 0, wantErr: "height out of"},
+		{tile: smt.Tile{}, height: 256, wantErr: "height out of"},
+		{tile: smt.Tile{ID: tree.NewNodeID2("\xFF", 5)}, height: 8, wantErr: "root unaligned"},
+		{
+			tile: smt.Tile{
+				ID:     tree.NewNodeID2("\xFF", 8),
+				Leaves: []smt.NodeUpdate{{ID: tree.NewNodeID2("\xFF0000", 24)}},
+			},
+			height:  8,
+			wantErr: "wrong ID bits",
+		},
+		{
+			tile: smt.Tile{
+				ID:     tree.NewNodeID2("\xFF", 8),
+				Leaves: []smt.NodeUpdate{{ID: tree.NewNodeID2("\xF000", 16)}},
+			},
+			height:  8,
+			wantErr: "unrelated leaf ID",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			_, err := Marshal(tc.tile, tc.height)
+			if err == nil {
+				t.Fatal("Marshal did not return error")
+			}
+			if got, want := err.Error(), tc.wantErr; !strings.Contains(got, want) {
+				t.Errorf("Marshal: %s, want error containing %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	upd := []smt.NodeUpdate{
+		{ID: tree.NewNodeID2("0", 8), Hash: []byte("a")},
+		{ID: tree.NewNodeID2("1", 8), Hash: []byte("b")},
+	}
+	deepUpd := []smt.NodeUpdate{
+		{ID: tree.NewNodeID2("\x0F\x00\x00", 24), Hash: []byte("a")},
+		{ID: tree.NewNodeID2("\x0F\xFF\x00", 24), Hash: []byte("b")},
+		{ID: tree.NewNodeID2("\x0F\xFF\x01", 24), Hash: []byte("c")},
+		{ID: tree.NewNodeID2("\x0F\xFF\x03", 24), Hash: []byte("d")},
+		{ID: tree.NewNodeID2("\x0F\xFF\x09", 24), Hash: []byte("e")},
+		{ID: tree.NewNodeID2("\x0F\xFF\xFF", 24), Hash: []byte("f")},
+	}
+
+	for _, tc := range []struct {
+		tile   smt.Tile
+		height uint
+	}{
+		{tile: smt.Tile{}, height: 8},
+		{tile: smt.Tile{Leaves: upd[:1]}, height: 8},
+		{tile: smt.Tile{Leaves: upd}, height: 8},
+		{tile: smt.Tile{ID: tree.NewNodeID2("\x0F", 0), Leaves: deepUpd}, height: 24},
+		{tile: smt.Tile{ID: tree.NewNodeID2("\x0F", 8), Leaves: deepUpd}, height: 16},
+		{tile: smt.Tile{ID: tree.NewNodeID2("\x0F\xFF", 16), Leaves: deepUpd[1:]}, height: 8},
+	} {
+		t.Run("", func(t *testing.T) {
+			sp, err := Marshal(tc.tile, tc.height)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			clone := proto.Clone(sp).(*SubtreeProto) // Break memory dependency.
+			tile, err := Unmarshal(clone)
+			if err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got, want := tile, tc.tile; !reflect.DeepEqual(got, want) {
+				t.Errorf("Tile mismatch: got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/storage/storagepb/gen.go
+++ b/storage/storagepb/gen.go
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package storagepb contains protobuf definitions and helpers used by various
+// storage implementations.
+//
+// TODO(pavelkalinnikov, v2): It's a bad practice to reuse the same protobuf
+// across multiple repositories/implementations. Remove it, and operate with
+// regular in-memory Golang structs through the storage API boundary.
 package storagepb
 
 //go:generate protoc -I=. -I=$GOPATH/src/ --go_out=plugins=grpc:. storage.proto

--- a/storage/storagepb/gen.go
+++ b/storage/storagepb/gen.go
@@ -15,9 +15,13 @@
 // Package storagepb contains protobuf definitions and helpers used by various
 // storage implementations.
 //
-// TODO(pavelkalinnikov, v2): It's a bad practice to reuse the same protobuf
-// across multiple repositories/implementations. Remove it, and operate with
-// regular in-memory Golang structs through the storage API boundary.
+// TODO(pavelkalinnikov, v2): SubtreeProto is used as:
+//  a) database storage unit in multiple storage implementations;
+//  b) data exchange format between storage and application layers;
+//  c) nodes index data structure.
+// We should change it so that:
+//  a) individual storage implementations define their own formats;
+//  b) data structures are defined in the application layer.
 package storagepb
 
 //go:generate protoc -I=. -I=$GOPATH/src/ --go_out=plugins=grpc:. storage.proto


### PR DESCRIPTION
This change introduces a new non-proto `Tile` type which will be used for exchanging tiles through the map storage API boundary. Using `SubtreeProto` directly seems like a bad practice for reasons: a) implementations might want to not use proto; b) the internal structure of `SubtreeProto` has `base64`-encoded node IDs which has no reason to be used on the application layer.

This change also adds functions for converting between `Tile` and the legacy `SubtreeProto`.

This is part of #1932 which uses the `Tile` structure.