### PR TITLE
Allow 1% drop in test coverage before CodeCov complains

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,10 @@ ignore:
   - "examples"
   - "integration"
   - "testonly"
+
+coverage:
+  status:
+    project:
+      default:
+        # Allow 1% coverage drop without complaining, to avoid being too noisy.
+        threshold: 1%


### PR DESCRIPTION
Non-deterministic tests can result in fluctuations in our test coverage,
which end up flag PRs as reducing test coverage when they actually
don't. Introduce a margin of error for test coverage so that only
significant reductions in test coverage are flagged.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
