### PR TITLE
Move quota providers into packages under /quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ Not yet released; provisionally v1.4.0 (may change).
 The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`
 binaries have moved from `github.com/google/trillian/server/` to
 `github.com/google/trillian/cmd`. A subset of the `server` package has also
-moved and has been split into
-`github.com/google/trillian/cmd/internal/serverutil` and
-`github.com/google/trillian/quota/etcd`.
+moved and has been split into `cmd/internal/serverutil`, `quota/etcd` and
+`quota/mysqlqm` packages.
 
 ### Bazel Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ Not yet released; provisionally v1.4.0 (may change).
 The `trillian_log_server`, `trillian_log_signer` and `trillian_map_server`
 binaries have moved from `github.com/google/trillian/server/` to
 `github.com/google/trillian/cmd`. A subset of the `server` package has also
-moved and now resides in `github.com/google/trillian/cmd/internal/serverutil`.
+moved and has been split into
+`github.com/google/trillian/cmd/internal/serverutil` and
+`github.com/google/trillian/quota/etcd`.
 
 ### Bazel Changes
+
 Python support is disabled unless we hear that the community cares about this
 being re-enabled. This was broken by a downstream change and without a signal
 from the Trillian community to say this is needed, the pragmatic action is to

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
@@ -131,7 +132,7 @@ func main() {
 		defer unannounceHTTP()
 	}
 
-	qm, err := server.NewQuotaManagerFromFlags()
+	qm, err := quota.NewManagerFromFlags()
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}
@@ -167,7 +168,7 @@ func main() {
 			if err := trillian.RegisterTrillianLogHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
 				return err
 			}
-			if *server.QuotaSystem == etcd.Quota {
+			if *quota.System == etcd.QuotaManagerName {
 				return quotapb.RegisterQuotaHandlerFromEndpoint(ctx, mux, endpoint, opts)
 			}
 			return nil
@@ -178,7 +179,7 @@ func main() {
 				return err
 			}
 			trillian.RegisterTrillianLogServer(s, logServer)
-			if *server.QuotaSystem == etcd.Quota {
+			if *quota.System == etcd.QuotaManagerName {
 				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
 			}
 			return nil

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -56,6 +56,9 @@ import (
 
 	// Load hashers
 	_ "github.com/google/trillian/merkle/rfc6962"
+
+	// Load MySQL quota provider
+	_ "github.com/google/trillian/quota/mysqlqm"
 )
 
 var (

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -35,12 +35,13 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota/etcd"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util/clock"
-	"github.com/google/trillian/util/etcd"
+	etcdutil "github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
@@ -114,9 +115,9 @@ func main() {
 	}
 	defer sp.Close()
 
-	client, err := etcd.NewClientFromString(*server.EtcdServers)
+	client, err := etcdutil.NewClientFromString(*etcd.Servers)
 	if err != nil {
-		glog.Exitf("Failed to connect to etcd at %v: %v", *server.EtcdServers, err)
+		glog.Exitf("Failed to connect to etcd at %v: %v", *etcd.Servers, err)
 	}
 
 	// Announce our endpoints to etcd if so configured.
@@ -163,7 +164,7 @@ func main() {
 			if err := trillian.RegisterTrillianLogHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
 				return err
 			}
-			if *server.QuotaSystem == server.QuotaEtcd {
+			if *server.QuotaSystem == etcd.Quota {
 				return quotapb.RegisterQuotaHandlerFromEndpoint(ctx, mux, endpoint, opts)
 			}
 			return nil
@@ -174,7 +175,7 @@ func main() {
 				return err
 			}
 			trillian.RegisterTrillianLogServer(s, logServer)
-			if *server.QuotaSystem == server.QuotaEtcd {
+			if *server.QuotaSystem == etcd.Quota {
 				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
 			}
 			return nil

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota/etcd"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
@@ -39,7 +40,7 @@ import (
 	"github.com/google/trillian/util/election"
 	"github.com/google/trillian/util/election2"
 	etcdelect "github.com/google/trillian/util/election2/etcd"
-	"github.com/google/trillian/util/etcd"
+	etcdutil "github.com/google/trillian/util/etcd"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 
@@ -109,9 +110,9 @@ func main() {
 	}
 	defer sp.Close()
 
-	client, err := etcd.NewClientFromString(*server.EtcdServers)
+	client, err := etcdutil.NewClientFromString(*etcd.Servers)
 	if err != nil {
-		glog.Exitf("Failed to connect to etcd at %v: %v", server.EtcdServers, err)
+		glog.Exitf("Failed to connect to etcd at %v: %v", etcd.Servers, err)
 	}
 	if client != nil {
 		defer client.Close()

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -57,6 +57,9 @@ import (
 
 	// Load hashers
 	_ "github.com/google/trillian/merkle/rfc6962"
+
+	// Load MySQL quota provider
+	_ "github.com/google/trillian/quota/mysqlqm"
 )
 
 var (

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -32,8 +32,8 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd"
-	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/clock"
@@ -138,7 +138,7 @@ func main() {
 		glog.Exit("Either --force_master or --etcd_servers must be supplied")
 	}
 
-	qm, err := server.NewQuotaManagerFromFlags()
+	qm, err := quota.NewManagerFromFlags()
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}

--- a/cmd/trillian_map_server/main.go
+++ b/cmd/trillian_map_server/main.go
@@ -54,6 +54,9 @@ import (
 	// Load hashers
 	_ "github.com/google/trillian/merkle/coniks"
 	_ "github.com/google/trillian/merkle/maphasher"
+
+	// Load MySQL quota provider
+	_ "github.com/google/trillian/quota/mysqlqm"
 )
 
 var (

--- a/cmd/trillian_map_server/main.go
+++ b/cmd/trillian_map_server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/opencensus"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd"
 	"github.com/google/trillian/quota/etcd/quotaapi"
 	"github.com/google/trillian/quota/etcd/quotapb"
@@ -119,7 +120,7 @@ func main() {
 		glog.Exitf("Failed to connect to etcd at %v: %v", etcd.Servers, err)
 	}
 
-	qm, err := server.NewQuotaManagerFromFlags()
+	qm, err := quota.NewManagerFromFlags()
 	if err != nil {
 		glog.Exitf("Error creating quota manager: %v", err)
 	}
@@ -157,7 +158,7 @@ func main() {
 			if err := trillian.RegisterTrillianMapHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
 				return err
 			}
-			if *server.QuotaSystem == etcd.Quota {
+			if *quota.System == etcd.QuotaManagerName {
 				return quotapb.RegisterQuotaHandlerFromEndpoint(ctx, mux, endpoint, opts)
 			}
 			return nil
@@ -182,7 +183,7 @@ func main() {
 			}
 			trillian.RegisterTrillianMapWriteServer(s, writeServer)
 
-			if *server.QuotaSystem == etcd.Quota {
+			if *quota.System == etcd.QuotaManagerName {
 				quotapb.RegisterQuotaServer(s, quotaapi.NewServer(client))
 			}
 			return nil

--- a/quota/etcd/quota_provider.go
+++ b/quota/etcd/quota_provider.go
@@ -39,7 +39,7 @@ var (
 )
 
 func init() {
-	if err := quota.RegisterManager(QuotaManagerName, newEtcdQuotaManager); err != nil {
+	if err := quota.RegisterProvider(QuotaManagerName, newEtcdQuotaManager); err != nil {
 		glog.Fatalf("Failed to register quota manager %v: %v", QuotaManagerName, err)
 	}
 }

--- a/quota/etcd/quota_provider.go
+++ b/quota/etcd/quota_provider.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package etcd
 
 import (
 	"flag"
@@ -22,15 +22,16 @@ import (
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/cacheqm"
 	"github.com/google/trillian/quota/etcd/etcdqm"
+	"github.com/google/trillian/server"
 	"github.com/google/trillian/util/etcd"
 )
 
-// QuotaEtcd represents the etcd quota implementation.
-const QuotaEtcd = "etcd"
+// Quota represents the etcd quota implementation.
+const Quota = "etcd"
 
 var (
-	// EtcdServers is a flag containing the address(es) of etcd servers
-	EtcdServers = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
+	// Servers is a flag containing the address(es) of etcd servers
+	Servers = flag.String("etcd_servers", "", "A comma-separated list of etcd servers; no etcd registration if empty")
 	// TODO(Martin2112): suggested renaming these to etc_... to avoid clashes, but will it break existing deploys?
 	quotaMinBatchSize = flag.Int("quota_min_batch_size", cacheqm.DefaultMinBatchSize, "Minimum number of tokens to request from the quota system. "+
 		"Zero or lower means batching is disabled. Applicable for etcd quotas.")
@@ -39,18 +40,18 @@ var (
 )
 
 func init() {
-	if err := RegisterQuotaManager(QuotaEtcd, newEtcdQuotaManager); err != nil {
-		glog.Fatalf("Failed to register quota manager %v: %v", QuotaEtcd, err)
+	if err := server.RegisterQuotaManager(Quota, newEtcdQuotaManager); err != nil {
+		glog.Fatalf("Failed to register quota manager %v: %v", Quota, err)
 	}
 }
 
 func newEtcdQuotaManager() (quota.Manager, error) {
-	if *EtcdServers == "" {
+	if *Servers == "" {
 		return nil, fmt.Errorf("can't create etcd quotamanager - etcd_servers flag is unset")
 	}
-	client, err := etcd.NewClientFromString(*EtcdServers)
+	client, err := etcd.NewClientFromString(*Servers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to etcd at %v: %v", *EtcdServers, err)
+		return nil, fmt.Errorf("failed to connect to etcd at %v: %v", *Servers, err)
 	}
 
 	qm := etcdqm.New(client)

--- a/quota/etcd/quota_provider.go
+++ b/quota/etcd/quota_provider.go
@@ -22,12 +22,11 @@ import (
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/cacheqm"
 	"github.com/google/trillian/quota/etcd/etcdqm"
-	"github.com/google/trillian/server"
 	"github.com/google/trillian/util/etcd"
 )
 
-// Quota represents the etcd quota implementation.
-const Quota = "etcd"
+// QuotaManagerName identifies the etcd quota implementation.
+const QuotaManagerName = "etcd"
 
 var (
 	// Servers is a flag containing the address(es) of etcd servers
@@ -40,8 +39,8 @@ var (
 )
 
 func init() {
-	if err := server.RegisterQuotaManager(Quota, newEtcdQuotaManager); err != nil {
-		glog.Fatalf("Failed to register quota manager %v: %v", Quota, err)
+	if err := quota.RegisterManager(QuotaManagerName, newEtcdQuotaManager); err != nil {
+		glog.Fatalf("Failed to register quota manager %v: %v", QuotaManagerName, err)
 	}
 }
 

--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package mysqlqm
 
 import (
 	"flag"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/quota"
-	"github.com/google/trillian/quota/mysqlqm"
+	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
 )
 
-// QuotaMySQL represents the MySQL quota implementation.
-const QuotaMySQL = "mysql"
+// Quota represents the MySQL quota implementation.
+const Quota = "mysql"
 
 var (
-	maxUnsequencedRows = flag.Int("max_unsequenced_rows", mysqlqm.DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
 		"Only effective for quota_system=mysql.")
 )
 
 func init() {
-	if err := RegisterQuotaManager(QuotaMySQL, newMySQLQuotaManager); err != nil {
-		glog.Fatalf("Failed to register quota manager %v: %v", QuotaMySQL, err)
+	if err := server.RegisterQuotaManager(Quota, newMySQLQuotaManager); err != nil {
+		glog.Fatalf("Failed to register quota manager %v: %v", Quota, err)
 	}
 }
 
@@ -42,7 +42,7 @@ func newMySQLQuotaManager() (quota.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	qm := &mysqlqm.QuotaManager{
+	qm := &QuotaManager{
 		DB:                 db,
 		MaxUnsequencedRows: *maxUnsequencedRows,
 	}

--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -19,12 +19,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/quota"
-	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage/mysql"
 )
 
-// Quota represents the MySQL quota implementation.
-const Quota = "mysql"
+// QuotaManagerName identifies the MySQL quota implementation.
+const QuotaManagerName = "mysql"
 
 var (
 	maxUnsequencedRows = flag.Int("max_unsequenced_rows", DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
@@ -32,8 +31,8 @@ var (
 )
 
 func init() {
-	if err := server.RegisterQuotaManager(Quota, newMySQLQuotaManager); err != nil {
-		glog.Fatalf("Failed to register quota manager %v: %v", Quota, err)
+	if err := quota.RegisterManager(QuotaManagerName, newMySQLQuotaManager); err != nil {
+		glog.Fatalf("Failed to register quota manager %v: %v", QuotaManagerName, err)
 	}
 }
 

--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	if err := quota.RegisterManager(QuotaManagerName, newMySQLQuotaManager); err != nil {
+	if err := quota.RegisterProvider(QuotaManagerName, newMySQLQuotaManager); err != nil {
 		glog.Fatalf("Failed to register quota manager %v: %v", QuotaManagerName, err)
 	}
 }

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -21,16 +21,16 @@ import (
 	"github.com/golang/glog"
 )
 
-// NoopManagerName represents the noop quota implementation.
-const NoopManagerName = "noop"
+// noopManagerName represents the noop quota implementation.
+const noopManagerName = "noop"
 
 type noopManager struct{}
 
 func init() {
-	if err := RegisterManager(NoopManagerName, func() (Manager, error) {
+	if err := RegisterManager(noopManagerName, func() (Manager, error) {
 		return Noop(), nil
 	}); err != nil {
-		glog.Fatalf("Failed to register %v: %v", NoopManagerName, err)
+		glog.Fatalf("Failed to register %q: %v", noopManagerName, err)
 	}
 }
 

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -27,7 +27,7 @@ const noopManagerName = "noop"
 type noopManager struct{}
 
 func init() {
-	if err := RegisterManager(noopManagerName, func() (Manager, error) {
+	if err := RegisterProvider(noopManagerName, func() (Manager, error) {
 		return Noop(), nil
 	}); err != nil {
 		glog.Fatalf("Failed to register %q: %v", noopManagerName, err)

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -17,9 +17,22 @@ package quota
 import (
 	"context"
 	"fmt"
+
+	"github.com/golang/glog"
 )
 
+// NoopManagerName represents the noop quota implementation.
+const NoopManagerName = "noop"
+
 type noopManager struct{}
+
+func init() {
+	if err := RegisterManager(NoopManagerName, func() (Manager, error) {
+		return Noop(), nil
+	}); err != nil {
+		glog.Fatalf("Failed to register %v: %v", NoopManagerName, err)
+	}
+}
 
 // Noop returns a noop implementation of Manager. It allows all requests without restriction.
 func Noop() Manager {

--- a/quota/provider.go
+++ b/quota/provider.go
@@ -34,8 +34,8 @@ var (
 // to provide instances of a quota manager.
 type NewManagerFunc func() (Manager, error)
 
-// RegisterManager registers the provided Manager function.
-func RegisterManager(name string, qp NewManagerFunc) error {
+// RegisterProvider registers a function that provides Manager instances.
+func RegisterProvider(name string, qp NewManagerFunc) error {
 	qpMu.Lock()
 	defer qpMu.Unlock()
 

--- a/quota/provider.go
+++ b/quota/provider.go
@@ -34,7 +34,7 @@ var (
 // to provide instances of a quota manager.
 type NewManagerFunc func() (Manager, error)
 
-// RegisterManager registers the provided Manager.
+// RegisterManager registers the provided Manager function.
 func RegisterManager(name string, qp NewManagerFunc) error {
 	qpMu.Lock()
 	defer qpMu.Unlock()

--- a/quota/provider_test.go
+++ b/quota/provider_test.go
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package quota
 
 import (
 	"testing"
-
-	"github.com/google/trillian/quota"
 )
 
 func TestQuotaProviderRegistration(t *testing.T) {
@@ -42,20 +40,20 @@ func TestQuotaProviderRegistration(t *testing.T) {
 			name := test.desc
 
 			if test.reg {
-				if err := RegisterQuotaManager(name, func() (quota.Manager, error) {
+				if err := RegisterManager(name, func() (Manager, error) {
 					called = true
 					return nil, nil
 				}); err != nil {
-					t.Fatalf("RegisterQuotaManager(%s)=%v", name, err)
+					t.Fatalf("RegisterManager(%s)=%v", name, err)
 				}
 			}
 
-			_, err := NewQuotaManager(name)
+			_, err := NewManager(name)
 			if err != nil && !test.wantErr {
-				t.Fatalf("NewQuotaManager = %v, want no error", err)
+				t.Fatalf("NewManager = %v, want no error", err)
 			}
 			if err == nil && test.wantErr {
-				t.Fatalf("NewQuotaManager = no error, want error")
+				t.Fatalf("NewManager = no error, want error")
 			}
 
 			if !called && !test.wantErr {
@@ -66,11 +64,11 @@ func TestQuotaProviderRegistration(t *testing.T) {
 }
 
 func TestQuotaSystems(t *testing.T) {
-	if err := RegisterQuotaManager("a", func() (quota.Manager, error) { return nil, nil }); err != nil {
-		t.Fatalf("RegisterQuotaManager(a)=%v", err)
+	if err := RegisterManager("a", func() (Manager, error) { return nil, nil }); err != nil {
+		t.Fatalf("RegisterManager(a)=%v", err)
 	}
-	if err := RegisterQuotaManager("b", func() (quota.Manager, error) { return nil, nil }); err != nil {
-		t.Fatalf("RegisterQuotaManager(b)=%v", err)
+	if err := RegisterManager("b", func() (Manager, error) { return nil, nil }); err != nil {
+		t.Fatalf("RegisterManager(b)=%v", err)
 	}
 	qs := quotaSystems()
 

--- a/quota/provider_test.go
+++ b/quota/provider_test.go
@@ -14,9 +14,7 @@
 
 package quota
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestQuotaProviderRegistration(t *testing.T) {
 	for _, test := range []struct {

--- a/quota/provider_test.go
+++ b/quota/provider_test.go
@@ -38,11 +38,11 @@ func TestQuotaProviderRegistration(t *testing.T) {
 			name := test.desc
 
 			if test.reg {
-				if err := RegisterManager(name, func() (Manager, error) {
+				if err := RegisterProvider(name, func() (Manager, error) {
 					called = true
 					return nil, nil
 				}); err != nil {
-					t.Fatalf("RegisterManager(%s)=%v", name, err)
+					t.Fatalf("RegisterProvider(%s)=%v", name, err)
 				}
 			}
 
@@ -62,11 +62,11 @@ func TestQuotaProviderRegistration(t *testing.T) {
 }
 
 func TestQuotaSystems(t *testing.T) {
-	if err := RegisterManager("a", func() (Manager, error) { return nil, nil }); err != nil {
-		t.Fatalf("RegisterManager(a)=%v", err)
+	if err := RegisterProvider("a", func() (Manager, error) { return nil, nil }); err != nil {
+		t.Fatalf("RegisterProvider(a)=%v", err)
 	}
-	if err := RegisterManager("b", func() (Manager, error) { return nil, nil }); err != nil {
-		t.Fatalf("RegisterManager(b)=%v", err)
+	if err := RegisterProvider("b", func() (Manager, error) { return nil, nil }); err != nil {
+		t.Fatalf("RegisterProvider(b)=%v", err)
 	}
 	qs := quotaSystems()
 


### PR DESCRIPTION
Makes them optional to import, which is useful if you want to build a server binary without one or more of them.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
