### PR TITLE
Replicate Travis CI in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,7 +15,7 @@ substitutions:
   _MYSQL_ROOT_PASSWORD: ""
   _MYSQL_PASSWORD: ""
 options:
-  machineType: N1_HIGHCPU_32
+  machineType: E2_HIGHCPU_32
   env:
     - GO111MODULE=on
     - GOPROXY=https://proxy.golang.org
@@ -101,7 +101,7 @@ steps:
     - GOPATH=/throwaway
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmit
 
 # Presubmit (PKCS11)
 - id: presubmit_pkcs11
@@ -114,7 +114,19 @@ steps:
     - GOFLAGS=-race --tags=pkcs11
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmit
+
+# Try to spread the load a bit, we'll wait for all the presubmit.* steps
+# to finish before starting the integration.* ones.
+# Having too many "big" things running concurrently leads to problems
+# with timeouts and mysql issues.
+- id: presubmits_done
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: /bin/true
+  waitFor:
+    - presubmit
+    - presubmit_batched
+    - presubmit_pkcs11
 
 # Integration
 - id: integration
@@ -125,7 +137,7 @@ steps:
     - HAMMER_OPTS=--operations=150
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmits_done
 
 # Integration (etcd)
 - id: integration_etcd
@@ -138,7 +150,7 @@ steps:
     - HAMMER_OPTS=--operations=50
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmits_done
 
 # Integration (Batched queue)
 - id: integration_batched
@@ -150,7 +162,7 @@ steps:
     - HAMMER_OPTS=--operations=50
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmits_done
 
 # Integration (PKCS11)
 - id: integration_pkcs11
@@ -162,7 +174,7 @@ steps:
     - HAMMER_OPTS=--operations=50
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - presubmits_done
 
 ############################################################################
 ## End of replicated section.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,12 +13,7 @@ substitutions:
   _MASTER_ZONE: us-central1-a
   _MYSQL_TAG: "5.7"
   _MYSQL_ROOT_PASSWORD: ""
-  _MYSQL_HOST: "cloudbuild_db_1"
-  _MYSQL_PORT: "3306"
-  _MYSQL_USER: "test"
-  _MYSQL_PASSWORD: "zaphod"
-  _MYSQL_ROOT_PASSWORD: "bananas"
-  _MYSQL_USER_HOST: '%'
+  _MYSQL_PASSWORD: ""
 options:
   machineType: N1_HIGHCPU_32
   env:
@@ -26,12 +21,8 @@ options:
     - GOPROXY=https://proxy.golang.org
     - PROJECT_ROOT=github.com/google/trillian
     - GOPATH=/go
-    - MYSQL_HOST=${_MYSQL_HOST}
-    - MYSQL_PORT=${_MYSQL_PORT}
-    - MYSQL_USER=${_MYSQL_USER}
-    - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
-    - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
-    - MYSQL_USER_HOST=${_MYSQL_USER_HOST}
+    - DOCKER_CLIENT_TIMEOUT=120
+    - COMPOSE_HTTP_TIMEOUT=120
 
 steps:
 # First build a "trillian_testbase" docker image which contains most of the tools we need for the later steps:
@@ -93,83 +84,85 @@ steps:
     - --no-generate
   env:
     - GOFLAGS=-race
+    - GOPATH=/throwaway
     - GO_TEST_TIMEOUT=20m
   waitFor:
     - prepare
 
-# # Presubmit (Batched queue)
-# - id: presubmit_batched
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_presubmit.sh
-#   args:
-#     - --no-linters
-#     - --no-generate
-#   env:
-#     - GOFLAGS=-race --tags=batched_queue
-#     - GO_TEST_TIMEOUT=20m
-#   waitFor:
-#     - prepare
+# Presubmit (Batched queue)
+- id: presubmit_batched
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_presubmit.sh
+  args:
+    - --no-linters
+    - --no-generate
+  env:
+    - GOFLAGS=-race --tags=batched_queue
+    - GOPATH=/throwaway
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
-# # Presubmit (PKCS11)
-# - id: presubmit_pkcs11
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_presubmit.sh
-#   args:
-#     - --no-linters
-#     - --no-generate
-#   env:
-#     - GOFLAGS=-race --tags=pkcs11
-#     - GO_TEST_TIMEOUT=20m
-#   waitFor:
-#     - prepare
+# Presubmit (PKCS11)
+- id: presubmit_pkcs11
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_presubmit.sh
+  args:
+    - --no-linters
+    - --no-generate
+  env:
+    - GOFLAGS=-race --tags=pkcs11
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
-# # Integration
-# - id: integration
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_integration.sh
-#   env:
-#     - HAMMER_OPTS=--operations=150
-#     - GO_TEST_TIMEOUT=20m
-#     - MYSQL_DATABASE=integration
-#   waitFor:
-#     - prepare
+# Integration
+- id: integration
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_integration.sh
+  env:
+    - GOPATH=/throwaway
+    - HAMMER_OPTS=--operations=150
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
-# # Integration (etcd)
-# - id: integration_etcd
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_integration.sh
-#   env:
-#     - ETCD_DIR=/go/bin
-#     - GOFLAGS=-race
-#     - HAMMER_OPTS=--operations=50
-#     - GO_TEST_TIMEOUT=20m
-#     - MYSQL_DATABASE=integration_etcd
-#   waitFor:
-#     - prepare
+# Integration (etcd)
+- id: integration_etcd
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_integration.sh
+  env:
+    - ETCD_DIR=/go/bin
+    - GOPATH=/throwaway
+    - GOFLAGS=-race
+    - HAMMER_OPTS=--operations=50
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
-# # Integration (Batched queue)
-# - id: integration_batched
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_integration.sh
-#   env:
-#     - GOFLAGS=-race
-#     - HAMMER_OPTS=--operations=50
-#     - GO_TEST_TIMEOUT=20m
-#     - MYSQL_DATABASE=integration_batched
-#   waitFor:
-#     - prepare
+# Integration (Batched queue)
+- id: integration_batched
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_integration.sh
+  env:
+    - GOFLAGS=-race
+    - GOPATH=/throwaway
+    - HAMMER_OPTS=--operations=50
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
-# # Integration (PKCS11)
-# - id: integration_pkcs11
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: ./integration/cloudbuild/run_integration.sh
-#   env:
-#     - GOFLAGS=-tags=pkcs11
-#     - HAMMER_OPTS=--operations=50
-#     - GO_TEST_TIMEOUT=20m
-#     - MYSQL_DATABASE=integration_pkcs11
-#   waitFor:
-#     - prepare
+# Integration (PKCS11)
+- id: integration_pkcs11
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_integration.sh
+  env:
+    - GOFLAGS=-tags=pkcs11
+    - GOPATH=/throwaway
+    - HAMMER_OPTS=--operations=50
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
 
 # ############################################################################
 # ## End of replicated section.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,185 +1,358 @@
+#############################################################################
+## The top section of this file is identical in the 3 cloudbuild.*yaml files.
+## Make sure any edits you make here are copied over to the other files too
+## if appropriate.
+##
+## TODO(al): consider if it's possible to merge these 3 files and control via
+## substitutions.
+#############################################################################
+
 timeout: 1800s
 substitutions:
   _CLUSTER_NAME: trillian-opensource-ci
   _MASTER_ZONE: us-central1-a
   _MYSQL_TAG: "5.7"
   _MYSQL_ROOT_PASSWORD: ""
-  _MYSQL_PASSWORD: ""
+  _MYSQL_HOST: "cloudbuild_db_1"
+  _MYSQL_PORT: "3306"
+  _MYSQL_USER: "test"
+  _MYSQL_PASSWORD: "zaphod"
+  _MYSQL_ROOT_PASSWORD: "bananas"
+  _MYSQL_USER_HOST: '%'
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: N1_HIGHCPU_32
+  env:
+    - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
+    - PROJECT_ROOT=github.com/google/trillian
+    - GOPATH=/go
+    - MYSQL_HOST=${_MYSQL_HOST}
+    - MYSQL_PORT=${_MYSQL_PORT}
+    - MYSQL_USER=${_MYSQL_USER}
+    - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
+    - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
+    - MYSQL_USER_HOST=${_MYSQL_USER_HOST}
+
 steps:
-- id: pull_mysql
-  name : gcr.io/cloud-builders/docker
+# First build a "trillian_testbase" docker image which contains most of the tools we need for the later steps:
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker pull gcr.io/$PROJECT_ID/trillian_testbase:latest || exit 0']
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '-t', 'gcr.io/$PROJECT_ID/trillian_testbase:latest',
+    '--cache-from', 'gcr.io/$PROJECT_ID/trillian_testbase:latest',
+    '-f', './integration/cloudbuild/testbase/Dockerfile',
+    '.'
+  ]
+
+# Set up tools and any other common steps which should not be part of Docker image.
+- id: prepare
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/prepare.sh
+
+# # Run lint and porcelain checks
+# - id: lint
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: bash
+#   args:
+#     - -exc
+#     - |
+#       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+#       golangci-lint run --deadline=8m
+#       ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
+#   waitFor:
+#     - prepare
+
+# # Run Bazel check
+# - id: bazel
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: bash
+#   args:
+#     - -exc
+#     - |
+#       bazel build //:*
+#   waitFor:
+#     - prepare
+
+
+# # Run Docker check
+# - id: docker
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/docker_compose_integration_test.sh
+#   waitFor:
+#     - prepare
+
+# Presubmit
+- id: presubmit
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_presubmit.sh
   args:
-  - pull
-  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
-- id: tag_mysql
-  name: gcr.io/cloud-builders/docker
-  args:
-  - tag
-  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
-  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
-  waitFor:
-  - pull_mysql
-- id: push_mysql
-  name: gcr.io/cloud-builders/docker
-  args:
-  - push
-  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
-  waitFor:
-  - tag_mysql
-- id: build_db_server
-  name: gcr.io/kaniko-project/executor
-  args:
-  - --dockerfile=examples/deployment/docker/db_server/Dockerfile
-  - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-  - --cache=true
-  - --cache-dir= # Cache is in Google Container Registry
-  waitFor:
-  - push_mysql
-- id: build_log_server
-  name: gcr.io/kaniko-project/executor
-  args:
-  - --dockerfile=examples/deployment/docker/log_server/Dockerfile
-  - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-  - --cache=true
-  - --cache-dir= # Cache is in Google Container Registry
-  waitFor: ["-"]
-- id: build_log_signer
-  name: gcr.io/kaniko-project/executor
-  args:
-  - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
-  - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-  - --cache=true
-  - --cache-dir= # Cache is in Google Container Registry
-  waitFor: ["-"]
-- id: build_map_server
-  name: gcr.io/kaniko-project/executor
-  args:
-  - --dockerfile=examples/deployment/docker/map_server/Dockerfile
-  - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
-  - --cache=true
-  - --cache-dir= # Cache is in Google Container Registry
-  waitFor: ["-"]
-- id: build_envsubst
-  name: gcr.io/cloud-builders/docker
-  args:
-  - build
-  - examples/deployment/docker/envsubst
-  - -t
-  - envsubst
-  waitFor: ["-"]
-- id: apply_k8s_cfgs_for_clusterwide_etcd_operator_dryrun
-  name: gcr.io/cloud-builders/kubectl
-  args:
-  - apply
-  - --server-dry-run
-  - -f=examples/deployment/kubernetes/etcd-deployment.yaml
+    - --no-linters
+    - --no-generate
   env:
-  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-  waitFor: ["-"]
-- id: copy_k8s_cfgs_for_spanner
-  name: busybox
-  entrypoint: cp
-  args:
-  - -r
-  - examples/deployment/kubernetes/
-  - envsubst-spanner/
-  waitFor: ['-']
-- id: envsubst_k8s_cfgs_for_spanner
-  name: envsubst
-  args:
-  - envsubst-spanner/etcd-cluster.yaml
-  - envsubst-spanner/trillian-ci-spanner.yaml
-  - envsubst-spanner/trillian-log-deployment.yaml
-  - envsubst-spanner/trillian-log-service.yaml
-  - envsubst-spanner/trillian-log-signer-deployment.yaml
-  - envsubst-spanner/trillian-log-signer-service.yaml
-  - envsubst-spanner/trillian-map-deployment.yaml
-  - envsubst-spanner/trillian-map-service.yaml
-  env:
-  - PROJECT_ID=${PROJECT_ID}
-  - IMAGE_TAG=${COMMIT_SHA}
+    - GOFLAGS=-race
+    - GO_TEST_TIMEOUT=20m
   waitFor:
-  - build_envsubst
-  - copy_k8s_cfgs_for_spanner
-- id: apply_k8s_cfgs_for_spanner_dryrun
-  name: gcr.io/cloud-builders/kubectl
-  args:
-  - apply
-  - --server-dry-run
-  - -f=envsubst-spanner/etcd-cluster.yaml
-  - -f=envsubst-spanner/trillian-ci-spanner.yaml
-  - -f=envsubst-spanner/trillian-log-deployment.yaml
-  - -f=envsubst-spanner/trillian-log-service.yaml
-  - -f=envsubst-spanner/trillian-log-signer-deployment.yaml
-  - -f=envsubst-spanner/trillian-log-signer-service.yaml
-  - -f=envsubst-spanner/trillian-map-deployment.yaml
-  - -f=envsubst-spanner/trillian-map-service.yaml
-  - --prune
-  - --all
-  - --prune-whitelist=core/v1/ConfigMap
-  env:
-  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-  waitFor:
-  - envsubst_k8s_cfgs_for_spanner
-  - build_log_server
-  - build_log_signer
-  - build_map_server
-- id: copy_k8s_cfgs_for_mysql
-  name: busybox
-  entrypoint: cp
-  args:
-  - -r
-  - examples/deployment/kubernetes/
-  - envsubst-mysql/
-  waitFor: ['-']
-- id: envsubst_k8s_cfgs_for_mysql
-  name: envsubst
-  args:
-  - envsubst-mysql/etcd-cluster.yaml
-  - envsubst-mysql/trillian-ci-mysql.yaml
-  - envsubst-mysql/trillian-mysql.yaml
-  - envsubst-mysql/trillian-log-deployment.yaml
-  - envsubst-mysql/trillian-log-service.yaml
-  - envsubst-mysql/trillian-log-signer-deployment.yaml
-  - envsubst-mysql/trillian-log-signer-service.yaml
-  - envsubst-mysql/trillian-map-deployment.yaml
-  - envsubst-mysql/trillian-map-service.yaml
-  env:
-  - PROJECT_ID=${PROJECT_ID}
-  - IMAGE_TAG=${COMMIT_SHA}
-  - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
-  - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
-  waitFor:
-  - build_envsubst
-  - copy_k8s_cfgs_for_mysql
-- id: apply_k8s_cfgs_for_mysql_dryrun
-  name: gcr.io/cloud-builders/kubectl
-  args:
-  - apply
-  - --server-dry-run
-  - --namespace=mysql
-  - -f=envsubst-mysql/etcd-cluster.yaml
-  - -f=envsubst-mysql/trillian-ci-mysql.yaml
-  - -f=envsubst-mysql/trillian-mysql.yaml
-  - -f=envsubst-mysql/trillian-log-deployment.yaml
-  - -f=envsubst-mysql/trillian-log-service.yaml
-  - -f=envsubst-mysql/trillian-log-signer-deployment.yaml
-  - -f=envsubst-mysql/trillian-log-signer-service.yaml
-  - -f=envsubst-mysql/trillian-map-deployment.yaml
-  - -f=envsubst-mysql/trillian-map-service.yaml
-  - --prune
-  - --all
-  - --prune-whitelist=core/v1/ConfigMap
-  env:
-  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-  waitFor:
-  - envsubst_k8s_cfgs_for_mysql
-  - build_db_server
-  - build_log_server
-  - build_log_signer
-  - build_map_server
+    - prepare
+
+# # Presubmit (Batched queue)
+# - id: presubmit_batched
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_presubmit.sh
+#   args:
+#     - --no-linters
+#     - --no-generate
+#   env:
+#     - GOFLAGS=-race --tags=batched_queue
+#     - GO_TEST_TIMEOUT=20m
+#   waitFor:
+#     - prepare
+
+# # Presubmit (PKCS11)
+# - id: presubmit_pkcs11
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_presubmit.sh
+#   args:
+#     - --no-linters
+#     - --no-generate
+#   env:
+#     - GOFLAGS=-race --tags=pkcs11
+#     - GO_TEST_TIMEOUT=20m
+#   waitFor:
+#     - prepare
+
+# # Integration
+# - id: integration
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_integration.sh
+#   env:
+#     - HAMMER_OPTS=--operations=150
+#     - GO_TEST_TIMEOUT=20m
+#     - MYSQL_DATABASE=integration
+#   waitFor:
+#     - prepare
+
+# # Integration (etcd)
+# - id: integration_etcd
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_integration.sh
+#   env:
+#     - ETCD_DIR=/go/bin
+#     - GOFLAGS=-race
+#     - HAMMER_OPTS=--operations=50
+#     - GO_TEST_TIMEOUT=20m
+#     - MYSQL_DATABASE=integration_etcd
+#   waitFor:
+#     - prepare
+
+# # Integration (Batched queue)
+# - id: integration_batched
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_integration.sh
+#   env:
+#     - GOFLAGS=-race
+#     - HAMMER_OPTS=--operations=50
+#     - GO_TEST_TIMEOUT=20m
+#     - MYSQL_DATABASE=integration_batched
+#   waitFor:
+#     - prepare
+
+# # Integration (PKCS11)
+# - id: integration_pkcs11
+#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+#   entrypoint: ./integration/cloudbuild/run_integration.sh
+#   env:
+#     - GOFLAGS=-tags=pkcs11
+#     - HAMMER_OPTS=--operations=50
+#     - GO_TEST_TIMEOUT=20m
+#     - MYSQL_DATABASE=integration_pkcs11
+#   waitFor:
+#     - prepare
+
+# ############################################################################
+# ## End of replicated section.
+# ## Below are deployment/dry-run specific steps for the CD env.
+# ############################################################################
+# - id: pull_mysql
+#   name : gcr.io/cloud-builders/docker
+#   args:
+#   - pull
+#   - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+# - id: tag_mysql
+#   name: gcr.io/cloud-builders/docker
+#   args:
+#   - tag
+#   - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+#   - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+#   waitFor:
+#   - pull_mysql
+# - id: push_mysql
+#   name: gcr.io/cloud-builders/docker
+#   args:
+#   - push
+#   - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+#   waitFor:
+#   - tag_mysql
+# - id: build_db_server
+#   name: gcr.io/kaniko-project/executor
+#   args:
+#   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
+#   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
+#   - --cache=true
+#   - --cache-dir= # Cache is in Google Container Registry
+#   waitFor:
+#   - push_mysql
+# - id: build_log_server
+#   name: gcr.io/kaniko-project/executor
+#   args:
+#   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
+#   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
+#   - --cache=true
+#   - --cache-dir= # Cache is in Google Container Registry
+#   waitFor:
+#     - prepare
+# - id: build_log_signer
+#   name: gcr.io/kaniko-project/executor
+#   args:
+#   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
+#   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
+#   - --cache=true
+#   - --cache-dir= # Cache is in Google Container Registry
+#   waitFor:
+#     - prepare
+# - id: build_map_server
+#   name: gcr.io/kaniko-project/executor
+#   args:
+#   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
+#   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+#   - --cache=true
+#   - --cache-dir= # Cache is in Google Container Registry
+#   waitFor:
+#     - prepare
+# - id: build_envsubst
+#   name: gcr.io/cloud-builders/docker
+#   args:
+#   - build
+#   - examples/deployment/docker/envsubst
+#   - -t
+#   - envsubst
+#   waitFor: ["-"]
+# - id: apply_k8s_cfgs_for_clusterwide_etcd_operator_dryrun
+#   name: gcr.io/cloud-builders/kubectl
+#   args:
+#   - apply
+#   - --server-dry-run
+#   - -f=examples/deployment/kubernetes/etcd-deployment.yaml
+#   env:
+#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+#   waitFor:
+#     - prepare
+# - id: copy_k8s_cfgs_for_spanner
+#   name: busybox
+#   entrypoint: cp
+#   args:
+#   - -r
+#   - examples/deployment/kubernetes/
+#   - envsubst-spanner/
+#   waitFor:
+#     - prepare
+# - id: envsubst_k8s_cfgs_for_spanner
+#   name: envsubst
+#   args:
+#   - envsubst-spanner/etcd-cluster.yaml
+#   - envsubst-spanner/trillian-ci-spanner.yaml
+#   - envsubst-spanner/trillian-log-deployment.yaml
+#   - envsubst-spanner/trillian-log-service.yaml
+#   - envsubst-spanner/trillian-log-signer-deployment.yaml
+#   - envsubst-spanner/trillian-log-signer-service.yaml
+#   - envsubst-spanner/trillian-map-deployment.yaml
+#   - envsubst-spanner/trillian-map-service.yaml
+#   env:
+#   - PROJECT_ID=${PROJECT_ID}
+#   - IMAGE_TAG=${COMMIT_SHA}
+#   waitFor:
+#   - build_envsubst
+#   - copy_k8s_cfgs_for_spanner
+# - id: apply_k8s_cfgs_for_spanner_dryrun
+#   name: gcr.io/cloud-builders/kubectl
+#   args:
+#   - apply
+#   - --server-dry-run
+#   - -f=envsubst-spanner/etcd-cluster.yaml
+#   - -f=envsubst-spanner/trillian-ci-spanner.yaml
+#   - -f=envsubst-spanner/trillian-log-deployment.yaml
+#   - -f=envsubst-spanner/trillian-log-service.yaml
+#   - -f=envsubst-spanner/trillian-log-signer-deployment.yaml
+#   - -f=envsubst-spanner/trillian-log-signer-service.yaml
+#   - -f=envsubst-spanner/trillian-map-deployment.yaml
+#   - -f=envsubst-spanner/trillian-map-service.yaml
+#   - --prune
+#   - --all
+#   - --prune-whitelist=core/v1/ConfigMap
+#   env:
+#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+#   waitFor:
+#   - envsubst_k8s_cfgs_for_spanner
+#   - build_log_server
+#   - build_log_signer
+#   - build_map_server
+# - id: copy_k8s_cfgs_for_mysql
+#   name: busybox
+#   entrypoint: cp
+#   args:
+#   - -r
+#   - examples/deployment/kubernetes/
+#   - envsubst-mysql/
+#   waitFor:
+#     - prepare
+# - id: envsubst_k8s_cfgs_for_mysql
+#   name: envsubst
+#   args:
+#   - envsubst-mysql/etcd-cluster.yaml
+#   - envsubst-mysql/trillian-ci-mysql.yaml
+#   - envsubst-mysql/trillian-mysql.yaml
+#   - envsubst-mysql/trillian-log-deployment.yaml
+#   - envsubst-mysql/trillian-log-service.yaml
+#   - envsubst-mysql/trillian-log-signer-deployment.yaml
+#   - envsubst-mysql/trillian-log-signer-service.yaml
+#   - envsubst-mysql/trillian-map-deployment.yaml
+#   - envsubst-mysql/trillian-map-service.yaml
+#   env:
+#   - PROJECT_ID=${PROJECT_ID}
+#   - IMAGE_TAG=${COMMIT_SHA}
+#   - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
+#   - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
+#   waitFor:
+#   - build_envsubst
+#   - copy_k8s_cfgs_for_mysql
+# - id: apply_k8s_cfgs_for_mysql_dryrun
+#   name: gcr.io/cloud-builders/kubectl
+#   args:
+#   - apply
+#   - --server-dry-run
+#   - --namespace=mysql
+#   - -f=envsubst-mysql/etcd-cluster.yaml
+#   - -f=envsubst-mysql/trillian-ci-mysql.yaml
+#   - -f=envsubst-mysql/trillian-mysql.yaml
+#   - -f=envsubst-mysql/trillian-log-deployment.yaml
+#   - -f=envsubst-mysql/trillian-log-service.yaml
+#   - -f=envsubst-mysql/trillian-log-signer-deployment.yaml
+#   - -f=envsubst-mysql/trillian-log-signer-service.yaml
+#   - -f=envsubst-mysql/trillian-map-deployment.yaml
+#   - -f=envsubst-mysql/trillian-map-service.yaml
+#   - --prune
+#   - --all
+#   - --prune-whitelist=core/v1/ConfigMap
+#   env:
+#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+#   waitFor:
+#   - envsubst_k8s_cfgs_for_mysql
+#   - build_db_server
+#   - build_log_server
+#   - build_log_signer
+#   - build_map_server

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,31 +43,31 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./integration/cloudbuild/prepare.sh
 
-# # Run lint and porcelain checks
-# - id: lint
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: bash
-#   args:
-#     - -exc
-#     - |
-#       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
-#       golangci-lint run --deadline=8m
-#       ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
-#   waitFor:
-#     - prepare
+# Run lint and porcelain checks
+- id: lint
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: bash
+  args:
+    - -exc
+    - |
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      golangci-lint run --deadline=8m
+      ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
+  waitFor:
+    - prepare
 
-# # Run Bazel check
-# - id: bazel
-#   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-#   entrypoint: bash
-#   args:
-#     - -exc
-#     - |
-#       bazel build //:*
-#   waitFor:
-#     - prepare
+# Run Bazel check
+- id: bazel
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: bash
+  args:
+    - -exc
+    - |
+      bazel build //:*
+  waitFor:
+    - prepare
 
-
+# TODO(al): This needs fixing
 # # Run Docker check
 # - id: docker
 #   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
@@ -164,188 +164,188 @@ steps:
   waitFor:
     - prepare
 
-# ############################################################################
-# ## End of replicated section.
-# ## Below are deployment/dry-run specific steps for the CD env.
-# ############################################################################
-# - id: pull_mysql
-#   name : gcr.io/cloud-builders/docker
-#   args:
-#   - pull
-#   - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
-# - id: tag_mysql
-#   name: gcr.io/cloud-builders/docker
-#   args:
-#   - tag
-#   - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
-#   - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
-#   waitFor:
-#   - pull_mysql
-# - id: push_mysql
-#   name: gcr.io/cloud-builders/docker
-#   args:
-#   - push
-#   - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
-#   waitFor:
-#   - tag_mysql
-# - id: build_db_server
-#   name: gcr.io/kaniko-project/executor
-#   args:
-#   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
-#   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
-#   - --cache=true
-#   - --cache-dir= # Cache is in Google Container Registry
-#   waitFor:
-#   - push_mysql
-# - id: build_log_server
-#   name: gcr.io/kaniko-project/executor
-#   args:
-#   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
-#   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
-#   - --cache=true
-#   - --cache-dir= # Cache is in Google Container Registry
-#   waitFor:
-#     - prepare
-# - id: build_log_signer
-#   name: gcr.io/kaniko-project/executor
-#   args:
-#   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
-#   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
-#   - --cache=true
-#   - --cache-dir= # Cache is in Google Container Registry
-#   waitFor:
-#     - prepare
-# - id: build_map_server
-#   name: gcr.io/kaniko-project/executor
-#   args:
-#   - --dockerfile=examples/deployment/docker/map_server/Dockerfile
-#   - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
-#   - --cache=true
-#   - --cache-dir= # Cache is in Google Container Registry
-#   waitFor:
-#     - prepare
-# - id: build_envsubst
-#   name: gcr.io/cloud-builders/docker
-#   args:
-#   - build
-#   - examples/deployment/docker/envsubst
-#   - -t
-#   - envsubst
-#   waitFor: ["-"]
-# - id: apply_k8s_cfgs_for_clusterwide_etcd_operator_dryrun
-#   name: gcr.io/cloud-builders/kubectl
-#   args:
-#   - apply
-#   - --server-dry-run
-#   - -f=examples/deployment/kubernetes/etcd-deployment.yaml
-#   env:
-#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-#   waitFor:
-#     - prepare
-# - id: copy_k8s_cfgs_for_spanner
-#   name: busybox
-#   entrypoint: cp
-#   args:
-#   - -r
-#   - examples/deployment/kubernetes/
-#   - envsubst-spanner/
-#   waitFor:
-#     - prepare
-# - id: envsubst_k8s_cfgs_for_spanner
-#   name: envsubst
-#   args:
-#   - envsubst-spanner/etcd-cluster.yaml
-#   - envsubst-spanner/trillian-ci-spanner.yaml
-#   - envsubst-spanner/trillian-log-deployment.yaml
-#   - envsubst-spanner/trillian-log-service.yaml
-#   - envsubst-spanner/trillian-log-signer-deployment.yaml
-#   - envsubst-spanner/trillian-log-signer-service.yaml
-#   - envsubst-spanner/trillian-map-deployment.yaml
-#   - envsubst-spanner/trillian-map-service.yaml
-#   env:
-#   - PROJECT_ID=${PROJECT_ID}
-#   - IMAGE_TAG=${COMMIT_SHA}
-#   waitFor:
-#   - build_envsubst
-#   - copy_k8s_cfgs_for_spanner
-# - id: apply_k8s_cfgs_for_spanner_dryrun
-#   name: gcr.io/cloud-builders/kubectl
-#   args:
-#   - apply
-#   - --server-dry-run
-#   - -f=envsubst-spanner/etcd-cluster.yaml
-#   - -f=envsubst-spanner/trillian-ci-spanner.yaml
-#   - -f=envsubst-spanner/trillian-log-deployment.yaml
-#   - -f=envsubst-spanner/trillian-log-service.yaml
-#   - -f=envsubst-spanner/trillian-log-signer-deployment.yaml
-#   - -f=envsubst-spanner/trillian-log-signer-service.yaml
-#   - -f=envsubst-spanner/trillian-map-deployment.yaml
-#   - -f=envsubst-spanner/trillian-map-service.yaml
-#   - --prune
-#   - --all
-#   - --prune-whitelist=core/v1/ConfigMap
-#   env:
-#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-#   waitFor:
-#   - envsubst_k8s_cfgs_for_spanner
-#   - build_log_server
-#   - build_log_signer
-#   - build_map_server
-# - id: copy_k8s_cfgs_for_mysql
-#   name: busybox
-#   entrypoint: cp
-#   args:
-#   - -r
-#   - examples/deployment/kubernetes/
-#   - envsubst-mysql/
-#   waitFor:
-#     - prepare
-# - id: envsubst_k8s_cfgs_for_mysql
-#   name: envsubst
-#   args:
-#   - envsubst-mysql/etcd-cluster.yaml
-#   - envsubst-mysql/trillian-ci-mysql.yaml
-#   - envsubst-mysql/trillian-mysql.yaml
-#   - envsubst-mysql/trillian-log-deployment.yaml
-#   - envsubst-mysql/trillian-log-service.yaml
-#   - envsubst-mysql/trillian-log-signer-deployment.yaml
-#   - envsubst-mysql/trillian-log-signer-service.yaml
-#   - envsubst-mysql/trillian-map-deployment.yaml
-#   - envsubst-mysql/trillian-map-service.yaml
-#   env:
-#   - PROJECT_ID=${PROJECT_ID}
-#   - IMAGE_TAG=${COMMIT_SHA}
-#   - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
-#   - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
-#   waitFor:
-#   - build_envsubst
-#   - copy_k8s_cfgs_for_mysql
-# - id: apply_k8s_cfgs_for_mysql_dryrun
-#   name: gcr.io/cloud-builders/kubectl
-#   args:
-#   - apply
-#   - --server-dry-run
-#   - --namespace=mysql
-#   - -f=envsubst-mysql/etcd-cluster.yaml
-#   - -f=envsubst-mysql/trillian-ci-mysql.yaml
-#   - -f=envsubst-mysql/trillian-mysql.yaml
-#   - -f=envsubst-mysql/trillian-log-deployment.yaml
-#   - -f=envsubst-mysql/trillian-log-service.yaml
-#   - -f=envsubst-mysql/trillian-log-signer-deployment.yaml
-#   - -f=envsubst-mysql/trillian-log-signer-service.yaml
-#   - -f=envsubst-mysql/trillian-map-deployment.yaml
-#   - -f=envsubst-mysql/trillian-map-service.yaml
-#   - --prune
-#   - --all
-#   - --prune-whitelist=core/v1/ConfigMap
-#   env:
-#   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-#   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-#   waitFor:
-#   - envsubst_k8s_cfgs_for_mysql
-#   - build_db_server
-#   - build_log_server
-#   - build_log_signer
-#   - build_map_server
+############################################################################
+## End of replicated section.
+## Below are deployment/dry-run specific steps for the CD env.
+############################################################################
+- id: pull_mysql
+  name : gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+- id: tag_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - marketplace.gcr.io/google/mysql5:${_MYSQL_TAG}
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - pull_mysql
+- id: push_mysql
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/mysql5:${_MYSQL_TAG}
+  waitFor:
+  - tag_mysql
+- id: build_db_server
+  name: gcr.io/kaniko-project/executor
+  args:
+  - --dockerfile=examples/deployment/docker/db_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
+  waitFor:
+  - push_mysql
+- id: build_log_server
+  name: gcr.io/kaniko-project/executor
+  args:
+  - --dockerfile=examples/deployment/docker/log_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
+  waitFor:
+    - prepare
+- id: build_log_signer
+  name: gcr.io/kaniko-project/executor
+  args:
+  - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}
+  - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
+  waitFor:
+    - prepare
+- id: build_map_server
+  name: gcr.io/kaniko-project/executor
+  args:
+  - --dockerfile=examples/deployment/docker/map_server/Dockerfile
+  - --destination=gcr.io/${PROJECT_ID}/map_server:${COMMIT_SHA}
+  - --cache=true
+  - --cache-dir= # Cache is in Google Container Registry
+  waitFor:
+    - prepare
+- id: build_envsubst
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - examples/deployment/docker/envsubst
+  - -t
+  - envsubst
+  waitFor: ["-"]
+- id: apply_k8s_cfgs_for_clusterwide_etcd_operator_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - -f=examples/deployment/kubernetes/etcd-deployment.yaml
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor:
+    - prepare
+- id: copy_k8s_cfgs_for_spanner
+  name: busybox
+  entrypoint: cp
+  args:
+  - -r
+  - examples/deployment/kubernetes/
+  - envsubst-spanner/
+  waitFor:
+    - prepare
+- id: envsubst_k8s_cfgs_for_spanner
+  name: envsubst
+  args:
+  - envsubst-spanner/etcd-cluster.yaml
+  - envsubst-spanner/trillian-ci-spanner.yaml
+  - envsubst-spanner/trillian-log-deployment.yaml
+  - envsubst-spanner/trillian-log-service.yaml
+  - envsubst-spanner/trillian-log-signer-deployment.yaml
+  - envsubst-spanner/trillian-log-signer-service.yaml
+  - envsubst-spanner/trillian-map-deployment.yaml
+  - envsubst-spanner/trillian-map-service.yaml
+  env:
+  - PROJECT_ID=${PROJECT_ID}
+  - IMAGE_TAG=${COMMIT_SHA}
+  waitFor:
+  - build_envsubst
+  - copy_k8s_cfgs_for_spanner
+- id: apply_k8s_cfgs_for_spanner_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - -f=envsubst-spanner/etcd-cluster.yaml
+  - -f=envsubst-spanner/trillian-ci-spanner.yaml
+  - -f=envsubst-spanner/trillian-log-deployment.yaml
+  - -f=envsubst-spanner/trillian-log-service.yaml
+  - -f=envsubst-spanner/trillian-log-signer-deployment.yaml
+  - -f=envsubst-spanner/trillian-log-signer-service.yaml
+  - -f=envsubst-spanner/trillian-map-deployment.yaml
+  - -f=envsubst-spanner/trillian-map-service.yaml
+  - --prune
+  - --all
+  - --prune-whitelist=core/v1/ConfigMap
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor:
+  - envsubst_k8s_cfgs_for_spanner
+  - build_log_server
+  - build_log_signer
+  - build_map_server
+- id: copy_k8s_cfgs_for_mysql
+  name: busybox
+  entrypoint: cp
+  args:
+  - -r
+  - examples/deployment/kubernetes/
+  - envsubst-mysql/
+  waitFor:
+    - prepare
+- id: envsubst_k8s_cfgs_for_mysql
+  name: envsubst
+  args:
+  - envsubst-mysql/etcd-cluster.yaml
+  - envsubst-mysql/trillian-ci-mysql.yaml
+  - envsubst-mysql/trillian-mysql.yaml
+  - envsubst-mysql/trillian-log-deployment.yaml
+  - envsubst-mysql/trillian-log-service.yaml
+  - envsubst-mysql/trillian-log-signer-deployment.yaml
+  - envsubst-mysql/trillian-log-signer-service.yaml
+  - envsubst-mysql/trillian-map-deployment.yaml
+  - envsubst-mysql/trillian-map-service.yaml
+  env:
+  - PROJECT_ID=${PROJECT_ID}
+  - IMAGE_TAG=${COMMIT_SHA}
+  - MYSQL_ROOT_PASSWORD=${_MYSQL_ROOT_PASSWORD}
+  - MYSQL_PASSWORD=${_MYSQL_PASSWORD}
+  waitFor:
+  - build_envsubst
+  - copy_k8s_cfgs_for_mysql
+- id: apply_k8s_cfgs_for_mysql_dryrun
+  name: gcr.io/cloud-builders/kubectl
+  args:
+  - apply
+  - --server-dry-run
+  - --namespace=mysql
+  - -f=envsubst-mysql/etcd-cluster.yaml
+  - -f=envsubst-mysql/trillian-ci-mysql.yaml
+  - -f=envsubst-mysql/trillian-mysql.yaml
+  - -f=envsubst-mysql/trillian-log-deployment.yaml
+  - -f=envsubst-mysql/trillian-log-service.yaml
+  - -f=envsubst-mysql/trillian-log-signer-deployment.yaml
+  - -f=envsubst-mysql/trillian-log-signer-service.yaml
+  - -f=envsubst-mysql/trillian-map-deployment.yaml
+  - -f=envsubst-mysql/trillian-map-service.yaml
+  - --prune
+  - --all
+  - --prune-whitelist=core/v1/ConfigMap
+  env:
+  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
+  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
+  waitFor:
+  - envsubst_k8s_cfgs_for_mysql
+  - build_db_server
+  - build_log_server
+  - build_log_signer
+  - build_map_server

--- a/integration/cloudbuild/docker-compose-mysql.yaml
+++ b/integration/cloudbuild/docker-compose-mysql.yaml
@@ -8,10 +8,9 @@ services:
       MYSQL_ROOT_PASSWORD: 'bananas'
       MYSQL_USER: 'test'
       MYSQL_PASSWORD: 'zaphod'
+      MYSQL_TCP_PORT: ${MYSQL_PORT:-3306}
     ports:
-      - '3306:3306'
-    expose:
-      - '3306'
+      - '${MYSQL_PORT:-3306}:${MYSQL_PORT:-3306}'
 
 networks:
   default:

--- a/integration/cloudbuild/docker-compose-mysql.yaml
+++ b/integration/cloudbuild/docker-compose-mysql.yaml
@@ -1,0 +1,19 @@
+version: '3.1'
+
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 'bananas'
+      MYSQL_USER: 'test'
+      MYSQL_PASSWORD: 'zaphod'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'
+
+networks:
+  default:
+    external:
+      name: cloudbuild

--- a/integration/cloudbuild/prepare.sh
+++ b/integration/cloudbuild/prepare.sh
@@ -10,12 +10,6 @@ go install \
     github.com/golang/protobuf/protoc-gen-go \
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
     github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
-go mod download
 
-# finally, spin up an ephemeral mysql instance for tests
+# Cache mysql image for later steps.
 docker-compose -f ./integration/cloudbuild/docker-compose-mysql.yaml pull
-docker-compose -f ./integration/cloudbuild/docker-compose-mysql.yaml up -d
-# Wait for mysql instance to be ready
-while ! mysql --protocol=TCP --host=${MYSQL_HOST} --user=${MYSQL_USER} -p${MYSQL_PASSWORD} -e quit ; do
- sleep 1
-done

--- a/integration/cloudbuild/prepare.sh
+++ b/integration/cloudbuild/prepare.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+set -e
+
+git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
+go install \
+    github.com/golang/protobuf/proto \
+    github.com/golang/mock/mockgen \
+    golang.org/x/tools/cmd/stringer \
+    github.com/golang/protobuf/protoc-gen-go \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
+    github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+go mod download
+
+# finally, spin up an ephemeral mysql instance for tests
+docker-compose -f ./integration/cloudbuild/docker-compose-mysql.yaml pull
+docker-compose -f ./integration/cloudbuild/docker-compose-mysql.yaml up -d
+# Wait for mysql instance to be ready
+while ! mysql --protocol=TCP --host=${MYSQL_HOST} --user=${MYSQL_USER} -p${MYSQL_PASSWORD} -e quit ; do
+ sleep 1
+done

--- a/integration/cloudbuild/run_integration.sh
+++ b/integration/cloudbuild/run_integration.sh
@@ -2,6 +2,21 @@
 set -e
 set -x
 
+export MYSQL_HOST="${HOSTNAME}_db_1"
+export MYSQL_PORT=$(( 10000 + $RANDOM % 30000))
+export MYSQL_DATABASE="test"
+export MYSQL_USER="test"
+export MYSQL_PASSWORD="zaphod"
+export MYSQL_USER_HOST="%"
+
+docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-mysql.yaml up -d
+trap "docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-mysql.yaml down" EXIT
+
+# Wait for mysql instance to be ready
+while ! mysql --protocol=TCP --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root -pbananas -e quit ; do
+ sleep 1
+done
+
 export MYSQL_URI="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}"
 
 # If the test will use etcd, then install etcd + tools.

--- a/integration/cloudbuild/run_integration.sh
+++ b/integration/cloudbuild/run_integration.sh
@@ -7,6 +7,7 @@ export MYSQL_PORT=$(( 10000 + $RANDOM % 30000))
 export MYSQL_DATABASE="test"
 export MYSQL_USER="test"
 export MYSQL_PASSWORD="zaphod"
+export MYSQL_ROOT_PASSWORD="bananas"
 export MYSQL_USER_HOST="%"
 
 docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-mysql.yaml up -d
@@ -14,10 +15,10 @@ trap "docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-m
 
 # Wait for mysql instance to be ready
 while ! mysql --protocol=TCP --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root -pbananas -e quit ; do
- sleep 1
+ sleep 5
 done
 
-export MYSQL_URI="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}"
+export TEST_MYSQL_URI="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}"
 
 # If the test will use etcd, then install etcd + tools.
 if [ "${ETCD_DIR}" != "" ]; then

--- a/integration/cloudbuild/run_integration.sh
+++ b/integration/cloudbuild/run_integration.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+
+export MYSQL_URI="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}"
+
+# If the test will use etcd, then install etcd + tools.
+if [ "${ETCD_DIR}" != "" ]; then
+  go install go.etcd.io/etcd go.etcd.io/etcd/etcdctl github.com/fullstorydev/grpcurl/cmd/grpcurl
+fi
+
+./integration/integration_test.sh
+./integration/maphammer.sh 3

--- a/integration/cloudbuild/run_presubmit.sh
+++ b/integration/cloudbuild/run_presubmit.sh
@@ -10,11 +10,11 @@ trap "docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-m
 
 # Wait for mysql instance to be ready
 while ! mysql --protocol=TCP --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root -pbananas -e quit ; do
- sleep 1
+ sleep 5
 done
 
 # Presumbits need a user with CREATE DATABASE grants since they create temporary databases.
 # For the same reason, this is a URI prefix - tests will add DB names to the end.
-export MYSQL_URI="root:bananas@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
+export TEST_MYSQL_URI="root:bananas@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
 
 ./scripts/presubmit.sh $*

--- a/integration/cloudbuild/run_presubmit.sh
+++ b/integration/cloudbuild/run_presubmit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+set -x
+
+
+# Presumbits need a user with CREATE DATABASE grants since they create temporary databases.
+# For the same reason, this is a URI prefix - tests will add DB names to the end.
+export MYSQL_URI="root:${MYSQL_ROOT_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
+
+./scripts/presubmit.sh $*

--- a/integration/cloudbuild/run_presubmit.sh
+++ b/integration/cloudbuild/run_presubmit.sh
@@ -2,9 +2,19 @@
 set -e
 set -x
 
+export MYSQL_PORT=$((10000 + $RANDOM % 30000))
+export MYSQL_HOST="${HOSTNAME}_db_1"
+
+docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-mysql.yaml up -d
+trap "docker-compose -p ${HOSTNAME} -f ./integration/cloudbuild/docker-compose-mysql.yaml down" EXIT
+
+# Wait for mysql instance to be ready
+while ! mysql --protocol=TCP --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root -pbananas -e quit ; do
+ sleep 1
+done
 
 # Presumbits need a user with CREATE DATABASE grants since they create temporary databases.
 # For the same reason, this is a URI prefix - tests will add DB names to the end.
-export MYSQL_URI="root:${MYSQL_ROOT_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
+export MYSQL_URI="root:bananas@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
 
 ./scripts/presubmit.sh $*

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -1,0 +1,31 @@
+# This Dockerfile builds a base image for the Trillan CloudBuild integration testing.
+FROM ubuntu as trillian_testbase
+
+WORKDIR /testbase
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+ENV GOPATH /go
+
+RUN apt-get update && apt-get -y install build-essential curl docker-compose lsof mysql-client socat unzip wget xxd softhsm
+
+RUN curl -sfL https://golang.org/dl/go1.15.7.linux-amd64.tar.gz | tar -xzf - -C /usr/local
+ENV PATH /usr/local/go/bin:$PATH
+
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+RUN mkdir protoc && \
+    (cd protoc && \
+    PROTOC_VERSION="3.11.4" && \
+    PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip" && \
+    wget "https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}" && \
+    unzip -o ${PROTOC_ZIP} -d /usr/local bin/protoc && \
+    unzip -o ${PROTOC_ZIP} -d /usr/local 'include/*' \
+    )
+ENV PATH /usr/local/bin:$PATH
+RUN BAZEL_VERSION="1.1.0" && \
+    wget --quiet -O install.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh" && \
+    chmod +x install.sh && \
+    ./install.sh
+
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:$PATH

--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -100,6 +100,8 @@ kill_pid() {
 # Parameters:
 #   - number of log servers to run
 #   - number of log signers to run
+# Env:
+#   - If TEST_MYSQL_URI is set, uses that for the server --mysql_uri flag.
 # Populates:
 #  - HTTP_SERVER_1   : first HTTP server
 #  - RPC_SERVER_1    : first RPC server
@@ -112,7 +114,7 @@ kill_pid() {
 #  - ETCD_DB_DIR     : location of etcd database
 # If WITH_PKCS11 is set, also populates:
 #  - SOFTHSM_CONF    : location of the SoftHSM configuration file
-# IF MYSQL_URI is set, uses that for the server mysql_uri flag.
+#
 log_prep_test() {
   # Default to one of each.
   local rpc_server_count=${1:-1}
@@ -129,9 +131,9 @@ log_prep_test() {
   local logsigner_opts=''
   local has_etcd=0
 
-  if [[ "${MYSQL_URI}" != "" ]]; then
-    logserver_opts+=" --mysql_uri=${MYSQL_URI}"
-    logsigner_opts+=" --mysql_uri=${MYSQL_URI}"
+  if [[ "${TEST_MYSQL_URI}" != "" ]]; then
+    logserver_opts+=" --mysql_uri=${TEST_MYSQL_URI}"
+    logsigner_opts+=" --mysql_uri=${TEST_MYSQL_URI}"
   fi
 
   # Start a local etcd instance (if configured).
@@ -273,6 +275,8 @@ EOF
 # map_prep_test prepares a set of running processes for a Trillian map test.
 # Parameters:
 #   - number of map servers to run
+# Env:
+#   - If TEST_MYSQL_URI is set, uses that for the server --mysql_uri flag.
 # Populates:
 #  - RPC_SERVER_1    : first RPC server
 #  - RPC_SERVERS     : RPC target, either comma-separated list of RPC addresses or etcd service
@@ -288,8 +292,8 @@ map_prep_test() {
   yes | bash "${TRILLIAN_PATH}/scripts/resetdb.sh"
 
   local mapserver_opts=''
-  if [[ "${MYSQL_URI}" != "" ]]; then
-    mapserver_opts+=" --mysql_uri=${MYSQL_URI}"
+  if [[ "${TEST_MYSQL_URI}" != "" ]]; then
+    mapserver_opts+=" --mysql_uri=${TEST_MYSQL_URI}"
   fi
 
   # Start a set of Map RPC servers.

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -6,6 +6,3 @@ INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 run_test "Map integration test" "${INTEGRATION_DIR}/map_integration_test.sh" "$@"
 run_test "Log integration test" "${INTEGRATION_DIR}/log_integration_test.sh" "$@"
-
-# See if this helps debug the deadlocks we keep seeing.
-mysql -u root -e 'SHOW ENGINE INNODB STATUS'


### PR DESCRIPTION
This change adds most of the Travis CI builds to Could Build. It will allow migrating off Travis.

Part of #2298.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).