### PR TITLE
Put the signer constructor back as it was being used outside the repo

### DIFF
--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -49,6 +49,17 @@ func NewSigner(keyID int64, signer crypto.Signer, hash crypto.Hash) *Signer {
 	}
 }
 
+// NewSHA256Signer creates a new SHA256 based Signer and a KeyID of 0.
+//
+// Deprecated: NewSHA256Signer was only meant for use in tests. It can be
+// replaced by NewSigner(0, key, crypto.SHA256).
+func NewSHA256Signer(signer crypto.Signer) *Signer {
+	return &Signer{
+		Hash:   crypto.SHA256,
+		Signer: signer,
+	}
+}
+
 // Public returns the public key that can verify signatures produced by s.
 func (s *Signer) Public() crypto.PublicKey {
 	return s.Signer.Public()


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
