### PR TITLE
Use installer for golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
     - name: "lint"
       before_install: skip
       install:
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
       - go install github.com/uber/prototool/cmd/prototool
       - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
       before_script: skip

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d // indirect
-	github.com/golangci/golangci-lint v1.21.0
+	github.com/golangci/golangci-lint v1.21.0 // indirect
 	github.com/golangci/revgrep v0.0.0-20180812185044-276a5c0a1039 // indirect
 	github.com/google/btree v1.0.0
 	github.com/google/certificate-transparency-go v1.1.0

--- a/tools.go
+++ b/tools.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golang/protobuf/proto"
 	_ "github.com/golang/protobuf/protoc-gen-go"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 	_ "github.com/uber/prototool/cmd/prototool"


### PR DESCRIPTION
By removing golangci-lint from `tools.go` we avoid pulling in a huge dependency tree. 
Furthermore, this is not the recommended way to install golangci-lint. 

Related PR: https://github.com/google/certificate-transparency-go/pull/630

Note: the dependency will not fully disappear until Trillian updates its dependency on certificate-transparency-go

### Checklist
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).