### PR TITLE
Tag redistb_test as an integration test.

### DIFF
--- a/quota/redis/redistb/redistb_test.go
+++ b/quota/redis/redistb/redistb_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 // Copyright 2017 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
It will not be run with the default "go test ./...". To run it,
you need to have a redis server running and then add the
"-tags=integration" flag to "go test".

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
