### PR TITLE
Reset flags in a cleaner way

### DIFF
--- a/cmd/createtree/main_test.go
+++ b/cmd/createtree/main_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"testing"
 	"time"
 
@@ -89,7 +88,7 @@ func TestCreateTree(t *testing.T) {
 		{
 			desc: "mandatoryOptsNotSet",
 			// Undo the flags set by runTest, so that mandatory options are no longer set.
-			setFlags:    resetFlags,
+			setFlags:    flagsaver.Save().MustRestore,
 			validateErr: errAdminAddrNotSet,
 			wantErr:     true,
 		},
@@ -193,11 +192,4 @@ func expectCalls(call *gomock.Call, err error, prevErr ...error) *gomock.Call {
 	}
 	// If this function succeeds it should only be called once.
 	return call.Times(1)
-}
-
-// resetFlags sets all flags to their default values.
-func resetFlags() {
-	flag.Visit(func(f *flag.Flag) {
-		f.Value.Set(f.DefValue)
-	})
 }

--- a/cmd/updatetree/main_test.go
+++ b/cmd/updatetree/main_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"testing"
 	"time"
 
@@ -47,7 +46,7 @@ func TestFreezeTree(t *testing.T) {
 		{
 			desc: "mandatoryOptsNotSet",
 			// Undo the flags set by runTest, so that mandatory options are no longer set.
-			setFlags: resetFlags,
+			setFlags: flagsaver.Save().MustRestore,
 			wantErr:  true,
 		},
 		{
@@ -170,11 +169,4 @@ func expectCalls(call *gomock.Call, err error, prevErr ...error) *gomock.Call {
 	}
 	// If this function succeeds it should only be called once.
 	return call.Times(1)
-}
-
-// resetFlags sets all flags to their default values.
-func resetFlags() {
-	flag.Visit(func(f *flag.Flag) {
-		f.Value.Set(f.DefValue)
-	})
 }

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -102,14 +102,13 @@ main() {
     go build ./...
 
     export TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT:-5m}"
-    export TEST_FLAGS_SUFFIX="-alsologtostderr"
 
     if [[ ${coverage} -eq 1 ]]; then
       TEST_FLAGS+=" -covermode=atomic -coverprofile=coverage.txt"
     fi
 
     echo "running go test ${TEST_FLAGS} ./..."
-    go test ${TEST_FLAGS} ./... ${TEST_FLAGS_SUFFIX}
+    go test ${TEST_FLAGS} ./... -alsologtostderr
   fi
 
   if [[ "${run_lint}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -86,8 +86,6 @@ main() {
     exit 1
   fi
 
-  # This is the go minor version. It's asumed that the major version is 1.
-  GOVER=`go version | awk -F. '{print $2}' | awk '{print $1}'`
   if [[ "$fix" -eq 1 ]]; then
     check_pkg goimports golang.org/x/tools/cmd/goimports || exit 1
 
@@ -108,11 +106,6 @@ main() {
 
     if [[ ${coverage} -eq 1 ]]; then
       TEST_FLAGS+=" -covermode=atomic -coverprofile=coverage.txt"
-    fi
-
-    if [[ ${GOVER} -ge 16 ]]; then
-      # https://github.com/google/trillian/issues/2364
-      TEST_FLAGS_SUFFIX+=" -test.paniconexit0=false"
     fi
 
     echo "running go test ${TEST_FLAGS} ./..."


### PR DESCRIPTION
This avoids fiddling with the flag used by go's test framework, which fixes #2364 and means that the hack from #2365 can be removed.
