### PR TITLE
Try specific larger machine type for cloudbuilds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,8 @@ substitutions:
   _MYSQL_TAG: "5.7"
   _MYSQL_ROOT_PASSWORD: ""
   _MYSQL_PASSWORD: ""
+options:
+  machineType: N1_HIGHCPU_8
 steps:
 - id: pull_mysql
   name : gcr.io/cloud-builders/docker

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -5,6 +5,8 @@ substitutions:
   _MYSQL_TAG: "5.7"
   _MYSQL_ROOT_PASSWORD: ""
   _MYSQL_PASSWORD: ""
+options:
+  machineType: N1_HIGHCPU_8
 steps:
 - id: pull_mysql
   name : gcr.io/cloud-builders/docker

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,6 +1,8 @@
 timeout: 1800s
 substitutions:
   _MYSQL_TAG: "5.7"
+options:
+  machineType: N1_HIGHCPU_8
 steps:
 - id: pull_mysql
   name : gcr.io/cloud-builders/docker


### PR DESCRIPTION
Try to speed up CloudBuild runs by explicitly requesting a larger machine type.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
