### PR TITLE
Set default code owners to google/trillian-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,13 @@
 
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
+#
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @google/trillian-team will be requested for
+# review when someone opens a pull request.
+*                                @google/trillian-team
 
-# Default
 /*.proto                         @Martin2112 @AlCutter
 /trillian_map_api.proto          @Martin2112 @AlCutter @mhutchinson
 /storage/storagepb/storage.proto @Martin2112 @AlCutter


### PR DESCRIPTION
By providing a default code owner for the Trillian repo,
all pull requets will get a reviewer automatically assigned.

Using the team settings for @google/trillian-team, we can then auto-assign a particular revieweer so no PRs get lost.