### PR TITLE
Prepare to delete deprecated test constructor

### DIFF
--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -57,7 +57,7 @@ func addSequencedLeaves(ctx context.Context, env *integration.LogEnv, client *Lo
 func clientEnvForTest(ctx context.Context, t *testing.T, template *trillian.Tree) (*integration.LogEnv, *LogClient) {
 	t.Helper()
 	testdb.SkipIfNoMySQL(t)
-	env, err := integration.NewLogEnv(ctx, 1, "unused")
+	env, err := integration.NewLogEnvWithGRPCOptions(ctx, 1, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -95,7 +95,7 @@ func TestInProcessLogIntegration(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	const numSequencers = 2
-	env, err := integration.NewLogEnv(ctx, numSequencers, "unused")
+	env, err := integration.NewLogEnvWithGRPCOptions(ctx, 1, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/log_integration_test.go
+++ b/integration/log_integration_test.go
@@ -95,7 +95,7 @@ func TestInProcessLogIntegration(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()
 	const numSequencers = 2
-	env, err := integration.NewLogEnvWithGRPCOptions(ctx, 1, nil, nil)
+	env, err := integration.NewLogEnvWithGRPCOptions(ctx, numSequencers, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -83,7 +83,7 @@ func NewLogEnv(ctx context.Context, numSequencers int, _ string) (*LogEnv, error
 // NewLogEnvWithGRPCOptions creates a fresh DB, log server, and client. The
 // numSequencers parameter indicates how many sequencers to run in parallel;
 // if numSequencers is zero a manually-controlled test sequencer is used.
-// additional grpc.ServerOption and grpc.DialOption values can be provided.
+// Additional grpc.ServerOption and grpc.DialOption values can be provided.
 func NewLogEnvWithGRPCOptions(ctx context.Context, numSequencers int, serverOpts []grpc.ServerOption, clientOpts []grpc.DialOption) (*LogEnv, error) {
 	db, done, err := testdb.NewTrillianDB(ctx)
 	if err != nil {

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -74,8 +74,8 @@ type LogEnv struct {
 // NewLogEnv creates a fresh DB, log server, and client. The numSequencers parameter
 // indicates how many sequencers to run in parallel; if numSequencers is zero a
 // manually-controlled test sequencer is used.
-// TODO(codingllama): Remove 3rd parameter (need to coordinate with
-// github.com/google/certificate-transparency-go)
+// TODO(Martin2112): Remove this constructor, it is only used by tests and
+// can be replaced by one of the others.
 func NewLogEnv(ctx context.Context, numSequencers int, _ string) (*LogEnv, error) {
 	return NewLogEnvWithGRPCOptions(ctx, numSequencers, nil, nil)
 }

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -80,7 +80,10 @@ func NewLogEnv(ctx context.Context, numSequencers int, _ string) (*LogEnv, error
 	return NewLogEnvWithGRPCOptions(ctx, numSequencers, nil, nil)
 }
 
-// NewLogEnvWithGRPCOptions works the same way as NewLogEnv, but allows callers to also set additional grpc.ServerOption and grpc.DialOption values.
+// NewLogEnvWithGRPCOptions creates a fresh DB, log server, and client. The
+// numSequencers parameter indicates how many sequencers to run in parallel;
+// if numSequencers is zero a manually-controlled test sequencer is used.
+// additional grpc.ServerOption and grpc.DialOption values can be provided.
 func NewLogEnvWithGRPCOptions(ctx context.Context, numSequencers int, serverOpts []grpc.ServerOption, clientOpts []grpc.DialOption) (*LogEnv, error) {
 	db, done, err := testdb.NewTrillianDB(ctx)
 	if err != nil {

--- a/testonly/integration/logenv.go
+++ b/testonly/integration/logenv.go
@@ -74,6 +74,9 @@ type LogEnv struct {
 // NewLogEnv creates a fresh DB, log server, and client. The numSequencers parameter
 // indicates how many sequencers to run in parallel; if numSequencers is zero a
 // manually-controlled test sequencer is used.
+//
+// Deprecated: Use NewLogEnvWithGRPCOptions instead
+//
 // TODO(Martin2112): Remove this constructor, it is only used by tests and
 // can be replaced by one of the others.
 func NewLogEnv(ctx context.Context, numSequencers int, _ string) (*LogEnv, error) {


### PR DESCRIPTION
Remove usages of it in this repo. Can't delete it straight away as we need https://github.com/google/certificate-transparency-go/pull/627 to remove it from CT integration tests.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
