### PR TITLE
smt: Introduce MapHasher wrapper

### DIFF
--- a/merkle/smt/hasher.go
+++ b/merkle/smt/hasher.go
@@ -25,8 +25,8 @@ type mapHasher struct {
 	treeID int64
 }
 
-// wrapHasher returns a mapHasher binding the given hasher to a tree ID.
-func wrapHasher(hasher hashers.MapHasher, treeID int64) mapHasher {
+// bindHasher returns a mapHasher binding the given hasher to a tree ID.
+func bindHasher(hasher hashers.MapHasher, treeID int64) mapHasher {
 	return mapHasher{mh: hasher, treeID: treeID}
 }
 

--- a/merkle/smt/hasher.go
+++ b/merkle/smt/hasher.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage/tree"
+)
+
+// mapHasher is a wrapper around MapHasher bound to a specific tree ID.
+type mapHasher struct {
+	mh     hashers.MapHasher
+	treeID int64
+}
+
+// wrapHasher returns a mapHasher binding the given hasher to a tree ID.
+func wrapHasher(hasher hashers.MapHasher, treeID int64) mapHasher {
+	return mapHasher{mh: hasher, treeID: treeID}
+}
+
+// hashEmpty returns the hash of an empty subtree with the given root ID.
+func (h mapHasher) hashEmpty(id tree.NodeID2) []byte {
+	oldID := tree.NewNodeIDFromID2(id)
+	height := h.mh.BitLen() - oldID.PrefixLenBits
+	// TODO(pavelkalinnikov): Make HashEmpty method take the NodeID2 directly.
+	return h.mh.HashEmpty(h.treeID, oldID.Path, height)
+}

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -52,7 +52,7 @@ func BenchmarkHStar3Root(b *testing.B) {
 		if err != nil {
 			b.Fatalf("NewHStar3: %v", err)
 		}
-		nodes := &emptyNodes{h: wrapHasher(hasher, 42)}
+		nodes := &emptyNodes{h: bindHasher(hasher, 42)}
 		if _, err := hs.Update(nodes); err != nil {
 			b.Fatalf("Update: %v", err)
 		}
@@ -67,7 +67,7 @@ func TestHStar3Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHStar3: %v", err)
 	}
-	nodes := &emptyNodes{h: wrapHasher(hasher, 42)}
+	nodes := &emptyNodes{h: bindHasher(hasher, 42)}
 	upd, err := hs.Update(nodes)
 	if err != nil {
 		t.Fatalf("Update: %v", err)
@@ -138,7 +138,7 @@ func TestHStar3Prepare(t *testing.T) {
 	}
 	rs := idsToMap(t, hs.Prepare())
 
-	nodes := &emptyNodes{h: wrapHasher(hasher, 42), ids: rs}
+	nodes := &emptyNodes{h: bindHasher(hasher, 42), ids: rs}
 	if _, err = hs.Update(nodes); err != nil {
 		t.Errorf("Update: %v", err)
 	}

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -24,14 +24,12 @@ import (
 	"testing"
 
 	"github.com/google/trillian/merkle/coniks"
-	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/storage/tree"
 )
 
 type emptyNodes struct {
-	treeID int64
-	hasher hashers.MapHasher
-	ids    map[tree.NodeID2]bool
+	h   mapHasher
+	ids map[tree.NodeID2]bool
 }
 
 func (e *emptyNodes) Get(id tree.NodeID2) ([]byte, error) {
@@ -41,7 +39,7 @@ func (e *emptyNodes) Get(id tree.NodeID2) ([]byte, error) {
 		}
 		delete(e.ids, id) // Allow getting this ID only once.
 	}
-	return hashEmpty(e.hasher, e.treeID, id), nil
+	return e.h.hashEmpty(id), nil
 }
 
 func (e *emptyNodes) Set(id tree.NodeID2, hash []byte) {}
@@ -54,7 +52,7 @@ func BenchmarkHStar3Root(b *testing.B) {
 		if err != nil {
 			b.Fatalf("NewHStar3: %v", err)
 		}
-		nodes := &emptyNodes{treeID: 42, hasher: hasher}
+		nodes := &emptyNodes{h: wrapHasher(hasher, 42)}
 		if _, err := hs.Update(nodes); err != nil {
 			b.Fatalf("Update: %v", err)
 		}
@@ -69,7 +67,7 @@ func TestHStar3Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHStar3: %v", err)
 	}
-	nodes := &emptyNodes{treeID: 42, hasher: hasher}
+	nodes := &emptyNodes{h: wrapHasher(hasher, 42)}
 	upd, err := hs.Update(nodes)
 	if err != nil {
 		t.Fatalf("Update: %v", err)
@@ -140,7 +138,7 @@ func TestHStar3Prepare(t *testing.T) {
 	}
 	rs := idsToMap(t, hs.Prepare())
 
-	nodes := &emptyNodes{treeID: 42, hasher: hasher, ids: rs}
+	nodes := &emptyNodes{h: wrapHasher(hasher, 42), ids: rs}
 	if _, err = hs.Update(nodes); err != nil {
 		t.Errorf("Update: %v", err)
 	}

--- a/merkle/smt/writer.go
+++ b/merkle/smt/writer.go
@@ -51,7 +51,7 @@ func NewWriter(treeID int64, hasher hashers.MapHasher, height, split uint) *Writ
 	if split > height {
 		panic(fmt.Errorf("NewWriter: split(%d) > height(%d)", split, height))
 	}
-	return &Writer{h: wrapHasher(hasher, treeID), height: height, split: split}
+	return &Writer{h: bindHasher(hasher, treeID), height: height, split: split}
 }
 
 // Split sorts and splits the given list of node hash updates into shards, i.e.


### PR DESCRIPTION
This change introduces an unexported map hasher wrapper in `smt` package, to simplify the usage of (hasher, treeID) pair throughout the package and make it safer.