### PR TITLE
Fix a deadlock in OperationLoop/Election

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Not yet released; provisionally v1.4.0 (may change).
 
+### Log Changes
+
+#### Potential sequencer hang fixed
+A potential deadlock condition in the log sequencer when the process is
+attempting to exit has been addressed.
+
 ### Map Changes
 
 The verifiable map is still experimental. APIs, such as SetLeaves, have been

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -332,14 +332,6 @@ loop:
 		}
 		glog.V(1).Infof("Log operation manager pass complete")
 
-		// See if it's time to quit
-		select {
-		case <-ctx.Done():
-			glog.Infof("Log operation manager shutting down")
-			break loop
-		default:
-		}
-
 		// Process any pending resignations while there's no activity.
 		doneResigning := false
 		for !doneResigning {
@@ -350,6 +342,14 @@ loop:
 			default:
 				doneResigning = true
 			}
+		}
+
+		// See if it's time to quit
+		select {
+		case <-ctx.Done():
+			glog.Infof("Log operation manager shutting down")
+			break loop
+		default:
 		}
 
 		// Wait for the configured time before going for another pass


### PR DESCRIPTION
This fixes a potential deadlock condition where:
 -  an election queues up a `Resignation` while a sequencing run is happening, AND
 - the sequencing operation loop context is cancelled:

The election runner blocks to wait on the `Resignation` being actioned, but the `OperationLoop` will immediately exit and never action any pending `Resignation`s, causing the runner to block forever and the election to never successfully close.
 
Fixes #1955 

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
