### PR TITLE
Fix generic comparisons on protobuf messages

### DIFF
--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/trillian/examples/ct/ctmapper/ctmapperpb"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 
 	stestonly "github.com/google/trillian/storage/testonly"
 )
@@ -212,7 +211,7 @@ func RunMapRevisionZero(ctx context.Context, t *testing.T, tadmin trillian.Trill
 				}
 
 				got, want := getSmrByRevResp.GetMapRoot(), getSmrResp.GetMapRoot()
-				if diff := pretty.Compare(got, want); diff != "" {
+				if diff := cmp.Diff(got, want, cmp.Comparer(proto.Equal)); diff != "" {
 					t.Errorf("GetSignedMapRootByRevision() != GetSignedMapRoot(); diff (-got +want):\n%v", diff)
 				}
 

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -279,7 +279,7 @@ func TestServer_GetTree(t *testing.T) {
 
 		wantTree := proto.Clone(storedTree).(*trillian.Tree)
 		wantTree.PrivateKey = nil // redacted
-		if diff := pretty.Compare(tree, &wantTree); diff != "" {
+		if diff := cmp.Diff(tree, wantTree, cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%v: post-GetTree diff (-got +want):\n%v", test.desc, diff)
 		}
 	}

--- a/server/errors/errors_test.go
+++ b/server/errors/errors_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	_ "github.com/golang/glog"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -48,8 +47,8 @@ func TestWrapError(t *testing.T) {
 	}
 	for _, test := range tests {
 		// We can't use == for rpcErrors because grpc.Errorf returns *rpcError.
-		if diff := pretty.Compare(WrapError(test.err), test.wantErr); diff != "" {
-			t.Errorf("WrapError('%T') diff:\n%s", test.err, diff)
+		if gotErr := WrapError(test.err); gotErr.Error() != test.wantErr.Error() {
+			t.Errorf("WrapError('%T') = %v, want %v", test.err, gotErr, test.wantErr)
 		}
 	}
 }

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -837,11 +837,15 @@ func TestErrorWrapper(t *testing.T) {
 			if resp != test.resp {
 				t.Errorf("resp = %v, want = %v", resp, test.resp)
 			}
-			if diff := pretty.Compare(err, test.wantErr); diff != "" {
-				t.Errorf("post-WrapErrors diff:\n%v", diff)
+			if !equalError(err, test.wantErr) {
+				t.Errorf("post-WrapErrors: got %v, want %v", err, test.wantErr)
 			}
 		})
 	}
+}
+
+func equalError(x, y error) bool {
+	return x == y || (x != nil && y != nil && x.Error() == y.Error())
 }
 
 type fakeHandler struct {


### PR DESCRIPTION
Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
