### PR TITLE
[treetex] Add leaf data nodes too

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -362,11 +362,8 @@ func main() {
 		leaves := strings.Split(*leafData, ",")
 		*treeSize = uint64(len(leaves))
 		log.Printf("Overriding treeSize to %d since --leaf_data was set", *treeSize)
-		nodeText = func(id compact.NodeID) string {
-			if id.Level == 0 {
-				return leaves[id.Index]
-			}
-			return innerNodeText(id)
+		dataFormat = func(id compact.NodeID) string {
+			return leaves[id.Index]
 		}
 	}
 

--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -334,6 +334,8 @@ var nodeFormats = map[string]nodeTextFunc{
 		return fmt.Sprintf("%d.%d", id.Level, id.Index)
 	},
 	"hash": func(id compact.NodeID) string {
+		// For "hash" format node text, levels >=1 need a different format
+		// [H=H(childL|childR)]from the base level (H=H(leafN)].
 		if id.Level >= 1 {
 			childLevel := id.Level - 1
 			leftChild := id.Index * 2


### PR DESCRIPTION
Add box nodes representing leaf data on `treetex` images.

e.g.:

![image](https://user-images.githubusercontent.com/7648032/69754045-da8bc080-114c-11ea-80a4-ee05ac8aa113.png)


### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
