### PR TITLE
Disabled python support in Bazel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Not yet released; provisionally v1.4.0 (may change).
 
+### Bazel Changes
+Python support is disabled unless we hear that the community cares about this
+being re-enabled. This was broken by a downstream change and without a signal
+from the Trillian community to say this is needed, the pragmatic action is to
+not spend time investigating this issue.
+
 ### Log Changes
 
 #### Potential sequencer hang fixed

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ switched_rules_by_language(
     name = "com_google_googleapis_imports",
     go = True,
     java = True,
-    python = True,
+    python = False, # Broken by https://github.com/googleapis/googleapis/commit/248abde0
 )
 
 http_archive(


### PR DESCRIPTION
This was broken by an upstream change. We can only use master from repo because they don't have any tagged releases that are recent enough to build on a recognisable version of Bazel. Python support was changed in a recent commit upstream that breaks things for our usage. This is almost certainly fixable with enough time investigating, but AFAIK we have zero clients integrating by Bazel, and of this empty set, we know of zero Python users. Noted it in the CHANGELOG, and if anyone shouts we can prioritize.
