### PR TITLE
Refactor rehasher tests

### DIFF
--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -41,21 +41,22 @@ type rehashTest struct {
 // An arbitrary tree revision to be used in tests.
 const testTreeRevision int64 = 3
 
-// Raw hashes for dummy storage nodes
-var h1 = th.HashLeaf([]byte("Hash 1"))
-var h2 = th.HashLeaf([]byte("Hash 2"))
-var h3 = th.HashLeaf([]byte("Hash 3"))
-var h4 = th.HashLeaf([]byte("Hash 4"))
-var h5 = th.HashLeaf([]byte("Hash 5"))
-
-// And the dummy nodes themselves.
-var sn1 = tree.Node{NodeID: tree.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
-var sn2 = tree.Node{NodeID: tree.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
-var sn3 = tree.Node{NodeID: tree.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
-var sn4 = tree.Node{NodeID: tree.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
-var sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
-
 func TestRehasher(t *testing.T) {
+	var (
+		// Raw hashes for dummy storage nodes.
+		h1 = th.HashLeaf([]byte("Hash 1"))
+		h2 = th.HashLeaf([]byte("Hash 2"))
+		h3 = th.HashLeaf([]byte("Hash 3"))
+		h4 = th.HashLeaf([]byte("Hash 4"))
+		h5 = th.HashLeaf([]byte("Hash 5"))
+		// And the dummy nodes themselves.
+		sn1 = tree.Node{NodeID: tree.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
+		sn2 = tree.Node{NodeID: tree.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
+		sn3 = tree.Node{NodeID: tree.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
+		sn4 = tree.Node{NodeID: tree.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
+		sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
+	)
+
 	hasher := rfc6962.DefaultHasher
 	rehashTests := []rehashTest{
 		{

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -85,22 +85,19 @@ func TestRehasher(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := &rehasher{th: th}
+			r := rehasher{th: th}
 			for i, hash := range tc.hashes {
-				// TODO(pavelkalinnikov): Pass hash directly.
+				// TODO(pavelkalinnikov): Pass the hash and rehash directly.
 				r.process(tree.Node{Hash: hash}, merkle.NodeFetch{Rehash: tc.rehash[i]})
 			}
-
+			got, err := r.rehashedProof(tc.index)
+			if err != nil {
+				t.Fatalf("rehashedProof: %v", err)
+			}
 			want := &trillian.Proof{
 				LeafIndex: tc.index,
 				Hashes:    tc.want,
 			}
-			got, err := r.rehashedProof(tc.index)
-
-			if err != nil {
-				t.Fatalf("rehashedProof: %v", err)
-			}
-
 			if !proto.Equal(got, want) {
 				t.Errorf("proofs mismatch:\ngot: %v\nwant: %v", got, want)
 			}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -77,6 +77,8 @@ func TestRehasher(t *testing.T) {
 			want:   [][]byte{h[0], th.HashChildren(h[3], th.HashChildren(h[2], h[1])), h[4]},
 		},
 		{
+			// TODO(pavelkalinnikov): This will never happen in our use-case. Design
+			// the type to not allow multi-rehash by design.
 			desc:   "multiple rehash",
 			index:  45,
 			hashes: h[:5],

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -40,16 +40,10 @@ func TestRehasher(t *testing.T) {
 		th.HashLeaf([]byte("Hash 4")),
 		th.HashLeaf([]byte("Hash 5")),
 	}
+	// Note: Node IDs and revisions are ignored by the algorithm.
 	nodes := []tree.Node{
-		{NodeID: tree.NewNodeIDFromHash(h[0]), Hash: h[0], NodeRevision: 11},
-		{NodeID: tree.NewNodeIDFromHash(h[1]), Hash: h[1], NodeRevision: 22},
-		{NodeID: tree.NewNodeIDFromHash(h[2]), Hash: h[2], NodeRevision: 33},
-		{NodeID: tree.NewNodeIDFromHash(h[3]), Hash: h[3], NodeRevision: 44},
-		{NodeID: tree.NewNodeIDFromHash(h[4]), Hash: h[4], NodeRevision: 55},
-	}
+		{Hash: h[0]}, {Hash: h[1]}, {Hash: h[2]}, {Hash: h[3]}, {Hash: h[4]}}
 
-	// For each test, input data like the storage hashes and revisions can be
-	// arbitrary but the nodes should have distinct values.
 	for _, rehashTest := range []struct {
 		desc    string
 		index   int64

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -44,7 +44,7 @@ func TestRehasher(t *testing.T) {
 	nodes := []tree.Node{
 		{Hash: h[0]}, {Hash: h[1]}, {Hash: h[2]}, {Hash: h[3]}, {Hash: h[4]}}
 
-	for _, rehashTest := range []struct {
+	for _, tc := range []struct {
 		desc    string
 		index   int64
 		nodes   []tree.Node
@@ -88,22 +88,22 @@ func TestRehasher(t *testing.T) {
 		},
 	} {
 		r := &rehasher{th: th}
-		for i, node := range rehashTest.nodes {
-			r.process(node, rehashTest.fetches[i])
+		for i, node := range tc.nodes {
+			r.process(node, tc.fetches[i])
 		}
 
 		want := &trillian.Proof{
-			LeafIndex: rehashTest.index,
-			Hashes:    rehashTest.want,
+			LeafIndex: tc.index,
+			Hashes:    tc.want,
 		}
-		got, err := r.rehashedProof(rehashTest.index)
+		got, err := r.rehashedProof(tc.index)
 
 		if err != nil {
-			t.Fatalf("rehash test %s unexpected error: %v", rehashTest.desc, err)
+			t.Fatalf("rehash test %s unexpected error: %v", tc.desc, err)
 		}
 
 		if !proto.Equal(got, want) {
-			t.Errorf("rehash test %s:\ngot: %v\nwant: %v", rehashTest.desc, got, want)
+			t.Errorf("rehash test %s:\ngot: %v\nwant: %v", tc.desc, got, want)
 		}
 	}
 }

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -87,24 +87,26 @@ func TestRehasher(t *testing.T) {
 			want:    [][]byte{th.HashChildren(h[1], h[0]), h[2], th.HashChildren(h[4], h[3])},
 		},
 	} {
-		r := &rehasher{th: th}
-		for i, node := range tc.nodes {
-			r.process(node, tc.fetches[i])
-		}
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &rehasher{th: th}
+			for i, node := range tc.nodes {
+				r.process(node, tc.fetches[i])
+			}
 
-		want := &trillian.Proof{
-			LeafIndex: tc.index,
-			Hashes:    tc.want,
-		}
-		got, err := r.rehashedProof(tc.index)
+			want := &trillian.Proof{
+				LeafIndex: tc.index,
+				Hashes:    tc.want,
+			}
+			got, err := r.rehashedProof(tc.index)
 
-		if err != nil {
-			t.Fatalf("rehash test %s unexpected error: %v", tc.desc, err)
-		}
+			if err != nil {
+				t.Fatalf("rehashedProof: %v", err)
+			}
 
-		if !proto.Equal(got, want) {
-			t.Errorf("rehash test %s:\ngot: %v\nwant: %v", tc.desc, got, want)
-		}
+			if !proto.Equal(got, want) {
+				t.Errorf("proofs mismatch:\ngot: %v\nwant: %v", got, want)
+			}
+		})
 	}
 }
 

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -33,20 +33,20 @@ const testTreeRevision int64 = 3
 
 func TestRehasher(t *testing.T) {
 	th := rfc6962.DefaultHasher
-	var (
-		// Raw hashes for dummy storage nodes.
-		h1 = th.HashLeaf([]byte("Hash 1"))
-		h2 = th.HashLeaf([]byte("Hash 2"))
-		h3 = th.HashLeaf([]byte("Hash 3"))
-		h4 = th.HashLeaf([]byte("Hash 4"))
-		h5 = th.HashLeaf([]byte("Hash 5"))
-		// And the dummy nodes themselves.
-		sn1 = tree.Node{NodeID: tree.NewNodeIDFromHash(h1), Hash: h1, NodeRevision: 11}
-		sn2 = tree.Node{NodeID: tree.NewNodeIDFromHash(h2), Hash: h2, NodeRevision: 22}
-		sn3 = tree.Node{NodeID: tree.NewNodeIDFromHash(h3), Hash: h3, NodeRevision: 33}
-		sn4 = tree.Node{NodeID: tree.NewNodeIDFromHash(h4), Hash: h4, NodeRevision: 44}
-		sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
-	)
+	h := [][]byte{
+		th.HashLeaf([]byte("Hash 1")),
+		th.HashLeaf([]byte("Hash 2")),
+		th.HashLeaf([]byte("Hash 3")),
+		th.HashLeaf([]byte("Hash 4")),
+		th.HashLeaf([]byte("Hash 5")),
+	}
+	nodes := []tree.Node{
+		{NodeID: tree.NewNodeIDFromHash(h[0]), Hash: h[0], NodeRevision: 11},
+		{NodeID: tree.NewNodeIDFromHash(h[1]), Hash: h[1], NodeRevision: 22},
+		{NodeID: tree.NewNodeIDFromHash(h[2]), Hash: h[2], NodeRevision: 33},
+		{NodeID: tree.NewNodeIDFromHash(h[3]), Hash: h[3], NodeRevision: 44},
+		{NodeID: tree.NewNodeIDFromHash(h[4]), Hash: h[4], NodeRevision: 55},
+	}
 
 	// For each test, input data like the storage hashes and revisions can be
 	// arbitrary but the nodes should have distinct values.
@@ -60,51 +60,51 @@ func TestRehasher(t *testing.T) {
 		{
 			desc:    "no rehash",
 			index:   126,
-			nodes:   []tree.Node{sn1, sn2, sn3},
+			nodes:   nodes[:3],
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: false}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 126,
-				Hashes:    [][]byte{h1, h2, h3},
+				Hashes:    h[:3],
 			},
 		},
 		{
 			desc:    "single rehash",
 			index:   999,
-			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   nodes[:5],
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 999,
-				Hashes:    [][]byte{h1, th.HashChildren(h3, h2), h4, h5},
+				Hashes:    [][]byte{h[0], th.HashChildren(h[2], h[1]), h[3], h[4]},
 			},
 		},
 		{
 			desc:    "single rehash at end",
 			index:   11,
-			nodes:   []tree.Node{sn1, sn2, sn3},
+			nodes:   nodes[:3],
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}},
 			output: &trillian.Proof{
 				LeafIndex: 11,
-				Hashes:    [][]byte{h1, th.HashChildren(h3, h2)},
+				Hashes:    [][]byte{h[0], th.HashChildren(h[2], h[1])},
 			},
 		},
 		{
 			desc:    "single rehash multiple nodes",
 			index:   23,
-			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   nodes[:5],
 			fetches: []merkle.NodeFetch{{Rehash: false}, {Rehash: true}, {Rehash: true}, {Rehash: true}, {Rehash: false}},
 			output: &trillian.Proof{
 				LeafIndex: 23,
-				Hashes:    [][]byte{h1, th.HashChildren(h4, th.HashChildren(h3, h2)), h5},
+				Hashes:    [][]byte{h[0], th.HashChildren(h[3], th.HashChildren(h[2], h[1])), h[4]},
 			},
 		},
 		{
 			desc:    "multiple rehash",
 			index:   45,
-			nodes:   []tree.Node{sn1, sn2, sn3, sn4, sn5},
+			nodes:   nodes[:5],
 			fetches: []merkle.NodeFetch{{Rehash: true}, {Rehash: true}, {Rehash: false}, {Rehash: true}, {Rehash: true}},
 			output: &trillian.Proof{
 				LeafIndex: 45,
-				Hashes:    [][]byte{th.HashChildren(h2, h1), h3, th.HashChildren(h5, h4)},
+				Hashes:    [][]byte{th.HashChildren(h[1], h[0]), h[2], th.HashChildren(h[4], h[3])},
 			},
 		},
 	} {

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -42,6 +42,7 @@ type rehashTest struct {
 const testTreeRevision int64 = 3
 
 func TestRehasher(t *testing.T) {
+	th := rfc6962.DefaultHasher
 	var (
 		// Raw hashes for dummy storage nodes.
 		h1 = th.HashLeaf([]byte("Hash 1"))
@@ -57,7 +58,6 @@ func TestRehasher(t *testing.T) {
 		sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 	)
 
-	hasher := rfc6962.DefaultHasher
 	rehashTests := []rehashTest{
 		{
 			desc:    "no rehash",
@@ -112,7 +112,7 @@ func TestRehasher(t *testing.T) {
 	}
 
 	for _, rehashTest := range rehashTests {
-		r := &rehasher{th: hasher}
+		r := &rehasher{th: th}
 		for i, node := range rehashTest.nodes {
 			r.process(node, rehashTest.fetches[i])
 		}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -28,16 +28,6 @@ import (
 	"github.com/google/trillian/storage/tree"
 )
 
-// rehashTest encapsulates one test case for the rehasher in isolation. Input data like the storage
-// hashes and revisions can be arbitrary but the nodes should have distinct values
-type rehashTest struct {
-	desc    string
-	index   int64
-	nodes   []tree.Node
-	fetches []merkle.NodeFetch
-	output  *trillian.Proof
-}
-
 // An arbitrary tree revision to be used in tests.
 const testTreeRevision int64 = 3
 
@@ -58,7 +48,15 @@ func TestRehasher(t *testing.T) {
 		sn5 = tree.Node{NodeID: tree.NewNodeIDFromHash(h5), Hash: h5, NodeRevision: 55}
 	)
 
-	rehashTests := []rehashTest{
+	// For each test, input data like the storage hashes and revisions can be
+	// arbitrary but the nodes should have distinct values.
+	for _, rehashTest := range []struct {
+		desc    string
+		index   int64
+		nodes   []tree.Node
+		fetches []merkle.NodeFetch
+		output  *trillian.Proof
+	}{
 		{
 			desc:    "no rehash",
 			index:   126,
@@ -109,9 +107,7 @@ func TestRehasher(t *testing.T) {
 				Hashes:    [][]byte{th.HashChildren(h2, h1), h3, th.HashChildren(h5, h4)},
 			},
 		},
-	}
-
-	for _, rehashTest := range rehashTests {
+	} {
 		r := &rehasher{th: th}
 		for i, node := range rehashTest.nodes {
 			r.process(node, rehashTest.fetches[i])


### PR DESCRIPTION
This change improves readability of `rehasher` tests in preparation for
migrating the type to `merkle` package.

Part of #2143