### PR TITLE
mapTreeUpdater: Use the preloaded hashes

### DIFF
--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -459,9 +459,9 @@ func TestSetLeaves(t *testing.T) {
 						// Leaves are in different shards because the leaf indices are
 						// random. We query one shard per leaf, plus the root shard.
 						merkleGets := count + 1
-						// Plus, possibly, there is a "global" preloading query.
+						// There is only one "global" query if preloading is used.
 						if tc.preload {
-							merkleGets++
+							merkleGets = 1
 						}
 						mockTX.EXPECT().GetMerkleNodes(gomock.Any(), gomock.Any(), gomock.Any()).Times(merkleGets)
 						// Store each leaf's shard, and the root shard.

--- a/server/map_tree_updater.go
+++ b/server/map_tree_updater.go
@@ -120,6 +120,7 @@ type txAccessor struct {
 }
 
 func (t txAccessor) Get(ctx context.Context, ids []tree.NodeID2) (map[tree.NodeID2][]byte, error) {
+	// TODO(pavelkalinnikov): Factor out preload into another accessor.
 	if t.preload {
 		return t.hashes, nil
 	}


### PR DESCRIPTION
This change modifies `mapTreeUpdater` so that it uses the result of `GetMerkleNodes` of the preloading phase. It eliminates a bunch of redundant `GetMerkleNodes` calls that previously followed the preload. It also allows avoiding extra `SubtreeCache` coordination happening behind the scenes.