### PR TITLE
Set Kaniko --cache-dir to empty in cloudbuild configs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -40,6 +41,7 @@ steps:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -47,6 +49,7 @@ steps:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -54,6 +57,7 @@ steps:
   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_envsubst
   name: gcr.io/cloud-builders/docker

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -33,6 +33,7 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/db_server:latest
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -42,6 +43,7 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/log_server:latest
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -50,6 +52,7 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/log_signer:latest
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -58,6 +61,7 @@ steps:
   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
   - --destination=gcr.io/${PROJECT_ID}/map_server:latest
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_envsubst
   name: gcr.io/cloud-builders/docker

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -28,6 +28,7 @@ steps:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor:
   - push_mysql
 - id: build_log_server
@@ -36,6 +37,7 @@ steps:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
   name: gcr.io/kaniko-project/executor
@@ -43,6 +45,7 @@ steps:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_map_server
   name: gcr.io/kaniko-project/executor
@@ -50,4 +53,5 @@ steps:
   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/map_server:${TAG_NAME}
   - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]


### PR DESCRIPTION
This suppresses some build log spam about "Error while retrieving image from cache".

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
