### PR TITLE
Increase etcd cluster size from 3 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ being re-enabled. This was broken by a downstream change and without a signal
 from the Trillian community to say this is needed, the pragmatic action is to
 not spend time investigating this issue.
 
+### Deployments
+
+The Kubernetes configs will now provision 5 nodes for Trillian's Etcd cluster,
+instead of 3 nodes.
+[This makes the Etcd cluster more resilient](https://etcd.io/docs/v3.2.17/faq/#what-is-failure-tolerance)
+to nodes becoming temporarily unavailable, such as during updates (it can now
+tolerate 2 nodes being unavailable, instead of just 1).
+
 ### Log Changes
 
 #### Potential sequencer hang fixed

--- a/deployment/etcd-cluster.yaml
+++ b/deployment/etcd-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     etcd.database.coreos.com/scope: clusterwide
 spec:
-  size: 3
+  size: 5
   version: "3.2.13"
   pod:
     annotations:

--- a/examples/deployment/kubernetes/etcd-cluster.yaml
+++ b/examples/deployment/kubernetes/etcd-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     etcd.database.coreos.com/scope: clusterwide
 spec:
-  size: 3
+  size: 5
   version: "3.2.13"
   pod:
     annotations:


### PR DESCRIPTION
Makes it more resilient to cluster nodes being rescheduled because now
it can tolerate 2 nodes being offline, rather than just 1.

https://etcd.io/docs/v3.2.17/faq/#what-is-failure-tolerance

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
