### PR TITLE
Disable flakey election2 test

### DIFF
--- a/util/election2/testonly/tests.go
+++ b/util/election2/testonly/tests.go
@@ -210,7 +210,9 @@ func runElectionClose(t *testing.T, f election2.Factory) {
 		{desc: "master-error", beMaster: true, err: closeErr, wantErr: closeErr},
 		{desc: "not-master", beMaster: false, wantErr: nil},
 		{desc: "not-master-error", err: closeErr, wantErr: closeErr},
+		/* TODO(pavelkalinnikov): reinstate when not flaky.
 		{desc: "cancel", cancel: true, wantErr: nil},
+		*/
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()

--- a/util/election2/testonly/tests.go
+++ b/util/election2/testonly/tests.go
@@ -210,9 +210,8 @@ func runElectionClose(t *testing.T, f election2.Factory) {
 		{desc: "master-error", beMaster: true, err: closeErr, wantErr: closeErr},
 		{desc: "not-master", beMaster: false, wantErr: nil},
 		{desc: "not-master-error", err: closeErr, wantErr: closeErr},
-		/* TODO(pavelkalinnikov): reinstate when not flaky.
-		{desc: "cancel", cancel: true, wantErr: nil},
-		*/
+		// TODO(pavelkalinnikov): reinstate when not flaky.
+		// {desc: "cancel", cancel: true, wantErr: nil},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()


### PR DESCRIPTION
Temporarily disable the `RunElectionClose/cancel` test.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
