### PR TITLE
Remove trailing foreward slash from clone url

### DIFF
--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -11,7 +11,7 @@ Both build and example deployment files are stored within this repo. For any of
 the below deployment methods, start by cloning the repo.
 
 ```shell
-git clone https://github.com/google/trillian.git/
+git clone https://github.com/google/trillian.git
 cd trillian
 ```
 


### PR DESCRIPTION
The example/README.md has a trailing `/` after the clone URL
which if used in a terminal will result in error expressing
the repo cannot be found.
