### PR TITLE
remove PeekTokens from quota.Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### Misc improvements
+
+ * Removed unused `PeekTokens` method from the `quota.Manager` interface.
+
 ## v1.3.11
 [Published 2020-10-06](https://github.com/google/trillian/releases/tag/v1.3.11)
 

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.37 h1:gBtB/F3dophWpsUQKN/Kni+JzYEH2mGHF4hWNtfED1w=
 github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.27.0 h1:0xphMHGMLBrPMfxR2AmVjZKcMEESEgWF8Kru94BNByk=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -214,6 +215,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -442,6 +444,7 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
+github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -455,6 +458,7 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
+github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -462,6 +466,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/pseudomuto/protoc-gen-doc v1.3.2 h1:61vWZuxYa8D7Rn4h+2dgoTNqnluBmJya2MgbqO32z6g=
 github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=
@@ -483,6 +488,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -563,6 +569,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -693,6 +700,7 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -882,6 +890,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.6 h1:97YCGUei5WVbkKfogoJQsLwUJ17cWvpLrgNvlcbxikE=
 gopkg.in/yaml.v2 v2.2.6/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/quota/cacheqm/cache.go
+++ b/quota/cacheqm/cache.go
@@ -77,11 +77,6 @@ func NewCachedManager(qm quota.Manager, minBatchSize, maxEntries int) (quota.Man
 	}, nil
 }
 
-// PeekTokens implements Manager.PeekTokens.
-func (m *manager) PeekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
-	return m.qm.PeekTokens(ctx, specs)
-}
-
 // PutTokens implements Manager.PutTokens.
 func (m *manager) PutTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
 	return m.qm.PutTokens(ctx, numTokens, specs)

--- a/quota/etcd/etcdqm/etcdqm.go
+++ b/quota/etcd/etcdqm/etcdqm.go
@@ -29,7 +29,7 @@ type manager struct {
 }
 
 // New returns a new etcd-based quota.Manager.
-func New(client *clientv3.Client) quota.Manager {
+func New(client *clientv3.Client) *manager {
 	return &manager{qs: &storage.QuotaStorage{Client: client}}
 }
 
@@ -38,8 +38,7 @@ func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Sp
 	return m.qs.Get(ctx, configNames(specs), int64(numTokens))
 }
 
-// PeekTokens implements the quota.Manager API.
-func (m *manager) PeekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
+func (m *manager) peekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
 	names := configNames(specs)
 	nameToSpec := make(map[string]quota.Spec)
 	for i, name := range names {

--- a/quota/etcd/etcdqm/etcdqm_test.go
+++ b/quota/etcd/etcdqm/etcdqm_test.go
@@ -163,49 +163,6 @@ func TestManager_GetTokensErrors(t *testing.T) {
 	}
 }
 
-func TestManager_PeekTokens(t *testing.T) {
-	ctx := context.Background()
-	qs := &storage.QuotaStorage{Client: client}
-	if err := reset(ctx, qs, cfgs); err != nil {
-		t.Fatalf("reset() returned err = %v", err)
-	}
-
-	tests := []struct {
-		desc  string
-		specs []quota.Spec
-		want  map[quota.Spec]int
-	}{
-		{
-			desc:  "singleSpec",
-			specs: []quota.Spec{globalWriteSpec},
-			want: map[quota.Spec]int{
-				globalWriteSpec: int(globalWriteConfig.MaxTokens),
-			},
-		},
-		{
-			desc:  "multiSpecs",
-			specs: []quota.Spec{userReadSpec, treeWriteSpec, globalWriteSpec},
-			want: map[quota.Spec]int{
-				globalWriteSpec: int(globalWriteConfig.MaxTokens),
-				treeWriteSpec:   int(treeWriteConfig.MaxTokens),
-				userReadSpec:    int(userReadConfig.MaxTokens),
-			},
-		},
-	}
-
-	qm := New(client)
-	for _, test := range tests {
-		tokens, err := qm.PeekTokens(ctx, test.specs)
-		if err != nil {
-			t.Errorf("%v: PeekTokens() returned err = %v", test.desc, err)
-			continue
-		}
-		if diff := cmp.Diff(tokens, test.want); diff != "" {
-			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
-		}
-	}
-}
-
 func TestManager_PutTokens(t *testing.T) {
 	ctx := context.Background()
 	qs := &storage.QuotaStorage{Client: client}
@@ -282,12 +239,12 @@ func TestManager_ResetQuota(t *testing.T) {
 			t.Errorf("%v: ResetQuota() returned err = %v", test.desc, err)
 			continue
 		}
-		tokens, err := qm.PeekTokens(ctx, test.specs)
+		tokens, err := qm.peekTokens(ctx, test.specs)
 		if err != nil {
-			t.Fatalf("%v: PeekTokens() returned err = %v", test.desc, err)
+			t.Fatalf("%v: peekTokens() returned err = %v", test.desc, err)
 		}
 		if diff := cmp.Diff(tokens, test.want); diff != "" {
-			t.Errorf("%v: post-PeekTokens() diff (-got +want):\n%v", test.desc, diff)
+			t.Errorf("%v: post-peekTokens() diff (-got +want):\n%v", test.desc, diff)
 		}
 	}
 }

--- a/quota/etcd/quota_provider.go
+++ b/quota/etcd/quota_provider.go
@@ -53,7 +53,8 @@ func newEtcdQuotaManager() (quota.Manager, error) {
 		return nil, fmt.Errorf("failed to connect to etcd at %v: %v", *Servers, err)
 	}
 
-	qm := etcdqm.New(client)
+	var qm quota.Manager
+	qm = etcdqm.New(client)
 	if *quotaMinBatchSize > 0 && *quotaMaxCacheEntries > 0 {
 		cachedQM, err := cacheqm.NewCachedManager(qm, *quotaMinBatchSize, *quotaMaxCacheEntries)
 		if err != nil {

--- a/quota/mock_quota.go
+++ b/quota/mock_quota.go
@@ -47,21 +47,6 @@ func (mr *MockManagerMockRecorder) GetTokens(arg0, arg1, arg2 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokens", reflect.TypeOf((*MockManager)(nil).GetTokens), arg0, arg1, arg2)
 }
 
-// PeekTokens mocks base method
-func (m *MockManager) PeekTokens(arg0 context.Context, arg1 []Spec) (map[Spec]int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PeekTokens", arg0, arg1)
-	ret0, _ := ret[0].(map[Spec]int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PeekTokens indicates an expected call of PeekTokens
-func (mr *MockManagerMockRecorder) PeekTokens(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeekTokens", reflect.TypeOf((*MockManager)(nil).PeekTokens), arg0, arg1)
-}
-
 // PutTokens mocks base method
 func (m *MockManager) PutTokens(arg0 context.Context, arg1 int, arg2 []Spec) error {
 	m.ctrl.T.Helper()

--- a/quota/mysqlqm/mysql_quota.go
+++ b/quota/mysqlqm/mysql_quota.go
@@ -79,27 +79,6 @@ func (m *QuotaManager) GetTokens(ctx context.Context, numTokens int, specs []quo
 	return nil
 }
 
-// PeekTokens implements quota.Manager.PeekTokens.
-// Global/Write tokens reflect the number of rows in the Unsequenced tables, other specs are
-// considered infinite.
-func (m *QuotaManager) PeekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
-	tokens := make(map[quota.Spec]int)
-	for _, spec := range specs {
-		var num int
-		if spec.Group == quota.Global && spec.Kind == quota.Write {
-			count, err := m.countUnsequenced(ctx)
-			if err != nil {
-				return nil, err
-			}
-			num = m.MaxUnsequencedRows - count
-		} else {
-			num = quota.MaxTokens
-		}
-		tokens[spec] = num
-	}
-	return tokens, nil
-}
-
 // PutTokens implements quota.Manager.PutTokens.
 // It's a noop for QuotaManager.
 func (m *QuotaManager) PutTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/mysqlqm"

--- a/quota/mysqlqm/mysql_quota_test.go
+++ b/quota/mysqlqm/mysql_quota_test.go
@@ -182,48 +182,6 @@ func TestQuotaManager_GetTokens_InformationSchema(t *testing.T) {
 	}
 }
 
-func TestQuotaManager_PeekTokens(t *testing.T) {
-	testdb.SkipIfNoMySQL(t)
-	ctx := context.Background()
-
-	db, done, err := testdb.NewTrillianDB(ctx)
-	if err != nil {
-		t.Fatalf("GetTestDB() returned err = %v", err)
-	}
-	defer done(ctx)
-
-	tree, err := createTree(ctx, db)
-	if err != nil {
-		t.Fatalf("createTree() returned err = %v", err)
-	}
-
-	unsequencedRows := 10
-	maxUnsequencedRows := 1000
-	wantRows := maxUnsequencedRows - unsequencedRows
-	if err := setUnsequencedRows(ctx, db, tree, unsequencedRows); err != nil {
-		t.Fatalf("setUnsequencedRows() returned err = %v", err)
-	}
-
-	// Test using select count(*) to allow for precise assertions without flakiness.
-	qm := &mysqlqm.QuotaManager{DB: db, MaxUnsequencedRows: maxUnsequencedRows, UseSelectCount: true}
-	specs := allSpecs(ctx, qm, tree.TreeId)
-	tokens, err := qm.PeekTokens(ctx, specs)
-	if err != nil {
-		t.Fatalf("PeekTokens() returned err = %v", err)
-	}
-
-	// All specs but Global/Write are infinite
-	wantTokens := make(map[quota.Spec]int)
-	for _, spec := range specs {
-		wantTokens[spec] = quota.MaxTokens
-	}
-	wantTokens[quota.Spec{Group: quota.Global, Kind: quota.Write}] = wantRows
-
-	if diff := cmp.Diff(tokens, wantTokens); diff != "" {
-		t.Errorf("post-PeekTokens() diff:\n%v", diff)
-	}
-}
-
 func TestQuotaManager_Noops(t *testing.T) {
 	testdb.SkipIfNoMySQL(t)
 	ctx := context.Background()

--- a/quota/noop.go
+++ b/quota/noop.go
@@ -46,17 +46,6 @@ func (n noopManager) GetTokens(ctx context.Context, numTokens int, specs []Spec)
 	return validateSpecs(specs)
 }
 
-func (n noopManager) PeekTokens(ctx context.Context, specs []Spec) (map[Spec]int, error) {
-	if err := validateSpecs(specs); err != nil {
-		return nil, err
-	}
-	tokens := make(map[Spec]int)
-	for _, spec := range specs {
-		tokens[spec] = MaxTokens
-	}
-	return tokens, nil
-}
-
 func (n noopManager) PutTokens(ctx context.Context, numTokens int, specs []Spec) error {
 	if err := validateNumTokens(numTokens); err != nil {
 		return err

--- a/quota/noop_test.go
+++ b/quota/noop_test.go
@@ -92,11 +92,6 @@ func TestNoop_ValidatesSpecs(t *testing.T) {
 			t.Errorf("%v: GetTokens() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
 		}
 
-		_, err = qm.PeekTokens(ctx, test.specs)
-		if hasErr := err != nil; hasErr != test.wantErr {
-			t.Errorf("%v: PeekTokens() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
-		}
-
 		err = qm.PutTokens(ctx, 1 /* numTokens */, test.specs)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("%v: PutTokens() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
@@ -105,30 +100,6 @@ func TestNoop_ValidatesSpecs(t *testing.T) {
 		err = qm.ResetQuota(ctx, test.specs)
 		if hasErr := err != nil; hasErr != test.wantErr {
 			t.Errorf("%v: ResetQuota() returned err = %q, wantErr = %v", test.desc, err, test.wantErr)
-		}
-	}
-}
-
-func TestNoopManager_PeekTokens(t *testing.T) {
-	ctx := context.Background()
-	qm := Noop()
-
-	specs := []Spec{
-		{Group: User, Kind: Read, User: "ermintrude"},
-		{Group: Tree, Kind: Read, TreeID: 12345},
-		{Group: Global, Kind: Read},
-	}
-	tokens, err := qm.PeekTokens(ctx, specs)
-	if err != nil {
-		t.Fatalf("PeekTokens() returned err = %v", err)
-	}
-	if got, want := len(tokens), len(specs); got != want {
-		t.Fatalf("len(tokens) = %v, want = %v", got, want)
-	}
-	want := MaxTokens
-	for _, spec := range specs {
-		if got := tokens[spec]; got != want {
-			t.Errorf("tokens[%#v] = %v, want = %v", spec, got, want)
 		}
 	}
 }

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -108,10 +108,6 @@ type Manager interface {
 	// Returns error if numTokens could not be acquired for all specs.
 	GetTokens(ctx context.Context, numTokens int, specs []Spec) error
 
-	// PeekTokens returns how many tokens are available for each spec, without acquiring any.
-	// Infinite quotas should return MaxTokens.
-	PeekTokens(ctx context.Context, specs []Spec) (map[Spec]int, error)
-
 	// PutTokens adds numTokens for all specs.
 	PutTokens(ctx context.Context, numTokens int, specs []Spec) error
 


### PR DESCRIPTION
This remove the `PeekTokens` (which is only used for testing) method from the `quota.Manager` interface.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
