### PR TITLE
smt: Introduce type for sorted list of nodes

### DIFF
--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -41,8 +41,8 @@ type Tile struct {
 }
 
 // Merge returns a new tile which is a combination of this tile with the given
-// updates. The resulting tile contains all the nodes from the updates tile,
-// and all the nodes from the original tile not present in the updates.
+// updates. The resulting tile contains all the nodes from the updates, and all
+// the nodes from the original tile not present in the updates.
 func (t Tile) Merge(updates NodesRow) (Tile, error) {
 	if len(updates) == 0 {
 		return t, nil

--- a/merkle/smt/tile_test.go
+++ b/merkle/smt/tile_test.go
@@ -38,11 +38,12 @@ func TestTileMerge(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc string
-		was  []Node
-		upd  []Node
-		want []Node
+		was  NodesRow
+		upd  NodesRow
+		want NodesRow
 	}{
-		{desc: "empty", want: []Node{}},
+		{desc: "empty", want: nil},
+		{desc: "no-updates", was: []Node{n(3, "h")}, want: []Node{n(3, "h")}},
 		{desc: "add-to-empty", upd: []Node{n(0, "h")}, want: []Node{n(0, "h")}},
 		{
 			desc: "override-one",
@@ -71,8 +72,7 @@ func TestTileMerge(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			was := Tile{ID: id, Leaves: tc.was}
-			upd := Tile{ID: id, Leaves: tc.upd}
-			got, err := was.Merge(upd)
+			got, err := was.Merge(tc.upd)
 			if err != nil {
 				t.Fatalf("Merge: %v", err)
 			}

--- a/merkle/smt/tiles.go
+++ b/merkle/smt/tiles.go
@@ -29,14 +29,14 @@ import (
 // TODO(pavelkalinnikov): Make it immutable.
 type TileSet struct {
 	layout *tree.Layout
-	tiles  map[tree.NodeID2][]Node
+	tiles  map[tree.NodeID2]NodesRow
 	hashes map[tree.NodeID2][]byte
 	h      mapHasher
 }
 
 // NewTileSet creates an empty TileSet with the given tree parameters.
 func NewTileSet(treeID int64, hasher hashers.MapHasher, layout *tree.Layout) *TileSet {
-	tiles := make(map[tree.NodeID2][]Node)
+	tiles := make(map[tree.NodeID2]NodesRow)
 	hashes := make(map[tree.NodeID2][]byte)
 	h := bindHasher(hasher, treeID)
 	return &TileSet{layout: layout, tiles: tiles, hashes: hashes, h: h}
@@ -99,13 +99,12 @@ func (t *TileSetMutation) Build() ([]Tile, error) {
 		sort.Slice(upd, func(i, j int) bool {
 			return compareHorizontal(upd[i].ID, upd[j].ID) < 0
 		})
-		updates := Tile{ID: id, Leaves: upd}
 		had, ok := t.read.tiles[id]
 		if !ok {
-			res = append(res, updates)
+			res = append(res, Tile{ID: id, Leaves: upd})
 			continue
 		}
-		tile, err := Tile{ID: id, Leaves: had}.Merge(updates)
+		tile, err := Tile{ID: id, Leaves: had}.Merge(upd)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change introduces `NodesRow` type which encapsulates a list of nodes with unique and sorted IDs. This type is used for storing nodes in `Tile` type, and for passing in updates to its `Merge` method. More usages will be added in follow-up PRs.

So far `NodesRow` is backwards compatible with the previously used plain slice `[]Node`.