### PR TITLE
monitoring: Increase the default latency range

### DIFF
--- a/monitoring/buckets.go
+++ b/monitoring/buckets.go
@@ -35,9 +35,9 @@ func PercentileBuckets(inc int64) []float64 {
 
 // LatencyBuckets returns a reasonable range of histogram upper limits for most
 // latency-in-seconds usecases. The thresholds increase exponentially from 0.04
-// seconds to ~1 day.
+// seconds to ~282 days.
 func LatencyBuckets() []float64 {
-	return ExpBuckets(0.04, 1.05, 300)
+	return ExpBuckets(0.04, 1.07, 300)
 }
 
 // ExpBuckets returns the specified number of histogram buckets with

--- a/monitoring/buckets_test.go
+++ b/monitoring/buckets_test.go
@@ -63,9 +63,9 @@ func TestPercentileBuckets(t *testing.T) {
 func TestLatencyBuckets(t *testing.T) {
 	// Just do some probes on the result to make sure it looks sensible.
 	buckets := monitoring.LatencyBuckets()
-	checkExpBuckets(t, buckets, 0.04, 1.05, 300)
-	// Highest bucket should be about 86400 sec = 1 day (allow some leeway).
-	if got, want := math.Abs(buckets[len(buckets)-1]-86400.0), 300.0; got > want {
+	checkExpBuckets(t, buckets, 0.04, 1.07, 300)
+	// Highest bucket should be about 282 days (allow some leeway).
+	if got, want := math.Abs(buckets[len(buckets)-1]-282*24*3600.0), 72000.0; got > want {
 		t.Errorf("LatencyBuckets(): got last bucket diff: %v, want: <%v", got, want)
 	}
 }

--- a/monitoring/buckets_test.go
+++ b/monitoring/buckets_test.go
@@ -65,8 +65,10 @@ func TestLatencyBuckets(t *testing.T) {
 	buckets := monitoring.LatencyBuckets()
 	checkExpBuckets(t, buckets, 0.04, 1.07, 300)
 	// Highest bucket should be about 282 days (allow some leeway).
-	if got, want := math.Abs(buckets[len(buckets)-1]-282*24*3600.0), 72000.0; got > want {
-		t.Errorf("LatencyBuckets(): got last bucket diff: %v, want: <%v", got, want)
+	expected := 282 * 24 * 3600.0 // 282 days.
+	precision := 17 * 3600.0      // A bit less than one day.
+	if got := math.Abs(buckets[len(buckets)-1] - expected); got > precision {
+		t.Errorf("LatencyBuckets(): got last bucket diff: %v, want: <%v", got, precision)
 	}
 }
 


### PR DESCRIPTION
This change does not harm precision of lower buckets in a significant way.