### PR TITLE
add streaming method to rfc6962 hasher

### DIFF
--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -18,6 +18,9 @@ package rfc6962
 import (
 	"crypto"
 	_ "crypto/sha256" // SHA256 is the default algorithm.
+	"fmt"
+
+	"io"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
@@ -58,6 +61,17 @@ func (t *Hasher) HashLeaf(leaf []byte) []byte {
 	h.Write([]byte{RFC6962LeafHashPrefix})
 	h.Write(leaf)
 	return h.Sum(nil)
+}
+
+// HashLeafStream returns the Merkle tree leaf hash of the Reader passed in through leaf.
+// The data in leaf is prefixed by the LeafHashPrefix.
+func (t *Hasher) HashLeafStream(reader io.Reader) ([]byte, error) {
+	h := t.New()
+	h.Write([]byte{RFC6962LeafHashPrefix})
+	if _, err := io.Copy(h, reader); err != nil {
+		return nil, fmt.Errorf("error while reading: %v", err)
+	}
+	return h.Sum(nil), nil
 }
 
 // hashChildrenOld returns the inner Merkle tree node hash of the two child nodes l and r.


### PR DESCRIPTION
This convenience method computes a hash for a stream (e.g a large file) without holding the entire object in memory.

Fixes #2252

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
