### PR TITLE
smt: Formalise Tile struct semantics

### DIFF
--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -22,8 +22,16 @@ import "github.com/google/trillian/storage/tree"
 // contains the list of non-empty leaf nodes, which can be used to reconstruct
 // all the remaining inner nodes of the tile.
 //
-// TODO(pavelkalinnikov): Make Tile immutable.
-// TODO(pavelkalinnikov): Introduce invariants on the order/content of Leaves.
+// Invariants of this structure that must be preserved at all times:
+//  - ID is a prefix of Leaves' IDs, i.e. the nodes are in the same subtree.
+//  - IDs of Leaves have the same length, i.e. the nodes are at the same level.
+//  - Leaves are ordered by ID from left to right.
+//  - IDs of Leaves are unique.
+//
+// Algorithms that create Tile structures must ensure that these invariants
+// hold. Use smt.Prepare function to help ordering nodes.
+//
+// TODO(pavelkalinnikov): Add SortedNodes type to statically "assert" order.
 type Tile struct {
 	ID     tree.NodeID2
 	Leaves []Node

--- a/merkle/smt/tiles_test.go
+++ b/merkle/smt/tiles_test.go
@@ -107,6 +107,7 @@ func TestTileSetMutationBuild(t *testing.T) {
 		tree.NewNodeID2("\x01\x01", 16),
 		tree.NewNodeID2("\xFF\xFF", 16),
 		tree.NewNodeID2("\x77\x77", 16),
+		tree.NewNodeID2("\x77\x88", 16),
 	}
 	ts := NewTileSet(0, maphasher.Default, l)
 	for _, tile := range []Tile{
@@ -168,9 +169,57 @@ func TestTileSetMutationBuild(t *testing.T) {
 			upd: []Node{{ID: ids[0].Sibling(), Hash: []byte("new_0001")}},
 			want: map[tree.NodeID2][]Node{
 				ids[0].Prefix(8): {
-					{ID: ids[0].Sibling(), Hash: []byte("new_0001")},
 					{ID: ids[0], Hash: []byte("hash_0000")},
+					{ID: ids[0].Sibling(), Hash: []byte("new_0001")},
 					{ID: ids[1], Hash: []byte("hash_0070")},
+				},
+			},
+		},
+		{ // Multiple updates in order.
+			upd: []Node{
+				{ID: ids[0], Hash: []byte("new_0000")},
+				{ID: ids[1], Hash: []byte("new_0001")},
+			},
+			want: map[tree.NodeID2][]Node{
+				ids[0].Prefix(8): {
+					{ID: ids[0], Hash: []byte("new_0000")},
+					{ID: ids[1], Hash: []byte("new_0001")},
+				},
+			},
+		},
+		{ // Multiple updates out of order.
+			upd: []Node{
+				{ID: ids[1], Hash: []byte("new_0001")},
+				{ID: ids[0], Hash: []byte("new_0000")},
+			},
+			want: map[tree.NodeID2][]Node{
+				ids[0].Prefix(8): {
+					{ID: ids[0], Hash: []byte("new_0000")},
+					{ID: ids[1], Hash: []byte("new_0001")},
+				},
+			},
+		},
+		{ // Multiple updates of a non-existing tile in order.
+			upd: []Node{
+				{ID: ids[4], Hash: []byte("new_7777")},
+				{ID: ids[5], Hash: []byte("new_7788")},
+			},
+			want: map[tree.NodeID2][]Node{
+				ids[4].Prefix(8): {
+					{ID: ids[4], Hash: []byte("new_7777")},
+					{ID: ids[5], Hash: []byte("new_7788")},
+				},
+			},
+		},
+		{ // Multiple updates of a non-existing tile out of order.
+			upd: []Node{
+				{ID: ids[5], Hash: []byte("new_7788")},
+				{ID: ids[4], Hash: []byte("new_7777")},
+			},
+			want: map[tree.NodeID2][]Node{
+				ids[4].Prefix(8): {
+					{ID: ids[4], Hash: []byte("new_7777")},
+					{ID: ids[5], Hash: []byte("new_7788")},
 				},
 			},
 		},


### PR DESCRIPTION
This change:

- Clarifies the semantics of `Tile` in the type comment.
- Refactors the `TileSet` type so that the invariants are preserved.
- Adds a couple of tests that catch situations where the invariants weren't previously held.