### PR TITLE
README: correct logged map

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ without anyone noticing.
 
 A future plan to deal with this is to create a *Logged Map*, which combines a
 Trillian Map with a Trillian Log so that all published revisions of the Map
-have their signed tree head data appended to the corresponding Map.
+have their signed tree head data appended to the corresponding Log.
 
 The mapping between the source Log data and the key:value data stored in the
 Map is application-specific, and so is implemented as a Trillian personality.


### PR DESCRIPTION
Hi folks, I *think* this correction is right: revisions of the Map have their signed tree head data appended to the corresponding *Log* not *Map*, right?

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

I don't think either of these apply to this README change:

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
