### PR TITLE
Update etcd-operator from v0.9.1 to v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ instead of 3 nodes.
 to nodes becoming temporarily unavailable, such as during updates (it can now
 tolerate 2 nodes being unavailable, instead of just 1).
 
+The etcd-operator deployment has been updated from v0.9.1 to v0.9.4.
+
 ### Log Changes
 
 #### Potential sequencer hang fixed

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -67,6 +67,16 @@ steps:
   - -t
   - envsubst
   waitFor: ["-"]
+- id: apply_k8s_cfgs_for_clusterwide_etcd_operator_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - -f=examples/deployment/kubernetes/etcd-deployment.yaml
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor: ["-"]
 - id: copy_k8s_cfgs_for_spanner
   name: busybox
   entrypoint: cp

--- a/examples/deployment/kubernetes/etcd-deployment.yaml
+++ b/examples/deployment/kubernetes/etcd-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: trillian-etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.9.1
+        image: quay.io/coreos/etcd-operator:v0.9.4
         command:
         - etcd-operator
         - -cluster-wide


### PR DESCRIPTION
Deploys the fix for https://github.com/coreos/etcd-operator/issues/1954, which was causing problems in our CI GCP environment. The fork of this k8s config file in /deployment has already been updated.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
