### PR TITLE
cloudbuild: Add empty diff check

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,13 +52,16 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./integration/cloudbuild/prepare.sh
 
-# Run lint and porcelain checks.
+# Run lint and porcelain checks, make sure the diff is empty and no files need
+# to be updated. This includes gofmt, golangci-linter, go mod tidy, go mod
+# generate and a few more.
 - id: lint
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./scripts/presubmit.sh
   args:
     - --no-build
-    - --no-generate
+    - --fix
+    - --empty-diff
   waitFor:
     - prepare
 

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -26,7 +26,7 @@ check_cmd() {
 }
 
 usage() {
-  echo "$0 [--coverage] [--fix] [--no-build] [--no-linters] [--no-generate]"
+  echo "$0 [--coverage] [--fix] [--no-build] [--no-linters] [--no-generate] [--empty-diff]"
 }
 
 main() {
@@ -35,6 +35,7 @@ main() {
   local run_build=1
   local run_lint=1
   local run_generate=1
+  local empty_diff=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --coverage)
@@ -55,6 +56,9 @@ main() {
         ;;
       --no-generate)
         run_generate=0
+        ;;
+      --empty-diff)
+        empty_diff=1
         ;;
       *)
         usage
@@ -126,6 +130,11 @@ main() {
     go generate -run="protoc" ./...
     go generate -run="mockgen" ./...
     go generate -run="stringer" ./...
+  fi
+
+  if [[ "${empty_diff}" -eq 1 ]]; then
+    echo 'checking git diff is empty'
+    git diff --exit-code
   fi
 }
 


### PR DESCRIPTION
This change adds a check that `go generate`, `gofmt`, `go mod tidy`, among
other tools that can modify the source files, leave the repository intact. This
means that the developer submitted all the files in the correct state.

Part of #2298