### PR TITLE
Dry-run Kubernetes changes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,10 @@
 timeout: 1800s
 substitutions:
+  _CLUSTER_NAME: trillian-opensource-ci
+  _MASTER_ZONE: us-central1-a
   _MYSQL_TAG: "5.7"
+  _MYSQL_ROOT_PASSWORD: ""
+  _MYSQL_PASSWORD: ""
 steps:
 - id: pull_mysql
   name : gcr.io/cloud-builders/docker
@@ -51,3 +55,115 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --cache=true
   waitFor: ["-"]
+- id: build_envsubst
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - examples/deployment/docker/envsubst
+  - -t
+  - envsubst
+  waitFor: ["-"]
+- id: copy_k8s_cfgs_for_spanner
+  name: busybox
+  entrypoint: cp
+  args:
+  - -r
+  - examples/deployment/kubernetes/
+  - envsubst-spanner/
+  waitFor: ['-']
+- id: envsubst_k8s_cfgs_for_spanner
+  name: envsubst
+  args:
+  - envsubst-spanner/etcd-cluster.yaml
+  - envsubst-spanner/trillian-ci-spanner.yaml
+  - envsubst-spanner/trillian-log-deployment.yaml
+  - envsubst-spanner/trillian-log-service.yaml
+  - envsubst-spanner/trillian-log-signer-deployment.yaml
+  - envsubst-spanner/trillian-log-signer-service.yaml
+  - envsubst-spanner/trillian-map-deployment.yaml
+  - envsubst-spanner/trillian-map-service.yaml
+  env:
+  - PROJECT_ID=${PROJECT_ID}
+  - IMAGE_TAG=${COMMIT_SHA}
+  waitFor:
+  - build_envsubst
+  - copy_k8s_cfgs_for_spanner
+- id: apply_k8s_cfgs_for_spanner_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - -f=envsubst-spanner/etcd-cluster.yaml
+  - -f=envsubst-spanner/trillian-ci-spanner.yaml
+  - -f=envsubst-spanner/trillian-log-deployment.yaml
+  - -f=envsubst-spanner/trillian-log-service.yaml
+  - -f=envsubst-spanner/trillian-log-signer-deployment.yaml
+  - -f=envsubst-spanner/trillian-log-signer-service.yaml
+  - -f=envsubst-spanner/trillian-map-deployment.yaml
+  - -f=envsubst-spanner/trillian-map-service.yaml
+  - --prune
+  - --all
+  - --prune-whitelist=core/v1/ConfigMap
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor:
+  - envsubst_k8s_cfgs_for_spanner
+  - build_log_server
+  - build_log_signer
+  - build_map_server
+- id: copy_k8s_cfgs_for_mysql
+  name: busybox
+  entrypoint: cp
+  args:
+  - -r
+  - examples/deployment/kubernetes/
+  - envsubst-mysql/
+  waitFor: ['-']
+- id: envsubst_k8s_cfgs_for_mysql
+  name: envsubst
+  args:
+  - envsubst-mysql/etcd-cluster.yaml
+  - envsubst-mysql/trillian-ci-mysql.yaml
+  - envsubst-mysql/trillian-mysql.yaml
+  - envsubst-mysql/trillian-log-deployment.yaml
+  - envsubst-mysql/trillian-log-service.yaml
+  - envsubst-mysql/trillian-log-signer-deployment.yaml
+  - envsubst-mysql/trillian-log-signer-service.yaml
+  - envsubst-mysql/trillian-map-deployment.yaml
+  - envsubst-mysql/trillian-map-service.yaml
+  env:
+  - PROJECT_ID=${PROJECT_ID}
+  - IMAGE_TAG=${COMMIT_SHA}
+  - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
+  - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
+  waitFor:
+  - build_envsubst
+  - copy_k8s_cfgs_for_mysql
+- id: apply_k8s_cfgs_for_mysql_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - --namespace=mysql
+  - -f=envsubst-mysql/etcd-cluster.yaml
+  - -f=envsubst-mysql/trillian-ci-mysql.yaml
+  - -f=envsubst-mysql/trillian-mysql.yaml
+  - -f=envsubst-mysql/trillian-log-deployment.yaml
+  - -f=envsubst-mysql/trillian-log-service.yaml
+  - -f=envsubst-mysql/trillian-log-signer-deployment.yaml
+  - -f=envsubst-mysql/trillian-log-signer-service.yaml
+  - -f=envsubst-mysql/trillian-map-deployment.yaml
+  - -f=envsubst-mysql/trillian-map-service.yaml
+  - --prune
+  - --all
+  - --prune-whitelist=core/v1/ConfigMap
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor:
+  - envsubst_k8s_cfgs_for_mysql
+  - build_db_server
+  - build_log_server
+  - build_log_signer
+  - build_map_server

--- a/examples/deployment/kubernetes/trillian-ci-mysql.yaml
+++ b/examples/deployment/kubernetes/trillian-ci-mysql.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deploy-config
+data:
+  STORAGE_SYSTEM: mysql
+  GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
+  SIGNER_BATCH_SIZE: "--batch_size=500"
+  SIGNER_INTERVAL: "--sequencer_interval=20ms"
+  SIGNER_NUM_SEQUENCERS: "--num_sequencers=10"
+  SIGNER_MASTER_HOLD_JITTER: "--master_hold_jitter=7200s"

--- a/examples/deployment/kubernetes/trillian-ci-spanner.yaml
+++ b/examples/deployment/kubernetes/trillian-ci-spanner.yaml
@@ -1,13 +1,20 @@
 apiVersion: v1
+kind: Secret
+metadata:
+  name: trillian-secrets
+type: Opaque
+stringData:
+  STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-opensource-ci/databases/trillian-opensource-ci-db
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deploy-config
 data:
   STORAGE_SYSTEM: cloud_spanner
-  STORAGE_FLAG: --cloudspanner_uri=projects/${PROJECT_ID}/instances/trillian-opensource-ci/databases/trillian-opensource-ci-db
   GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
-  SIGNER_DEQUEUE_BUCKET_FRACTION: "0.0078"
-  SIGNER_BATCH_SIZE: "1800"
-  SIGNER_INTERVAL: "2ms"
-  SIGNER_NUM_SEQUENCERS: "10"
-  SIGNER_MASTER_HOLD_JITTER: "7200s"
+  SIGNER_DEQUEUE_BUCKET_FRACTION: "--cloudspanner_dequeue_bucket_fraction=0.0078"
+  SIGNER_BATCH_SIZE: "--batch_size=1800"
+  SIGNER_INTERVAL: "--sequencer_interval=2ms"
+  SIGNER_NUM_SEQUENCERS: "--num_sequencers=10"
+  SIGNER_MASTER_HOLD_JITTER: "--master_hold_jitter=7200s"

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -30,11 +30,11 @@ spec:
         "--etcd_http_service=trillian-logsigner-http",
         "--http_endpoint=0.0.0.0:8091",
         "--sequencer_guard_window=1s",
-        "--sequencer_interval=$(SIGNER_INTERVAL)",
-        "--num_sequencers=$(SIGNER_NUM_SEQUENCERS)",
-        "--batch_size=$(SIGNER_BATCH_SIZE)",
-        "--cloudspanner_dequeue_bucket_fraction=$(SIGNER_DEQUEUE_BUCKET_FRACTION)",
-        "--master_hold_jitter=$(SIGNER_MASTER_HOLD_JITTER)",
+        "$(SIGNER_INTERVAL)",
+        "$(SIGNER_NUM_SEQUENCERS)",
+        "$(SIGNER_BATCH_SIZE)",
+        "$(SIGNER_DEQUEUE_BUCKET_FRACTION)",
+        "$(SIGNER_MASTER_HOLD_JITTER)",
         "--alsologtostderr"
         ]
         envFrom:

--- a/examples/deployment/kubernetes/trillian-mysql.yaml
+++ b/examples/deployment/kubernetes/trillian-mysql.yaml
@@ -1,17 +1,86 @@
-# This configmap is for running Trillian with a MySQL database on Kubernetes.
-# You'll want to update the storage-flag below with the correct configuration
-# info for the database.
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: deploy-config
-data:
-  CLOUD_PROJECT: ${PROJECT_ID}
-  # Update this with your DB connection string:
-  STORAGE_FLAG: --mysql_uri=test:zaphod@tcp(db:3306)/test
-  STORAGE_SYSTEM: mysql
-  GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
-  SIGNER_BATCH_SIZE: "500"
-  SIGNER_INTERVAL: "20ms"
-  SIGNER_NUM_SEQUENCERS: "10"
-  SIGNER_MASTER_HOLD_JITTER: "7200s"
+  name: trillian-secrets
+type: Opaque
+stringData:
+  # TODO(RJPercival): Pass this flag via --config to protect the password from being seen by `ps`
+  STORAGE_FLAG: --mysql_uri=${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(trillian-mysql:3306)/${MYSQL_DATABASE}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trillian-mysql-secrets
+  labels:
+    app: mysql
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+  MYSQL_USER: "${MYSQL_USER}"
+  MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+  MYSQL_DATABASE: "${MYSQL_DATABASE}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: trillian-mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+  selector:
+    app: mysql
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: trillian-mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: trillian-mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - name: mysql
+        image: gcr.io/${PROJECT_ID}/db_server:${IMAGE_TAG}
+        envFrom:
+        - secretRef:
+            name: trillian-mysql-secrets
+        ports:
+        - name: mysql
+          containerPort: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          subPath: mysql
+        resources:
+          requests:
+            cpu: 4
+            memory: 48Gi
+        # TODO(RJPercival): Add livenessProbe/readinessProbe
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      storageClassName: fast
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 500Gi


### PR DESCRIPTION
The default Cloud Build configuration now makes a dry-run attempt at
applying the Kubernetes configuration. This is helpful when working on
changes that affect this configuration, as it gives increased confidence
in correctness before merging to master.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
