### PR TITLE
Add a presubmit to prevent .pb.txt and .proto.txt files being added

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -77,7 +77,7 @@ main() {
   # Prevent the creation of proto files with .txt extensions.
   bad_protos="$(find . -name '*.pb.txt' -o -name '*.proto.txt')"
   if [[ "${#bad_protos}" -ne 0 ]]; then
-    echo "Text based protos must use the textproto extension:"
+    echo "Text-based protos must use the .textproto extension:"
     echo $bad_protos
     exit 1
   fi

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -74,6 +74,14 @@ main() {
     grep -v _string.go | \
     tr '\n' ' ')"
 
+  # Prevent the creation of proto files with .txt extensions.
+  bad_protos="$(find . -name '*.pb.txt' -o -name '*.proto.txt')"
+  if [[ "${#bad_protos}" -ne 0 ]]; then
+    echo "Text based protos must use the textproto extension:"
+    echo $bad_protos
+    exit 1
+  fi
+
   if [[ "$fix" -eq 1 ]]; then
     check_pkg goimports golang.org/x/tools/cmd/goimports || exit 1
 


### PR DESCRIPTION
Add a section to `presubmit.sh` that will fail if there are any `.pb.txt` or `.proto.txt` files present. These should be named `.textproto`.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
