### PR TITLE
Move server binaries to /cmd directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Not yet released; provisionally v1.4.0 (may change).
 
+### Server Binaries
+
+The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`
+binaries have moved from `github.com/google/trillian/server/` to
+`github.com/google/trillian/cmd`. A subset of the `server` package has also
+moved and now resides in `github.com/google/trillian/cmd/internal/serverutil`.
+
 ### Bazel Changes
 Python support is disabled unless we hear that the community cares about this
 being re-enabled. This was broken by a downstream change and without a signal

--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package server holds code for running Trillian servers.
-package server
+// Package serverutil holds code for running Trillian servers.
+package serverutil
 
 import (
 	"context"

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/cmd"
+	"github.com/google/trillian/cmd/internal/serverutil"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
@@ -68,8 +69,8 @@ var (
 	quotaDryRun = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 
 	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
-	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
-	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", server.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
+	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", serverutil.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
+	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", serverutil.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
 
 	tracing          = flag.Bool("tracing", false, "If true opencensus Stackdriver tracing will be enabled. See https://opencensus.io/.")
 	tracingProjectID = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
@@ -119,10 +120,10 @@ func main() {
 	}
 
 	// Announce our endpoints to etcd if so configured.
-	unannounce := server.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint)
+	unannounce := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint)
 	defer unannounce()
 	if *httpEndpoint != "" {
-		unannounceHTTP := server.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
 		defer unannounceHTTP()
 	}
 
@@ -148,7 +149,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	m := server.Main{
+	m := serverutil.Main{
 		RPCEndpoint:  *rpcEndpoint,
 		HTTPEndpoint: *httpEndpoint,
 		TLSCertFile:  *tlsCertFile,

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/cmd"
+	"github.com/google/trillian/cmd/internal/serverutil"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/monitoring"
@@ -43,6 +44,7 @@ import (
 	"google.golang.org/grpc"
 
 	tpb "github.com/google/trillian"
+
 	// Register key ProtoHandlers
 	_ "github.com/google/trillian/crypto/keys/der/proto"
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
@@ -148,7 +150,7 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP := server.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
 		defer unannounceHTTP()
 	}
 
@@ -180,7 +182,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	m := server.Main{
+	m := serverutil.Main{
 		RPCEndpoint:  *rpcEndpoint,
 		HTTPEndpoint: *httpEndpoint,
 		TLSCertFile:  *tlsCertFile,

--- a/cmd/trillian_map_server/main.go
+++ b/cmd/trillian_map_server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian"
 	"github.com/google/trillian/cmd"
+	"github.com/google/trillian/cmd/internal/serverutil"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/extension"
@@ -64,8 +65,8 @@ var (
 	quotaDryRun = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 
 	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
-	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", server.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
-	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", server.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
+	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", serverutil.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")
+	treeDeleteMinRunInterval = flag.Duration("tree_delete_min_run_interval", serverutil.DefaultTreeDeleteMinInterval, "Minimum interval between tree garbage collection sweeps. Actual runs happen randomly between [minInterval,2*minInterval).")
 
 	tracing          = flag.Bool("tracing", false, "If true opencensus Stackdriver tracing will be enabled. See https://opencensus.io/.")
 	tracingProjectID = flag.String("tracing_project_id", "", "project ID to pass to Stackdriver client. Can be empty for GCP, consult docs for other platforms.")
@@ -138,7 +139,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	m := server.Main{
+	m := serverutil.Main{
 		RPCEndpoint:  *rpcEndpoint,
 		HTTPEndpoint: *httpEndpoint,
 		TLSCertFile:  *tlsCertFile,

--- a/examples/ct/ctmapper/README.md
+++ b/examples/ct/ctmapper/README.md
@@ -14,7 +14,7 @@ which have that domain in their subject/SAN fields.
 # contents of storage/mysql/schema/storage.sql
 yes | scripts/resetdb.sh
 
-go build ./server/trillian_map_server
+go build ./cmd/trillian_map_server
 go build ./examples/ct/ctmapper/mapper
 go build ./examples/ct/ctmapper/lookup
 

--- a/examples/deployment/aws/terraform.tf
+++ b/examples/deployment/aws/terraform.tf
@@ -132,7 +132,7 @@ mkdir -p /go
 export GOPATH=/go
 
 # Install Trillian
-go get github.com/google/trillian/server/trillian_log_server
+go get github.com/google/trillian/cmd/trillian_log_server
 
 # Setup the DB
 cd /go/src/github.com/google/trillian

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -14,9 +14,9 @@ RUN go mod download
 COPY . .
 
 # Build the server.
-RUN go get ./server/trillian_log_server
+RUN go get ./cmd/trillian_log_server
 # Run the licensing tool and save licenses, copyright notices, etc.
-RUN go run github.com/google/go-licenses save ./server/trillian_log_server --save_path /THIRD_PARTY_NOTICES
+RUN go run github.com/google/go-licenses save ./cmd/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 
 # Make a minimal image.
 FROM gcr.io/distroless/base

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -14,9 +14,9 @@ RUN go mod download
 COPY . .
 
 # Build the signer.
-RUN go get ./server/trillian_log_signer
+RUN go get ./cmd/trillian_log_signer
 # Run the licensing tool and save licenses, copyright notices, etc.
-RUN go run github.com/google/go-licenses save ./server/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
+RUN go run github.com/google/go-licenses save ./cmd/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 
 # Make a minimal image.
 FROM gcr.io/distroless/base

--- a/examples/deployment/docker/map_server/Dockerfile
+++ b/examples/deployment/docker/map_server/Dockerfile
@@ -14,9 +14,9 @@ RUN go mod download
 COPY . .
 
 # Build the server.
-RUN go get ./server/trillian_map_server
+RUN go get ./cmd/trillian_map_server
 # Run the licensing tool and save licenses, copyright notices, etc.
-RUN go run github.com/google/go-licenses save ./server/trillian_map_server --save_path /THIRD_PARTY_NOTICES
+RUN go run github.com/google/go-licenses save ./cmd/trillian_map_server --save_path /THIRD_PARTY_NOTICES
 
 # Make a minimal image.
 FROM gcr.io/distroless/base

--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -118,8 +118,8 @@ log_prep_test() {
   local log_signer_count=${2:-1}
 
   echo "Building Trillian log code"
-  go build ${GOFLAGS} github.com/google/trillian/server/trillian_log_server/
-  go build ${GOFLAGS} github.com/google/trillian/server/trillian_log_signer/
+  go build ${GOFLAGS} github.com/google/trillian/cmd/trillian_log_server/
+  go build ${GOFLAGS} github.com/google/trillian/cmd/trillian_log_signer/
 
   # Wipe the test database
   yes | bash "${TRILLIAN_PATH}/scripts/resetdb.sh"
@@ -281,7 +281,7 @@ map_prep_test() {
   local rpc_server_count=${1:-1}
 
   echo "Building Trillian map code"
-  go build ${GOFLAGS} github.com/google/trillian/server/trillian_map_server/
+  go build ${GOFLAGS} github.com/google/trillian/cmd/trillian_map_server/
 
   # Wipe the test database
   yes | bash "${TRILLIAN_PATH}/scripts/resetdb.sh"


### PR DESCRIPTION
Also moves /server/main.go to /cmd/server, because this part of the "server" package is fairly specific to those binaries.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
