### PR TITLE
Fix go 1.15 warnings about into to string conversion.

### DIFF
--- a/storage/tree/node_id2_test.go
+++ b/storage/tree/node_id2_test.go
@@ -180,7 +180,7 @@ func BenchmarkNodeID2Siblings(b *testing.B) {
 	const batch = 512
 	ids := make([]NodeID2, batch)
 	for i := range ids {
-		bytes := "0123456789012345678901234567" + string(i&255) + string((i>>8)&255)
+		bytes := fmt.Sprintf("0123456789012345678901234567%02x%02x", i&255, (i>>8)&255)
 		ids[i] = NewNodeID2(bytes, uint(len(bytes))*8)
 	}
 	for i, n := 0, b.N; i < n; i++ {


### PR DESCRIPTION
Fixes the warnings that were added in go 1.15:

```
storage/tree/node_id2_test.go:183:45: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
storage/tree/node_id2_test.go:183:61: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```


<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
