### PR TITLE
Run binaries via "go run" to avoid local artifacts

### DIFF
--- a/integration/log_integration_test.sh
+++ b/integration/log_integration_test.sh
@@ -30,8 +30,7 @@ else
 fi
 
 echo "Provision log"
-go build github.com/google/trillian/cmd/createtree/
-TEST_TREE_ID=$(./createtree \
+TEST_TREE_ID=$(go run github.com/google/trillian/cmd/createtree \
   --admin_server="${TRILLIAN_SERVER}" \
   ${KEY_ARGS})
 echo "Created tree ${TEST_TREE_ID}"

--- a/integration/log_md_test.sh
+++ b/integration/log_md_test.sh
@@ -14,12 +14,12 @@ TRILLIAN_SERVER="${RPC_SERVER_1}"
 
 metrics_port=$(pick_unused_port ${port})
 echo "Running test against ephemeral tree, metrics on http://localhost:${metrics_port}/metrics"
-go build ${GOFLAGS} github.com/google/trillian/testonly/mdm/mdmtest
-./mdmtest --rpc_server="${TRILLIAN_SERVER}" \
-          --metrics_endpoint="localhost:${metrics_port}" \
-          --checkers=10 \
-          --new_leaf_chance=90 \
-          --logtostderr
+go run ${GOFLAGS} github.com/google/trillian/testonly/mdm/mdmtest \
+  --rpc_server="${TRILLIAN_SERVER}" \
+  --metrics_endpoint="localhost:${metrics_port}" \
+  --checkers=10 \
+  --new_leaf_chance=90 \
+  --logtostderr
 RESULT=$?
 set -e
 

--- a/integration/maphammer.sh
+++ b/integration/maphammer.sh
@@ -6,7 +6,6 @@ INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 # Default to one map
 MAP_COUNT=${1:-1}
 
-go build ${GOFLAGS} github.com/google/trillian/testonly/internal/hammer/maphammer
 map_prep_test 1
 TO_KILL+=(${RPC_SERVER_PIDS[@]})
 
@@ -16,7 +15,8 @@ map_provision "${RPC_SERVER_1}" ${MAP_COUNT}
 metrics_port=$(pick_unused_port)
 echo "Running test(s) with metrics at localhost:${metrics_port}"
 set +e
-./maphammer --map_ids=${MAP_IDS} --admin_server=${RPC_SERVER_1} --rpc_server=${RPC_SERVER_1} --metrics_endpoint="localhost:${metrics_port}" --logtostderr ${HAMMER_OPTS}
+go run ${GOFLAGS} github.com/google/trillian/testonly/internal/hammer/maphammer \
+  --map_ids=${MAP_IDS} --admin_server=${RPC_SERVER_1} --rpc_server=${RPC_SERVER_1} --metrics_endpoint="localhost:${metrics_port}" --logtostderr ${HAMMER_OPTS}
 RESULT=$?
 set -e
 

--- a/integration/mapreplay.sh
+++ b/integration/mapreplay.sh
@@ -9,11 +9,9 @@ if [[ ! -f "${MAP_JOURNAL}" ]]; then
   exit 1
 fi
 
-echo "Building mapreplay"
-go build github.com/google/trillian/testonly/internal/hammer/mapreplay
-
 declare -a OLD_MAP_ARRAY
-OLD_MAP_IDS=$(./mapreplay --logtostderr -v 2 --replay_from ${MAP_JOURNAL} 2>&1 >/dev/null | grep "map_id:" | sed 's/.*map_id:\([0-9]\+\).*/\1/' | sort | uniq)
+OLD_MAP_IDS=$(go run github.com/google/trillian/testonly/internal/hammer/mapreplay \
+  --logtostderr -v 2 --replay_from ${MAP_JOURNAL} 2>&1 >/dev/null | grep "map_id:" | sed 's/.*map_id:\([0-9]\+\).*/\1/' | sort | uniq)
 for mapid in "${OLD_MAP_IDS}"; do
   OLD_MAP_ARRAY+=(${mapid})
 done
@@ -45,7 +43,8 @@ echo "Mapping map/tree IDs ${MAPMAP}"
 
 echo "Replaying requests from ${MAP_JOURNAL}"
 set +e
-./mapreplay --map_ids=${MAPMAP} --rpc_server=${RPC_SERVER_1} --logtostderr -v 1 --replay_from "${MAP_JOURNAL}"
+go run github.com/google/trillian/testonly/internal/hammer/mapreplay \
+  --map_ids=${MAPMAP} --rpc_server=${RPC_SERVER_1} --logtostderr -v 1 --replay_from "${MAP_JOURNAL}"
 RESULT=$?
 set -e
 


### PR DESCRIPTION
This change eliminates racing between different Cloud Build steps,
over the generated binaries in the filesystem.

Part of #2298