### PR TITLE
TestDB uses ENV var for DB connection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
    are initialised properly. It might break depending builds relying on these
    flags. Suggested fix: add the flags to `main.go`.
  * Made signer tolerate mastership election failues [#1150].
- * `testdb` no longer accepts the `--test_mysq_uri` flag, and instead honours the
+ * `testdb` no longer accepts the `--test_mysql_uri` flag, and instead honours the
    `MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
    specific test DB instance.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
    are initialised properly. It might break depending builds relying on these
    flags. Suggested fix: add the flags to `main.go`.
  * Made signer tolerate mastership election failues [#1150].
+ * `testdb` no longer accepts the `--test_mysq_uri` flag, and instead honours the
+   `MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
+   specific test DB instance.
 
 ## v1.3.11
 [Published 2020-10-06](https://github.com/google/trillian/releases/tag/v1.3.11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
    flags. Suggested fix: add the flags to `main.go`.
  * Made signer tolerate mastership election failues [#1150].
  * `testdb` no longer accepts the `--test_mysql_uri` flag, and instead honours the
-   `MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
+   `TEST_MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
    specific test DB instance.
 
 ## v1.3.11

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -174,4 +174,5 @@ func SkipIfNoMySQL(t *testing.T) {
 	if !MySQLAvailable() {
 		t.Skip("Skipping test as MySQL not available")
 	}
+	t.Logf("Test MySQL available at %q", mysqlURI())
 }

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -19,10 +19,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -34,14 +34,35 @@ import (
 	_ "github.com/go-sql-driver/mysql" // mysql driver
 )
 
-var (
-	trillianSQL   = testonly.RelativeToPackage("../mysql/schema/storage.sql")
-	dataSourceURI = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "The MySQL uri to use when running tests")
+const (
+	// MySQLURIEnv is the name of the ENV var checked for the test mysql instance URI to use.
+	MySQLURIEnv = "MYSQL_URI"
+
+	defaultMySQLURI = "root@tcp(127.0.0.1)/"
 )
+
+var (
+	trillianSQL = testonly.RelativeToPackage("../mysql/schema/storage.sql")
+)
+
+// mysqlURI returns the connection URI to use for tests.
+// It will prefer the value in the MYSQL_URI env var, and if empty/unset, it'll
+// return the DefaultMySQLURI value.
+//
+// Only a subset of the suite of tests in this repo require a database it's
+// not possible to blanket apply the test_mysql_uri flag, and maintaining a separate
+// list of tests which needs DB connectivity is brittle, so this fallback approach
+// means we can provide the connection info in a more ambient fashion.
+func mysqlURI() string {
+	if e := os.Getenv(MySQLURIEnv); len(e) > 0 {
+		return e
+	}
+	return defaultMySQLURI
+}
 
 // MySQLAvailable indicates whether a default MySQL database is available.
 func MySQLAvailable() bool {
-	db, err := sql.Open("mysql", *dataSourceURI)
+	db, err := sql.Open("mysql", mysqlURI())
 	if err != nil {
 		log.Printf("sql.Open(): %v", err)
 		return false
@@ -78,7 +99,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, func(context.Context), error) {
 	if err := SetFDLimit(2048); err != nil {
 		return nil, nil, err
 	}
-	db, err := sql.Open("mysql", *dataSourceURI)
+	db, err := sql.Open("mysql", mysqlURI())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +113,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, func(context.Context), error) {
 	}
 
 	db.Close()
-	db, err = sql.Open("mysql", *dataSourceURI+name)
+	db, err = sql.Open("mysql", mysqlURI()+name)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/storage/testdb/testdb.go
+++ b/storage/testdb/testdb.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	// MySQLURIEnv is the name of the ENV var checked for the test mysql instance URI to use.
-	MySQLURIEnv = "MYSQL_URI"
+	// MySQLURIEnv is the name of the ENV var checked for the test MySQL
+	// instance URI to use.
+	MySQLURIEnv = "TEST_MYSQL_URI"
 
-	defaultMySQLURI = "root@tcp(127.0.0.1)/"
+	defaultTestMySQLURI = "root@tcp(127.0.0.1)"
 )
 
 var (
@@ -47,7 +48,7 @@ var (
 
 // mysqlURI returns the connection URI to use for tests.
 // It will prefer the value in the MYSQL_URI env var, and if empty/unset, it'll
-// return the DefaultMySQLURI value.
+// return the defaultTestMySQLURI value.
 //
 // Only a subset of the suite of tests in this repo require a database it's
 // not possible to blanket apply the test_mysql_uri flag, and maintaining a separate
@@ -57,10 +58,10 @@ func mysqlURI() string {
 	if e := os.Getenv(MySQLURIEnv); len(e) > 0 {
 		return e
 	}
-	return defaultMySQLURI
+	return defaultTestMySQLURI
 }
 
-// MySQLAvailable indicates whether a default MySQL database is available.
+// MySQLAvailable indicates whether the configured MySQL database is available.
 func MySQLAvailable() bool {
 	db, err := sql.Open("mysql", mysqlURI())
 	if err != nil {
@@ -113,7 +114,7 @@ func newEmptyDB(ctx context.Context) (*sql.DB, func(context.Context), error) {
 	}
 
 	db.Close()
-	db, err = sql.Open("mysql", mysqlURI()+name)
+	db, err = sql.Open("mysql", mysqlURI()+"/"+name)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Tests which rely on DB storage provide a flag to specify the DB connection string, but since not all tests accept this flag it makes it difficult to use in practice. Specifying the test DB URI in an env var makes it a lot easier.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
