### PR TITLE
log: Clean up election in the operation loop

### DIFF
--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -114,12 +114,15 @@ type OperationManager struct {
 	// logOperation is the task that gets run across active logs in the scheduling loop
 	logOperation Operation
 
+	// runnerWG groups all goroutines with election Runners.
+	runnerWG sync.WaitGroup
 	// runnerCancels contains cancel function for each logID election Runner.
-	runnerCancels       map[string]context.CancelFunc
+	runnerCancels map[string]context.CancelFunc
+	// pendingResignations delivers resignation requests from election Runners.
 	pendingResignations chan election.Resignation
-	runnerWG            sync.WaitGroup
-	tracker             *election.MasterTracker
-	lastHeld            []int64
+
+	tracker  *election.MasterTracker
+	lastHeld []int64
 	// Cache of logID => name; assumed not to change during runtime
 	logNamesMutex sync.Mutex
 	logNames      map[int64]string

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -93,7 +93,7 @@ type OperationInfo struct {
 	// The following parameters govern the overall scheduling of Operations
 	// by a OperationManager.
 
-	// Election-related configuration.
+	// Election-related configuration. Copied for each log.
 	ElectionConfig election.RunnerConfig
 
 	// RunInterval is the time between starting batches of processing.  If a

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -264,13 +264,13 @@ func (o *OperationManager) runElection(ctx context.Context, logID string) (conte
 		cancel()
 		return nil, fmt.Errorf("failed to create election for %v: %v", logID, err)
 	}
-	// TODO(pavelkalinnikov): Passing the cancel function is not needed here.
-	r := election.NewRunner(logID, &o.info.ElectionConfig, o.tracker, cancel, e)
 	o.runnerWG.Add(1)
-	go func(r *election.Runner) {
+	go func() {
 		defer o.runnerWG.Done()
+		// TODO(pavelkalinnikov): Passing the cancel function is not needed here.
+		r := election.NewRunner(logID, &o.info.ElectionConfig, o.tracker, cancel, e)
 		r.Run(cctx, o.pendingResignations)
-	}(r)
+	}()
 	return cancel, nil
 }
 

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -267,8 +267,11 @@ func (o *OperationManager) runElection(ctx context.Context, logID string) (conte
 	o.runnerWG.Add(1)
 	go func() {
 		defer o.runnerWG.Done()
+		// Warning: NewRunner can attempt to modify the config. Make a separate
+		// copy of the config for each log, to avoid data races.
+		config := o.info.ElectionConfig
 		// TODO(pavelkalinnikov): Passing the cancel function is not needed here.
-		r := election.NewRunner(logID, &o.info.ElectionConfig, o.tracker, cancel, e)
+		r := election.NewRunner(logID, &config, o.tracker, cancel, e)
 		r.Run(cctx, o.pendingResignations)
 	}()
 	return cancel, nil

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -380,13 +380,12 @@ loop:
 
 	}
 
-	// Terminate all the election runners
+	// Terminate all the election Runners.
 	for logID, cancel := range o.runnerCancels {
-		if cancel == nil {
-			continue
+		if cancel != nil {
+			glog.V(1).Infof("cancel election runner for %s", logID)
+			cancel()
 		}
-		glog.V(1).Infof("cancel election runner for %s", logID)
-		cancel()
 	}
 
 	// Drain any remaining resignations which might have triggered.


### PR DESCRIPTION
Comments, variable renames, and factoring out some code.
Review commit by commit.

This is in preparation for fixing #1150.