### PR TITLE
client: Fix flaky WaitForInclusion test attempt 2

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -268,6 +268,10 @@ func (m *mySQLLogStorage) beginInternal(ctx context.Context, tree *trillian.Tree
 	return ltx, nil
 }
 
+// TODO(pavelkalinnikov): This and many other methods of this storage
+// implementation can leak a specific sql.ErrTxDone all the way to the client,
+// if the transaction is rolled back as a result of a canceled context. It must
+// return "generic" errors, and only log the specific ones for debugging.
 func (m *mySQLLogStorage) ReadWriteTransaction(ctx context.Context, tree *trillian.Tree, f storage.LogTXFunc) error {
 	tx, err := m.beginInternal(ctx, tree)
 	if err != nil && err != storage.ErrTreeNeedsInit {


### PR DESCRIPTION
Sometimes the test fails with this error:

```
WaitForInclusion before sequencing: rpc error: code = Unknown desc =
sql: transaction has already been committed or rolled back, want:
not-nil
```

This is because MySQL storage layer can return a different error when the
context is canceled (ErrTxDone: https://golang.org/pkg/database/sql/#Tx).

For the purposes of the test it is sufficient to check that *some* error
is returned rather than a concrete cancelation error.