### PR TITLE
Use stdlib encoding/asn1, instead of ct-go/asn1 fork

### DIFF
--- a/crypto/keys/testonly/keys.go
+++ b/crypto/keys/testonly/keys.go
@@ -21,11 +21,11 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/asn1"
 	"errors"
 	"fmt"
 	"math/big"
 
-	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keys/pem"

--- a/crypto/verifier.go
+++ b/crypto/verifier.go
@@ -18,11 +18,11 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"encoding/asn1"
 	"errors"
 	"fmt"
 	"math/big"
 
-	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/trillian"
 	"github.com/google/trillian/types"
 	"golang.org/x/crypto/ed25519"


### PR DESCRIPTION
Does what it says on the tin.