### PR TITLE
Export a metric of total number of leaves fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ A potential deadlock condition in the log sequencer when the process is
 attempting to exit has been addressed.
 
 #### Monitoring & Metrics
-A count of the total number of individual leaves fetched via the GetEntries.\*
-API methods has been added.
+A count of the total number of individual leaves the logserver attempts to
+fetch via the GetEntries.\* API methods has been added.
 
 ### Map Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ tolerate 2 nodes being unavailable, instead of just 1).
 A potential deadlock condition in the log sequencer when the process is
 attempting to exit has been addressed.
 
+#### Monitoring & Metrics
+A count of the total number of individual leaves fetched via the GetEntries.\*
+API methods has been added.
+
 ### Map Changes
 
 The verifiable map is still experimental. APIs, such as SetLeaves, have been

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -505,6 +505,7 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 	}
 	defer t.closeAndLog(ctx, tree.TreeId, tx, "GetLeavesByIndex")
 
+	t.fetchedLeaves.Add(float64(len(req.LeafIndex)))
 	leaves, err := tx.GetLeavesByIndex(ctx, req.LeafIndex)
 	if err != nil {
 		return nil, err
@@ -513,8 +514,6 @@ func (t *TrillianLogRPCServer) GetLeavesByIndex(ctx context.Context, req *trilli
 	if err := t.commitAndLog(ctx, req.LogId, tx, "GetLeavesByIndex"); err != nil {
 		return nil, err
 	}
-
-	t.fetchedLeaves.Add(float64(len(req.LeafIndex)))
 
 	slr, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
@@ -548,8 +547,6 @@ func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trilli
 	}
 	defer t.closeAndLog(ctx, tree.TreeId, tx, "GetLeavesByRange")
 
-	t.fetchedLeaves.Add(float64(req.Count))
-
 	slr, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {
 		return nil, err
@@ -562,6 +559,7 @@ func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trilli
 	r := &trillian.GetLeavesByRangeResponse{SignedLogRoot: slr}
 
 	if req.StartIndex < int64(root.TreeSize) {
+		t.fetchedLeaves.Add(float64(req.Count))
 		leaves, err := tx.GetLeavesByRange(ctx, req.StartIndex, req.Count)
 		if err != nil {
 			return nil, err
@@ -598,12 +596,11 @@ func (t *TrillianLogRPCServer) GetLeavesByHash(ctx context.Context, req *trillia
 	}
 	defer t.closeAndLog(ctx, tree.TreeId, tx, "GetLeavesByHash")
 
+	t.fetchedLeaves.Add(float64(len(req.LeafHash)))
 	leaves, err := tx.GetLeavesByHash(ctx, req.LeafHash, req.OrderBySequence)
 	if err != nil {
 		return nil, err
 	}
-
-	t.fetchedLeaves.Add(float64(len(req.LeafHash)))
 
 	slr, err := tx.LatestSignedLogRoot(ctx)
 	if err != nil {

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -425,6 +425,10 @@ func TestGetLeavesByRange(t *testing.T) {
 		if got := rsp.Leaves; !cmp.Equal(got, test.want, cmp.Comparer(proto.Equal)) {
 			t.Errorf("GetLeavesByRange(%d, %+d)=%+v; want %+v", req.StartIndex, req.Count, got, test.want)
 		}
+
+		if gotCount, wantCount := server.fetchedLeaves.Value(), float64(test.count); gotCount != wantCount {
+			t.Errorf("GetLeavesByRange() incremented fetched count by %f,  want %f", gotCount, wantCount)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a simple metric to track the number of individual entries fetched by calls to the `GetEntriesBy.*` API calls.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
