### PR TITLE
Drain pending resignations before exiting operation manager loop

### DIFF
--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -375,6 +375,14 @@ loop:
 		glog.V(1).Infof("cancel election runner for %s", logID)
 		runner.Cancel()
 	}
+
+	// Drain any remaining resignations which might have triggered.
+	close(o.pendingResignations)
+	for r := range o.pendingResignations {
+		resignations.Inc(r.ID)
+		r.Execute(ctx)
+	}
+
 	glog.Infof("wait for termination of election runners...")
 	o.runnerWG.Wait()
 	glog.Infof("wait for termination of election runners...done")

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -148,8 +148,12 @@ func (er *Runner) beMaster(ctx context.Context, pending chan<- Resignation) erro
 		glog.Infof("%s: queue up resignation of mastership", er.id)
 		done := make(chan struct{})
 		r := Resignation{ID: er.id, er: er, done: done}
-		pending <- r
-		<-done // Block until acted on.
+		select {
+		case pending <- r:
+			<-done // Block until acted on.
+		default:
+			glog.Warning("Dropping resignation because operation manager seems to be exiting")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Try to fix another deadlock issue in operation manager. (#1955)

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
