### PR TITLE
Delete leaves from queue in UpdateLeaves

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -250,8 +250,9 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree
 	}
 
 	ltx := &logTreeTX{
-		treeTX: ttx,
-		ls:     m,
+		treeTX:   ttx,
+		ls:       m,
+		dequeued: make(map[string]dequeuedLeaf),
 	}
 	ltx.slr, err = ltx.fetchLatestRoot(ctx)
 	if err == storage.ErrTreeNeedsInit {
@@ -348,9 +349,10 @@ func (m *mySQLLogStorage) QueueLeaves(ctx context.Context, tree *trillian.Tree, 
 
 type logTreeTX struct {
 	treeTX
-	ls   *mySQLLogStorage
-	root types.LogRootV1
-	slr  *trillian.SignedLogRoot
+	ls       *mySQLLogStorage
+	root     types.LogRootV1
+	slr      *trillian.SignedLogRoot
+	dequeued map[string]dequeuedLeaf
 }
 
 func (t *logTreeTX) ReadRevision(ctx context.Context) (int64, error) {
@@ -389,7 +391,6 @@ func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime tim
 	defer stx.Close()
 
 	leaves := make([]*trillian.LogLeaf, 0, limit)
-	dq := make([]dequeuedLeaf, 0, limit)
 	rows, err := stx.QueryContext(ctx, t.treeID, cutoffTime.UnixNano(), limit)
 	if err != nil {
 		glog.Warningf("Failed to select rows for work: %s", err)
@@ -408,8 +409,13 @@ func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime tim
 			return nil, errors.New("dequeued a leaf with incorrect hash size")
 		}
 
+		k := string(leaf.LeafIdentityHash)
+		if _, ok := t.dequeued[k]; ok {
+			// dupe, user probably called DequeueLeaves more than once.
+			continue
+		}
+		t.dequeued[k] = dqInfo
 		leaves = append(leaves, leaf)
-		dq = append(dq, dqInfo)
 	}
 
 	if rows.Err() != nil {

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -416,23 +416,12 @@ func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime tim
 		return nil, rows.Err()
 	}
 	label := labelForTX(t)
-	selectDuration := time.Since(start)
-	observe(dequeueSelectLatency, selectDuration, label)
-
-	// The convention is that if leaf processing succeeds (by committing this tx)
-	// then the unsequenced entries for them are removed
-	if len(leaves) > 0 {
-		err = t.removeSequencedLeaves(ctx, dq)
-	}
+	observe(dequeueSelectLatency, time.Since(start), label)
 
 	if err != nil {
 		return nil, err
 	}
-
-	totalDuration := time.Since(start)
-	removeDuration := totalDuration - selectDuration
-	observe(dequeueRemoveLatency, removeDuration, label)
-	observe(dequeueLatency, totalDuration, label)
+	observe(dequeueLatency, time.Since(start), label)
 	dequeuedCounter.Add(float64(len(leaves)), label)
 
 	return leaves, nil

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -294,6 +294,14 @@ func TestDequeueLeaves(t *testing.T) {
 				t.Fatalf("Dequeued %d leaves but expected to get %d", len(leaves2), leavesToInsert)
 			}
 			ensureAllLeavesDistinct(leaves2, t)
+			iTimestamp := ptypes.TimestampNow()
+			for i, l := range leaves2 {
+				l.IntegrateTimestamp = iTimestamp
+				l.LeafIndex = int64(i)
+			}
+			if err := tx2.UpdateSequencedLeaves(ctx, leaves2); err != nil {
+				t.Fatalf("UpdateSequencedLeaves(): %v", err)
+			}
 			return nil
 		})
 	}
@@ -372,6 +380,14 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 			}
 			ensureAllLeavesDistinct(leaves2, t)
 			ensureLeavesHaveQueueTimestamp(t, leaves2, fakeDequeueCutoffTime)
+			iTimestamp := ptypes.TimestampNow()
+			for i, l := range leaves2 {
+				l.IntegrateTimestamp = iTimestamp
+				l.LeafIndex = int64(i)
+			}
+			if err := tx2.UpdateSequencedLeaves(ctx, leaves2); err != nil {
+				t.Fatalf("UpdateSequencedLeaves(): %v", err)
+			}
 			return nil
 		})
 
@@ -390,6 +406,14 @@ func TestDequeueLeavesTwoBatches(t *testing.T) {
 			// Plus the union of the leaf batches should all have distinct hashes
 			leaves4 = append(leaves2, leaves3...)
 			ensureAllLeavesDistinct(leaves4, t)
+			iTimestamp := ptypes.TimestampNow()
+			for i, l := range leaves3 {
+				l.IntegrateTimestamp = iTimestamp
+				l.LeafIndex = int64(i + leavesToDequeue1)
+			}
+			if err := tx3.UpdateSequencedLeaves(ctx, leaves3); err != nil {
+				t.Fatalf("UpdateSequencedLeaves(): %v", err)
+			}
 			return nil
 		})
 	}
@@ -490,6 +514,15 @@ func TestDequeueLeavesTimeOrdering(t *testing.T) {
 			if !leafInBatch(dequeue1[0], leaves2) || !leafInBatch(dequeue1[1], leaves2) {
 				t.Fatalf("Got leaf from wrong batch (1st dequeue): %v", dequeue1)
 			}
+			iTimestamp := ptypes.TimestampNow()
+			for i, l := range dequeue1 {
+				l.IntegrateTimestamp = iTimestamp
+				l.LeafIndex = int64(i)
+			}
+			if err := tx2.UpdateSequencedLeaves(ctx, dequeue1); err != nil {
+				t.Fatalf("UpdateSequencedLeaves(): %v", err)
+			}
+
 			return nil
 		})
 

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -107,7 +107,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 
 		qe, ok := t.dequeued[string(leaf.LeafIdentityHash)]
 		if !ok {
-			return fmt.Errorf("attempting to assign unknown merkleleafhash %x", leaf.MerkleLeafHash)
+			return fmt.Errorf("attempting to update leaf that wasn't dequeued. IdentityHash: %x", leaf.LeafIdentityHash)
 		}
 		dequeuedLeaves = append(dequeuedLeaves, qe)
 	}

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -95,6 +95,7 @@ func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []in
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
 	querySuffix := []string{}
 	args := []interface{}{}
+	dequeuedLeaves := make([]dequeuedLeaf, 0, len(leaves))
 	for _, leaf := range leaves {
 		iTimestamp, err := ptypes.Timestamp(leaf.IntegrateTimestamp)
 		if err != nil {
@@ -102,12 +103,21 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 		}
 		querySuffix = append(querySuffix, valuesPlaceholder5)
 		args = append(args, t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano())
+		qe, ok := t.dequeued[string(leaf.LeafIdentityHash)]
+		if !ok {
+			return fmt.Errorf("attempting to assign unknown merkleleafhash %x", leaf.MerkleLeafHash)
+		}
+		dequeuedLeaves = append(dequeuedLeaves, qe)
 	}
 	result, err := t.tx.ExecContext(ctx, insertSequencedLeafSQL+strings.Join(querySuffix, ","), args...)
 	if err != nil {
 		glog.Warningf("Failed to update sequenced leaves: %s", err)
 	}
-	return checkResultOkAndRowCountIs(result, err, int64(len(leaves)))
+	if err := checkResultOkAndRowCountIs(result, err, int64(len(leaves))); err != nil {
+		return err
+	}
+
+	return t.removeSequencedLeaves(ctx, dequeuedLeaves)
 }
 
 func (m *mySQLLogStorage) getDeleteUnsequencedStmt(ctx context.Context, num int) (*sql.Stmt, error) {

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -105,7 +105,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 		args = append(args, t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano())
 		qe, ok := t.dequeued[string(leaf.LeafIdentityHash)]
 		if !ok {
-			return fmt.Errorf("attempting to assign unknown merkleleafhash %x", leaf.MerkleLeafHash)
+			return fmt.Errorf("attempting to update leaf that wasn't dequeued. IdentityHash: %x", leaf.LeafIdentityHash)
 		}
 		dequeuedLeaves = append(dequeuedLeaves, qe)
 	}


### PR DESCRIPTION
This change brings the mysql implementation into line with what spanner does so we can have a consistent behavior between implementations. 

Previous behavior:
- mysql impl deleted leaves from the queue inside `Dequeue`
- spanner does not delete inside `Dequeue`, it does it in `UpdateLeaves`

New / spanner behavior:
- mysql deletes leaves inside of `UpdateLeaves`
- updated mysql tests

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
