### PR TITLE
Split/move hasher/registry packages to break inadvertent deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
  * Breaking unnecessary dependencies for Trillian clients:
    * Moved verifiers from `merkle` into `merkle/{log,map}verifier`sub-pacakges,
      reducing the amount of extra baggage inadvertently pulled in by clients.
+  * Concrete hashers have been moved into subpackages, separating them from their
+    registration code, allowing clients to direcly pull just the hasher they're
+    interested in and avoid the Trillian hasher registry+protobuf deps.
  * Moved some packages intended for internal-only use into `internal` packages:
    * InMemoryMerkleTree (indended to only be used by Trillian tests)
 

--- a/client/log_verifier.go
+++ b/client/log_verifier.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/logverifier"
 	"github.com/google/trillian/trees"
 	"github.com/google/trillian/types"
@@ -63,7 +64,7 @@ func NewLogVerifierFromTree(config *trillian.Tree) (*LogVerifier, error) {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): TreeType: %v, want %v or %v", got, log, pLog)
 	}
 
-	logHasher, err := hashers.NewLogHasher(config.HashStrategy)
+	logHasher, err := registry.NewLogHasher(config.HashStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("client: NewLogVerifierFromTree(): NewLogHasher(): %v", err)
 	}

--- a/client/map_verifier.go
+++ b/client/map_verifier.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/maps"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/mapverifier"
 	"github.com/google/trillian/types"
 	"golang.org/x/sync/errgroup"
@@ -58,7 +59,7 @@ func NewMapVerifier(config *trillian.Tree, rootVerifier *maps.RootVerifier) (*Ma
 		return nil, fmt.Errorf("client: NewMapVerifierFromTree(): TreeType: %v, want %v", got, want)
 	}
 
-	mapHasher, err := hashers.NewMapHasher(config.HashStrategy)
+	mapHasher, err := registry.NewMapHasher(config.HashStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating MapHasher: %v", err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,7 @@ github.com/apache/beam v2.24.0+incompatible h1:oATgc+AEkjL3zE1e0f/7u3u6eBEpeaiTn
 github.com/apache/beam v2.24.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/beam v2.26.0+incompatible h1:BFyRqKyUCaZDWVXOXtEjUVeAngilWOZzMG3KWUXFlZU=
 github.com/apache/beam v2.26.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
+github.com/apache/beam v2.27.0+incompatible h1:Ua4pP8fXzq6AlwcLbOyvtdx+6QA+GNMA11xAIDrm+eY=
 github.com/apache/beam v2.27.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -179,6 +180,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-redis/redis v6.15.8+incompatible h1:BKZuG6mCnRj5AOaWJXoCgf6rqTYnYJLe4en2hxT7r9o=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
@@ -242,6 +244,7 @@ github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -354,6 +357,7 @@ github.com/lib/pq v1.7.1 h1:FvD5XTVTDt+KON6oIoOmHq6B6HzGuYEhuTMpEG0yuBQ=
 github.com/lib/pq v1.7.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -455,6 +459,7 @@ github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNja
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
+github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -470,6 +475,7 @@ github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lN
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -713,6 +719,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -84,7 +84,6 @@ github.com/apache/beam v2.24.0+incompatible h1:oATgc+AEkjL3zE1e0f/7u3u6eBEpeaiTn
 github.com/apache/beam v2.24.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/beam v2.26.0+incompatible h1:BFyRqKyUCaZDWVXOXtEjUVeAngilWOZzMG3KWUXFlZU=
 github.com/apache/beam v2.26.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
-github.com/apache/beam v2.27.0+incompatible h1:Ua4pP8fXzq6AlwcLbOyvtdx+6QA+GNMA11xAIDrm+eY=
 github.com/apache/beam v2.27.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -180,7 +179,6 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-redis/redis v6.15.8+incompatible h1:BKZuG6mCnRj5AOaWJXoCgf6rqTYnYJLe4en2hxT7r9o=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
-github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
@@ -244,7 +242,6 @@ github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -357,7 +354,6 @@ github.com/lib/pq v1.7.1 h1:FvD5XTVTDt+KON6oIoOmHq6B6HzGuYEhuTMpEG0yuBQ=
 github.com/lib/pq v1.7.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -459,7 +455,6 @@ github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNja
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
-github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -475,7 +470,6 @@ github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lN
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -719,7 +713,6 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/log/sequencer_manager.go
+++ b/log/sequencer_manager.go
@@ -24,7 +24,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/extension"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/trees"
 
 	tcrypto "github.com/google/trillian/crypto"
@@ -61,7 +61,7 @@ func (s *SequencerManager) ExecutePass(ctx context.Context, logID int64, info *O
 	}
 	ctx = trees.NewContext(ctx, tree)
 
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		return 0, fmt.Errorf("error getting hasher for log %v: %v", logID, err)
 	}

--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -48,7 +48,7 @@ type Hasher struct {
 
 // New creates a new hashers.TreeHasher using the passed in hash function.
 func New(h crypto.Hash) *Hasher {
-	return &hasher{Hash: h}
+	return &Hasher{Hash: h}
 }
 
 // EmptyRoot returns the root of an empty tree.

--- a/merkle/coniks/coniks.go
+++ b/merkle/coniks/coniks.go
@@ -12,152 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package coniks provides hashing for maps.
+// Package coniks provides CONIKS hashing for maps.
 package coniks
 
 import (
-	"bytes"
 	"crypto"
-	"encoding/binary"
-	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/coniks/hasher"
 	"github.com/google/trillian/merkle/hashers/registry"
 )
 
+// Default is the standard CONIKS hasher.
+//
+// Deprecated: moved to hasher subpackage.
+var Default = hasher.Default
+
 func init() {
 	registry.RegisterMapHasher(trillian.HashStrategy_CONIKS_SHA512_256, Default)
-	registry.RegisterMapHasher(trillian.HashStrategy_CONIKS_SHA256, New(crypto.SHA256))
+	registry.RegisterMapHasher(trillian.HashStrategy_CONIKS_SHA256, hasher.New(crypto.SHA256))
 }
-
-// Domain separation prefixes
-var (
-	leafIdentifier  = []byte("L")
-	emptyIdentifier = []byte("E")
-	// Default is the standard CONIKS hasher.
-	Default = New(crypto.SHA512_256)
-	// Some zeroes, to avoid allocating temporary slices.
-	zeroes = make([]byte, 32)
-)
 
 // Hasher implements the sparse merkle tree hashing algorithm specified in the CONIKS paper.
-type Hasher struct {
-	crypto.Hash
-}
+//
+// Deprecated: moved to hasher subpackage.
+type Hasher = hasher.Hasher
 
 // New creates a new hashers.TreeHasher using the passed in hash function.
-func New(h crypto.Hash) *Hasher {
-	return &Hasher{Hash: h}
-}
-
-// EmptyRoot returns the root of an empty tree.
-func (m *Hasher) EmptyRoot() []byte {
-	panic("EmptyRoot() not defined for coniks.Hasher")
-}
-
-// HashEmpty returns the hash of an empty subtree of the given height at the
-// position defined by the BitLen()-height most significant bits of the given
-// index. Note that a height of 0 indicates a leaf.
-func (m *Hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
-	depth := m.BitLen() - height
-
-	buf := bytes.NewBuffer(make([]byte, 0, 32))
-	h := m.New()
-	buf.Write(emptyIdentifier)
-	binary.Write(buf, binary.BigEndian, uint64(treeID))
-	m.writeMaskedIndex(buf, index, depth)
-	binary.Write(buf, binary.BigEndian, uint32(depth))
-	h.Write(buf.Bytes())
-	r := h.Sum(nil)
-	if glog.V(5) {
-		glog.Infof("HashEmpty(%x, %d): %x", index, depth, r)
-	}
-	return r
-}
-
-// HashLeaf calculate the merkle tree leaf value:
-// H(Identifier || treeID || depth || index || dataHash)
-func (m *Hasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
-	depth := m.BitLen()
-	buf := bytes.NewBuffer(make([]byte, 0, 32+len(leaf)))
-	h := m.New()
-	buf.Write(leafIdentifier)
-	binary.Write(buf, binary.BigEndian, uint64(treeID))
-	m.writeMaskedIndex(buf, index, depth)
-	binary.Write(buf, binary.BigEndian, uint32(depth))
-	buf.Write(leaf)
-	h.Write(buf.Bytes())
-	p := h.Sum(nil)
-	if glog.V(5) {
-		glog.Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
-	}
-	return p
-}
-
-// HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
-// The hashed structure is  H(l || r).
-func (m *Hasher) HashChildren(l, r []byte) []byte {
-	buf := bytes.NewBuffer(make([]byte, 0, 32+len(l)+len(r)))
-	h := m.New()
-	buf.Write(l)
-	buf.Write(r)
-	h.Write(buf.Bytes())
-	p := h.Sum(nil)
-	if glog.V(5) {
-		glog.Infof("HashChildren(%x, %x): %x", l, r, p)
-	}
-	return p
-}
-
-// BitLen returns the number of bits in the hash function.
-func (m *Hasher) BitLen() int {
-	return m.Size() * 8
-}
-
-// leftmask contains bitmasks indexed such that the left x bits are set. It is
-// indexed by byte position from 0-7 0 is special cased to 0xFF since 8 mod 8
-// is 0. leftmask is only used to mask the last byte.
-var leftmask = [8]byte{0xFF, 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE}
-
-// writeMaskedIndex writes the left depth bits of index to the Buffer (which
-// never returns an error on writes), padded with zero bits to the byte Size()
-// of the hashes in use by this hasher.
 //
-// TODO(pavelkalinnikov): We must not use BitLen() and Size() interchangeably.
-// The tree height and hash size could be different.
-// TODO(pavelkalinnikov): Padding with zeroes doesn't buy us anything, as the
-// depth is also written to the Buffer.
-func (m *Hasher) writeMaskedIndex(b *bytes.Buffer, index []byte, depth int) {
-	if got, min := len(index)*8, depth; got < min {
-		panic(fmt.Sprintf("index bits: %d, want >= %d", got, min))
-	}
-	if got, want := depth, m.BitLen(); got < 0 || got > want {
-		panic(fmt.Sprintf("depth: %d, want <= %d && >= 0", got, want))
-	}
-
-	prevLen := b.Len()
-	if depth > 0 {
-		// Write the first depthBytes, if there are any complete bytes.
-		depthBytes := depth / 8
-		if depthBytes > 0 {
-			b.Write(index[:depthBytes])
-		}
-		// Mask off unwanted bits in the last byte, if there is an incomplete one.
-		if depth%8 != 0 {
-			b.WriteByte(index[depthBytes] & leftmask[depth%8])
-		}
-	}
-	// Pad to the correct length with zeroes. Allow for future hashers that might
-	// be > 256 bits.
-	// TODO(pavelkalinnikov): YAGNI. Simplify this until that actually happens.
-	for need := prevLen + m.Size() - b.Len(); need > 0; {
-		chunkSize := need
-		if chunkSize > 32 {
-			chunkSize = 32
-		}
-		// Use the pre-allocated zeroes to avoid allocating them each time.
-		b.Write(zeroes[:chunkSize])
-		need -= chunkSize
-	}
+// Deprecated: moved to hasher subpackage.
+func New(h crypto.Hash) *Hasher {
+	return hasher.New(h)
 }

--- a/merkle/coniks/coniks_test.go
+++ b/merkle/coniks/coniks_test.go
@@ -98,7 +98,7 @@ func TestHashLeaf(t *testing.T) {
 }
 
 func TestWriteMaskedIndex(t *testing.T) {
-	h := &hasher{crypto.SHA1} // Use a shorter hash for shorter test vectors.
+	h := &Hasher{crypto.SHA1} // Use a shorter hash for shorter test vectors.
 	for _, tc := range []struct {
 		index []byte
 		depth int
@@ -131,7 +131,7 @@ func TestWriteMaskedIndex(t *testing.T) {
 }
 
 func TestWriteMaskedIndex512Bits(t *testing.T) {
-	h := &hasher{crypto.SHA512} // Use a hasher with > 32 byte length.
+	h := &Hasher{crypto.SHA512} // Use a hasher with > 32 byte length.
 	for _, tc := range []struct {
 		index []byte
 		depth int
@@ -237,7 +237,7 @@ func TestWriteMaskedIndex512Bits(t *testing.T) {
 
 func TestWriteMaskedIndexBits(t *testing.T) {
 	allFF := h2b("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
-	h := &hasher{crypto.SHA512} // Use a hasher with > 32 byte length.
+	h := &Hasher{crypto.SHA512} // Use a hasher with > 32 byte length.
 	ref := new(big.Int)
 	// Go through all the bits, set them one at a time in the big.Int and compare
 	// the results against writeMaskedIndex with a depth of that many set bits.

--- a/merkle/coniks/hasher/coniks.go
+++ b/merkle/coniks/hasher/coniks.go
@@ -1,0 +1,156 @@
+// Copyright 2017 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hasher provides CONIKS hashing for maps.
+package hasher
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/golang/glog"
+)
+
+// Domain separation prefixes
+var (
+	leafIdentifier  = []byte("L")
+	emptyIdentifier = []byte("E")
+	// Default is the standard CONIKS hasher.
+	Default = New(crypto.SHA512_256)
+	// Some zeroes, to avoid allocating temporary slices.
+	zeroes = make([]byte, 32)
+)
+
+// Hasher implements the sparse merkle tree hashing algorithm specified in the CONIKS paper.
+type Hasher struct {
+	crypto.Hash
+}
+
+// New creates a new hashers.TreeHasher using the passed in hash function.
+func New(h crypto.Hash) *Hasher {
+	return &Hasher{Hash: h}
+}
+
+// EmptyRoot returns the root of an empty tree.
+func (m *Hasher) EmptyRoot() []byte {
+	panic("EmptyRoot() not defined for coniks.Hasher")
+}
+
+// HashEmpty returns the hash of an empty subtree of the given height at the
+// position defined by the BitLen()-height most significant bits of the given
+// index. Note that a height of 0 indicates a leaf.
+func (m *Hasher) HashEmpty(treeID int64, index []byte, height int) []byte {
+	depth := m.BitLen() - height
+
+	buf := bytes.NewBuffer(make([]byte, 0, 32))
+	h := m.New()
+	buf.Write(emptyIdentifier)
+	binary.Write(buf, binary.BigEndian, uint64(treeID))
+	m.writeMaskedIndex(buf, index, depth)
+	binary.Write(buf, binary.BigEndian, uint32(depth))
+	h.Write(buf.Bytes())
+	r := h.Sum(nil)
+	if glog.V(5) {
+		glog.Infof("HashEmpty(%x, %d): %x", index, depth, r)
+	}
+	return r
+}
+
+// HashLeaf calculate the merkle tree leaf value:
+// H(Identifier || treeID || depth || index || dataHash)
+func (m *Hasher) HashLeaf(treeID int64, index []byte, leaf []byte) []byte {
+	depth := m.BitLen()
+	buf := bytes.NewBuffer(make([]byte, 0, 32+len(leaf)))
+	h := m.New()
+	buf.Write(leafIdentifier)
+	binary.Write(buf, binary.BigEndian, uint64(treeID))
+	m.writeMaskedIndex(buf, index, depth)
+	binary.Write(buf, binary.BigEndian, uint32(depth))
+	buf.Write(leaf)
+	h.Write(buf.Bytes())
+	p := h.Sum(nil)
+	if glog.V(5) {
+		glog.Infof("HashLeaf(%x, %d, %s): %x", index, depth, leaf, p)
+	}
+	return p
+}
+
+// HashChildren returns the internal Merkle tree node hash of the the two child nodes l and r.
+// The hashed structure is  H(l || r).
+func (m *Hasher) HashChildren(l, r []byte) []byte {
+	buf := bytes.NewBuffer(make([]byte, 0, 32+len(l)+len(r)))
+	h := m.New()
+	buf.Write(l)
+	buf.Write(r)
+	h.Write(buf.Bytes())
+	p := h.Sum(nil)
+	if glog.V(5) {
+		glog.Infof("HashChildren(%x, %x): %x", l, r, p)
+	}
+	return p
+}
+
+// BitLen returns the number of bits in the hash function.
+func (m *Hasher) BitLen() int {
+	return m.Size() * 8
+}
+
+// leftmask contains bitmasks indexed such that the left x bits are set. It is
+// indexed by byte position from 0-7 0 is special cased to 0xFF since 8 mod 8
+// is 0. leftmask is only used to mask the last byte.
+var leftmask = [8]byte{0xFF, 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE}
+
+// writeMaskedIndex writes the left depth bits of index to the Buffer (which
+// never returns an error on writes), padded with zero bits to the byte Size()
+// of the hashes in use by this hasher.
+//
+// TODO(pavelkalinnikov): We must not use BitLen() and Size() interchangeably.
+// The tree height and hash size could be different.
+// TODO(pavelkalinnikov): Padding with zeroes doesn't buy us anything, as the
+// depth is also written to the Buffer.
+func (m *Hasher) writeMaskedIndex(b *bytes.Buffer, index []byte, depth int) {
+	if got, min := len(index)*8, depth; got < min {
+		panic(fmt.Sprintf("index bits: %d, want >= %d", got, min))
+	}
+	if got, want := depth, m.BitLen(); got < 0 || got > want {
+		panic(fmt.Sprintf("depth: %d, want <= %d && >= 0", got, want))
+	}
+
+	prevLen := b.Len()
+	if depth > 0 {
+		// Write the first depthBytes, if there are any complete bytes.
+		depthBytes := depth / 8
+		if depthBytes > 0 {
+			b.Write(index[:depthBytes])
+		}
+		// Mask off unwanted bits in the last byte, if there is an incomplete one.
+		if depth%8 != 0 {
+			b.WriteByte(index[depthBytes] & leftmask[depth%8])
+		}
+	}
+	// Pad to the correct length with zeroes. Allow for future hashers that might
+	// be > 256 bits.
+	// TODO(pavelkalinnikov): YAGNI. Simplify this until that actually happens.
+	for need := prevLen + m.Size() - b.Len(); need > 0; {
+		chunkSize := need
+		if chunkSize > 32 {
+			chunkSize = 32
+		}
+		// Use the pre-allocated zeroes to avoid allocating them each time.
+		b.Write(zeroes[:chunkSize])
+		need -= chunkSize
+	}
+}

--- a/merkle/coniks/hasher/coniks_test.go
+++ b/merkle/coniks/hasher/coniks_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package coniks
+package hasher
 
 import (
 	"bytes"

--- a/merkle/hashers/registry/registry.go
+++ b/merkle/hashers/registry/registry.go
@@ -1,0 +1,54 @@
+// Package registry provides a mechanism to register and discover tree hashers.
+package registry
+
+import (
+	"fmt"
+
+	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/hashers"
+)
+
+var (
+	logHashers = make(map[trillian.HashStrategy]hashers.LogHasher)
+	mapHashers = make(map[trillian.HashStrategy]hashers.MapHasher)
+)
+
+// RegisterLogHasher registers a hasher for use.
+func RegisterLogHasher(h trillian.HashStrategy, f hashers.LogHasher) {
+	if h == trillian.HashStrategy_UNKNOWN_HASH_STRATEGY {
+		panic(fmt.Sprintf("RegisterLogHasher(%s) of unknown hasher", h))
+	}
+	if logHashers[h] != nil {
+		panic(fmt.Sprintf("%v already registered as a LogHasher", h))
+	}
+	logHashers[h] = f
+}
+
+// RegisterMapHasher registers a hasher for use.
+func RegisterMapHasher(h trillian.HashStrategy, f hashers.MapHasher) {
+	if h == trillian.HashStrategy_UNKNOWN_HASH_STRATEGY {
+		panic(fmt.Sprintf("RegisterMapHasher(%s) of unknown hasher", h))
+	}
+	if mapHashers[h] != nil {
+		panic(fmt.Sprintf("%v already registered as a MapHasher", h))
+	}
+	mapHashers[h] = f
+}
+
+// NewLogHasher returns a LogHasher.
+func NewLogHasher(h trillian.HashStrategy) (hashers.LogHasher, error) {
+	f := logHashers[h]
+	if f != nil {
+		return f, nil
+	}
+	return nil, fmt.Errorf("LogHasher(%s) is an unknown hasher", h)
+}
+
+// NewMapHasher returns a MapHasher.
+func NewMapHasher(h trillian.HashStrategy) (hashers.MapHasher, error) {
+	f := mapHashers[h]
+	if f != nil {
+		return f, nil
+	}
+	return nil, fmt.Errorf("MapHasher(%s) is an unknown hasher", h)
+}

--- a/merkle/hashers/registry/registry.go
+++ b/merkle/hashers/registry/registry.go
@@ -1,4 +1,18 @@
-// Package registry provides a mechanism to register and discover tree hashers.
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.// Package registry provides a mechanism to register and discover tree hashers.
+
+// Package registry provides a global registry for hasher implementations.
 package registry
 
 import (

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -14,12 +14,6 @@
 
 package hashers
 
-import (
-	"fmt"
-
-	"github.com/google/trillian"
-)
-
 // LogHasher provides the hash functions needed to compute dense merkle trees.
 type LogHasher interface {
 	// EmptyRoot supports returning a special case for the root of an empty tree.
@@ -64,49 +58,4 @@ type MapHasher interface {
 	// BitLen returns the number of bits in the underlying hash function.
 	// It is also the height of the merkle tree.
 	BitLen() int
-}
-
-var (
-	logHashers = make(map[trillian.HashStrategy]LogHasher)
-	mapHashers = make(map[trillian.HashStrategy]MapHasher)
-)
-
-// RegisterLogHasher registers a hasher for use.
-func RegisterLogHasher(h trillian.HashStrategy, f LogHasher) {
-	if h == trillian.HashStrategy_UNKNOWN_HASH_STRATEGY {
-		panic(fmt.Sprintf("RegisterLogHasher(%s) of unknown hasher", h))
-	}
-	if logHashers[h] != nil {
-		panic(fmt.Sprintf("%v already registered as a LogHasher", h))
-	}
-	logHashers[h] = f
-}
-
-// RegisterMapHasher registers a hasher for use.
-func RegisterMapHasher(h trillian.HashStrategy, f MapHasher) {
-	if h == trillian.HashStrategy_UNKNOWN_HASH_STRATEGY {
-		panic(fmt.Sprintf("RegisterMapHasher(%s) of unknown hasher", h))
-	}
-	if mapHashers[h] != nil {
-		panic(fmt.Sprintf("%v already registered as a MapHasher", h))
-	}
-	mapHashers[h] = f
-}
-
-// NewLogHasher returns a LogHasher.
-func NewLogHasher(h trillian.HashStrategy) (LogHasher, error) {
-	f := logHashers[h]
-	if f != nil {
-		return f, nil
-	}
-	return nil, fmt.Errorf("LogHasher(%s) is an unknown hasher", h)
-}
-
-// NewMapHasher returns a MapHasher.
-func NewMapHasher(h trillian.HashStrategy) (MapHasher, error) {
-	f := mapHashers[h]
-	if f != nil {
-		return f, nil
-	}
-	return nil, fmt.Errorf("MapHasher(%s) is an unknown hasher", h)
 }

--- a/merkle/maphasher/maphasher.go
+++ b/merkle/maphasher/maphasher.go
@@ -22,10 +22,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 )
 
 func init() {
-	hashers.RegisterMapHasher(trillian.HashStrategy_TEST_MAP_HASHER, Default)
+	registry.RegisterMapHasher(trillian.HashStrategy_TEST_MAP_HASHER, Default)
 }
 
 // Domain separation prefixes

--- a/merkle/rfc6962/hasher/rfc6962.go
+++ b/merkle/rfc6962/hasher/rfc6962.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hasher provides hashing functionality according to RFC6962.
+package hasher
+
+import (
+	"crypto"
+	_ "crypto/sha256" // SHA256 is the default algorithm.
+)
+
+// Domain separation prefixes
+const (
+	RFC6962LeafHashPrefix = 0
+	RFC6962NodeHashPrefix = 1
+)
+
+// DefaultHasher is a SHA256 based LogHasher.
+var DefaultHasher = New(crypto.SHA256)
+
+// Hasher implements the RFC6962 tree hashing algorithm.
+type Hasher struct {
+	crypto.Hash
+}
+
+// New creates a new Hashers.LogHasher on the passed in hash function.
+func New(h crypto.Hash) *Hasher {
+	return &Hasher{Hash: h}
+}
+
+// EmptyRoot returns a special case for an empty tree.
+func (t *Hasher) EmptyRoot() []byte {
+	return t.New().Sum(nil)
+}
+
+// HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
+// The data in leaf is prefixed by the LeafHashPrefix.
+func (t *Hasher) HashLeaf(leaf []byte) []byte {
+	h := t.New()
+	h.Write([]byte{RFC6962LeafHashPrefix})
+	h.Write(leaf)
+	return h.Sum(nil)
+}
+
+// hashChildrenOld returns the inner Merkle tree node hash of the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+// TODO(al): Remove me.
+func (t *Hasher) hashChildrenOld(l, r []byte) []byte {
+	h := t.New()
+	h.Write([]byte{RFC6962NodeHashPrefix})
+	h.Write(l)
+	h.Write(r)
+	return h.Sum(nil)
+}
+
+// HashChildren returns the inner Merkle tree node hash of the two child nodes l and r.
+// The hashed structure is NodeHashPrefix||l||r.
+func (t *Hasher) HashChildren(l, r []byte) []byte {
+	h := t.New()
+	b := append(append(append(
+		make([]byte, 0, 1+len(l)+len(r)),
+		RFC6962NodeHashPrefix),
+		l...),
+		r...)
+
+	h.Write(b)
+	return h.Sum(nil)
+}

--- a/merkle/rfc6962/hasher/rfc6962_test.go
+++ b/merkle/rfc6962/hasher/rfc6962_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package rfc6962
+package hasher
 
 import (
 	"bytes"

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -20,11 +20,11 @@ import (
 	_ "crypto/sha256" // SHA256 is the default algorithm.
 
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 )
 
 func init() {
-	hashers.RegisterLogHasher(trillian.HashStrategy_RFC6962_SHA256, New(crypto.SHA256))
+	registry.RegisterLogHasher(trillian.HashStrategy_RFC6962_SHA256, New(crypto.SHA256))
 }
 
 // Domain separation prefixes

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC. All Rights Reserved.
+// Copyright 2021 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package rfc6962
 
 import (
 	"crypto"
-	_ "crypto/sha256" // SHA256 is the default algorithm.
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers/registry"
+	"github.com/google/trillian/merkle/rfc6962/hasher"
 )
 
 func init() {
@@ -28,59 +28,26 @@ func init() {
 }
 
 // Domain separation prefixes
+//
+// Deprecated: moved to hasher subpackage.
 const (
-	RFC6962LeafHashPrefix = 0
-	RFC6962NodeHashPrefix = 1
+	RFC6962LeafHashPrefix = hasher.RFC6962LeafHashPrefix
+	RFC6962NodeHashPrefix = hasher.RFC6962NodeHashPrefix
 )
 
 // DefaultHasher is a SHA256 based LogHasher.
-var DefaultHasher = New(crypto.SHA256)
+//
+// Deprecated: moved to hasher subpackage.
+var DefaultHasher = hasher.DefaultHasher
 
 // Hasher implements the RFC6962 tree hashing algorithm.
-type Hasher struct {
-	crypto.Hash
-}
+//
+// Deprecated: moved to hasher subpackage.
+type Hasher = hasher.Hasher
 
 // New creates a new Hashers.LogHasher on the passed in hash function.
+//
+// Deprecated: moved to hasher subpackage.
 func New(h crypto.Hash) *Hasher {
-	return &Hasher{Hash: h}
-}
-
-// EmptyRoot returns a special case for an empty tree.
-func (t *Hasher) EmptyRoot() []byte {
-	return t.New().Sum(nil)
-}
-
-// HashLeaf returns the Merkle tree leaf hash of the data passed in through leaf.
-// The data in leaf is prefixed by the LeafHashPrefix.
-func (t *Hasher) HashLeaf(leaf []byte) []byte {
-	h := t.New()
-	h.Write([]byte{RFC6962LeafHashPrefix})
-	h.Write(leaf)
-	return h.Sum(nil)
-}
-
-// hashChildrenOld returns the inner Merkle tree node hash of the two child nodes l and r.
-// The hashed structure is NodeHashPrefix||l||r.
-// TODO(al): Remove me.
-func (t *Hasher) hashChildrenOld(l, r []byte) []byte {
-	h := t.New()
-	h.Write([]byte{RFC6962NodeHashPrefix})
-	h.Write(l)
-	h.Write(r)
-	return h.Sum(nil)
-}
-
-// HashChildren returns the inner Merkle tree node hash of the two child nodes l and r.
-// The hashed structure is NodeHashPrefix||l||r.
-func (t *Hasher) HashChildren(l, r []byte) []byte {
-	h := t.New()
-	b := append(append(append(
-		make([]byte, 0, 1+len(l)+len(r)),
-		RFC6962NodeHashPrefix),
-		l...),
-		r...)
-
-	h.Write(b)
-	return h.Sum(nil)
+	return hasher.New(h)
 }

--- a/server/admin/admin_server.go
+++ b/server/admin/admin_server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/extension"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/trees"
 	"google.golang.org/genproto/protobuf/field_mask"
@@ -90,11 +90,11 @@ func (s *Server) CreateTree(ctx context.Context, req *trillian.CreateTreeRequest
 	}
 	switch tree.TreeType {
 	case trillian.TreeType_LOG, trillian.TreeType_PREORDERED_LOG:
-		if _, err := hashers.NewLogHasher(tree.HashStrategy); err != nil {
+		if _, err := registry.NewLogHasher(tree.HashStrategy); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to create hasher for tree: %v", err.Error())
 		}
 	case trillian.TreeType_MAP:
-		if _, err := hashers.NewMapHasher(tree.HashStrategy); err != nil {
+		if _, err := registry.NewMapHasher(tree.HashStrategy); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to create hasher for tree: %v", err.Error())
 		}
 	default:

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/trees"
@@ -740,7 +741,7 @@ func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int6
 	if err != nil {
 		return nil, nil, err
 	}
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/map_rpc_server.go
+++ b/server/map_rpc_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/trillian/extension"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/smt"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
@@ -500,7 +501,7 @@ func (t *TrillianMapServer) getTreeAndHasher(ctx context.Context, treeID int64, 
 	if err != nil {
 		return nil, nil, err
 	}
-	th, err := hashers.NewMapHasher(tree.HashStrategy)
+	th, err := registry.NewMapHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -839,16 +839,16 @@ func (tx *logTX) GetLeavesByIndex(ctx context.Context, indices []int64) ([]*tril
 	// TODO: replace with INNER JOIN when spannertest supports JOINs
 	// https://github.com/googleapis/google-cloud-go/tree/master/spanner/spannertest
 	stmt := spanner.NewStatement(
-		`SELECT
+		`SELECT 
 		   TreeID,
 		   SequenceNumber,
 		   LeafIdentityHash,
-		   MerkleLeafHash,
+		   MerkleLeafHash, 
 		   IntegrateTimestampNanos
-		FROM
+		FROM 
 		   SequencedLeafData
-		WHERE
-		   TreeID = @tree_id AND
+		WHERE 
+		   TreeID = @tree_id AND 
 		   SequenceNumber IN UNNEST(@seq_nums)`)
 	stmt.Params["tree_id"] = tx.treeID
 	stmt.Params["seq_nums"] = indices
@@ -870,16 +870,16 @@ func (tx *logTX) GetLeavesByIndex(ctx context.Context, indices []int64) ([]*tril
 	}
 
 	stmt = spanner.NewStatement(
-		`SELECT
+		`SELECT 
 		   TreeID,
-		   LeafIdentityHash,
-		   LeafValue,
-		   ExtraData,
+		   LeafIdentityHash, 
+		   LeafValue, 
+		   ExtraData, 
 		   QueueTimestampNanos
-		 FROM
+		 FROM 
 		   SequencedLeafData
-		 WHERE
-		   TreeID = @tree_id AND
+		 WHERE 
+		   TreeID = @tree_id AND 
 		   LeafIdentityHash IN UNNEST(@id_hashes)`)
 	stmt.Params["tree_id"] = tx.treeID
 	stmt.Params["id_hashes"] = idHashes
@@ -943,17 +943,17 @@ func (tx *logTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*t
 	// TODO: replace with INNER JOIN when spannertest supports JOINs
 	// https://github.com/googleapis/google-cloud-go/tree/master/spanner/spannertest
 	stmt := spanner.NewStatement(
-		`SELECT
+		`SELECT 
 		   TreeID,
 		   SequenceNumber,
 		   LeafIdentityHash,
-		   MerkleLeafHash,
+		   MerkleLeafHash, 
 		   IntegrateTimestampNanos
-		 FROM
+		 FROM 
 		   SequencedLeafData
-		 WHERE
-		   TreeID = @tree_id AND
-		   SequenceNumber >= @start AND
+		 WHERE 
+		   TreeID = @tree_id AND 
+		   SequenceNumber >= @start AND 
 		   SequenceNumber < @xend`)
 	stmt.Params["tree_id"] = tx.treeID
 	stmt.Params["start"] = start
@@ -976,16 +976,16 @@ func (tx *logTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*t
 	}
 
 	stmt = spanner.NewStatement(
-		`SELECT
+		`SELECT 
 		   TreeID,
-		   LeafIdentityHash,
-		   LeafValue,
-		   ExtraData,
+		   LeafIdentityHash, 
+		   LeafValue, 
+		   ExtraData, 
 		   QueueTimestampNanos
-		 FROM
+		 FROM 
 		   LeafData
-		 WHERE
-		   TreeID = @tree_id AND
+		 WHERE 
+		   TreeID = @tree_id AND 
 		   LeafIdentityHash IN UNNEST(@id_hashes)`)
 	stmt.Params["tree_id"] = tx.treeID
 	stmt.Params["id_hashes"] = idHashes

--- a/storage/cloudspanner/map_storage.go
+++ b/storage/cloudspanner/map_storage.go
@@ -23,7 +23,7 @@ import (
 	"cloud.google.com/go/spanner"
 	"github.com/golang/glog"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/smt"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -82,7 +82,7 @@ func (ms *mapStorage) CheckDatabaseAccessible(ctx context.Context) error {
 }
 
 func newMapCache(tree *trillian.Tree) (*cache.SubtreeCache, error) {
-	hasher, err := hashers.NewMapHasher(tree.HashStrategy)
+	hasher, err := registry.NewMapHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/google/btree"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -151,7 +151,7 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, tree *trillian.Tre
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -238,7 +238,7 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mysql/map_storage.go
+++ b/storage/mysql/map_storage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/smt"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -77,7 +78,7 @@ func (m *mySQLMapStorage) begin(ctx context.Context, tree *trillian.Tree, readon
 	if got, want := tree.TreeType, trillian.TreeType_MAP; got != want {
 		return nil, fmt.Errorf("begin(tree.TreeType: %v), want %v", got, want)
 	}
-	hasher, err := hashers.NewMapHasher(tree.HashStrategy)
+	hasher, err := registry.NewMapHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
@@ -258,7 +258,7 @@ func (m *postgresLogStorage) beginInternal(ctx context.Context, tree *trillian.T
 	once.Do(func() {
 		createMetrics(m.metricFactory)
 	})
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -39,7 +39,7 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/log"
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
@@ -196,7 +196,7 @@ func createTree(as storage.AdminStorage, ls storage.LogStorage) (*trillian.Tree,
 		glog.Fatalf("Create tree: %v", err)
 	}
 
-	hasher, err := hashers.NewLogHasher(tree.HashStrategy)
+	hasher, err := registry.NewLogHasher(tree.HashStrategy)
 	if err != nil {
 		glog.Fatalf("NewLogHasher: %v", err)
 	}
@@ -301,7 +301,7 @@ func Main(args Options) string {
 		formatter = fullProto
 	}
 
-	hasher, err := hashers.NewLogHasher(trillian.HashStrategy_RFC6962_SHA256)
+	hasher, err := registry.NewLogHasher(trillian.HashStrategy_RFC6962_SHA256)
 	if err != nil {
 		glog.Fatalf("Failed to create a log hasher: %v", err)
 	}

--- a/storage/tools/hasher/main.go
+++ b/storage/tools/hasher/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers/registry"
 	_ "github.com/google/trillian/merkle/rfc6962" // Load hashers
 )
 
@@ -39,7 +40,7 @@ func createHasher() hashers.LogHasher {
 		glog.Fatalf("Unknown hash strategy: %s", *hashStrategyFlag)
 	}
 
-	hasher, err := hashers.NewLogHasher(trillian.HashStrategy(strategy))
+	hasher, err := registry.NewLogHasher(trillian.HashStrategy(strategy))
 	if err != nil {
 		glog.Fatalf("Failed to create a log hasher for strategy %s: %v", *hashStrategyFlag, err)
 	}


### PR DESCRIPTION
Break some more inadvertent deps.

The result of this PR & the earlier verifier-splitting one, is an 8MB reduction in client binary size - mostly gained since these changes allow us to avoid importing protobuf etc. in unnecessarily.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
