### PR TITLE
Stop using the deprecated hasher symbols

### DIFF
--- a/client/log_client_test.go
+++ b/client/log_client_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/testonly/integration"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"

--- a/client/log_verifier_test.go
+++ b/client/log_verifier_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys/pem"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 

--- a/experimental/batchmap/cmd/build/mapdemo.go
+++ b/experimental/batchmap/cmd/build/mapdemo.go
@@ -33,7 +33,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/google/trillian/experimental/batchmap"
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 )
 
 const hash = crypto.SHA512_256

--- a/experimental/batchmap/cmd/verify/verify.go
+++ b/experimental/batchmap/cmd/verify/verify.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/experimental/batchmap"
 	"github.com/google/trillian/merkle"
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 )
 
 const hash = crypto.SHA512_256

--- a/experimental/batchmap/tmap.go
+++ b/experimental/batchmap/tmap.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/google/trillian/storage/tree"
 
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/merkle/smt"
 )

--- a/integration/log.go
+++ b/integration/log.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/trillian/internal/merkle/inmemory"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/types"
 )
 

--- a/integration/storagetest/logtests.go
+++ b/integration/storagetest/logtests.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"

--- a/internal/merkle/inmemory/merkle_tree_test.go
+++ b/internal/merkle/inmemory/merkle_tree_test.go
@@ -24,7 +24,7 @@ import (
 
 	_ "github.com/golang/glog"
 	"github.com/google/trillian/merkle/hashers"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 )
 
 // Note test inputs came from the values used by the C++ code. The original

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -27,18 +27,17 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
+	stestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
-
-	tcrypto "github.com/google/trillian/crypto"
-	stestonly "github.com/google/trillian/storage/testonly"
-	"github.com/google/trillian/storage/tree"
 )
 
 // Arbitrary time for use in tests

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -30,6 +30,7 @@ import (
 	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys/pem"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/merkle/testonly"
 )
 

--- a/merkle/hstar2_test.go
+++ b/merkle/hstar2_test.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/merkle/maphasher"
 	"github.com/google/trillian/storage/tree"

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 )
 
 // TestCalcInclusionProofNodeAddresses contains inclusion proof tests. For

--- a/merkle/logverifier/log_verifier_test.go
+++ b/merkle/logverifier/log_verifier_test.go
@@ -23,7 +23,7 @@ import (
 
 	_ "github.com/golang/glog"
 	"github.com/google/trillian/internal/merkle/inmemory"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 )
 
 type inclusionProofTestVector struct {

--- a/merkle/mapverifier/map_verifier_test.go
+++ b/merkle/mapverifier/map_verifier_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 	"github.com/google/trillian/merkle/maphasher"
 	"github.com/google/trillian/testonly"
 )

--- a/merkle/smt/hstar3_test.go
+++ b/merkle/smt/hstar3_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/trillian/merkle/coniks"
+	coniks "github.com/google/trillian/merkle/coniks/hasher"
 	"github.com/google/trillian/storage/tree"
 )
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/extension"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage"
 	stestonly "github.com/google/trillian/storage/testonly"

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -27,21 +27,20 @@ import (
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/extension"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage"
+	stestonly "github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	tcrypto "github.com/google/trillian/crypto"
-	stestonly "github.com/google/trillian/storage/testonly"
-	"github.com/google/trillian/storage/tree"
 )
 
 // cmpMatcher is a custom gomock.Matcher that uses cmp.Equal combined with a

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/trillian/internal/merkle/inmemory"
 	"github.com/google/trillian/merkle"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage/testonly"
 )
 

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -24,13 +24,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/maphasher"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage/storagepb"
+	stestonly "github.com/google/trillian/storage/testonly"
 	"github.com/google/trillian/storage/tree"
 
 	"github.com/golang/mock/gomock"
-
-	stestonly "github.com/google/trillian/storage/testonly"
 )
 
 var (

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -28,16 +28,15 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/testdb"
+	storageto "github.com/google/trillian/storage/testonly"
 	stree "github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/testonly"
 	"github.com/google/trillian/types"
-
-	tcrypto "github.com/google/trillian/crypto"
-	storageto "github.com/google/trillian/storage/testonly"
 )
 
 func TestNodeRoundTrip(t *testing.T) {

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/testonly"
 	"google.golang.org/grpc/codes"

--- a/storage/testonly/fake_node_reader.go
+++ b/storage/testonly/fake_node_reader.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/storage/tree"
 )
 

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -34,13 +34,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/merkle/hashers/registry"
-	"github.com/google/trillian/merkle/rfc6962"
+	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
@@ -51,8 +52,6 @@ import (
 	"github.com/google/trillian/trees"
 	"github.com/google/trillian/types"
 	"github.com/google/trillian/util/clock"
-
-	tcrypto "github.com/google/trillian/crypto"
 )
 
 var leafHashesFlag bool

--- a/storage/tools/dump_tree/dumplib/dumplib.go
+++ b/storage/tools/dump_tree/dumplib/dumplib.go
@@ -41,6 +41,7 @@ import (
 	"github.com/google/trillian/crypto/sigpb"
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/merkle/hashers/registry"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"


### PR DESCRIPTION
This change removes direct referencing the symbols that were moved
and deprecated in #2278.

Factored out from #2310.