### PR TITLE
Run presubmit.sh with more linter checks

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -89,7 +89,7 @@ steps:
     - GOFLAGS=-race
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - prepare
+    - lint
 
 # Codecov
 - id: codecov
@@ -104,7 +104,7 @@ steps:
     - GO_TEST_TIMEOUT=20m
     - CODECOV_TOKEN=${_CODECOV_TOKEN}
   waitFor:
-    - prepare
+    - lint
 
 # Presubmit (Batched queue)
 - id: presubmit_batched
@@ -117,7 +117,7 @@ steps:
     - GOFLAGS=-race --tags=batched_queue
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - presubmit
+    - lint
 
 # Presubmit (PKCS11)
 - id: presubmit_pkcs11
@@ -130,7 +130,7 @@ steps:
     - GOFLAGS=-race --tags=pkcs11
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - presubmit
+    - lint
 
 # Try to spread the load a bit, we'll wait for all the presubmit.* steps
 # to finish before starting the integration.* ones.
@@ -140,6 +140,7 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: /bin/true
   waitFor:
+    - codecov
     - presubmit
     - presubmit_batched
     - presubmit_pkcs11

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,12 +55,10 @@ steps:
 # Run lint and porcelain checks.
 - id: lint
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
-  entrypoint: bash
+  entrypoint: ./scripts/presubmit.sh
   args:
-    - -exc
-    - |
-      golangci-lint run --deadline=8m
-      ./scripts/check_license.sh $(find . -name '*.go' | grep -v mock_ | grep -v .pb.go | grep -v .pb.gw.go | grep -v _string.go | tr '\n' ' ')
+    - --no-build
+    - --no-generate
   waitFor:
     - prepare
 

--- a/integration/cloudbuild/prepare.sh
+++ b/integration/cloudbuild/prepare.sh
@@ -21,4 +21,5 @@ go install \
     github.com/golang/protobuf/proto \
     github.com/golang/protobuf/protoc-gen-go \
     github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc \
+    golang.org/x/tools/cmd/goimports \
     golang.org/x/tools/cmd/stringer

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -71,6 +71,7 @@ main() {
     grep -v mock_ | \
     grep -v .pb.go | \
     grep -v _string.go | \
+    grep -v .shims.go | \
     tr '\n' ' ')"
 
   # Prevent the creation of proto files with .txt extensions.


### PR DESCRIPTION
This change replaces the inline script in the "linter" Cloud Build step with the pre-existing
`scripts/presubmit.sh`. The replacement script does more useful checks.

Part of #2298