### PR TITLE
merkle: Move rehashing algorithm in

### DIFF
--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -179,7 +179,6 @@ type Rehasher struct {
 	rehashing  bool
 	rehashHash []byte
 	proof      [][]byte
-	proofError error
 }
 
 func (r *Rehasher) Process(hash []byte, rehash bool) {
@@ -220,9 +219,9 @@ func (r *Rehasher) endRehashing() {
 	}
 }
 
-func (r *Rehasher) RehashedProof() ([][]byte, error) {
+func (r *Rehasher) RehashedProof() [][]byte {
 	r.endRehashing()
-	return r.proof, r.proofError
+	return r.proof
 }
 
 func reverse(ids []compact.NodeID) []compact.NodeID {

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -188,9 +188,13 @@ func Rehash(h [][]byte, nf []NodeFetch, hc func(left, right []byte) []byte) ([][
 		return nil, errors.New("slice lengths mismatch")
 	}
 	cursor := 0
+	// Scan the list of node hashes, and store the rehashed list in-place.
+	// Invariant: cursor <= i, and h[:cursor] contains all the hashes of the
+	// rehashed list after scanning h up to index i-1.
 	for i, ln := 0, len(h); i < ln; i, cursor = i+1, cursor+1 {
 		hash := h[i]
 		if nf[i].Rehash {
+			// Scan the block of node hashes that need rehashing.
 			for i++; i < len(nf) && nf[i].Rehash; i++ {
 				hash = hc(h[i], hash)
 			}

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -184,34 +184,34 @@ type Rehasher struct {
 	proofError error
 }
 
-func (r *Rehasher) Process(node tree.Node, fetch NodeFetch) {
+func (r *Rehasher) Process(hash []byte, rehash bool) {
 	switch {
-	case !r.rehashing && fetch.Rehash:
+	case !r.rehashing && rehash:
 		// Start of a rehashing chain
-		r.startRehashing(node)
+		r.startRehashing(hash)
 
-	case r.rehashing && !fetch.Rehash:
+	case r.rehashing && !rehash:
 		// End of a rehash chain, resulting in a rehashed proof node
 		r.endRehashing()
 		// And the current node needs to be added to the proof
-		r.emitNode(node)
+		r.emitNode(hash)
 
-	case r.rehashing && fetch.Rehash:
+	case r.rehashing && rehash:
 		// Continue with rehashing, update the node we're recomputing
-		r.rehashNode.Hash = r.Hasher.HashChildren(node.Hash, r.rehashNode.Hash)
+		r.rehashNode.Hash = r.Hasher.HashChildren(hash, r.rehashNode.Hash)
 
 	default:
 		// Not rehashing, just pass the node through
-		r.emitNode(node)
+		r.emitNode(hash)
 	}
 }
 
-func (r *Rehasher) emitNode(node tree.Node) {
-	r.proof = append(r.proof, node.Hash)
+func (r *Rehasher) emitNode(hash []byte) {
+	r.proof = append(r.proof, hash)
 }
 
-func (r *Rehasher) startRehashing(node tree.Node) {
-	r.rehashNode = tree.Node{Hash: node.Hash}
+func (r *Rehasher) startRehashing(hash []byte) {
+	r.rehashNode = tree.Node{Hash: hash}
 	r.rehashing = true
 }
 

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math/bits"
 
-	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/storage/tree"
@@ -223,12 +222,9 @@ func (r *Rehasher) endRehashing() {
 	}
 }
 
-func (r *Rehasher) RehashedProof(leafIndex int64) (*trillian.Proof, error) {
+func (r *Rehasher) RehashedProof() ([][]byte, error) {
 	r.endRehashing()
-	return &trillian.Proof{
-		LeafIndex: leafIndex,
-		Hashes:    r.proof,
-	}, r.proofError
+	return r.proof, r.proofError
 }
 
 func reverse(ids []compact.NodeID) []compact.NodeID {

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -47,6 +47,8 @@ func checkSnapshot(ssDesc string, ss, treeSize int64) error {
 // inclusion proof for a specified leaf and tree size. The snapshot parameter
 // is the tree size being queried for, treeSize is the actual size of the tree
 // at the revision we are using to fetch nodes (this can be > snapshot).
+//
+// Use Rehash function to compose the proof after the node hashes are fetched.
 func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64) ([]NodeFetch, error) {
 	if err := checkSnapshot("snapshot", snapshot, treeSize); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for inclusion proof: %v", err)
@@ -72,6 +74,8 @@ func CalcInclusionProofNodeAddresses(snapshot, index, treeSize int64) ([]NodeFet
 // to valid tree heads. All returned NodeIDs are tree coordinates within the
 // new tree. It is assumed that they will be fetched from storage at a revision
 // corresponding to the STH associated with the treeSize parameter.
+//
+// Use Rehash function to compose the proof after the node hashes are fetched.
 func CalcConsistencyProofNodeAddresses(snapshot1, snapshot2, treeSize int64) ([]NodeFetch, error) {
 	if err := checkSnapshot("snapshot1", snapshot1, treeSize); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: %v", err)

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -19,7 +19,6 @@ import (
 	"math/bits"
 
 	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/storage/tree"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -177,7 +176,7 @@ func proofNodes(index uint64, level uint, size uint64, rehash bool) []NodeFetch 
 
 // Rehasher bundles the rehashing logic into a simple state machine
 type Rehasher struct {
-	Hasher     hashers.LogHasher
+	Hash       func(left, right []byte) []byte
 	rehashing  bool
 	rehashNode tree.Node
 	proof      [][]byte
@@ -198,7 +197,7 @@ func (r *Rehasher) Process(hash []byte, rehash bool) {
 
 	case r.rehashing && rehash:
 		// Continue with rehashing, update the node we're recomputing
-		r.rehashNode.Hash = r.Hasher.HashChildren(hash, r.rehashNode.Hash)
+		r.rehashNode.Hash = r.Hash(hash, r.rehashNode.Hash)
 
 	default:
 		// Not rehashing, just pass the node through

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -344,7 +344,7 @@ func TestRehasher(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := Rehasher{Hasher: th}
+			r := Rehasher{Hash: th.HashChildren}
 			for i, hash := range tc.hashes {
 				r.Process(hash, tc.rehash[i])
 			}

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -344,11 +344,16 @@ func TestRehasher(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := Rehasher{Hash: th.HashChildren}
-			for i, hash := range tc.hashes {
-				r.Process(hash, tc.rehash[i])
+			nf := make([]NodeFetch, len(tc.rehash))
+			for i, r := range tc.rehash {
+				nf[i].Rehash = r
 			}
-			if got, want := r.RehashedProof(), tc.want; !cmp.Equal(got, want) {
+			h := append([][]byte{}, tc.hashes...)
+			got, err := Rehash(h, nf, th.HashChildren)
+			if err != nil {
+				t.Errorf("Rehash: %v", err)
+			}
+			if want := tc.want; !cmp.Equal(got, want) {
 				t.Errorf("proofs mismatch:\ngot: %x\nwant: %x", got, want)
 			}
 		})

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -18,8 +18,13 @@ import (
 	"fmt"
 	"testing"
 
+	//nolint:staticcheck
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/compact"
+	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/google/trillian/storage/tree"
 )
 
 // TestCalcInclusionProofNodeAddresses contains inclusion proof tests. For
@@ -290,6 +295,82 @@ func TestConsistencySucceedsUpToTreeSize(t *testing.T) {
 				t.Errorf("CalcConsistencyProofNodeAddresses(%d, %d) = %v", s1, s2, err)
 			}
 		}
+	}
+}
+
+func TestRehasher(t *testing.T) {
+	th := rfc6962.DefaultHasher
+	h := [][]byte{
+		th.HashLeaf([]byte("Hash 1")),
+		th.HashLeaf([]byte("Hash 2")),
+		th.HashLeaf([]byte("Hash 3")),
+		th.HashLeaf([]byte("Hash 4")),
+		th.HashLeaf([]byte("Hash 5")),
+	}
+
+	for _, tc := range []struct {
+		desc   string
+		index  int64
+		hashes [][]byte
+		rehash []bool
+		want   [][]byte
+	}{
+		{
+			desc:   "no rehash",
+			index:  126,
+			hashes: h[:3],
+			rehash: []bool{false, false, false},
+			want:   h[:3],
+		},
+		{
+			desc:   "single rehash",
+			index:  999,
+			hashes: h[:5],
+			rehash: []bool{false, true, true, false, false},
+			want:   [][]byte{h[0], th.HashChildren(h[2], h[1]), h[3], h[4]},
+		},
+		{
+			desc:   "single rehash at end",
+			index:  11,
+			hashes: h[:3],
+			rehash: []bool{false, true, true},
+			want:   [][]byte{h[0], th.HashChildren(h[2], h[1])},
+		},
+		{
+			desc:   "single rehash multiple nodes",
+			index:  23,
+			hashes: h[:5],
+			rehash: []bool{false, true, true, true, false},
+			want:   [][]byte{h[0], th.HashChildren(h[3], th.HashChildren(h[2], h[1])), h[4]},
+		},
+		{
+			// TODO(pavelkalinnikov): This will never happen in our use-case. Design
+			// the type to not allow multi-rehash by design.
+			desc:   "multiple rehash",
+			index:  45,
+			hashes: h[:5],
+			rehash: []bool{true, true, false, true, true},
+			want:   [][]byte{th.HashChildren(h[1], h[0]), h[2], th.HashChildren(h[4], h[3])},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := Rehasher{Hasher: th}
+			for i, hash := range tc.hashes {
+				// TODO(pavelkalinnikov): Pass the hash and rehash directly.
+				r.Process(tree.Node{Hash: hash}, NodeFetch{Rehash: tc.rehash[i]})
+			}
+			got, err := r.RehashedProof(tc.index)
+			if err != nil {
+				t.Fatalf("rehashedProof: %v", err)
+			}
+			want := &trillian.Proof{
+				LeafIndex: tc.index,
+				Hashes:    tc.want,
+			}
+			if !proto.Equal(got, want) {
+				t.Errorf("proofs mismatch:\ngot: %v\nwant: %v", got, want)
+			}
+		})
 	}
 }
 

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -348,11 +348,7 @@ func TestRehasher(t *testing.T) {
 			for i, hash := range tc.hashes {
 				r.Process(hash, tc.rehash[i])
 			}
-			got, err := r.RehashedProof()
-			if err != nil {
-				t.Fatalf("rehashedProof: %v", err)
-			}
-			if want := tc.want; !cmp.Equal(got, want) {
+			if got, want := r.RehashedProof(), tc.want; !cmp.Equal(got, want) {
 				t.Errorf("proofs mismatch:\ngot: %x\nwant: %x", got, want)
 			}
 		})

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/google/trillian/storage/tree"
 )
 
 // TestCalcInclusionProofNodeAddresses contains inclusion proof tests. For
@@ -347,8 +346,7 @@ func TestRehasher(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			r := Rehasher{Hasher: th}
 			for i, hash := range tc.hashes {
-				// TODO(pavelkalinnikov): Pass the hash and rehash directly.
-				r.Process(tree.Node{Hash: hash}, NodeFetch{Rehash: tc.rehash[i]})
+				r.Process(hash, tc.rehash[i])
 			}
 			got, err := r.RehashedProof()
 			if err != nil {

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -43,7 +43,7 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 
 	r := merkle.Rehasher{Hasher: th}
 	for i, node := range proofNodes {
-		r.Process(node, proofNodeFetches[i])
+		r.Process(node.Hash, proofNodeFetches[i].Rehash)
 	}
 
 	proof, err := r.RehashedProof()

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -41,14 +41,18 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 		return nil, err
 	}
 
-	r := merkle.Rehasher{Hash: th.HashChildren}
+	h := make([][]byte, len(proofNodes))
 	for i, node := range proofNodes {
-		r.Process(node.Hash, proofNodeFetches[i].Rehash)
+		h[i] = node.Hash
+	}
+	proof, err := merkle.Rehash(h, proofNodeFetches, th.HashChildren)
+	if err != nil {
+		return nil, err
 	}
 
 	return &trillian.Proof{
 		LeafIndex: leafIndex,
-		Hashes:    r.RehashedProof(),
+		Hashes:    proof,
 	}, nil
 }
 

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -46,11 +46,10 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 		r.Process(node.Hash, proofNodeFetches[i].Rehash)
 	}
 
-	proof, err := r.RehashedProof()
 	return &trillian.Proof{
 		LeafIndex: leafIndex,
-		Hashes:    proof,
-	}, err
+		Hashes:    r.RehashedProof(),
+	}, nil
 }
 
 // fetchNodes extracts the NodeIDs from a list of NodeFetch structs and passes them

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -41,7 +41,7 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 		return nil, err
 	}
 
-	r := merkle.Rehasher{Hasher: th}
+	r := merkle.Rehasher{Hash: th.HashChildren}
 	for i, node := range proofNodes {
 		r.Process(node.Hash, proofNodeFetches[i].Rehash)
 	}

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -46,7 +46,11 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 		r.Process(node, proofNodeFetches[i])
 	}
 
-	return r.RehashedProof(leafIndex)
+	proof, err := r.RehashedProof()
+	return &trillian.Proof{
+		LeafIndex: leafIndex,
+		Hashes:    proof,
+	}, err
 }
 
 // fetchNodes extracts the NodeIDs from a list of NodeFetch structs and passes them

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -49,6 +49,9 @@ func TestTree813FetchAll(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		if got, want := proof.LeafIndex, int64(l); got != want {
+			t.Errorf("leaf index mismatch: got %d, want %d", got, want)
+		}
 
 		// We use +1 here because of the 1 based leaf indexing of this implementation
 		refProof := mt.PathToRootAtSnapshot(l+1, ts)
@@ -87,6 +90,9 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 				proof, err := fetchNodesAndBuildProof(ctx, r, hasher, testTreeRevision, int64(l), fetches)
 				if err != nil {
 					t.Fatal(err)
+				}
+				if got, want := proof.LeafIndex, int64(l); got != want {
+					t.Errorf("leaf index mismatch: got %d, want %d", got, want)
 				}
 
 				// We use +1 here because of the 1 based leaf indexing of this implementation

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -20,92 +20,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck
-	"github.com/google/trillian"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/storage/testonly"
-	"github.com/google/trillian/storage/tree"
 )
 
 // An arbitrary tree revision to be used in tests.
 const testTreeRevision int64 = 3
-
-func TestRehasher(t *testing.T) {
-	th := rfc6962.DefaultHasher
-	h := [][]byte{
-		th.HashLeaf([]byte("Hash 1")),
-		th.HashLeaf([]byte("Hash 2")),
-		th.HashLeaf([]byte("Hash 3")),
-		th.HashLeaf([]byte("Hash 4")),
-		th.HashLeaf([]byte("Hash 5")),
-	}
-
-	for _, tc := range []struct {
-		desc   string
-		index  int64
-		hashes [][]byte
-		rehash []bool
-		want   [][]byte
-	}{
-		{
-			desc:   "no rehash",
-			index:  126,
-			hashes: h[:3],
-			rehash: []bool{false, false, false},
-			want:   h[:3],
-		},
-		{
-			desc:   "single rehash",
-			index:  999,
-			hashes: h[:5],
-			rehash: []bool{false, true, true, false, false},
-			want:   [][]byte{h[0], th.HashChildren(h[2], h[1]), h[3], h[4]},
-		},
-		{
-			desc:   "single rehash at end",
-			index:  11,
-			hashes: h[:3],
-			rehash: []bool{false, true, true},
-			want:   [][]byte{h[0], th.HashChildren(h[2], h[1])},
-		},
-		{
-			desc:   "single rehash multiple nodes",
-			index:  23,
-			hashes: h[:5],
-			rehash: []bool{false, true, true, true, false},
-			want:   [][]byte{h[0], th.HashChildren(h[3], th.HashChildren(h[2], h[1])), h[4]},
-		},
-		{
-			// TODO(pavelkalinnikov): This will never happen in our use-case. Design
-			// the type to not allow multi-rehash by design.
-			desc:   "multiple rehash",
-			index:  45,
-			hashes: h[:5],
-			rehash: []bool{true, true, false, true, true},
-			want:   [][]byte{th.HashChildren(h[1], h[0]), h[2], th.HashChildren(h[4], h[3])},
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			r := rehasher{th: th}
-			for i, hash := range tc.hashes {
-				// TODO(pavelkalinnikov): Pass the hash and rehash directly.
-				r.process(tree.Node{Hash: hash}, merkle.NodeFetch{Rehash: tc.rehash[i]})
-			}
-			got, err := r.rehashedProof(tc.index)
-			if err != nil {
-				t.Fatalf("rehashedProof: %v", err)
-			}
-			want := &trillian.Proof{
-				LeafIndex: tc.index,
-				Hashes:    tc.want,
-			}
-			if !proto.Equal(got, want) {
-				t.Errorf("proofs mismatch:\ngot: %v\nwant: %v", got, want)
-			}
-		})
-	}
-}
 
 func TestTree813FetchAll(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
This change moves the `rehasher` algorithm to `merkle` package, and refactors it
to be a single function.

Part of #2143