### PR TITLE
Introduce TileSet primitives

### DIFF
--- a/merkle/smt/tiles.go
+++ b/merkle/smt/tiles.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/storage/tree"
+)
+
+// TileSet represenst a set of Merkle tree tiles and the corresponding nodes.
+//
+// TODO(pavelkalinnikov): Make it immutable.
+type TileSet struct {
+	layout *tree.Layout
+	tiles  map[tree.NodeID2][]Node
+	hashes map[tree.NodeID2][]byte
+	h      mapHasher
+}
+
+// NewTileSet creates an empty TileSet with the given tree parameters.
+func NewTileSet(treeID int64, hasher hashers.MapHasher, layout *tree.Layout) *TileSet {
+	tiles := make(map[tree.NodeID2][]Node)
+	hashes := make(map[tree.NodeID2][]byte)
+	h := bindHasher(hasher, treeID)
+	return &TileSet{layout: layout, tiles: tiles, hashes: hashes, h: h}
+}
+
+// Hashes returns a map containing all node hashes keyed by node IDs.
+func (t *TileSet) Hashes() map[tree.NodeID2][]byte {
+	return t.hashes
+}
+
+// Add puts the given tile into the set.
+//
+// TODO(pavelkalinnikov): Take a whole list of Tiles instead.
+func (t *TileSet) Add(tile Tile) error {
+	if _, ok := t.tiles[tile.ID]; ok {
+		return fmt.Errorf("tile already exists: %v", tile.ID)
+	}
+	t.tiles[tile.ID] = tile.Leaves
+	return tile.scan(t.layout, t.h, func(node Node) {
+		t.hashes[node.ID] = node.Hash
+	})
+}
+
+// TileSetMutation accumulates tree tiles that need to be updated.
+type TileSetMutation struct {
+	read  *TileSet
+	tiles map[tree.NodeID2][]Node
+	dirty map[tree.NodeID2]bool
+}
+
+// NewTileSetMutation creates a mutation which is based off the provided
+// TileSet. This means that each modification is checked against the hashes in
+// this set, and is applied if it does change the hash.
+func NewTileSetMutation(ts *TileSet) *TileSetMutation {
+	tiles := make(map[tree.NodeID2][]Node)
+	dirty := make(map[tree.NodeID2]bool)
+	return &TileSetMutation{read: ts, tiles: tiles, dirty: dirty}
+}
+
+// Set updates the hash of the given tree node.
+func (t *TileSetMutation) Set(id tree.NodeID2, hash []byte) {
+	root := t.read.layout.GetTileRootID(id)
+	height := uint(t.read.layout.TileHeight(int(root.BitLen())))
+	if root.BitLen()+height != id.BitLen() {
+		return // Not a leaf node of a tile.
+	}
+	if bytes.Equal(t.read.hashes[id], hash) {
+		// TODO(pavelkalinnikov): Consider checking the dirty state.
+		return // Nothing changed.
+	}
+	t.tiles[root] = append(t.tiles[root], Node{ID: id, Hash: hash})
+	t.dirty[id] = true
+}
+
+// Build returns the full set of tiles modified by this mutation.
+func (t *TileSetMutation) Build() ([]Tile, error) {
+	res := make([]Tile, 0, len(t.tiles))
+	for id, upd := range t.tiles {
+		had, ok := t.read.tiles[id]
+		if !ok {
+			res = append(res, Tile{ID: id, Leaves: upd})
+			continue
+		}
+		leaves := make([]Node, len(upd), len(upd)+len(had))
+		copy(leaves, upd)
+		for _, u := range had {
+			if !t.dirty[u.ID] {
+				leaves = append(leaves, u)
+			}
+		}
+		// TODO(pavelkalinnikov): Introduce a Tile merge operation.
+		// TODO(pavelkalinnikov): Sort leaves when the invariant is introduced.
+		res = append(res, Tile{ID: id, Leaves: leaves})
+	}
+	return res, nil
+}

--- a/merkle/smt/tiles.go
+++ b/merkle/smt/tiles.go
@@ -22,7 +22,8 @@ import (
 	"github.com/google/trillian/storage/tree"
 )
 
-// TileSet represenst a set of Merkle tree tiles and the corresponding nodes.
+// TileSet represents a set of Merkle tree tiles and the corresponding nodes.
+// This type is not thread-safe.
 //
 // TODO(pavelkalinnikov): Make it immutable.
 type TileSet struct {
@@ -45,7 +46,7 @@ func (t *TileSet) Hashes() map[tree.NodeID2][]byte {
 	return t.hashes
 }
 
-// Add puts the given tile into the set.
+// Add puts the given tile into the set. Not thread-safe.
 //
 // TODO(pavelkalinnikov): Take a whole list of Tiles instead.
 func (t *TileSet) Add(tile Tile) error {
@@ -58,7 +59,8 @@ func (t *TileSet) Add(tile Tile) error {
 	})
 }
 
-// TileSetMutation accumulates tree tiles that need to be updated.
+// TileSetMutation accumulates tree tiles that need to be updated. This type is
+// not thread-safe.
 type TileSetMutation struct {
 	read  *TileSet
 	tiles map[tree.NodeID2][]Node
@@ -74,7 +76,7 @@ func NewTileSetMutation(ts *TileSet) *TileSetMutation {
 	return &TileSetMutation{read: ts, tiles: tiles, dirty: dirty}
 }
 
-// Set updates the hash of the given tree node.
+// Set updates the hash of the given tree node. Not thread-safe.
 func (t *TileSetMutation) Set(id tree.NodeID2, hash []byte) {
 	root := t.read.layout.GetTileRootID(id)
 	height := uint(t.read.layout.TileHeight(int(root.BitLen())))

--- a/merkle/smt/tiles_test.go
+++ b/merkle/smt/tiles_test.go
@@ -1,0 +1,198 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/trillian/merkle/maphasher"
+	"github.com/google/trillian/storage/tree"
+)
+
+func TestTileSetAdd(t *testing.T) {
+	hasher := maphasher.Default
+	l := tree.NewLayout([]int{8, 8})
+
+	existing := Tile{
+		ID:     tree.NewNodeID2("\x00", 8),
+		Leaves: []Node{{ID: tree.NewNodeID2("\x00\x05", 16)}},
+	}
+	for _, tc := range []struct {
+		tile    Tile
+		wantErr string
+	}{
+		{tile: Tile{ID: tree.NewNodeID2("\x01", 8)}},
+		{tile: Tile{ID: tree.NewNodeID2("\x00", 8)}, wantErr: "exists"},
+		{
+			tile: Tile{
+				ID:     tree.NewNodeID2("\x01", 8),
+				Leaves: []Node{{ID: tree.NewNodeID2("\x00\x05\x00", 24)}},
+			},
+			wantErr: "invalid depth",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			ts := NewTileSet(0, hasher, l)
+			if err := ts.Add(existing); err != nil {
+				t.Fatalf("Add: %v", err)
+			}
+			got := ""
+			if err := ts.Add(tc.tile); err != nil {
+				got = err.Error()
+			}
+			if want := tc.wantErr; len(want) == 0 && len(got) != 0 {
+				t.Errorf("Add: %v", got)
+			} else if len(want) != 0 && !strings.Contains(got, want) {
+				t.Errorf("Add: err=%q; want err containing %q", got, want)
+			}
+		})
+	}
+}
+
+func TestTileSetHashes(t *testing.T) {
+	l := tree.NewLayout([]int{8, 8})
+	ts := NewTileSet(0, maphasher.Default, l)
+
+	count := 0
+	for i, tc := range []struct {
+		tile  Tile
+		added int
+	}{
+		{tile: Tile{ID: tree.NewNodeID2("\x02", 8), Leaves: nil}, added: 0},
+		{
+			tile: Tile{
+				ID:     tree.NewNodeID2("\x00", 8),
+				Leaves: []Node{{ID: tree.NewNodeID2("\x00\x01", 16)}},
+			},
+			added: 8,
+		},
+		{
+			tile: Tile{Leaves: []Node{
+				{ID: tree.NewNodeID2("\x00", 8)},
+				{ID: tree.NewNodeID2("\x02", 8)},
+			}},
+			added: 10,
+		},
+	} {
+		if err := ts.Add(tc.tile); err != nil {
+			t.Fatalf("Add(%d): %v", i, err)
+		}
+		count += tc.added
+		// TODO(pavelkalinnikov): Check the nodes containment.
+		if got, want := len(ts.Hashes()), count; got != want {
+			t.Fatalf("Hashes(%d): got %d nodes, want %d", i, got, want)
+		}
+	}
+}
+
+func TestTileSetMutationBuild(t *testing.T) {
+	l := tree.NewLayout([]int{8, 8})
+	ids := []tree.NodeID2{
+		tree.NewNodeID2("\x00\x00", 16),
+		tree.NewNodeID2("\x00\x70", 16),
+		tree.NewNodeID2("\x01\x01", 16),
+		tree.NewNodeID2("\xFF\xFF", 16),
+	}
+	ts := NewTileSet(0, maphasher.Default, l)
+	for _, tile := range []Tile{
+		{Leaves: []Node{ // Root tile.
+			{ID: ids[0].Prefix(8), Hash: []byte("hash_00")},
+			{ID: ids[2].Prefix(8), Hash: []byte("hash_01")},
+			{ID: ids[3].Prefix(8), Hash: []byte("hash_FF")},
+		}},
+		{ // Tile 0x00.
+			ID: ids[0].Prefix(8),
+			Leaves: []Node{
+				{ID: ids[0], Hash: []byte("hash_0000")},
+				{ID: ids[1], Hash: []byte("hash_0070")},
+			},
+		},
+		{ // Tile 0x01.
+			ID:     ids[2].Prefix(8),
+			Leaves: []Node{{ID: ids[2], Hash: []byte("hash_0101")}},
+		},
+		{ // Tile 0xFF.
+			ID:     ids[3].Prefix(8),
+			Leaves: []Node{{ID: ids[3], Hash: []byte("hash_FFFF")}},
+		},
+	} {
+		if err := ts.Add(tile); err != nil {
+			t.Fatalf("Add(%v): %v", tile.ID, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		upd  []Node                  // Node updates.
+		want map[tree.NodeID2][]Node // Updated tiles.
+	}{
+		{upd: nil, want: make(map[tree.NodeID2][]Node)},
+		{
+			upd: []Node{{ID: ids[0], Hash: []byte("new_0000")}},
+			want: map[tree.NodeID2][]Node{
+				ids[0].Prefix(8): []Node{
+					{ID: ids[0], Hash: []byte("new_0000")},
+					{ID: ids[1], Hash: []byte("hash_0070")},
+				},
+			},
+		},
+		{
+			upd: []Node{{ID: ids[0].Sibling(), Hash: []byte("new_0001")}},
+			want: map[tree.NodeID2][]Node{
+				ids[0].Prefix(8): []Node{
+					{ID: ids[0].Sibling(), Hash: []byte("new_0001")},
+					{ID: ids[0], Hash: []byte("hash_0000")},
+					{ID: ids[1], Hash: []byte("hash_0070")},
+				},
+			},
+		},
+		{
+			upd: []Node{
+				{ID: ids[0], Hash: []byte("new_0000")},
+				{ID: ids[2], Hash: []byte("new_0101")},
+			},
+			want: map[tree.NodeID2][]Node{
+				ids[0].Prefix(8): []Node{
+					{ID: ids[0], Hash: []byte("new_0000")},
+					{ID: ids[1], Hash: []byte("hash_0070")},
+				},
+				ids[2].Prefix(8): []Node{
+					{ID: ids[2], Hash: []byte("new_0101")},
+				},
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			m := NewTileSetMutation(ts)
+			for _, node := range tc.upd {
+				m.Set(node.ID, node.Hash)
+			}
+			tiles, err := m.Build()
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			got := make(map[tree.NodeID2][]Node, len(tiles))
+			for _, tile := range tiles {
+				got[tile.ID] = tile.Leaves
+			}
+			if want := tc.want; !reflect.DeepEqual(got, want) {
+				t.Logf("%v", got)
+				t.Logf("%v", want)
+				t.Fatalf("Tile mismatch: got %d tiles, want %d other ones", len(got), len(want))
+			}
+		})
+	}
+}

--- a/merkle/smt/tiles_test.go
+++ b/merkle/smt/tiles_test.go
@@ -143,7 +143,7 @@ func TestTileSetMutationBuild(t *testing.T) {
 		{
 			upd: []Node{{ID: ids[0], Hash: []byte("new_0000")}},
 			want: map[tree.NodeID2][]Node{
-				ids[0].Prefix(8): []Node{
+				ids[0].Prefix(8): {
 					{ID: ids[0], Hash: []byte("new_0000")},
 					{ID: ids[1], Hash: []byte("hash_0070")},
 				},
@@ -152,7 +152,7 @@ func TestTileSetMutationBuild(t *testing.T) {
 		{
 			upd: []Node{{ID: ids[0].Sibling(), Hash: []byte("new_0001")}},
 			want: map[tree.NodeID2][]Node{
-				ids[0].Prefix(8): []Node{
+				ids[0].Prefix(8): {
 					{ID: ids[0].Sibling(), Hash: []byte("new_0001")},
 					{ID: ids[0], Hash: []byte("hash_0000")},
 					{ID: ids[1], Hash: []byte("hash_0070")},
@@ -165,11 +165,11 @@ func TestTileSetMutationBuild(t *testing.T) {
 				{ID: ids[2], Hash: []byte("new_0101")},
 			},
 			want: map[tree.NodeID2][]Node{
-				ids[0].Prefix(8): []Node{
+				ids[0].Prefix(8): {
 					{ID: ids[0], Hash: []byte("new_0000")},
 					{ID: ids[1], Hash: []byte("hash_0070")},
 				},
-				ids[2].Prefix(8): []Node{
+				ids[2].Prefix(8): {
 					{ID: ids[2], Hash: []byte("new_0101")},
 				},
 			},

--- a/storage/tree/layout.go
+++ b/storage/tree/layout.go
@@ -104,6 +104,16 @@ func (l *Layout) TileHeight(rootDepth int) int {
 	return l.getStratumAt(rootDepth).height
 }
 
+// GetTileRootID returns the ID for the root of the tile that the node with the
+// given ID belongs to.
+func (l *Layout) GetTileRootID(id NodeID2) NodeID2 {
+	if depth := id.BitLen(); depth > 0 {
+		info := l.getStratumAt(int(depth) - 1)
+		return id.Prefix(uint(info.idBytes * 8))
+	}
+	return NodeID2{}
+}
+
 func (l *Layout) getStratumAt(depth int) stratumInfo {
 	return l.sIndex[depth/depthQuantum]
 }


### PR DESCRIPTION
This change introduces `TileSet` and `TileSetMutation` primitives. These are used by application layer to process and prepare tiles for exchanging with the storage layer. Effectively it is a cheaper `SubtreeCache`.

Part of #1932.