### PR TITLE
Run `go generate ./...` on clean tip of tree

### DIFF
--- a/crypto/keyspb/keyspb.pb.go
+++ b/crypto/keyspb/keyspb.pb.go
@@ -472,7 +472,9 @@ func init() {
 	proto.RegisterType((*PKCS11Config)(nil), "keyspb.PKCS11Config")
 }
 
-func init() { proto.RegisterFile("crypto/keyspb/keyspb.proto", fileDescriptor_c8ca2ab097770992) }
+func init() {
+	proto.RegisterFile("crypto/keyspb/keyspb.proto", fileDescriptor_c8ca2ab097770992)
+}
 
 var fileDescriptor_c8ca2ab097770992 = []byte{
 	// 432 bytes of a gzipped FileDescriptorProto

--- a/crypto/sigpb/sigpb.pb.go
+++ b/crypto/sigpb/sigpb.pb.go
@@ -157,7 +157,9 @@ func init() {
 	proto.RegisterType((*DigitallySigned)(nil), "sigpb.DigitallySigned")
 }
 
-func init() { proto.RegisterFile("crypto/sigpb/sigpb.proto", fileDescriptor_5a159192b6f2430c) }
+func init() {
+	proto.RegisterFile("crypto/sigpb/sigpb.proto", fileDescriptor_5a159192b6f2430c)
+}
 
 var fileDescriptor_5a159192b6f2430c = []byte{
 	// 280 bytes of a gzipped FileDescriptorProto

--- a/docs/api.md
+++ b/docs/api.md
@@ -1458,21 +1458,21 @@ Type of the tree.
 
 ## Scalar Value Types
 
-| .proto Type | Notes | C++ Type | Java Type | Python Type |
-| ----------- | ----- | -------- | --------- | ----------- |
-| <a name="double" /> double |  | double | double | float |
-| <a name="float" /> float |  | float | float | float |
-| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
-| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
-| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
-| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
-| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
-| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
-| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
-| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
-| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
-| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
-| <a name="bool" /> bool |  | bool | boolean | boolean |
-| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
-| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.4.0
-	github.com/golang/protobuf v1.3.2
+	github.com/golang/protobuf v1.3.4
 	github.com/google/btree v1.0.0
 	github.com/google/certificate-transparency-go v1.1.0
 	github.com/google/go-cmp v0.4.0
@@ -62,14 +62,14 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0 // indirect
 	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
-	golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98
 	google.golang.org/appengine v1.6.5 // indirect
-	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
-	google.golang.org/grpc v1.25.1
+	google.golang.org/genproto v0.0.0-20200306153348-d950eab6f860
+	google.golang.org/grpc v1.27.1
 	gopkg.in/yaml.v2 v2.2.6 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/emicklei/proto v1.7.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9
 github.com/emicklei/proto v1.8.0 h1:/MjKUvy7nh0ryszHc/PIIFiv/BU5XYX4NfvpM19C5+U=
 github.com/emicklei/proto v1.8.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.6.0 h1:66qjqZk8kalYAvDRtM1AdAJQI0tj4Wrue3Eq3B3pmFU=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -184,6 +185,9 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
+github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 h1:23T5iq8rbUYlhpt5DB4XJkc6BU31uODLD1o1gKvZmD0=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9uMCefW1WDie15eSP/4MssdenaM=
@@ -595,6 +599,8 @@ golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 h1:MlY3mEfbnWGmUi4rtHOtNnnnN4UJRGSyLPx+DXA5Sq4=
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -630,6 +636,8 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -722,6 +730,8 @@ google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvx
 google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11 h1:51D++eCgOHufw5VfDE9Uzqyyc+OyQIjb9hkYy9LN5Fk=
 google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/genproto v0.0.0-20200306153348-d950eab6f860 h1:QmnwU8dKvY8c/vZikd2jhBNwrrGS5qeyK/2Aeeh9Grk=
+google.golang.org/genproto v0.0.0-20200306153348-d950eab6f860/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
@@ -734,6 +744,9 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
+google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/quota/etcd/quotapb/quotapb.pb.go
+++ b/quota/etcd/quotapb/quotapb.pb.go
@@ -645,7 +645,9 @@ func init() {
 	proto.RegisterType((*UpdateConfigRequest)(nil), "quotapb.UpdateConfigRequest")
 }
 
-func init() { proto.RegisterFile("quotapb.proto", fileDescriptor_7358794d7f8089dd) }
+func init() {
+	proto.RegisterFile("quotapb.proto", fileDescriptor_7358794d7f8089dd)
+}
 
 var fileDescriptor_7358794d7f8089dd = []byte{
 	// 759 bytes of a gzipped FileDescriptorProto
@@ -701,11 +703,11 @@ var fileDescriptor_7358794d7f8089dd = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // QuotaClient is the client API for Quota service.
 //
@@ -725,10 +727,10 @@ type QuotaClient interface {
 }
 
 type quotaClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewQuotaClient(cc *grpc.ClientConn) QuotaClient {
+func NewQuotaClient(cc grpc.ClientConnInterface) QuotaClient {
 	return &quotaClient{cc}
 }
 

--- a/quota/etcd/storagepb/storagepb.pb.go
+++ b/quota/etcd/storagepb/storagepb.pb.go
@@ -350,7 +350,9 @@ func init() {
 	proto.RegisterType((*TimeBasedStrategy)(nil), "storagepb.TimeBasedStrategy")
 }
 
-func init() { proto.RegisterFile("storagepb.proto", fileDescriptor_607098b00d790b85) }
+func init() {
+	proto.RegisterFile("storagepb.proto", fileDescriptor_607098b00d790b85)
+}
 
 var fileDescriptor_607098b00d790b85 = []byte{
 	// 422 bytes of a gzipped FileDescriptorProto

--- a/skylog/storage/gcp/gcppb/gcp.pb.go
+++ b/skylog/storage/gcp/gcppb/gcp.pb.go
@@ -214,7 +214,9 @@ func init() {
 	proto.RegisterType((*SequenceSharding)(nil), "gcppb.SequenceSharding")
 }
 
-func init() { proto.RegisterFile("gcp.proto", fileDescriptor_b1f553190b5184fe) }
+func init() {
+	proto.RegisterFile("gcp.proto", fileDescriptor_b1f553190b5184fe)
+}
 
 var fileDescriptor_b1f553190b5184fe = []byte{
 	// 276 bytes of a gzipped FileDescriptorProto

--- a/storage/cloudspanner/spannerpb/spanner.pb.go
+++ b/storage/cloudspanner/spannerpb/spanner.pb.go
@@ -622,7 +622,9 @@ func init() {
 	proto.RegisterType((*TreeHead)(nil), "spannerpb.TreeHead")
 }
 
-func init() { proto.RegisterFile("spanner.proto", fileDescriptor_879d3e919e93c6ba) }
+func init() {
+	proto.RegisterFile("spanner.proto", fileDescriptor_879d3e919e93c6ba)
+}
 
 var fileDescriptor_879d3e919e93c6ba = []byte{
 	// 958 bytes of a gzipped FileDescriptorProto

--- a/storage/storagepb/storage.pb.go
+++ b/storage/storagepb/storage.pb.go
@@ -165,7 +165,9 @@ func init() {
 	proto.RegisterMapType((map[string][]byte)(nil), "storagepb.SubtreeProto.LeavesEntry")
 }
 
-func init() { proto.RegisterFile("storage.proto", fileDescriptor_0d2c4ccf1453ffdb) }
+func init() {
+	proto.RegisterFile("storage.proto", fileDescriptor_0d2c4ccf1453ffdb)
+}
 
 var fileDescriptor_0d2c4ccf1453ffdb = []byte{
 	// 308 bytes of a gzipped FileDescriptorProto

--- a/trillian.pb.go
+++ b/trillian.pb.go
@@ -707,7 +707,9 @@ func init() {
 	proto.RegisterType((*Proof)(nil), "trillian.Proof")
 }
 
-func init() { proto.RegisterFile("trillian.proto", fileDescriptor_364603a4e17a2a56) }
+func init() {
+	proto.RegisterFile("trillian.proto", fileDescriptor_364603a4e17a2a56)
+}
 
 var fileDescriptor_364603a4e17a2a56 = []byte{
 	// 1095 bytes of a gzipped FileDescriptorProto

--- a/trillian_admin_api.pb.go
+++ b/trillian_admin_api.pb.go
@@ -347,7 +347,9 @@ func init() {
 	proto.RegisterType((*UndeleteTreeRequest)(nil), "trillian.UndeleteTreeRequest")
 }
 
-func init() { proto.RegisterFile("trillian_admin_api.proto", fileDescriptor_aac35e28a5dd9ee3) }
+func init() {
+	proto.RegisterFile("trillian_admin_api.proto", fileDescriptor_aac35e28a5dd9ee3)
+}
 
 var fileDescriptor_aac35e28a5dd9ee3 = []byte{
 	// 548 bytes of a gzipped FileDescriptorProto
@@ -390,11 +392,11 @@ var fileDescriptor_aac35e28a5dd9ee3 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TrillianAdminClient is the client API for TrillianAdmin service.
 //
@@ -423,10 +425,10 @@ type TrillianAdminClient interface {
 }
 
 type trillianAdminClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTrillianAdminClient(cc *grpc.ClientConn) TrillianAdminClient {
+func NewTrillianAdminClient(cc grpc.ClientConnInterface) TrillianAdminClient {
 	return &trillianAdminClient{cc}
 }
 

--- a/trillian_log_api.pb.go
+++ b/trillian_log_api.pb.go
@@ -1789,7 +1789,9 @@ func init() {
 	proto.RegisterType((*LogLeaf)(nil), "trillian.LogLeaf")
 }
 
-func init() { proto.RegisterFile("trillian_log_api.proto", fileDescriptor_5ad20a6a54aa5af3) }
+func init() {
+	proto.RegisterFile("trillian_log_api.proto", fileDescriptor_5ad20a6a54aa5af3)
+}
 
 var fileDescriptor_5ad20a6a54aa5af3 = []byte{
 	// 1512 bytes of a gzipped FileDescriptorProto
@@ -1892,11 +1894,11 @@ var fileDescriptor_5ad20a6a54aa5af3 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TrillianLogClient is the client API for TrillianLog service.
 //
@@ -1969,10 +1971,10 @@ type TrillianLogClient interface {
 }
 
 type trillianLogClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTrillianLogClient(cc *grpc.ClientConn) TrillianLogClient {
+func NewTrillianLogClient(cc grpc.ClientConnInterface) TrillianLogClient {
 	return &trillianLogClient{cc}
 }
 

--- a/trillian_log_sequencer_api.pb.go
+++ b/trillian_log_sequencer_api.pb.go
@@ -22,7 +22,9 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-func init() { proto.RegisterFile("trillian_log_sequencer_api.proto", fileDescriptor_f32c68ea33658ef4) }
+func init() {
+	proto.RegisterFile("trillian_log_sequencer_api.proto", fileDescriptor_f32c68ea33658ef4)
+}
 
 var fileDescriptor_f32c68ea33658ef4 = []byte{
 	// 129 bytes of a gzipped FileDescriptorProto
@@ -39,11 +41,11 @@ var fileDescriptor_f32c68ea33658ef4 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TrillianLogSequencerClient is the client API for TrillianLogSequencer service.
 //
@@ -52,10 +54,10 @@ type TrillianLogSequencerClient interface {
 }
 
 type trillianLogSequencerClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTrillianLogSequencerClient(cc *grpc.ClientConn) TrillianLogSequencerClient {
+func NewTrillianLogSequencerClient(cc grpc.ClientConnInterface) TrillianLogSequencerClient {
 	return &trillianLogSequencerClient{cc}
 }
 

--- a/trillian_map_api.pb.go
+++ b/trillian_map_api.pb.go
@@ -1014,7 +1014,9 @@ func init() {
 	proto.RegisterType((*InitMapResponse)(nil), "trillian.InitMapResponse")
 }
 
-func init() { proto.RegisterFile("trillian_map_api.proto", fileDescriptor_28d34dfba22a7ce2) }
+func init() {
+	proto.RegisterFile("trillian_map_api.proto", fileDescriptor_28d34dfba22a7ce2)
+}
 
 var fileDescriptor_28d34dfba22a7ce2 = []byte{
 	// 988 bytes of a gzipped FileDescriptorProto
@@ -1084,11 +1086,11 @@ var fileDescriptor_28d34dfba22a7ce2 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TrillianMapClient is the client API for TrillianMap service.
 //
@@ -1103,11 +1105,15 @@ type TrillianMapClient interface {
 	GetLeavesByRevision(ctx context.Context, in *GetMapLeavesByRevisionRequest, opts ...grpc.CallOption) (*GetMapLeavesResponse, error)
 	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#GetLeavesByRevision
+	//
+	// Deprecated: Do not use.
 	GetLeavesByRevisionNoProof(ctx context.Context, in *GetMapLeavesByRevisionRequest, opts ...grpc.CallOption) (*MapLeaves, error)
 	// GetLastInRangeByRevision returns the last leaf in a requested range.
 	GetLastInRangeByRevision(ctx context.Context, in *GetLastInRangeByRevisionRequest, opts ...grpc.CallOption) (*MapLeaf, error)
 	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#WriteLeaves
+	//
+	// Deprecated: Do not use.
 	SetLeaves(ctx context.Context, in *SetMapLeavesRequest, opts ...grpc.CallOption) (*SetMapLeavesResponse, error)
 	GetSignedMapRoot(ctx context.Context, in *GetSignedMapRootRequest, opts ...grpc.CallOption) (*GetSignedMapRootResponse, error)
 	GetSignedMapRootByRevision(ctx context.Context, in *GetSignedMapRootByRevisionRequest, opts ...grpc.CallOption) (*GetSignedMapRootResponse, error)
@@ -1115,10 +1121,10 @@ type TrillianMapClient interface {
 }
 
 type trillianMapClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTrillianMapClient(cc *grpc.ClientConn) TrillianMapClient {
+func NewTrillianMapClient(cc grpc.ClientConnInterface) TrillianMapClient {
 	return &trillianMapClient{cc}
 }
 
@@ -1225,11 +1231,15 @@ type TrillianMapServer interface {
 	GetLeavesByRevision(context.Context, *GetMapLeavesByRevisionRequest) (*GetMapLeavesResponse, error)
 	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#GetLeavesByRevision
+	//
+	// Deprecated: Do not use.
 	GetLeavesByRevisionNoProof(context.Context, *GetMapLeavesByRevisionRequest) (*MapLeaves, error)
 	// GetLastInRangeByRevision returns the last leaf in a requested range.
 	GetLastInRangeByRevision(context.Context, *GetLastInRangeByRevisionRequest) (*MapLeaf, error)
 	// Deprecated: this should only be used by writers, which should migrate
 	// to TrillianMapWrite#WriteLeaves
+	//
+	// Deprecated: Do not use.
 	SetLeaves(context.Context, *SetMapLeavesRequest) (*SetMapLeavesResponse, error)
 	GetSignedMapRoot(context.Context, *GetSignedMapRootRequest) (*GetSignedMapRootResponse, error)
 	GetSignedMapRootByRevision(context.Context, *GetSignedMapRootByRevisionRequest) (*GetSignedMapRootResponse, error)
@@ -1517,10 +1527,10 @@ type TrillianMapWriteClient interface {
 }
 
 type trillianMapWriteClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTrillianMapWriteClient(cc *grpc.ClientConn) TrillianMapWriteClient {
+func NewTrillianMapWriteClient(cc grpc.ClientConnInterface) TrillianMapWriteClient {
 	return &trillianMapWriteClient{cc}
 }
 


### PR DESCRIPTION
Update generated pb files from tip of tree. The changes here are a
result of changes in the dependency chain and tooling. No changes in
code are included in this PR.

Note that a manual update to grpc was done via `go get -u
google.golang.org/grpc` as per suggestion by
https://github.com/grpc/grpc-go/issues/3347#issuecomment-580922023.

NOTE: no changes requiring updating of CHANGELOG nor documentation.