### PR TITLE
Do not refund tokens for Tree- and User- scoped buckets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,17 @@ support when the new API is tested.
 
 ### Quota
 
+#### New Features
+
 An experimental Redis-based `quota.Manager` implementation has been added.
+
+#### Behaviour Changes
+
+Quota used to be refunded for all failed requests. For uses of quota that were
+to protect against abuse or fair utilization, this could allow infinite QPS in
+situations that really should have the requests throttled. Refunds are now only
+performed for tokens in `Global` buckets, which prevents tokens being leaked if
+duplicate leaves are queued.
 
 ### Tools
 

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -67,6 +67,10 @@ type Spec struct {
 	// User identifies the user for specs of the User group.
 	// Not used for other specs.
 	User string
+
+	// Refundable indicates that the tokens acquired before the operation should be returned if
+	// the operation fails.
+	Refundable bool
 }
 
 // Name returns a textual representation of the Spec. Names are constant and may be relied upon to

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -220,7 +220,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -230,7 +230,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLeavesByIndexRequest{LogId: logTree.TreeId, LeafIndex: []int64{1, 2, 3}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 3,
 		},
@@ -240,7 +240,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 123,
 		},
@@ -250,7 +250,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: -123},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -260,7 +260,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLeavesByRangeRequest{LogId: logTree.TreeId, Count: 0},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -272,7 +272,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				{Group: quota.User, Kind: quota.Read, User: charge1},
 				{Group: quota.User, Kind: quota.Read, User: charge2},
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -282,7 +282,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.QueueLeafRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -294,7 +294,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				{Group: quota.User, Kind: quota.Write, User: charge1},
 				{Group: quota.User, Kind: quota.Write, User: charge2},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 1,
 		},
@@ -304,7 +304,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetMapLeavesRequest{MapId: mapTree.TreeId, Index: [][]byte{{0x01}, {0x02}}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: mapTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			wantTokens: 2,
 		},
@@ -325,7 +325,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 3,
 		},
@@ -338,7 +338,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: preorderedTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 3,
 		},
@@ -354,7 +354,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 				{Group: quota.User, Kind: quota.Write, User: charge1},
 				{Group: quota.User, Kind: quota.Write, User: charge2},
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 3,
 		},
@@ -367,7 +367,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: mapTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 5,
 		},
@@ -380,7 +380,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: mapTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantTokens: 5,
 		},
@@ -390,7 +390,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			getTokensErr: errors.New("not enough tokens"),
 			wantCode:     codes.ResourceExhausted,
@@ -403,7 +403,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			getTokensErr: errors.New("not enough tokens"),
 			wantTokens:   1,
@@ -462,7 +462,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			req:    &trillian.GetLatestSignedLogRootRequest{LogId: logTree.TreeId},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Read, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Read},
+				{Group: quota.Global, Kind: quota.Read, Refundable: true},
 			},
 			handlerErr:    errors.New("bad request"),
 			wantGetTokens: 1,
@@ -475,7 +475,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			resp:   &trillian.QueueLeafResponse{QueuedLeaf: &trillian.QueuedLogLeaf{}},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantGetTokens: 1,
 		},
@@ -490,7 +490,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantGetTokens: 1,
 			wantPutTokens: 1,
@@ -507,7 +507,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantGetTokens: 3,
 		},
@@ -527,7 +527,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			wantGetTokens: 3,
 			wantPutTokens: 2,
@@ -541,7 +541,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 			},
 			specs: []quota.Spec{
 				{Group: quota.Tree, Kind: quota.Write, TreeID: logTree.TreeId},
-				{Group: quota.Global, Kind: quota.Write},
+				{Group: quota.Global, Kind: quota.Write, Refundable: true},
 			},
 			handlerErr:    errors.New("bad request"),
 			wantGetTokens: 3,
@@ -577,7 +577,13 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 				qm.EXPECT().GetTokens(gomock.Any(), test.wantGetTokens, test.specs).Return(nil)
 			}
 			if test.wantPutTokens > 0 {
-				qm.EXPECT().PutTokens(gomock.Any(), test.wantPutTokens, test.specs).Do(func(ctx context.Context, numTokens int, specs []quota.Spec) {
+				refunds := make([]quota.Spec, 0)
+				for _, s := range test.specs {
+					if s.Refundable {
+						refunds = append(refunds, s)
+					}
+				}
+				qm.EXPECT().PutTokens(gomock.Any(), test.wantPutTokens, refunds).Do(func(ctx context.Context, numTokens int, specs []quota.Spec) {
 					switch d, ok := ctx.Deadline(); {
 					case !ok:
 						t.Errorf("PutTokens() ctx has no deadline: %v", ctx)


### PR DESCRIPTION
This prevents any user or log from being allowed infinite QPS if a reproducible failure is encountered. Failures can be more expensive than happy requests, and thus rate limiting them is fair game. The comments in the inteceptor strongly indicate that the refunding was only intended to be applied for global writes.

If needed, this can be extended in the future to allow the personality to specify whether a charge is refundable in addition to the accounting users.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
