### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
     - name: "lint"
       before_install: skip
       install:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
       - git clone --depth=1 https://github.com/googleapis/googleapis.git "$GOPATH/src/github.com/googleapis/googleapis"
       before_script: skip
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Upgrades
  * Dockerfiles are now based on Go 1.13 image.
  * The etcd is now pinned to v3.4.12.
+ * The golangci-lint suite is now at v1.36.0.
 
 ## v1.3.11
 [Published 2020-10-06](https://github.com/google/trillian/releases/tag/v1.3.11)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,14 +52,13 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./integration/cloudbuild/prepare.sh
 
-# Run lint and porcelain checks
+# Run lint and porcelain checks.
 - id: lint
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: bash
   args:
     - -exc
     - |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
       golangci-lint run --deadline=8m
       ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
   waitFor:

--- a/experimental/batchmap/cmd/verify/verify.go
+++ b/experimental/batchmap/cmd/verify/verify.go
@@ -100,6 +100,8 @@ func main() {
 		if leaf == nil {
 			glog.Fatalf("couldn't find expected leaf %x in tile %x", needLeafPath, tile.Path)
 		}
+		// TODO(pavelkalinnikov): Remove nolint after fixing
+		// https://github.com/dominikh/go-tools/issues/921.
 		if !bytes.Equal(leaf.Hash, needValue) { // nolint: staticcheck
 			glog.Fatalf("wrong leaf value in tile %x, leaf %x: got %x, want %x", tile.Path, leaf.Path, leaf.Hash, needValue)
 		}

--- a/experimental/batchmap/cmd/verify/verify.go
+++ b/experimental/batchmap/cmd/verify/verify.go
@@ -100,7 +100,7 @@ func main() {
 		if leaf == nil {
 			glog.Fatalf("couldn't find expected leaf %x in tile %x", needLeafPath, tile.Path)
 		}
-		if !bytes.Equal(leaf.Hash, needValue) {
+		if !bytes.Equal(leaf.Hash, needValue) { // nolint: staticcheck
 			glog.Fatalf("wrong leaf value in tile %x, leaf %x: got %x, want %x", tile.Path, leaf.Path, leaf.Hash, needValue)
 		}
 

--- a/experimental/batchmap/tmap.go
+++ b/experimental/batchmap/tmap.go
@@ -134,7 +134,7 @@ func updateStratum(s beam.Scope, base, deltas beam.PCollection, treeID int64, ha
 // serializable by the default Beam coder. Also, it allows changes to be made
 // to smt.Node without affecting this, which improves decoupling.
 type nodeHash struct {
-	// Path from root of the map to this node. Equivalant to NodeID2, but with the
+	// Path from root of the map to this node. Equivalent to NodeID2, but with the
 	// significant benefit that it will be serialized properly without writing a
 	// custom coder for nodeHash.
 	Path []byte

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sfL https://golang.org/dl/go1.15.7.linux-amd64.tar.gz | tar -xzf - -C /usr/local
 ENV PATH /usr/local/go/bin:$PATH
 
-# https://golangci-lint.run/usage/install/
+# Install golangci-lint. See docs at: https://golangci-lint.run/usage/install/.
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
 
 RUN mkdir protoc && \

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -23,7 +23,9 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sfL https://golang.org/dl/go1.15.7.linux-amd64.tar.gz | tar -xzf - -C /usr/local
 ENV PATH /usr/local/go/bin:$PATH
 
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+# https://golangci-lint.run/usage/install/
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+
 RUN mkdir protoc && \
     (cd protoc && \
     PROTOC_VERSION="3.12.4" && \

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -sfL https://golang.org/dl/go1.15.7.linux-amd64.tar.gz | tar -xzf - -C 
 ENV PATH /usr/local/go/bin:$PATH
 
 # https://golangci-lint.run/usage/install/
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
 
 RUN mkdir protoc && \
     (cd protoc && \

--- a/quota/etcd/etcdqm/etcdqm.go
+++ b/quota/etcd/etcdqm/etcdqm.go
@@ -24,21 +24,22 @@ import (
 	"go.etcd.io/etcd/clientv3"
 )
 
-type manager struct {
+// Manager implements a quota manager based on etcd.
+type Manager struct {
 	qs *storage.QuotaStorage
 }
 
 // New returns a new etcd-based quota.Manager.
-func New(client *clientv3.Client) *manager {
-	return &manager{qs: &storage.QuotaStorage{Client: client}}
+func New(client *clientv3.Client) *Manager {
+	return &Manager{qs: &storage.QuotaStorage{Client: client}}
 }
 
 // GetTokens implements the quota.Manager API.
-func (m *manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
+func (m *Manager) GetTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
 	return m.qs.Get(ctx, configNames(specs), int64(numTokens))
 }
 
-func (m *manager) peekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
+func (m *Manager) peekTokens(ctx context.Context, specs []quota.Spec) (map[quota.Spec]int, error) {
 	names := configNames(specs)
 	nameToSpec := make(map[string]quota.Spec)
 	for i, name := range names {
@@ -58,12 +59,12 @@ func (m *manager) peekTokens(ctx context.Context, specs []quota.Spec) (map[quota
 }
 
 // PutTokens implements the quota.Manager API.
-func (m *manager) PutTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
+func (m *Manager) PutTokens(ctx context.Context, numTokens int, specs []quota.Spec) error {
 	return m.qs.Put(ctx, configNames(specs), int64(numTokens))
 }
 
 // ResetQuota implements the quota.Manager API.
-func (m *manager) ResetQuota(ctx context.Context, specs []quota.Spec) error {
+func (m *Manager) ResetQuota(ctx context.Context, specs []quota.Spec) error {
 	return m.qs.Reset(ctx, configNames(specs))
 }
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -1446,7 +1446,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil) // nolint: megacheck
+				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},

--- a/storage/mysql/map_storage_test.go
+++ b/storage/mysql/map_storage_test.go
@@ -655,7 +655,7 @@ func mapTree(mapID int64) *trillian.Tree {
 	}
 }
 
-func createMapNodes(count int) []stree.Node {
+func createMapNodes(count int) []stree.Node { // nolint: unused
 	r := make([]stree.Node, count)
 	bs := make([]byte, 32) // Default value of 0 index in 2^256 keyspace.
 


### PR DESCRIPTION
This change upgrades the linter suite, and fixes the corresponding errors.

The tool in CI is too outdated, and doesn't work:

```
golangci-lint run --deadline=8m
Step #3 - "lint": level=warning msg="[runner] Can't run linter unused: <lots of errors> (unknown iexport format version 1), export data is newer version - update tool))]"
```

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
