### PR TITLE
Fix data race over flags in tests

### DIFF
--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -149,6 +149,10 @@ func TestCreateTree(t *testing.T) {
 func runTest(t *testing.T, tests []*testCase) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
+			// Note: Restore() must be called after the flag-reading bits are
+			// stopped, otherwise there might be a data race.
+			defer flagsaver.Save().MustRestore()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -157,7 +161,6 @@ func runTest(t *testing.T, tests []*testCase) {
 				t.Fatalf("Error starting fake server: %v", err)
 			}
 			defer stopFakeServer()
-			defer flagsaver.Save().MustRestore()
 			*adminServerAddr = s.Addr
 			if tc.setFlags != nil {
 				tc.setFlags()

--- a/cmd/get_tree_public_key/main_test.go
+++ b/cmd/get_tree_public_key/main_test.go
@@ -31,6 +31,10 @@ import (
 )
 
 func TestGetTreePublicKey(t *testing.T) {
+	// Note: Restore() must be called after the flag-reading bits are stopped,
+	// otherwise there is a data race. Here, the logEnv must be Closed first.
+	defer flagsaver.Save().MustRestore()
+
 	// Set up Trillian servers
 	const numSequencers = 0 // we don't actually need any sequencers.
 	serverOpts := []grpc.ServerOption{}
@@ -50,7 +54,6 @@ func TestGetTreePublicKey(t *testing.T) {
 	}
 
 	// Set the flags.
-	defer flagsaver.Save().MustRestore()
 	setup.SetFlag(t, "admin_server", logEnv.Address)
 	setup.SetFlag(t, "log_id", fmt.Sprint(log.TreeId))
 

--- a/cmd/updatetree/main_test.go
+++ b/cmd/updatetree/main_test.go
@@ -113,6 +113,10 @@ func TestFreezeTree(t *testing.T) {
 func runTest(t *testing.T, tests []*testCase) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
+			// Note: Restore() must be called after the flag-reading bits are
+			// stopped, otherwise there might be a data race.
+			defer flagsaver.Save().MustRestore()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -121,7 +125,6 @@ func runTest(t *testing.T, tests []*testCase) {
 				t.Fatalf("Error starting fake server: %v", err)
 			}
 			defer stopFakeServer()
-			defer flagsaver.Save().MustRestore()
 			*adminServerAddr = s.Addr
 			if tc.setFlags != nil {
 				tc.setFlags()


### PR DESCRIPTION
Fix the following race in CI:

```
WARNING: DATA RACE
Step #5 - "presubmit": Write at 0x00c0001f6998 by goroutine 8:
Step #5 - "presubmit": flag.(*intValue).Set()
...
Step #5 - "presubmit": github.com/google/trillian/testonly/flagsaver.(*Stash).MustRestore()
Step #5 - "presubmit": github.com/google/trillian/cmd/get_tree_public_key.TestGetTreePublicKey()
...
Step #5 - "presubmit": Previous read at 0x00c0001f6998 by goroutine 102:
...
Step #5 - "presubmit": github.com/google/trillian/log.(*SequencerManager).ExecutePass()
```