### PR TITLE
Remove tx.QueueLeaves interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Not yet released; provisionally v1.4.0 (may change).
 
+### Storage TX Interfaces
+- `QueueLeaves` has been removed from the `LogTreeTX` interface because
+  `QueueLeaves` is not transactionaal.  All callers use the
+  `QueueLeaves` function in the `LogStorage` interface.
+
 ### HTTP APIs
 
 The HTTP/JSON APIs have been removed in favor of a pure gRPC intereface.

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -337,10 +337,8 @@ func queueLeaves(ctx context.Context, db *sql.DB, tree *trillian.Tree, firstID, 
 	}
 
 	ls := mysql.NewLogStorage(db, nil)
-	return ls.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
-		_, err := tx.QueueLeaves(ctx, leaves, time.Now())
-		return err
-	})
+	_, err = ls.QueueLeaves(ctx, tree, leaves, time.Now())
+	return err
 }
 
 func setUnsequencedRows(ctx context.Context, db *sql.DB, tree *trillian.Tree, wantRows int) error {

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -532,10 +532,6 @@ func readLeaves(ctx context.Context, stx *spanner.ReadOnlyTransaction, logID int
 	})
 }
 
-func (tx *logTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, ts time.Time) ([]*trillian.LogLeaf, error) {
-	return nil, ErrNotImplemented
-}
-
 func (tx *logTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf, ts time.Time) ([]*trillian.QueuedLogLeaf, error) {
 	return nil, ErrNotImplemented
 }

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -76,16 +76,6 @@ type LogTreeTX interface {
 	// StoreSignedLogRoot stores a freshly created SignedLogRoot.
 	StoreSignedLogRoot(ctx context.Context, root *trillian.SignedLogRoot) error
 
-	// QueueLeaves enqueues leaves for later integration into the tree.
-	// If error is nil, the returned slice of leaves will be the same size as the
-	// input, and each entry will hold:
-	//  - the existing leaf data (the LogLeaf fields not marked output-only) if
-	//    a duplicate has been submitted
-	//  - nil otherwise.
-	// Duplicates are only reported if the underlying tree does not permit duplicates, and are
-	// considered duplicate if their leaf.LeafIdentityHash matches.
-	QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error)
-
 	// DequeueLeaves returns between [0, limit] leaves to be integrated to the
 	// tree.
 	//
@@ -159,9 +149,6 @@ type LogStorage interface {
 	//
 	// Duplicates are only reported if the underlying tree does not permit duplicates, and are
 	// considered duplicate if their leaf.LeafIdentityHash matches.
-	//
-	// Note that in contrast to LogTX.QueueLeaves, implementations of this func must not return
-	// slices with nil values.
 	QueueLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error)
 
 	// AddSequencedLeaves stores the `leaves` and associates them with the log

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -147,7 +147,7 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return getActiveLogIDs(t.ms.trees), nil
 }
 
-func (m *memoryLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree, readonly bool) (storage.LogTreeTX, error) {
+func (m *memoryLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree, readonly bool) (*logTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
@@ -206,7 +206,7 @@ func (m *memoryLogStorage) SnapshotForTree(ctx context.Context, tree *trillian.T
 	if err != nil {
 		return nil, err
 	}
-	return tx.(storage.ReadOnlyLogTreeTX), err
+	return tx, err
 }
 
 func (m *memoryLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.QueuedLogLeaf, error) {

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -574,21 +574,6 @@ func (mr *MockLogTreeTXMockRecorder) LatestSignedLogRoot(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestSignedLogRoot", reflect.TypeOf((*MockLogTreeTX)(nil).LatestSignedLogRoot), arg0)
 }
 
-// QueueLeaves mocks base method
-func (m *MockLogTreeTX) QueueLeaves(arg0 context.Context, arg1 []*trillian.LogLeaf, arg2 time.Time) ([]*trillian.LogLeaf, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueueLeaves", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*trillian.LogLeaf)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// QueueLeaves indicates an expected call of QueueLeaves
-func (mr *MockLogTreeTXMockRecorder) QueueLeaves(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueLeaves", reflect.TypeOf((*MockLogTreeTX)(nil).QueueLeaves), arg0, arg1, arg2)
-}
-
 // ReadRevision mocks base method
 func (m *MockLogTreeTX) ReadRevision(arg0 context.Context) (int64, error) {
 	m.ctrl.T.Helper()

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -234,7 +234,7 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return ids, rows.Err()
 }
 
-func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree) (storage.LogTreeTX, error) {
+func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree) (*logTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -189,7 +189,7 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 			for i, want := range test.want {
 				got := existing[i]
 				if want == nil {
-					if got, want := status.FromProto(got.GetStatus()).Code(), codes.OK; got != want {
+					if got.Status != nil {
 						t.Errorf("QueueLeaves()[%d].Code: %v; want %v", i, got, want)
 					}
 					return

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -254,7 +254,7 @@ func (t *readOnlyLogTX) GetActiveLogIDs(ctx context.Context) ([]int64, error) {
 	return ids, rows.Err()
 }
 
-func (m *postgresLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree) (storage.LogTreeTX, error) {
+func (m *postgresLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree) (*logTreeTX, error) {
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -389,7 +389,7 @@ func sequenceLeaves(ls storage.LogStorage, seq *log.Sequencer, tree *trillian.Tr
 
 		leafData := []byte(fmt.Sprintf(leafDataFormat, l))
 		hash := sha256.Sum256(leafData)
-		lh := []byte(hash[:])
+		lh := hash[:]
 		leaf := trillian.LogLeaf{LeafValue: leafData, LeafIdentityHash: lh, MerkleLeafHash: lh}
 		leaves := []*trillian.LogLeaf{&leaf}
 

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -388,19 +388,13 @@ func sequenceLeaves(ls storage.LogStorage, seq *log.Sequencer, tree *trillian.Tr
 		glog.V(1).Infof("Queuing leaf %d", l)
 
 		leafData := []byte(fmt.Sprintf(leafDataFormat, l))
-		err := ls.ReadWriteTransaction(context.TODO(), tree, func(ctx context.Context, tx storage.LogTreeTX) error {
-			hash := sha256.Sum256(leafData)
-			lh := []byte(hash[:])
-			leaf := trillian.LogLeaf{LeafValue: leafData, LeafIdentityHash: lh, MerkleLeafHash: lh}
-			leaves := []*trillian.LogLeaf{&leaf}
+		hash := sha256.Sum256(leafData)
+		lh := []byte(hash[:])
+		leaf := trillian.LogLeaf{LeafValue: leafData, LeafIdentityHash: lh, MerkleLeafHash: lh}
+		leaves := []*trillian.LogLeaf{&leaf}
 
-			if _, err := tx.QueueLeaves(context.TODO(), leaves, time.Now()); err != nil {
-				glog.Fatalf("QueueLeaves got: %v, want: no err", err)
-			}
-			return nil
-		})
-		if err != nil {
-			glog.Fatalf("ReadWriteTransaction: %v", err)
+		if _, err := ls.QueueLeaves(context.TODO(), tree, leaves, time.Now()); err != nil {
+			glog.Fatalf("QueueLeaves got: %v, want: no err", err)
 		}
 
 		if l > 0 && l%batchSize == 0 {


### PR DESCRIPTION
Rewrite tests in terms of the public `storage.QueueLeaves` API rather than the private `tx.QueueLeaves` interface.

Now we can delete `NotImplemented` functions in spanner.