### PR TITLE
Set HTTP endpoint to disabled by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ not spend time investigating this issue.
 A potential deadlock condition in the log sequencer when the process is
 attempting to exit has been addressed.
 
+### Log Server Changes
+Log Server HTTP Endpoint default has been changed to OFF.
+
 ### Map Changes
 
 The verifiable map is still experimental. APIs, such as SetLeaves, have been

--- a/server/trillian_log_server/main.go
+++ b/server/trillian_log_server/main.go
@@ -58,7 +58,7 @@ import (
 
 var (
 	rpcEndpoint     = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
-	httpEndpoint    = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
+	httpEndpoint    = flag.String("http_endpoint", "", "Endpoint for HTTP metrics and REST requests on (host:port, empty means disabled)")
 	healthzTimeout  = flag.Duration("healthz_timeout", time.Second*5, "Timeout used during healthz checks")
 	tlsCertFile     = flag.String("tls_cert_file", "", "Path to the TLS server certificate. If unset, the server will use unsecured connections.")
 	tlsKeyFile      = flag.String("tls_key_file", "", "Path to the TLS server key. If unset, the server will use unsecured connections.")


### PR DESCRIPTION
<!---
If HTTP Endpoint is deprecated, suggest changing default to OFF.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [N/A] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
