### PR TITLE
Migrate from kylelemons/godebug to google/cmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/kylelemons/godebug v1.1.0
 	github.com/letsencrypt/pkcs11key/v4 v4.0.0
 	github.com/lib/pq v1.5.2
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/letsencrypt/pkcs11key/v4 v4.0.0 h1:qLc/OznH7xMr5ARJgkZCCWk+EomQkiNTOoOF5LAgagc=
 github.com/letsencrypt/pkcs11key/v4 v4.0.0/go.mod h1:EFUvBDay26dErnNb70Nd0/VW3tJiIbETBPTl9ATXQag=
 github.com/lib/pq v1.5.2 h1:yTSXVswvWUOQ3k1sd7vJfDrbSl8lKuscqFJRqjC0ifw=

--- a/integration/admin/admin_integration_test.go
+++ b/integration/admin/admin_integration_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/testonly/integration"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -231,7 +230,7 @@ func TestAdminServer_UpdateTree(t *testing.T) {
 		want.CreateTime = tree.CreateTime
 		want.UpdateTime = tree.UpdateTime
 		if !proto.Equal(tree, want) {
-			diff := pretty.Compare(tree, want)
+			diff := cmp.Diff(tree, want)
 			t.Errorf("%v: post-UpdateTree diff:\n%v", test.desc, diff)
 		}
 	}
@@ -379,7 +378,7 @@ func TestAdminServer_DeleteTree(t *testing.T) {
 		want.Deleted = true
 		want.DeleteTime = deletedTree.DeleteTime
 		if got := deletedTree; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-DeleteTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 
@@ -388,7 +387,7 @@ func TestAdminServer_DeleteTree(t *testing.T) {
 			t.Fatalf("%v: GetTree() returned err = %v", test.desc, err)
 		}
 		if got, want := storedTree, deletedTree; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-GetTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}
@@ -470,7 +469,7 @@ func TestAdminServer_UndeleteTree(t *testing.T) {
 			continue
 		}
 		if got, want := undeletedTree, createdTree; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-UndeleteTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 
@@ -479,7 +478,7 @@ func TestAdminServer_UndeleteTree(t *testing.T) {
 			t.Fatalf("%v: GetTree() returned err = %v", test.desc, err)
 		}
 		if got, want := storedTree, createdTree; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-GetTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/merkle/testonly"
 )
@@ -214,8 +213,7 @@ func TestGoldenRanges(t *testing.T) {
 			if want := roots[size]; !bytes.Equal(hash, want) {
 				t.Errorf("root hash mismatch: got %x, want %x", hash, want)
 			}
-			// TODO(): Remove equate empty
-			if diff := cmp.Diff(cr.Hashes(), hashes[size], cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(cr.Hashes(), hashes[size]); diff != "" {
 				t.Errorf("hashes mismatch:\n%v", diff)
 			}
 		})

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/merkle/testonly"
-	"github.com/kylelemons/godebug/pretty"
 )
 
 var (
@@ -213,7 +214,8 @@ func TestGoldenRanges(t *testing.T) {
 			if want := roots[size]; !bytes.Equal(hash, want) {
 				t.Errorf("root hash mismatch: got %x, want %x", hash, want)
 			}
-			if diff := pretty.Compare(cr.Hashes(), hashes[size]); diff != "" {
+			// TODO(): Remove equate empty
+			if diff := cmp.Diff(cr.Hashes(), hashes[size], cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("hashes mismatch:\n%v", diff)
 			}
 		})

--- a/merkle/testonly/constants.go
+++ b/merkle/testonly/constants.go
@@ -83,7 +83,7 @@ func RootHashes() [][]byte {
 func CompactTrees() [][][]byte {
 	nh := NodeHashes()
 	return [][][]byte{
-		{}, // Empty tree.
+		nil, // Empty tree.
 		{nh[0][0]},
 		{nh[1][0]},
 		{nh[1][0], nh[0][2]},

--- a/quota/cacheqm/cache_test.go
+++ b/quota/cacheqm/cache_test.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/testonly/matchers"
-	"github.com/kylelemons/godebug/pretty"
 )
 
 const (
@@ -88,7 +88,7 @@ func TestCachedManager_PeekTokens(t *testing.T) {
 		}
 
 		tokens, err := qm.PeekTokens(ctx, specs)
-		if diff := pretty.Compare(tokens, test.wantTokens); diff != "" {
+		if diff := cmp.Diff(tokens, test.wantTokens); diff != "" {
 			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
 		}
 		if err != test.wantErr {

--- a/quota/etcd/etcdqm/etcdqm_test.go
+++ b/quota/etcd/etcdqm/etcdqm_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd/storage"
 	"github.com/google/trillian/quota/etcd/storagepb"
 	"github.com/google/trillian/testonly/integration/etcd"
-	"github.com/kylelemons/godebug/pretty"
 	"go.etcd.io/etcd/clientv3"
 )
 
@@ -200,7 +200,7 @@ func TestManager_PeekTokens(t *testing.T) {
 			t.Errorf("%v: PeekTokens() returned err = %v", test.desc, err)
 			continue
 		}
-		if diff := pretty.Compare(tokens, test.want); diff != "" {
+		if diff := cmp.Diff(tokens, test.want); diff != "" {
 			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}
@@ -286,7 +286,7 @@ func TestManager_ResetQuota(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v: PeekTokens() returned err = %v", test.desc, err)
 		}
-		if diff := pretty.Compare(tokens, test.want); diff != "" {
+		if diff := cmp.Diff(tokens, test.want); diff != "" {
 			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}

--- a/quota/etcd/quotaapi/conversions_test.go
+++ b/quota/etcd/quotaapi/conversions_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/quota/etcd/storagepb"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
@@ -178,7 +178,7 @@ func TestApplyMask(t *testing.T) {
 	for _, test := range tests {
 		applyMask(test.src, test.dest, test.mask)
 		if !proto.Equal(test.dest, test.want) {
-			t.Errorf("%v: post-applyMask() diff (-got +want):\n%v", test.desc, pretty.Compare(test.dest, test.want))
+			t.Errorf("%v: post-applyMask() diff (-got +want):\n%v", test.desc, cmp.Diff(test.dest, test.want))
 		}
 	}
 }
@@ -207,10 +207,10 @@ func TestConvert_APIAndStorage(t *testing.T) {
 	}
 	for _, test := range tests {
 		if got, want := convertToAPI(test.storage), test.api; !proto.Equal(got, want) {
-			t.Errorf("%v: post-convertToAPI() diff (-got +want):\n%v", test.desc, pretty.Compare(got, want))
+			t.Errorf("%v: post-convertToAPI() diff (-got +want):\n%v", test.desc, cmp.Diff(got, want))
 		}
 		if got, want := convertToStorage(test.api), test.storage; !proto.Equal(got, want) {
-			t.Errorf("%v: post-convertToStorage() diff (-got +want):\n%v", test.desc, pretty.Compare(got, want))
+			t.Errorf("%v: post-convertToStorage() diff (-got +want):\n%v", test.desc, cmp.Diff(got, want))
 		}
 	}
 }

--- a/quota/etcd/storage/quota_storage_test.go
+++ b/quota/etcd/storage/quota_storage_test.go
@@ -23,11 +23,12 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd/storagepb"
 	"github.com/google/trillian/testonly/integration/etcd"
 	"github.com/google/trillian/util/clock"
-	"github.com/kylelemons/godebug/pretty"
 	"go.etcd.io/etcd/clientv3"
 )
 
@@ -207,7 +208,7 @@ func TestQuotaStorage_UpdateConfigs(t *testing.T) {
 			continue
 		}
 		if got, want := cfgs, test.wantCfgs; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-UpdateConfigs() diff (-got +want)\n%v", test.desc, diff)
 		}
 
@@ -217,7 +218,7 @@ func TestQuotaStorage_UpdateConfigs(t *testing.T) {
 			continue
 		}
 		if got, want := stored, cfgs; !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-Configs() diff (-got +want)\n%v", test.desc, diff)
 		}
 
@@ -413,7 +414,7 @@ func TestQuotaStorage_UpdateConfigsErrors(t *testing.T) {
 				return
 			}
 			if got := stored; !proto.Equal(got, want) {
-				diff := pretty.Compare(got, want)
+				diff := cmp.Diff(got, want)
 				t.Fatalf("post-Configs() diff (-got +want)\n%v", diff)
 			}
 		})
@@ -925,7 +926,7 @@ func peekAndDiff(ctx context.Context, qs *QuotaStorage, want map[string]int64) e
 	if err != nil {
 		return err
 	}
-	if diff := pretty.Compare(got, want); diff != "" {
+	if diff := cmp.Diff(got, want, cmpopts.EquateEmpty()); diff != "" {
 		return fmt.Errorf("post-Peek() diff (-got +want):\n%v", diff)
 	}
 	return nil

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/mysqlqm"
@@ -31,7 +32,6 @@ import (
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/trees"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 
 	tcrypto "github.com/google/trillian/crypto"
 	stestonly "github.com/google/trillian/storage/testonly"
@@ -219,7 +219,7 @@ func TestQuotaManager_PeekTokens(t *testing.T) {
 	}
 	wantTokens[quota.Spec{Group: quota.Global, Kind: quota.Write}] = wantRows
 
-	if diff := pretty.Compare(tokens, wantTokens); diff != "" {
+	if diff := cmp.Diff(tokens, wantTokens); diff != "" {
 		t.Errorf("post-PeekTokens() diff:\n%v", diff)
 	}
 }

--- a/server/admin/admin_server_test.go
+++ b/server/admin/admin_server_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -188,7 +187,7 @@ func TestServer_ListTrees(t *testing.T) {
 		}
 		for i, wantTree := range want {
 			if !proto.Equal(resp.Tree[i], wantTree) {
-				t.Errorf("%v: post-ListTrees() diff (-got +want):\n%v", test.desc, pretty.Compare(resp.Tree, want))
+				t.Errorf("%v: post-ListTrees() diff (-got +want):\n%v", test.desc, cmp.Diff(resp.Tree, want))
 				break
 			}
 		}
@@ -738,7 +737,7 @@ func TestServer_UpdateTree(t *testing.T) {
 		}
 
 		if !proto.Equal(tree, test.wantTree) {
-			diff := pretty.Compare(tree, test.wantTree)
+			diff := cmp.Diff(tree, test.wantTree)
 			t.Errorf("%v: post-UpdateTree diff:\n%v", test.desc, diff)
 		}
 	}
@@ -787,7 +786,7 @@ func TestServer_DeleteTree(t *testing.T) {
 		want := proto.Clone(test.tree).(*trillian.Tree)
 		want.PrivateKey = nil // redacted
 		if !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-DeleteTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}
@@ -874,7 +873,7 @@ func TestServer_UndeleteTree(t *testing.T) {
 		want := proto.Clone(test.tree).(*trillian.Tree)
 		want.PrivateKey = nil // redacted
 		if !proto.Equal(got, want) {
-			diff := pretty.Compare(got, want)
+			diff := cmp.Diff(got, want)
 			t.Errorf("%v: post-UneleteTree() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -17,19 +17,20 @@ package interceptor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/trees"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -182,7 +183,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 				case !ok:
 					t.Error("tree not in handler ctx")
 				case !proto.Equal(tree, test.wantTree):
-					diff := pretty.Compare(tree, test.wantTree)
+					diff := cmp.Diff(tree, test.wantTree)
 					t.Errorf("post-FromContext diff:\n%v", diff)
 				}
 			}
@@ -811,8 +812,8 @@ func TestCombine(t *testing.T) {
 				}
 				wantCtx = h.ctx
 			}
-			if diff := pretty.Compare(handler.ctx, wantCtx); diff != "" {
-				t.Errorf("handler ctx diff:\n%v", diff)
+			if got, want := fmt.Sprintf("%v", handler.ctx), fmt.Sprintf("%v", wantCtx); got != want {
+				t.Errorf("handler ctx, %v, want %v", got, want)
 			}
 		})
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -502,7 +501,7 @@ func TestQueueLeaves(t *testing.T) {
 		t.Errorf("QueueLeaves().Status=%d,nil; want %d,nil", queuedLeaf.Status.Code, code.Code_OK)
 	}
 	if !proto.Equal(queueRequest0.Leaves[0], queuedLeaf.Leaf) {
-		diff := pretty.Compare(queueRequest0.Leaves[0], queuedLeaf.Leaf)
+		diff := cmp.Diff(queueRequest0.Leaves[0], queuedLeaf.Leaf)
 		t.Errorf("post-QueueLeaves() diff:\n%v", diff)
 	}
 
@@ -523,7 +522,7 @@ func TestQueueLeaves(t *testing.T) {
 		t.Errorf("QueueLeaves().Status=%v,nil; want %v,nil", sc, code.Code_ALREADY_EXISTS)
 	}
 	if !proto.Equal(queueRequest0.Leaves[0], queuedLeaf.Leaf) {
-		diff := pretty.Compare(queueRequest0.Leaves[0], queuedLeaf.Leaf)
+		diff := cmp.Diff(queueRequest0.Leaves[0], queuedLeaf.Leaf)
 		t.Errorf("post-QueueLeaves() diff:\n%v", diff)
 	}
 }

--- a/server/map_rpc_server_test.go
+++ b/server/map_rpc_server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/storage"
@@ -29,7 +30,6 @@ import (
 	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -227,7 +227,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 			}
 			want := &trillian.GetSignedMapRootResponse{MapRoot: test.mapRoot}
 			if got := smrResp; !proto.Equal(got, want) {
-				diff := pretty.Compare(got, want)
+				diff := cmp.Diff(got, want)
 				t.Errorf("GetSignedMapRoot() got != want, diff:\n%v", diff)
 			}
 		})
@@ -335,7 +335,7 @@ func TestGetSignedMapRootByRevision(t *testing.T) {
 			}
 			want := &trillian.GetSignedMapRootResponse{MapRoot: test.mapRoot}
 			if got := smrResp; !proto.Equal(got, want) {
-				diff := pretty.Compare(got, want)
+				diff := cmp.Diff(got, want)
 				t.Errorf("GetSignedMapRootByRevision() got != want, diff:\n%v", diff)
 			}
 		})

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/maphasher"
 	"github.com/google/trillian/merkle/rfc6962"
@@ -28,7 +29,6 @@ import (
 	"github.com/google/trillian/storage/tree"
 
 	"github.com/golang/mock/gomock"
-	"github.com/kylelemons/godebug/pretty"
 
 	stestonly "github.com/google/trillian/storage/testonly"
 )
@@ -272,7 +272,7 @@ func TestRepopulateLogSubtree(t *testing.T) {
 			if len(s.InternalNodes) != 0 {
 				t.Fatalf("(it %d) internal nodes should be empty but got: %v", numLeaves, s.InternalNodes)
 			}
-		} else if diff := pretty.Compare(cmtStorage.InternalNodes, s.InternalNodes); diff != "" {
+		} else if diff := cmp.Diff(cmtStorage.InternalNodes, s.InternalNodes); diff != "" {
 			t.Fatalf("(it %d) CMT/sparse internal nodes diff:\n%v", numLeaves, diff)
 		}
 	}

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -927,7 +927,7 @@ func leavesEquivalent(t *testing.T, gotLeaves, wantLeaves []*trillian.LogLeaf) {
 		k := sha256.Sum256([]byte(g.String()))
 		got[string(k[:])] = g
 	}
-	if diff := pretty.Compare(want, got); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("leaves not equivalent: diff -want,+got:\n%v", diff)
 	}
 }
@@ -1324,7 +1324,7 @@ func TestGetActiveLogIDs(t *testing.T) {
 	want := []int64{log1.TreeId, log2.TreeId, log3.TreeId, drainingLog.TreeId}
 	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
-	if diff := pretty.Compare(got, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("post-GetActiveLogIDs diff (-got +want):\n%v", diff)
 	}
 }

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -25,13 +25,13 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/integration/storagetest"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testdb"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 
 	tcrypto "github.com/google/trillian/crypto"
 	storageto "github.com/google/trillian/storage/testonly"
@@ -204,7 +204,7 @@ func TestMapRootUpdate(t *testing.T) {
 				}
 
 				if got, want := root.Metadata, tc.wantMetadata; !bytes.Equal(got, want) {
-					t.Errorf("%v: LatestSignedMapRoot() diff(-got, +want) \n%v", tc.desc, pretty.Compare(got, want))
+					t.Errorf("%v: LatestSignedMapRoot() diff(-got, +want) \n%v", tc.desc, cmp.Diff(got, want))
 				}
 				return nil
 			})

--- a/storage/postgres/log_storage_test.go
+++ b/storage/postgres/log_storage_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/types"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -1151,7 +1151,7 @@ func TestGetActiveLogIDs(t *testing.T) {
 	want := []int64{log1.TreeId, log2.TreeId, log3.TreeId, drainingLog.TreeId}
 	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
-	if diff := pretty.Compare(got, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("post-GetActiveLogIDs diff (-got +want):\n%v", diff)
 	}
 }

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -27,13 +27,13 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -230,7 +230,7 @@ func (tester *AdminStorageTester) TestCreateTree(t *testing.T) {
 			// Ignore storage_settings changes (OK to vary between implementations)
 			wantTree.StorageSettings = newTree.StorageSettings
 			if !proto.Equal(newTree, wantTree) {
-				diff := pretty.Compare(newTree, &wantTree)
+				diff := cmp.Diff(newTree, &wantTree)
 				t.Errorf("%v: post-CreateTree diff:\n%v", test.desc, diff)
 				return
 			}
@@ -396,7 +396,7 @@ func (tester *AdminStorageTester) TestUpdateTree(t *testing.T) {
 			t.StorageSettings = updatedTree.StorageSettings
 		})
 		if !proto.Equal(updatedTree, wantTree) {
-			diff := pretty.Compare(updatedTree, wantTree)
+			diff := cmp.Diff(updatedTree, wantTree)
 			t.Errorf("%v: updatedTree doesn't match wantTree:\n%s", test.desc, diff)
 		}
 
@@ -457,7 +457,7 @@ func runListTreeIDsTest(ctx context.Context, tx storage.ReadOnlyAdminTX, include
 
 	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
-	if diff := pretty.Compare(got, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		return fmt.Errorf("post-ListTreeIDs() diff (-got +want):\n%v", diff)
 	}
 	return nil
@@ -479,7 +479,7 @@ func runListTreesTest(ctx context.Context, tx storage.ReadOnlyAdminTX, includeDe
 
 	for i, wantTree := range want {
 		if !proto.Equal(got[i], wantTree) {
-			return fmt.Errorf("post-ListTrees() diff (-got +want):\n%v", pretty.Compare(got, want))
+			return fmt.Errorf("post-ListTrees() diff (-got +want):\n%v", cmp.Diff(got, want))
 		}
 	}
 	return nil
@@ -515,7 +515,7 @@ func (tester *AdminStorageTester) TestSoftDeleteTree(t *testing.T) {
 		wantTree.Deleted = true
 		wantTree.DeleteTime = deletedTree.DeleteTime
 		if got, want := deletedTree, wantTree; !proto.Equal(got, want) {
-			t.Errorf("%v: post-SoftDeleteTree diff (-got +want):\n%v", test.desc, pretty.Compare(got, want))
+			t.Errorf("%v: post-SoftDeleteTree diff (-got +want):\n%v", test.desc, cmp.Diff(got, want))
 		}
 
 		if err := assertStoredTree(ctx, s, deletedTree); err != nil {
@@ -619,7 +619,7 @@ func (tester *AdminStorageTester) TestUndeleteTree(t *testing.T) {
 		want.Deleted = false
 		want.DeleteTime = nil
 		if got := tree; !proto.Equal(got, want) {
-			t.Errorf("%v: post-UndeleteTree diff (-got +want):\n%v", test.desc, pretty.Compare(got, want))
+			t.Errorf("%v: post-UndeleteTree diff (-got +want):\n%v", test.desc, cmp.Diff(got, want))
 		}
 
 		if err := assertStoredTree(ctx, s, tree); err != nil {
@@ -708,7 +708,7 @@ func assertStoredTree(ctx context.Context, s storage.AdminStorage, want *trillia
 		return fmt.Errorf("GetTree() returned err = %v", err)
 	}
 	if !proto.Equal(got, want) {
-		return fmt.Errorf("post-GetTree() diff (-got +want):\n%v", pretty.Compare(got, want))
+		return fmt.Errorf("post-GetTree() diff (-got +want):\n%v", cmp.Diff(got, want))
 	}
 	return nil
 }

--- a/storage/tree/layout_test.go
+++ b/storage/tree/layout_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 )
 
 var defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
@@ -71,7 +71,7 @@ func TestStrataIndex(t *testing.T) {
 	want := []stratumInfo{{0, 8}, {1, 8}, {2, 16}, {2, 16}, {4, 32}, {4, 32}, {4, 32}, {4, 32}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {8, 64}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}, {16, 128}}
 
 	layout := NewLayout(heights)
-	if diff := pretty.Compare(layout.sIndex, want); diff != "" {
+	if diff := cmp.Diff(layout.sIndex, want, cmp.AllowUnexported(stratumInfo{})); diff != "" {
 		t.Fatalf("sIndex diff:\n%v", diff)
 	}
 }

--- a/trees/trees_test.go
+++ b/trees/trees_test.go
@@ -23,17 +23,18 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testonly"
-	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -323,7 +324,7 @@ func TestGetTree(t *testing.T) {
 		}
 
 		if !proto.Equal(tree, test.wantTree) {
-			diff := pretty.Compare(tree, test.wantTree)
+			diff := cmp.Diff(tree, test.wantTree)
 			t.Errorf("%v: post-GetTree diff:\n%v", test.desc, diff)
 		}
 	}
@@ -442,7 +443,7 @@ func TestSigner(t *testing.T) {
 			}
 
 			want := tcrypto.NewSigner(0, test.signer, crypto.SHA256)
-			if diff := pretty.Compare(signer, want); diff != "" {
+			if diff := cmp.Diff(signer, want, cmp.Comparer(func(a, b *big.Int) bool { return a.Cmp(b) == 0 })); diff != "" {
 				t.Fatalf("post-Signer(_, %s) diff:\n%v", test.sigAlgo, diff)
 			}
 		})


### PR DESCRIPTION
kylelemons does not support proto v1.4

`cmp` is stricter than `pretty`:
- `cmp` warns about unexported fields, which `pretty` would ignore. In some cases (context.Context) the structs being compared had no public fields, resulting in an always true test.
- `nil` is not equal to `{}`