### PR TITLE
Set golangci-lint --exclude-use-default=false

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,3 +32,7 @@ linters:
     - varcheck
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
+
+issues:
+  # Don't turn off any checks by default. We can do this explicitly if needed.
+  exclude-use-default: false

--- a/integration/maptest/map.go
+++ b/integration/maptest/map.go
@@ -581,6 +581,7 @@ func RunInclusion(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdm
 	}
 }
 
+// RunGetLeafByRevisionNoProof fails the test if the map server does not respond correctly to a GetLeavesByRevision request.
 func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trillian.TrillianAdminClient, tmap trillian.TrillianMapClient, twrite trillian.TrillianMapWriteClient) {
 	tree, err := newTreeWithHasher(ctx, tadmin, tmap, trillian.HashStrategy_TEST_MAP_HASHER)
 	if err != nil {
@@ -597,6 +598,7 @@ func RunGetLeafByRevisionNoProof(ctx context.Context, t *testing.T, tadmin trill
 		leaves = append(leaves, l)
 	}
 
+	// TODO(RJPercival): Should this be calling tmap.GetLeavesByRevisionNoProof() instead?
 	getResp, err := twrite.GetLeavesByRevision(ctx, &trillian.GetMapLeavesByRevisionRequest{
 		MapId:    tree.TreeId,
 		Index:    indexes,

--- a/integration/storagetest/maptestrunner.go
+++ b/integration/storagetest/maptestrunner.go
@@ -23,7 +23,10 @@ import (
 	"github.com/google/trillian/storage"
 )
 
+// MapStorageFactory creates MapStorage and AdminStorage for a test to use.
 type MapStorageFactory func(ctx context.Context, t *testing.T) (storage.MapStorage, storage.AdminStorage)
+
+// MapStorageTest executes a test using the given storage implementations.
 type MapStorageTest func(ctx context.Context, t *testing.T, s storage.MapStorage, as storage.AdminStorage)
 
 // RunMapStorageTests runs all the map storage tests against the provided map storage implementation.

--- a/integration/storagetest/maptests.go
+++ b/integration/storagetest/maptests.go
@@ -28,12 +28,14 @@ import (
 // MapTests is a suite of tests to run against the storage.MapTest interface.
 type MapTests struct{}
 
+// TestCheckDatabaseAccessible fails the test if the map storage is not accessible.
 func (*MapTests) TestCheckDatabaseAccessible(ctx context.Context, t *testing.T, s storage.MapStorage, _ storage.AdminStorage) {
 	if err := s.CheckDatabaseAccessible(ctx); err != nil {
 		t.Errorf("CheckDatabaseAccessible() = %v, want = nil", err)
 	}
 }
 
+// TestMapSnapshot fails the test if MapStorage.SnapshotForTree() does not behave correctly.
 func (*MapTests) TestMapSnapshot(ctx context.Context, t *testing.T, s storage.MapStorage, as storage.AdminStorage) {
 	frozenMap := createInitializedMapForTests(ctx, t, s, as)
 	storage.UpdateTree(ctx, as, frozenMap.TreeId, func(tree *trillian.Tree) {

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -22,8 +22,13 @@ import (
 // TODO(pavelkalinnikov, v2): These aliases were created to not break the code
 // that depended on these types. We should delete this.
 
+// NodeID is an alias to github.com/google/trillian/storage/tree.NodeID.
 type NodeID = tree.NodeID
+
+// Node is an alias to github.com/google/trillian/storage/tree.Node.
 type Node = tree.Node
+
+// Suffix is an alias to github.com/google/trillian/storage/tree.Suffix.
 type Suffix = tree.Suffix
 
 // PopulateSubtreeFunc is a function which knows how to re-populate a subtree
@@ -34,6 +39,7 @@ type PopulateSubtreeFunc func(*storagepb.SubtreeProto) error
 // type specific manipulation of a subtree before it's written to storage
 type PrepareSubtreeWriteFunc func(*storagepb.SubtreeProto) error
 
+// These are aliases for the functions of the same name in github.com/google/trillian/storage/tree.
 var (
 	NewNodeIDFromHash         = tree.NewNodeIDFromHash
 	NewNodeIDFromPrefix       = tree.NewNodeIDFromPrefix

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -54,7 +54,7 @@ func MySQLAvailable() bool {
 	return true
 }
 
-// SetFDULimit sets the soft limit on the maximum number of open file descriptors.
+// SetFDLimit sets the soft limit on the maximum number of open file descriptors.
 // See http://man7.org/linux/man-pages/man2/setrlimit.2.html
 func SetFDLimit(uLimit uint64) error {
 	var rLimit unix.Rlimit


### PR DESCRIPTION
This enables some checks that golangci-lint disables by default, such as checking for package comments. If it turns out that any of these checks are too noisy, we can re-enable them. However, right now, it's causing lint checks to fail when we try to import our code into Google (where these checks are not disabled).

See https://github.com/golangci/golangci-lint/blob/v1.21.0/README.md#command-line-options

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
