### PR TITLE
Fix iteration bug in memory/log_storage.go

### DIFF
--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -333,7 +333,7 @@ func (t *logTreeTX) GetLeavesByHash(ctx context.Context, leafHashes [][]byte, or
 	m := t.tx.Get(hashToSeqKey(t.treeID)).(*kv).v.(map[string][]int64)
 
 	ret := make([]*trillian.LogLeaf, 0, len(leafHashes))
-	for hash := range leafHashes {
+	for _, hash := range leafHashes {
 		seq, ok := m[string(hash)]
 		if !ok {
 			continue


### PR DESCRIPTION
Need to iterate over values not keys.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
