### PR TITLE
[treetex] Add more control over the generated tree

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -183,7 +183,7 @@ func perfect(prefix string, height uint, index uint64, nodeText nodeTextFunc) {
 // drawLeaf emits TeX code to render a leaf.
 func drawLeaf(prefix string, index uint64, text string) {
 	a := nInfo[compact.NewNodeID(0, index)]
-	fmt.Printf("%s [%s, %s, tier=leaf]\n", prefix, text, a.String())
+	fmt.Printf("%s [%s, %s, align=center, tier=leaf]\n", prefix, text, a.String())
 }
 
 // openInnerNode renders TeX code to open an internal node.
@@ -328,7 +328,7 @@ var nodeFormats = map[string]nodeTextFunc{
 	"hash": func(id compact.NodeID) string {
 		childLevel := id.Level - 1
 		leftChild := id.Index * 2
-		return fmt.Sprintf("{$H_{%d.%d} = \\\\ H(H_{%d.%d} || H_{%d.%d})$}", id.Level, id.Index, childLevel, leftChild, childLevel, leftChild+1)
+		return fmt.Sprintf("{$H_{%d.%d} =$ \\\\ $H(H_{%d.%d} || H_{%d.%d})$}", id.Level, id.Index, childLevel, leftChild, childLevel, leftChild+1)
 	},
 }
 
@@ -345,7 +345,7 @@ func main() {
 
 	var ldf nodeTextFunc = func(id compact.NodeID) string {
 		if id.Level == 0 {
-			return fmt.Sprintf("%d", id.Index)
+			return fmt.Sprintf("{$H_{0.%d} =$ \\\\ $H(leaf_{%[1]d})$}", id.Index)
 		}
 		return innerNodeText(id)
 	}

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -86,6 +86,9 @@ var (
 	megaMode  = flag.Uint("megamode_threshold", 4, "Treat perfect trees larger than this many layers as a single entity")
 	ranges    = flag.String("ranges", "", "Comma-separated Open-Closed ranges of the form L:R")
 
+	attrPerfectRoot   = flag.String("attr_perfect_root", "line width=4pt", "Latex treatment for perfect root nodes")
+	attrEphemeralNode = flag.String("attr_ephemeral_node", "draw, dotted", "Latex treatment for ephemeral nodes")
+
 	// nInfo holds nodeInfo data for the tree.
 	nInfo = make(map[compact.NodeID]nodeInfo)
 )
@@ -111,13 +114,13 @@ func (n nodeInfo) String() string {
 	// Figure out which colour to fill with:
 	fill := "white"
 	if n.perfectRoot {
-		attr = append(attr, "line width=4pt")
+		attr = append(attr, *attrPerfectRoot)
 	}
 	if n.incProof {
 		fill = "inclusion"
 		if n.ephemeral {
 			fill = "inclusion_ephemeral"
-			attr = append(attr, "draw, dotted")
+			attr = append(attr, *attrEphemeralNode)
 		}
 	}
 	if n.target {
@@ -145,7 +148,7 @@ func (n nodeInfo) String() string {
 	if !n.leaf {
 		attr = append(attr, "circle, minimum size=3em")
 	} else {
-		attr = append(attr, "minimum size=1.5em")
+		attr = append(attr, "minimum size=1.5em, align=center, base=bottom")
 	}
 	return strings.Join(attr, ", ")
 }


### PR DESCRIPTION
Adds a little more control over the tree rendered by `treetex`:
 - allow the setting of leaf data (rather than simply indices)
 - allow some of the node styles to be overridden

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
