### PR TITLE
Temporary fix for go1.16 tests

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -102,13 +102,14 @@ main() {
     go build ./...
 
     export TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT:-5m}"
+    export TEST_FLAGS_SUFFIX="-alsologtostderr -test.paniconexit0=false"
 
     if [[ ${coverage} -eq 1 ]]; then
       TEST_FLAGS+=" -covermode=atomic -coverprofile=coverage.txt"
     fi
 
     echo "running go test ${TEST_FLAGS} ./..."
-    go test ${TEST_FLAGS} ./... -alsologtostderr
+    go test ${TEST_FLAGS} ./... ${TEST_FLAGS_SUFFIX}
   fi
 
   if [[ "${run_lint}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -87,7 +87,7 @@ main() {
   fi
 
   # This is the go minor version. It's asumed that the major version is 1.
-  GOVER=`go version | awk -F. '{print $2}'`
+  GOVER=`go version | awk -F. '{print $2}' | awk '{print $1}'`
   if [[ "$fix" -eq 1 ]]; then
     check_pkg goimports golang.org/x/tools/cmd/goimports || exit 1
 

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -86,6 +86,8 @@ main() {
     exit 1
   fi
 
+  # This is the go minor version. It's asumed that the major version is 1.
+  GOVER=`go version | awk -F. '{print $2}'`
   if [[ "$fix" -eq 1 ]]; then
     check_pkg goimports golang.org/x/tools/cmd/goimports || exit 1
 
@@ -102,10 +104,15 @@ main() {
     go build ./...
 
     export TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT:-5m}"
-    export TEST_FLAGS_SUFFIX="-alsologtostderr -test.paniconexit0=false"
+    export TEST_FLAGS_SUFFIX="-alsologtostderr"
 
     if [[ ${coverage} -eq 1 ]]; then
       TEST_FLAGS+=" -covermode=atomic -coverprofile=coverage.txt"
+    fi
+
+    if [[ ${GOVER} -ge 16 ]]; then
+      # https://github.com/google/trillian/issues/2364
+      TEST_FLAGS_SUFFIX+=" -test.paniconexit0=false"
     fi
 
     echo "running go test ${TEST_FLAGS} ./..."


### PR DESCRIPTION
This is a workaround to make presubmit work while we work out and address the root cause for #2364.