### PR TITLE
Travis: go mod tidy allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-version: ~> 1.0
 os: linux
 dist: xenial
 language: go
@@ -134,7 +133,7 @@ jobs:
         - mysql -u root -e 'SHOW VARIABLES LIKE "%version%";'
         - go test ./storage/mysql/...
         - ./integration/integration_test.sh && HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
-  - allow_failures:
+  allow_failures:
     - name: "go mod tidy"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 jobs:
   fast_finish: true
   include:
-    - name: "gomod"
+    - name: "gomodtidy"
       before_install: skip
       install: skip
       before_script: go mod tidy -v
@@ -135,7 +135,7 @@ jobs:
         - go test ./storage/mysql/...
         - ./integration/integration_test.sh && HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
   - allow_failures:
-    - name "gomod"
+    - name: "gomodtidy"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 jobs:
   fast_finish: true
   include:
-    - name: "gomodtidy"
+    - name: "go mod tidy"
       before_install: skip
       install: skip
       before_script: go mod tidy -v
@@ -135,7 +135,7 @@ jobs:
         - go test ./storage/mysql/...
         - ./integration/integration_test.sh && HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
   - allow_failures:
-    - name: "gomodtidy"
+    - name: "go mod tidy"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ cache:
 jobs:
   fast_finish: true
   include:
+    - name: "gomod"
+      before_install: skip
+      install: skip
+      before_script: go mod tidy -v
+      script: git diff --exit-code -- go.mod go.sum
     - name: "build"
       before_install: skip
       install: skip
@@ -54,11 +59,6 @@ jobs:
         # that would be trimmed by 'go mod tidy'
         echo "Checking that generated files are the same as checked-in versions."
         git diff --exit-code -- ':!*.pb.go' ':!*_string.go' ':!go.*'
-    - name: "gomod"
-      before_install: skip
-      install: skip
-      before_script: go mod tidy -v
-      script: git diff --exit-code -- go.mod go.sum
     - name: "lint"
       before_install: skip
       install:
@@ -134,6 +134,8 @@ jobs:
         - mysql -u root -e 'SHOW VARIABLES LIKE "%version%";'
         - go test ./storage/mysql/...
         - ./integration/integration_test.sh && HAMMER_OPTS="--operations=50" ./integration/maphammer.sh 3
+  - allow_failures:
+    - name "gomod"
 
 services:
   - docker


### PR DESCRIPTION
Make the Travis `go mod tidy` check advisory.
Bumps the test to the top of the list too, so that it's in the same place on all our repos.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
