### PR TITLE
mysql: Convert known errors to GRPC status

### DIFF
--- a/storage/mysql/errors.go
+++ b/storage/mysql/errors.go
@@ -6,6 +6,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	// ER_DUP_ENTRY: Error returned by driver when inserting a duplicate row.
+	errNumDuplicate = 1062
+	// ER_LOCK_DEADLOCK: Error returned when there was a deadlock.
+	errNumDeadlock = 1213
+)
+
 // mysqlToGRPC converts some types of MySQL errors to GRPC errors. This gives
 // clients more signal when the operation can be retried.
 func mysqlToGRPC(err error) error {
@@ -13,8 +20,17 @@ func mysqlToGRPC(err error) error {
 	if !ok {
 		return err
 	}
-	if mysqlErr.Number == 1213 { // ER_LOCK_DEADLOCK
+	if mysqlErr.Number == errNumDeadlock {
 		return status.Errorf(codes.Aborted, "MySQL: %v", mysqlErr)
 	}
 	return err
+}
+
+func isDuplicateErr(err error) bool {
+	switch err := err.(type) {
+	case *mysql.MySQLError:
+		return err.Number == errNumDuplicate
+	default:
+		return false
+	}
 }

--- a/storage/mysql/errors.go
+++ b/storage/mysql/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mysql
 
 import (

--- a/storage/mysql/errors.go
+++ b/storage/mysql/errors.go
@@ -1,0 +1,20 @@
+package mysql
+
+import (
+	"github.com/go-sql-driver/mysql"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mysqlToGRPC converts some types of MySQL errors to GRPC errors. This gives
+// clients more signal when the operation can be retried.
+func mysqlToGRPC(err error) error {
+	mysqlErr, ok := err.(*mysql.MySQLError)
+	if !ok {
+		return err
+	}
+	if mysqlErr.Number == 1213 { // ER_LOCK_DEADLOCK
+		return status.Errorf(codes.Aborted, "MySQL: %v", mysqlErr)
+	}
+	return err
+}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
@@ -81,9 +80,6 @@ const (
 	// Same as above except with leaves ordered by sequence so we only incur this cost when necessary
 	orderBySequenceNumberSQL                     = " ORDER BY s.SequenceNumber"
 	selectLeavesByMerkleHashOrderedBySequenceSQL = selectLeavesByMerkleHashSQL + orderBySequenceNumberSQL
-
-	// Error code returned by driver when inserting a duplicate row
-	errNumDuplicate = 1062
 
 	logIDLabel = "logid"
 )
@@ -973,13 +969,4 @@ func (l byLeafIdentityHashWithPosition) Swap(i, j int) {
 
 func (l byLeafIdentityHashWithPosition) Less(i, j int) bool {
 	return bytes.Compare(l[i].leaf.LeafIdentityHash, l[j].leaf.LeafIdentityHash) == -1
-}
-
-func isDuplicateErr(err error) bool {
-	switch err := err.(type) {
-	case *mysql.MySQLError:
-		return err.Number == errNumDuplicate
-	default:
-		return false
-	}
 }

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -338,14 +338,14 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 func checkResultOkAndRowCountIs(res sql.Result, err error, count int64) error {
 	// The Exec() might have just failed
 	if err != nil {
-		return err
+		return mysqlToGRPC(err)
 	}
 
 	// Otherwise we have to look at the result of the operation
 	rowsAffected, rowsError := res.RowsAffected()
 
 	if rowsError != nil {
-		return rowsError
+		return mysqlToGRPC(rowsError)
 	}
 
 	if rowsAffected != count {


### PR DESCRIPTION
This helps clients have a better signal on whether the operation is restartable.
The `Backoff` package automatically honours the `Aborted` code as eligible
for restarts.

This change mitigates ones of the flaky integration tests in https://github.com/google/trillian/issues/2298#issuecomment-768325606.