### PR TITLE
Cloudbuild logs bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  * `testdb` no longer accepts the `--test_mysql_uri` flag, and instead honours the
    `TEST_MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
    specific test DB instance.
+ * Set GCS bucket to send build logs to in cloudbuild.yaml
 
 ### Upgrades
  * Dockerfiles are now based on Go 1.13 image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
  * `testdb` no longer accepts the `--test_mysql_uri` flag, and instead honours the
    `TEST_MYSQL_URI` ENV var. This makes it easier to blanket configure tests to use a
    specific test DB instance.
- * Set GCS bucket to send build logs to in cloudbuild.yaml
 
 ### Upgrades
  * Dockerfiles are now based on Go 1.13 image.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,9 @@ options:
 # TODO(pavelkalinnikov): Consider pushing this image only on commits to master.
 images: ['gcr.io/$PROJECT_ID/trillian_testbase:latest']
 
+# Cloud Build logs sent to GCS bucket
+logsBucket: 'gs://trillian-cloudbuild-logs'
+
 steps:
 
 # Try to pull the testbase image from Container Registry.


### PR DESCRIPTION
Send Cloudbuild logs to GCS storage bucket 'trillian-cloudbuild-logs'

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
