### PR TITLE
Deploy changes to EtcdCluster resource when updating CI "mysql" environment

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -162,6 +162,7 @@ steps:
   args:
   - apply
   - --namespace=mysql
+  - -f=envsubst-mysql/etcd-cluster.yaml
   - -f=envsubst-mysql/trillian-ci-mysql.yaml
   - -f=envsubst-mysql/trillian-mysql.yaml
   - -f=envsubst-mysql/trillian-log-deployment.yaml


### PR DESCRIPTION
The EtcdCluster in the "default" namespace was getting updated (the Cloud Spanner environment) but not in the "mysql" environment.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
