### PR TITLE
Extend CalcInclusionProofNodeAddresses tests

### DIFF
--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -154,11 +154,11 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	// Remember that our storage node layers are always populated from the bottom
 	// up, hence the gap at level 1, index 3 in the above picture.
 
-	// These should all successfully compute the expected path.
-	for _, testCase := range []struct {
-		treeSize     int64
-		leafIndex    int64
-		expectedPath []NodeFetch
+	// These should all successfully compute the expected proof.
+	for _, tc := range []struct {
+		size  int64
+		index int64
+		want  []NodeFetch
 	}{
 		{1, 0, []NodeFetch{}},
 		{7, 0, []NodeFetch{ // from a
@@ -181,13 +181,13 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 			newNodeFetch(2, 0, false), // k
 		}},
 	} {
-		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
+		proof, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)
 
 		if err != nil {
-			t.Fatalf("unexpected error calculating path %v: %v", testCase, err)
+			t.Fatalf("unexpected error calculating proof %v: %v", tc, err)
 		}
 
-		comparePaths(t, fmt.Sprintf("i(%d,%d)", testCase.leafIndex, testCase.treeSize), path, testCase.expectedPath)
+		comparePaths(t, fmt.Sprintf("i(%d,%d)", tc.index, tc.size), proof, tc.want)
 	}
 }
 

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -267,6 +267,7 @@ func TestCalcConsistencyProofNodeAddressesBadInputs(t *testing.T) {
 
 // TODO(pkalinnikov): Remove desc when all the tests use t.Run.
 func comparePaths(t *testing.T, desc string, got, expected []NodeFetch) {
+	t.Helper()
 	if len(expected) != len(got) {
 		t.Fatalf("%s: expected %d nodes in path but got %d: %v", desc, len(expected), len(got), got)
 	}

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -182,10 +182,10 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 		expectedPath []NodeFetch
 	}{
 		{1, 0, []NodeFetch{}},
-		{7, 3, expectedPathSize7Index3},
-		{7, 6, expectedPathSize7Index6},
 		{7, 0, expectedPathSize7Index0},
+		{7, 3, expectedPathSize7Index3},
 		{7, 4, expectedPathSize7Index4},
+		{7, 6, expectedPathSize7Index6},
 	} {
 		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
 

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -166,6 +166,16 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 			newNodeFetch(1, 1, false), // h
 			newNodeFetch(2, 1, false), // l
 		}},
+		{size: 7, index: 1, want: []NodeFetch{ // from b
+			newNodeFetch(0, 0, false), // a
+			newNodeFetch(1, 1, false), // h
+			newNodeFetch(2, 1, false), // l
+		}},
+		{size: 7, index: 2, want: []NodeFetch{ // from c
+			newNodeFetch(0, 3, false), // d
+			newNodeFetch(1, 0, false), // g
+			newNodeFetch(2, 1, false), // l
+		}},
 		{size: 7, index: 3, want: []NodeFetch{ // from d
 			newNodeFetch(0, 2, false), // c
 			newNodeFetch(1, 0, false), // g
@@ -173,6 +183,11 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 		}},
 		{size: 7, index: 4, want: []NodeFetch{ // from e
 			newNodeFetch(0, 5, false), // f
+			newNodeFetch(0, 6, false), // j
+			newNodeFetch(2, 0, false), // k
+		}},
+		{size: 7, index: 5, want: []NodeFetch{ // from f
+			newNodeFetch(0, 4, false), // e
 			newNodeFetch(0, 6, false), // j
 			newNodeFetch(2, 0, false), // k
 		}},

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -190,23 +190,23 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 }
 
 func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
-	// These should all fail.
-	for _, testCase := range []struct {
-		treeSize  int64
-		leafIndex int64
+	for _, tc := range []struct {
+		size  int64
+		index int64
 	}{
-		{0, 1},
-		{1, 2},
-		{0, 3},
-		{-1, 3},
-		{7, -1},
-		{7, 8},
+		{size: 0, index: 1},
+		{size: 1, index: 2},
+		{size: 0, index: 3},
+		{size: -1, index: 3},
+		{size: 7, index: -1},
+		{size: 7, index: 8},
 	} {
-		_, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
-
-		if err == nil {
-			t.Fatalf("incorrectly accepted bad params: %v", testCase)
-		}
+		t.Run(fmt.Sprintf("%d:%d", tc.size, tc.index), func(t *testing.T) {
+			_, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)
+			if err == nil {
+				t.Fatal("accepted bad params")
+			}
+		})
 	}
 }
 

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -21,48 +21,6 @@ import (
 	"github.com/google/trillian/merkle/compact"
 )
 
-// Expected inclusion proof paths built by examination of the example 7 leaf tree in RFC 6962:
-//
-//                hash              <== Level 3
-//               /    \
-//              /      \
-//             /        \
-//            /          \
-//           /            \
-//          k              l        <== Level 2
-//         / \            / \
-//        /   \          /   \
-//       /     \        /     \
-//      g       h      i      [ ]   <== Level 1
-//     / \     / \    / \    /
-//     a b     c d    e f    j      <== Level 0
-//     | |     | |    | |    |
-//     d0 d1   d2 d3  d4 d5  d6
-//
-// When comparing with the document remember that our storage node layers are always
-// populated from the bottom up, hence the gap at level 1, index 3 in the above picture.
-var (
-	expectedPathSize7Index0 = []NodeFetch{ // from a
-		newNodeFetch(0, 1, false), // b
-		newNodeFetch(1, 1, false), // h
-		newNodeFetch(2, 1, false), // l
-	}
-	expectedPathSize7Index3 = []NodeFetch{ // from d
-		newNodeFetch(0, 2, false), // c
-		newNodeFetch(1, 0, false), // g
-		newNodeFetch(2, 1, false), // l
-	}
-	expectedPathSize7Index4 = []NodeFetch{ // from e
-		newNodeFetch(0, 5, false), // f
-		newNodeFetch(0, 6, false), // j
-		newNodeFetch(2, 0, false), // k
-	}
-	expectedPathSize7Index6 = []NodeFetch{ // from j
-		newNodeFetch(1, 2, false), // i
-		newNodeFetch(2, 0, false), // k
-	}
-)
-
 // Expected consistency proofs built from the examples in RFC 6962. Again, in our implementation
 // node layers are filled from the bottom upwards.
 var (
@@ -174,6 +132,48 @@ var (
 )
 
 func TestCalcInclusionProofNodeAddresses(t *testing.T) {
+	// Expected inclusion proof paths built by examination of the example 7 leaf tree in RFC 6962:
+	//
+	//                hash              <== Level 3
+	//               /    \
+	//              /      \
+	//             /        \
+	//            /          \
+	//           /            \
+	//          k              l        <== Level 2
+	//         / \            / \
+	//        /   \          /   \
+	//       /     \        /     \
+	//      g       h      i      [ ]   <== Level 1
+	//     / \     / \    / \    /
+	//     a b     c d    e f    j      <== Level 0
+	//     | |     | |    | |    |
+	//     d0 d1   d2 d3  d4 d5  d6
+	//
+	// When comparing with the document remember that our storage node layers are always
+	// populated from the bottom up, hence the gap at level 1, index 3 in the above picture.
+	var (
+		expectedPathSize7Index0 = []NodeFetch{ // from a
+			newNodeFetch(0, 1, false), // b
+			newNodeFetch(1, 1, false), // h
+			newNodeFetch(2, 1, false), // l
+		}
+		expectedPathSize7Index3 = []NodeFetch{ // from d
+			newNodeFetch(0, 2, false), // c
+			newNodeFetch(1, 0, false), // g
+			newNodeFetch(2, 1, false), // l
+		}
+		expectedPathSize7Index4 = []NodeFetch{ // from e
+			newNodeFetch(0, 5, false), // f
+			newNodeFetch(0, 6, false), // j
+			newNodeFetch(2, 0, false), // k
+		}
+		expectedPathSize7Index6 = []NodeFetch{ // from j
+			newNodeFetch(1, 2, false), // i
+			newNodeFetch(2, 0, false), // k
+		}
+	)
+
 	// These should all successfully compute the expected path.
 	for _, testCase := range []struct {
 		treeSize     int64

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -132,7 +132,8 @@ var (
 )
 
 func TestCalcInclusionProofNodeAddresses(t *testing.T) {
-	// Expected inclusion proof paths built by examination of the example 7 leaf tree in RFC 6962:
+	// Expected inclusion proofs built by examination of the example 7 leaf tree
+	// in RFC 6962:
 	//
 	//                hash              <== Level 3
 	//               /    \
@@ -150,8 +151,8 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	//     | |     | |    | |    |
 	//     d0 d1   d2 d3  d4 d5  d6
 	//
-	// When comparing with the document remember that our storage node layers are always
-	// populated from the bottom up, hence the gap at level 1, index 3 in the above picture.
+	// Remember that our storage node layers are always populated from the bottom
+	// up, hence the gap at level 1, index 3 in the above picture.
 	var (
 		expectedPathSize7Index0 = []NodeFetch{ // from a
 			newNodeFetch(0, 1, false), // b

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -181,13 +181,13 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 			newNodeFetch(2, 0, false), // k
 		}},
 	} {
-		proof, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)
-
-		if err != nil {
-			t.Fatalf("unexpected error calculating proof %v: %v", tc, err)
-		}
-
-		comparePaths(t, fmt.Sprintf("i(%d,%d)", tc.index, tc.size), proof, tc.want)
+		t.Run(fmt.Sprintf("%d:%d", tc.size, tc.index), func(t *testing.T) {
+			proof, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)
+			if err != nil {
+				t.Fatalf("CalcInclusionProofNodeAddresses: %v", err)
+			}
+			comparePaths(t, "", proof, tc.want)
+		})
 	}
 }
 
@@ -263,6 +263,7 @@ func TestCalcConsistencyProofNodeAddressesBadInputs(t *testing.T) {
 	}
 }
 
+// TODO(pkalinnikov): Remove desc when all the tests use t.Run.
 func comparePaths(t *testing.T, desc string, got, expected []NodeFetch) {
 	if len(expected) != len(got) {
 		t.Fatalf("%s: expected %d nodes in path but got %d: %v", desc, len(expected), len(got), got)

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -160,23 +160,23 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 		index int64
 		want  []NodeFetch
 	}{
-		{1, 0, []NodeFetch{}},
-		{7, 0, []NodeFetch{ // from a
+		{size: 1, index: 0, want: nil},
+		{size: 7, index: 0, want: []NodeFetch{ // from a
 			newNodeFetch(0, 1, false), // b
 			newNodeFetch(1, 1, false), // h
 			newNodeFetch(2, 1, false), // l
 		}},
-		{7, 3, []NodeFetch{ // from d
+		{size: 7, index: 3, want: []NodeFetch{ // from d
 			newNodeFetch(0, 2, false), // c
 			newNodeFetch(1, 0, false), // g
 			newNodeFetch(2, 1, false), // l
 		}},
-		{7, 4, []NodeFetch{ // from e
+		{size: 7, index: 4, want: []NodeFetch{ // from e
 			newNodeFetch(0, 5, false), // f
 			newNodeFetch(0, 6, false), // j
 			newNodeFetch(2, 0, false), // k
 		}},
-		{7, 6, []NodeFetch{ // from j
+		{size: 7, index: 6, want: []NodeFetch{ // from j
 			newNodeFetch(1, 2, false), // i
 			newNodeFetch(2, 0, false), // k
 		}},

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -153,27 +153,6 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	//
 	// Remember that our storage node layers are always populated from the bottom
 	// up, hence the gap at level 1, index 3 in the above picture.
-	var (
-		expectedPathSize7Index0 = []NodeFetch{ // from a
-			newNodeFetch(0, 1, false), // b
-			newNodeFetch(1, 1, false), // h
-			newNodeFetch(2, 1, false), // l
-		}
-		expectedPathSize7Index3 = []NodeFetch{ // from d
-			newNodeFetch(0, 2, false), // c
-			newNodeFetch(1, 0, false), // g
-			newNodeFetch(2, 1, false), // l
-		}
-		expectedPathSize7Index4 = []NodeFetch{ // from e
-			newNodeFetch(0, 5, false), // f
-			newNodeFetch(0, 6, false), // j
-			newNodeFetch(2, 0, false), // k
-		}
-		expectedPathSize7Index6 = []NodeFetch{ // from j
-			newNodeFetch(1, 2, false), // i
-			newNodeFetch(2, 0, false), // k
-		}
-	)
 
 	// These should all successfully compute the expected path.
 	for _, testCase := range []struct {
@@ -182,10 +161,25 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 		expectedPath []NodeFetch
 	}{
 		{1, 0, []NodeFetch{}},
-		{7, 0, expectedPathSize7Index0},
-		{7, 3, expectedPathSize7Index3},
-		{7, 4, expectedPathSize7Index4},
-		{7, 6, expectedPathSize7Index6},
+		{7, 0, []NodeFetch{ // from a
+			newNodeFetch(0, 1, false), // b
+			newNodeFetch(1, 1, false), // h
+			newNodeFetch(2, 1, false), // l
+		}},
+		{7, 3, []NodeFetch{ // from d
+			newNodeFetch(0, 2, false), // c
+			newNodeFetch(1, 0, false), // g
+			newNodeFetch(2, 1, false), // l
+		}},
+		{7, 4, []NodeFetch{ // from e
+			newNodeFetch(0, 5, false), // f
+			newNodeFetch(0, 6, false), // j
+			newNodeFetch(2, 0, false), // k
+		}},
+		{7, 6, []NodeFetch{ // from j
+			newNodeFetch(1, 2, false), // i
+			newNodeFetch(2, 0, false), // k
+		}},
 	} {
 		path, err := CalcInclusionProofNodeAddresses(testCase.treeSize, testCase.leafIndex, testCase.treeSize)
 

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -191,18 +191,22 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 
 func TestCalcInclusionProofNodeAddressesBadRanges(t *testing.T) {
 	for _, tc := range []struct {
-		size  int64
-		index int64
+		size    int64 // The requested past tree size.
+		index   int64 // Leaf index in the requested tree.
+		bigSize int64 // The current tree size.
 	}{
-		{size: 0, index: 1},
-		{size: 1, index: 2},
-		{size: 0, index: 3},
-		{size: -1, index: 3},
-		{size: 7, index: -1},
-		{size: 7, index: 8},
+		{size: 0, index: 0, bigSize: 0},
+		{size: 0, index: 1, bigSize: 0},
+		{size: 1, index: 0, bigSize: 0},
+		{size: 1, index: 2, bigSize: 1},
+		{size: 0, index: 3, bigSize: 0},
+		{size: -1, index: 3, bigSize: -1},
+		{size: 7, index: -1, bigSize: 7},
+		{size: 7, index: 8, bigSize: 7},
+		{size: 7, index: 3, bigSize: -7},
 	} {
-		t.Run(fmt.Sprintf("%d:%d", tc.size, tc.index), func(t *testing.T) {
-			_, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)
+		t.Run(fmt.Sprintf("%d:%d:%d", tc.size, tc.index, tc.bigSize), func(t *testing.T) {
+			_, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.bigSize)
 			if err == nil {
 				t.Fatal("accepted bad params")
 			}

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -154,6 +154,9 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 	// Remember that our storage node layers are always populated from the bottom
 	// up, hence the gap at level 1, index 3 in the above picture.
 
+	node := func(level uint, index uint64) NodeFetch {
+		return newNodeFetch(level, index, false)
+	}
 	// These should all successfully compute the expected proof.
 	for _, tc := range []struct {
 		size  int64
@@ -161,40 +164,20 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 		want  []NodeFetch
 	}{
 		{size: 1, index: 0, want: nil},
-		{size: 7, index: 0, want: []NodeFetch{ // from a
-			newNodeFetch(0, 1, false), // b
-			newNodeFetch(1, 1, false), // h
-			newNodeFetch(2, 1, false), // l
-		}},
-		{size: 7, index: 1, want: []NodeFetch{ // from b
-			newNodeFetch(0, 0, false), // a
-			newNodeFetch(1, 1, false), // h
-			newNodeFetch(2, 1, false), // l
-		}},
-		{size: 7, index: 2, want: []NodeFetch{ // from c
-			newNodeFetch(0, 3, false), // d
-			newNodeFetch(1, 0, false), // g
-			newNodeFetch(2, 1, false), // l
-		}},
-		{size: 7, index: 3, want: []NodeFetch{ // from d
-			newNodeFetch(0, 2, false), // c
-			newNodeFetch(1, 0, false), // g
-			newNodeFetch(2, 1, false), // l
-		}},
-		{size: 7, index: 4, want: []NodeFetch{ // from e
-			newNodeFetch(0, 5, false), // f
-			newNodeFetch(0, 6, false), // j
-			newNodeFetch(2, 0, false), // k
-		}},
-		{size: 7, index: 5, want: []NodeFetch{ // from f
-			newNodeFetch(0, 4, false), // e
-			newNodeFetch(0, 6, false), // j
-			newNodeFetch(2, 0, false), // k
-		}},
-		{size: 7, index: 6, want: []NodeFetch{ // from j
-			newNodeFetch(1, 2, false), // i
-			newNodeFetch(2, 0, false), // k
-		}},
+		{size: 7, index: 0, want: []NodeFetch{
+			node(0, 1), node(1, 1), node(2, 1)}}, // b h l
+		{size: 7, index: 1, want: []NodeFetch{
+			node(0, 0), node(1, 1), node(2, 1)}}, // a h l
+		{size: 7, index: 2, want: []NodeFetch{
+			node(0, 3), node(1, 0), node(2, 1)}}, // d g l
+		{size: 7, index: 3, want: []NodeFetch{
+			node(0, 2), node(1, 0), node(2, 1)}}, // c g l
+		{size: 7, index: 4, want: []NodeFetch{
+			node(0, 5), node(0, 6), node(2, 0)}}, // f j k
+		{size: 7, index: 5, want: []NodeFetch{
+			node(0, 4), node(0, 6), node(2, 0)}}, // e j k
+		{size: 7, index: 6, want: []NodeFetch{
+			node(1, 2), node(2, 0)}}, // i k
 	} {
 		t.Run(fmt.Sprintf("%d:%d", tc.size, tc.index), func(t *testing.T) {
 			proof, err := CalcInclusionProofNodeAddresses(tc.size, tc.index, tc.size)


### PR DESCRIPTION
This change improves readability of `TestCalcInclusionProofNodeAddresses` and
adds some new tests for completeness.

Part of #2143