### PR TITLE
log: Restart election Runner in case of an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  * Moved `--quota_system` and `--storage_system` flags to `main.go` so that they
    are initialised properly. It might break depending builds relying on these
    flags. Suggested fix: add the flags to `main.go`.
+ * Made signer tolerate mastership election failues [#1150].
 
 ## v1.3.11
 [Published 2020-10-06](https://github.com/google/trillian/releases/tag/v1.3.11)

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -228,14 +228,9 @@ func (o *OperationManager) masterFor(ctx context.Context, allIDs []int64) ([]int
 	// Synchronize the set of log IDs with those we are tracking mastership for.
 	for _, logID := range allStringIDs {
 		knownLogs.Set(1, logID)
-		if o.runnerCancels[logID] != nil {
-			continue
+		if o.runnerCancels[logID] == nil {
+			o.runnerCancels[logID] = o.runElectionWithRestarts(ctx, logID)
 		}
-		cancel, err := o.runElection(ctx, logID)
-		if err != nil {
-			return nil, err
-		}
-		o.runnerCancels[logID] = cancel
 	}
 
 	held := o.tracker.Held()
@@ -256,25 +251,42 @@ func (o *OperationManager) masterFor(ctx context.Context, allIDs []int64) ([]int
 	return heldIDs, nil
 }
 
-func (o *OperationManager) runElection(ctx context.Context, logID string) (context.CancelFunc, error) {
+// runElectionWithRestarts runs the election/resignation loop for the given log
+// indefinitely, until the returned CancelFunc is invoked. Any failure during
+// the loop leads to a restart of the loop with a few seconds delay.
+func (o *OperationManager) runElectionWithRestarts(ctx context.Context, logID string) context.CancelFunc {
 	glog.Infof("create master election goroutine for %v", logID)
 	cctx, cancel := context.WithCancel(ctx)
-	e, err := o.info.Registry.ElectionFactory.NewElection(cctx, logID)
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("failed to create election for %v: %v", logID, err)
-	}
-	o.runnerWG.Add(1)
-	go func() {
-		defer o.runnerWG.Done()
+	run := func(ctx context.Context) {
+		e, err := o.info.Registry.ElectionFactory.NewElection(ctx, logID)
+		if err != nil {
+			glog.Errorf("failed to create election for %v: %v", logID, err)
+			return
+		}
 		// Warning: NewRunner can attempt to modify the config. Make a separate
 		// copy of the config for each log, to avoid data races.
 		config := o.info.ElectionConfig
 		// TODO(pavelkalinnikov): Passing the cancel function is not needed here.
 		r := election.NewRunner(logID, &config, o.tracker, cancel, e)
-		r.Run(cctx, o.pendingResignations)
-	}()
-	return cancel, nil
+		r.Run(ctx, o.pendingResignations)
+	}
+	o.runnerWG.Add(1)
+	go func(ctx context.Context) {
+		defer o.runnerWG.Done()
+		run(ctx)
+		// Note: run(ctx) terminates because of an error, or ctx cancelation.
+		// Continue only while the context is active.
+		for ctx.Err() == nil {
+			// Sleep before restarts, to not spam the log with errors.
+			// TODO(pavelkalinnikov): Make the interval configurable.
+			const pause = time.Duration(5 * time.Second)
+			if err := clock.SleepSource(ctx, pause, o.info.TimeSource); err != nil {
+				break // The context has been canceled during the sleep.
+			}
+			run(ctx)
+		}
+	}(cctx)
+	return cancel
 }
 
 // updateHeldIDs updates the process status with the number/list of logs that

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -254,6 +254,9 @@ func (o *OperationManager) masterFor(ctx context.Context, allIDs []int64) ([]int
 // runElectionWithRestarts runs the election/resignation loop for the given log
 // indefinitely, until the returned CancelFunc is invoked. Any failure during
 // the loop leads to a restart of the loop with a few seconds delay.
+//
+// TODO(pavelkalinnikov): Restart the whole log operation rather than just the
+// election, and have a metric for restarts.
 func (o *OperationManager) runElectionWithRestarts(ctx context.Context, logID string) context.CancelFunc {
 	glog.Infof("create master election goroutine for %v", logID)
 	cctx, cancel := context.WithCancel(ctx)

--- a/log/operation_manager.go
+++ b/log/operation_manager.go
@@ -273,17 +273,15 @@ func (o *OperationManager) runElectionWithRestarts(ctx context.Context, logID st
 	o.runnerWG.Add(1)
 	go func(ctx context.Context) {
 		defer o.runnerWG.Done()
-		run(ctx)
-		// Note: run(ctx) terminates because of an error, or ctx cancelation.
 		// Continue only while the context is active.
 		for ctx.Err() == nil {
+			run(ctx)
 			// Sleep before restarts, to not spam the log with errors.
 			// TODO(pavelkalinnikov): Make the interval configurable.
 			const pause = time.Duration(5 * time.Second)
 			if err := clock.SleepSource(ctx, pause, o.info.TimeSource); err != nil {
 				break // The context has been canceled during the sleep.
 			}
-			run(ctx)
 		}
 	}(cctx)
 	return cancel

--- a/log/operation_manager_test.go
+++ b/log/operation_manager_test.go
@@ -442,7 +442,7 @@ func TestMasterFor(t *testing.T) {
 		{desc: "no-factory", factory: nil, want1: firstIDs, want2: allIDs},
 		{desc: "noop-factory", factory: election2.NoopFactory{}, want1: firstIDs, want2: allIDs},
 		{desc: "master-for-even", factory: masterForEvenFactory{}, want1: []int64{2, 4}, want2: []int64{2, 4, 6}},
-		{desc: "failure-factory", factory: failureFactory{}, want1: nil, want2: nil},
+		{desc: "failure-factory", factory: failureFactory{}, want1: []int64{}, want2: []int64{}},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
This change makes the election/resignation loop restart indefinitely (with a reasonable
delay) in case it fails temporarily due to etcd issues.

Fixes #1150.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
