### PR TITLE
cloudbuild: Add Codecov reporting

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,7 @@ substitutions:
   _MYSQL_TAG: "5.7"
   _MYSQL_ROOT_PASSWORD: ""
   _MYSQL_PASSWORD: ""
+  _CODECOV_TOKEN: "" # The auth token for uploading coverage to Codecov.
 options:
   machineType: E2_HIGHCPU_32
   volumes:
@@ -112,6 +113,7 @@ steps:
   env:
     - GOFLAGS=-race
     - GO_TEST_TIMEOUT=20m
+    - CODECOV_TOKEN=${_CODECOV_TOKEN}
   waitFor:
     - prepare
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -101,6 +101,20 @@ steps:
   waitFor:
     - prepare
 
+# Codecov
+- id: codecov
+  name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
+  entrypoint: ./integration/cloudbuild/run_presubmit.sh
+  args:
+    - --coverage
+    - --no-linters
+    - --no-generate
+  env:
+    - GOFLAGS=-race
+    - GO_TEST_TIMEOUT=20m
+  waitFor:
+    - prepare
+
 # Presubmit (Batched queue)
 - id: presubmit_batched
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'

--- a/integration/cloudbuild/run_presubmit.sh
+++ b/integration/cloudbuild/run_presubmit.sh
@@ -18,3 +18,8 @@ done
 export TEST_MYSQL_URI="root:bananas@tcp(${MYSQL_HOST}:${MYSQL_PORT})/"
 
 ./scripts/presubmit.sh $*
+
+# TODO(pavelkalinnikov): Make the check more robust.
+if [ $1 = "--coverage" ]; then
+  bash <(curl -s https://codecov.io/bash)
+fi


### PR DESCRIPTION
This change adds a step to Cloud Build config, which generates tests
coverage reports and uploads to codecov.io. The step has a secret token
`_CODECOV_TOKEN` which should be configured via substitution variables.

Part of #2298