### PR TITLE
cloudspanner: Simplify parallelism with errgroup

### DIFF
--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -340,7 +340,9 @@ func (t *treeTX) parallelGetMerkleNodes(ctx context.Context, rev int64) func([]s
 		close(c)
 		ret := make([]*storagepb.SubtreeProto, 0, len(ids))
 		for st := range c {
-			ret = append(ret, st)
+			if st != nil {
+				ret = append(ret, st)
+			}
 		}
 		return ret, nil
 	}
@@ -418,7 +420,9 @@ func (tx *mapTX) Get(ctx context.Context, revision int64, indexes [][]byte) ([]*
 	close(c)
 	ret := make([]*trillian.MapLeaf, 0, len(indexes))
 	for l := range c {
-		ret = append(ret, l)
+		if l != nil {
+			ret = append(ret, l)
+		}
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Get seems to have a deadlock in it somewhere.
This should simplify processing and ensure that when an error condition
occurs, other threads are canceled.


<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).