### PR TITLE
NodeID: Remove unused BigInt format

### DIFF
--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -43,7 +43,6 @@ type PrepareSubtreeWriteFunc func(*storagepb.SubtreeProto) error
 var (
 	NewNodeIDFromHash         = tree.NewNodeIDFromHash
 	NewNodeIDFromPrefix       = tree.NewNodeIDFromPrefix
-	NewNodeIDFromBigInt       = tree.NewNodeIDFromBigInt
 	NewNodeIDForTreeCoords    = tree.NewNodeIDForTreeCoords
 	NewNodeIDFromPrefixSuffix = tree.NewNodeIDFromPrefixSuffix
 

--- a/storage/storagepb/convert/convert_test.go
+++ b/storage/storagepb/convert/convert_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/google/trillian/merkle/smt"
 	"github.com/google/trillian/storage/storagepb"

--- a/storage/tree/node_test.go
+++ b/storage/tree/node_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"testing"
+
+	_ "github.com/golang/glog"
 )
 
 func TestMaskLeft(t *testing.T) {


### PR DESCRIPTION
This format was only used by `HStar2` which was recently removed.

#2378