### PR TITLE
Add supported deployment with Terraform

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,46 @@
+# Trillian supported deployments
+
+This directory contains the supported deployment types for Trillian. Currently,
+this includes:
+
+- [Kubernetes on GCP using Cloud
+  Spanner](#kubernetes-on-gcp-using-cloud-spanner)
+
+Further deployment types (community-supported) can be found in the
+examples/deployment directory.
+
+# Kubernetes on GCP using Cloud Spanner
+
+## Architecture
+
+The infrastructure is created using Terraform. It consists of a Cloud Spanner
+database, a Trillian-specific etcd cluster, the Trillian logserver and
+logsigner. A Workload Identity is set up by Terraform to give the services access
+to Cloud Spanner. The container images are based on v1.3.3.
+
+## Prerequisites
+1. [Terraform](https://www.terraform.io/), [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/),
+   and [gcloud](https://cloud.google.com/sdk/gcloud/) are installed.
+1. You have a Google account with billing configured.
+1. Terraform should have access to the credentials to manage your Cloud Project. Follow the
+   instructions from the [Terraform Google Provider documentation](https://www.terraform.io/docs/providers/google/guides/provider_reference.html#full-reference) to set this up.
+
+## Installation
+1. Create a new project and copy its [Project
+   ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects).
+1. Create the infrastructure: `terraform init && terraform apply -var="gcp_project=PROJECT_ID"`.
+   It is ok to re-execute this command at any time.
+1. The script will output a gcloud command similar to:
+   ```shell
+   gcloud config set project PROJECT_ID && \
+   gcloud container clusters get-credentials cluster --region=us-west1
+   ```
+   Execute this set of commands to get the credentials for your new cluster.
+1. Deploy the containers: `kubectl apply -k .` This last command may fail with
+   an [error](https://github.com/google/trillian/issues/1820) similar to:
+   `unable to recognize ".": no matches for kind "EtcdCluster" in version "etcd.database.coreos.com/v1beta2"`.
+   In this case, simply re-run it until the error is not reported anymore.
+
+## Uninstall
+1. Destroy the infrastructure: `terraform destroy`.
+

--- a/deployment/deploy-config.yaml
+++ b/deployment/deploy-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deploy-config
+data:
+  STORAGE_SYSTEM: cloud_spanner
+  STORAGE_FLAG: --cloudspanner_uri=projects/PROJECT_ID/instances/trillian-spanner/databases/trillian-db
+  SIGNER_DEQUEUE_BUCKET_FRACTION: "--cloudspanner_dequeue_bucket_fraction=0.0078"
+  SIGNER_BATCH_SIZE: "--batch_size=1800"
+  SIGNER_INTERVAL: "--sequencer_interval=2ms"
+  SIGNER_NUM_SEQUENCERS: "--num_sequencers=10"
+  SIGNER_MASTER_HOLD_JITTER: "--master_hold_jitter=7200s"

--- a/deployment/etcd-cluster.yaml
+++ b/deployment/etcd-cluster.yaml
@@ -1,0 +1,27 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "trillian-etcd-cluster"
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+spec:
+  size: 3
+  version: "3.2.13"
+  pod:
+    annotations:
+      # Do not inject an Istio sidecar, because Etcd nodes require a network
+      # connection on startup and don't retry on failure. This is a problem for
+      # Istio because it takes a moment to start its proxy sidecar and, during
+      # that time, all network connections will be blocked.
+      sidecar.istio.io/inject: "false"
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: etcd_cluster
+                operator: In
+                values:
+                - trillian-etcd-cluster
+          topologyKey: kubernetes.io/hostname

--- a/deployment/etcd-crd.yaml
+++ b/deployment/etcd-crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdclusters.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  conversion:
+    strategy: None
+  names:
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    plural: etcdclusters
+    shortNames:
+    - etcd
+    singular: etcdcluster
+  scope: Namespaced
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true

--- a/deployment/etcd-deployment.yaml
+++ b/deployment/etcd-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: trillian-etcd-operator
+  # Cluster-wide etcd-operator, so should always be in default namespace.
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: trillian-etcd-operator
+    spec:
+      containers:
+      - name: trillian-etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.9.4
+        command:
+        - etcd-operator
+        - --cluster-wide
+        - --create-crd=false
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/deployment/etcd-role-binding.yaml
+++ b/deployment/etcd-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/deployment/etcd-role.yaml
+++ b/deployment/etcd-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - etcd-crd.yaml
+  - etcd-role-binding.yaml
+  - etcd-role.yaml
+  - etcd-deployment.yaml
+  - etcd-cluster.yaml
+  - deploy-config.yaml
+  - service-account.yaml
+  - log-deployment.yaml
+  - log-service.yaml
+  - log-signer-deployment.yaml
+  - log-signer-service.yaml
+patchesStrategicMerge:
+  - tf-patch.yaml

--- a/deployment/log-deployment.yaml
+++ b/deployment/log-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: trillian
+    app.kubernetes.io/component: logserver
+  name: trillian-log-deployment
+spec:
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trillian
+        app.kubernetes.io/component: logserver
+    spec:
+      serviceAccountName: trillian-svc
+      restartPolicy: Always
+      containers:
+      - name: trillian-logserver
+        args: [
+        "$(STORAGE_FLAG)",
+        "--storage_system=$(STORAGE_SYSTEM)",
+        "--quota_system=etcd",
+        "--etcd_servers=trillian-etcd-cluster-client:2379",
+        "--etcd_http_service=trillian-logserver-http",
+        "--rpc_endpoint=0.0.0.0:8090",
+        "--http_endpoint=0.0.0.0:8091",
+        "--tracing",
+        "--alsologtostderr"
+        ]
+        envFrom:
+        - configMapRef:
+            name: deploy-config
+        image: gcr.io/trillian-opensource-ci/log_server:v1.3.3
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "1.0"
+          requests:
+            cpu: "0.4"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8091
+          failureThreshold: 3
+          periodSeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8090
+          name: grpc
+        - containerPort: 8091
+          name: http-metrics
+      - name: prometheus-to-sd
+        image: gcr.io/google-containers/prometheus-to-sd:v0.5.2
+        ports:
+          - name: profiler
+            containerPort: 6060
+        command:
+          - /monitor
+          - --stackdriver-prefix=custom.googleapis.com
+          - --source=logserver:http://localhost:8091/metrics
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+          - --scrape-interval=5s
+          - --export-interval=60s
+        resources:
+          limits:
+            cpu: 20m
+          requests:
+            cpu: 20m
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/deployment/log-service.yaml
+++ b/deployment/log-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trillian-log-service
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: grpc
+    port: 8090
+    targetPort: 8090
+  - name: http-metrics
+    port: 8091
+    targetPort: 8091
+  selector:
+    app.kubernetes.io/name: trillian
+    app.kubernetes.io/component: logserver

--- a/deployment/log-signer-deployment.yaml
+++ b/deployment/log-signer-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: trillian
+    app.kubernetes.io/component: logsigner
+  name: trillian-log-signer-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trillian
+        app.kubernetes.io/component: logsigner
+    spec:
+      serviceAccountName: trillian-svc
+      restartPolicy: Always
+      containers:
+      - name: trillian-log-signer
+        args: [
+        "$(STORAGE_FLAG)",
+        "--storage_system=$(STORAGE_SYSTEM)",
+        "--etcd_servers=trillian-etcd-cluster-client:2379",
+        "--quota_system=etcd",
+        "--etcd_http_service=trillian-logsigner-http",
+        "--http_endpoint=0.0.0.0:8091",
+        "--sequencer_guard_window=1s",
+        "$(SIGNER_INTERVAL)",
+        "$(SIGNER_NUM_SEQUENCERS)",
+        "$(SIGNER_BATCH_SIZE)",
+        "$(SIGNER_DEQUEUE_BUCKET_FRACTION)",
+        "$(SIGNER_MASTER_HOLD_JITTER)",
+        "--alsologtostderr"
+        ]
+        envFrom:
+        - configMapRef:
+            name: deploy-config
+        image: gcr.io/trillian-opensource-ci/log_signer:v1.3.3
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "1"
+          requests:
+            cpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8091
+          failureThreshold: 3
+          periodSeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8091
+          name: http-metrics
+      - name: prometheus-to-sd
+        image: gcr.io/google-containers/prometheus-to-sd:v0.5.2
+        ports:
+          - name: profiler
+            containerPort: 6060
+        command:
+          - /monitor
+          - --stackdriver-prefix=custom.googleapis.com
+          - --source=logsigner:http://localhost:8091/metrics
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+          - --scrape-interval=5s
+          - --export-interval=60s
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/deployment/log-signer-service.yaml
+++ b/deployment/log-signer-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trillian-log-signer-service
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http-metrics
+    port: 8092
+    targetPort: 8091
+  selector:
+    app.kubernetes.io/name: trillian
+    app.kubernetes.io/component: logsigner

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,147 @@
+variable "gcp_project" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "us-west1"
+}
+
+provider "google" {
+  project = var.gcp_project
+  version = "~> v3.0.0-beta.1"
+}
+
+provider "google-beta" {
+  project = var.gcp_project
+  version = "~> v3.0.0-beta.1"
+}
+
+# Enable required API in the project
+
+resource "google_project_service" "container-api" {
+  service = "container.googleapis.com"
+}
+
+resource "google_project_service" "spanner-api" {
+  service = "spanner.googleapis.com"
+}
+
+# Main cluster definition
+
+## Force recent version for Kubernetes master
+data "google_container_engine_versions" "gke-ver" {
+  location       = var.region
+  version_prefix = "1.14."
+}
+
+resource "google_container_cluster" "trillian-cluster" {
+  provider           = google-beta
+  name               = "cluster"
+  location           = var.region
+  node_version       = data.google_container_engine_versions.gke-ver.latest_node_version
+  min_master_version = data.google_container_engine_versions.gke-ver.latest_node_version
+
+  initial_node_count = 3
+
+  node_config {
+    machine_type = "n1-standard-2"
+    image_type   = "COS"
+
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only"
+    ]
+  }
+
+  workload_identity_config {
+    identity_namespace = "${var.gcp_project}.svc.id.goog"
+  }
+
+  depends_on = [
+    google_project_service.container-api
+  ]
+}
+
+# Spanner instance
+
+locals {
+  trillian_ddl = file("${path.module}/../storage/cloudspanner/spanner.sdl")
+}
+
+resource "google_spanner_instance" "trillian-spanner" {
+  name         = "trillian-spanner"
+  display_name = "Trillian Spanner Instance"
+  config       = "regional-${var.region}"
+  num_nodes    = 1
+  depends_on = [
+    google_project_service.spanner-api
+  ]
+}
+
+resource "google_spanner_database" "trillian-db" {
+  instance = google_spanner_instance.trillian-spanner.name
+  name     = "trillian-db"
+  # Format the DDL (remove comment and split the lines)
+  ddl = split(";", replace(replace(local.trillian_ddl, "/--.*\\n/", ""), "\n", ""))
+}
+
+# Create a GCP service account, give it access to Spanner and add a binding so that a
+# kubernetes service account can use that account.
+
+resource "google_service_account" "trillian" {
+  account_id   = "trillian"
+  display_name = "Trillian service account"
+}
+
+resource "google_project_iam_binding" "trillian-sc-dbuser" {
+  role = "roles/spanner.databaseUser"
+  members = [
+    "serviceAccount:${google_service_account.trillian.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "trillian-sc-logwriter" {
+  role = "roles/logging.logWriter"
+  members = [
+    "serviceAccount:${google_service_account.trillian.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "trillian-sc-metricwriter" {
+  role = "roles/monitoring.metricWriter"
+  members = [
+    "serviceAccount:${google_service_account.trillian.email}",
+  ]
+}
+
+resource "google_service_account_iam_binding" "trillian-sc-identity" {
+  service_account_id = google_service_account.trillian.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.gcp_project}.svc.id.goog[default/trillian-svc]",
+  ]
+  depends_on = [
+    google_container_cluster.trillian-cluster
+  ]
+}
+
+output "next_steps" {
+  value       = <<EOT
+
+gcloud config set project ${var.gcp_project} && \
+gcloud container clusters get-credentials cluster --region=${var.region}
+
+	EOT
+  description = "Command to configure Kubernetes"
+}
+
+resource "local_file" "tf-patch" {
+  content  = templatefile("tf-patch.template.yaml", { project_id = var.gcp_project })
+  filename = "tf-patch.yaml"
+}

--- a/deployment/service-account.yaml
+++ b/deployment/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: trillian@PROJECT_ID.iam.gserviceaccount.com
+  name: trillian-svc

--- a/deployment/tf-patch.template.yaml
+++ b/deployment/tf-patch.template.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deploy-config
+data:
+  STORAGE_FLAG: --cloudspanner_uri=projects/${project_id}/instances/trillian-spanner/databases/trillian-db
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: trillian@${project_id}.iam.gserviceaccount.com
+  name: trillian-svc


### PR DESCRIPTION
Create a root directory with a default supported deployment (based on
previous resources from examples/deployment). The intent is to have
this directory for all the supported deployment types and keep examples/
for deployments that are considered community-supported.

The first supported deployment is Trillian on Google Cloud using Cloud
Spanner as a backend.

This is a follow up from the discussions in #1942 and contributes to #1952.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
