### PR TITLE
Make better use of etcd services & endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## HEAD
 
+### Functional changes
+
+etcd integration for `trillian_log_server` and `trillian_log_signer` have changed.
+ * Affects flag names (both now only have `etcd_service` and `etcd_http_service` is deleted).
+ * Keys that the endpoints are announced under are changed (the values are unchanged):
+   * `trillian-logserver-http/{host:port}` changed to `trillian-logserver/http`
+   * `trillian-logserver/{host:port}` changed to `trillian-logserver/rpc`
+   * `trillian-logsigner-http/{host:port}` changed to `trillian-logsigner/http`
+
 ### Dependency updates
  * Upgraded to etcd v3 in order to allow grpc to be upgraded (#2195)
    * etcd was `v0.5.0-alpha.5`, now `v3.5.0-alpha.0`

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -64,13 +64,12 @@ import (
 )
 
 var (
-	rpcEndpoint     = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
-	httpEndpoint    = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics (host:port, empty means disabled)")
-	healthzTimeout  = flag.Duration("healthz_timeout", time.Second*5, "Timeout used during healthz checks")
-	tlsCertFile     = flag.String("tls_cert_file", "", "Path to the TLS server certificate. If unset, the server will use unsecured connections.")
-	tlsKeyFile      = flag.String("tls_key_file", "", "Path to the TLS server key. If unset, the server will use unsecured connections.")
-	etcdService     = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
-	etcdHTTPService = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
+	rpcEndpoint    = flag.String("rpc_endpoint", "localhost:8090", "Endpoint for RPC requests (host:port)")
+	httpEndpoint   = flag.String("http_endpoint", "localhost:8091", "Endpoint for HTTP metrics (host:port, empty means disabled)")
+	healthzTimeout = flag.Duration("healthz_timeout", time.Second*5, "Timeout used during healthz checks")
+	tlsCertFile    = flag.String("tls_cert_file", "", "Path to the TLS server certificate. If unset, the server will use unsecured connections.")
+	tlsKeyFile     = flag.String("tls_key_file", "", "Path to the TLS server key. If unset, the server will use unsecured connections.")
+	etcdService    = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
 
 	quotaSystem = flag.String("quota_system", "mysql", fmt.Sprintf("Quota system to use. One of: %v", quota.Providers()))
 	quotaDryRun = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
@@ -135,10 +134,10 @@ func main() {
 	}
 
 	// Announce our endpoints to etcd if so configured.
-	unannounce := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint)
+	unannounce := serverutil.AnnounceSelf(ctx, client, *etcdService, "rpc", *rpcEndpoint)
 	defer unannounce()
 	if *httpEndpoint != "" {
-		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdService, "http", *httpEndpoint)
 		defer unannounceHTTP()
 	}
 

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -70,7 +70,7 @@ var (
 	numSeqFlag               = flag.Int("num_sequencers", 10, "Number of sequencer workers to run in parallel")
 	sequencerGuardWindowFlag = flag.Duration("sequencer_guard_window", 0, "If set, the time elapsed before submitted leaves are eligible for sequencing")
 	forceMaster              = flag.Bool("force_master", false, "If true, assume master for all logs")
-	etcdHTTPService          = flag.String("etcd_http_service", "trillian-logsigner-http", "Service name to announce our HTTP endpoint under")
+	etcdService              = flag.String("etcd_service", "trillian-logsigner", "Service name to announce our endpoints under")
 	lockDir                  = flag.String("lock_file_path", "/test/multimaster", "etcd lock file directory path")
 	healthzTimeout           = flag.Duration("healthz_timeout", time.Second*5, "Timeout used during healthz checks")
 
@@ -158,7 +158,7 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdService, "http", *httpEndpoint)
 		defer unannounceHTTP()
 	}
 

--- a/deployment/log-deployment.yaml
+++ b/deployment/log-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         "--storage_system=$(STORAGE_SYSTEM)",
         "--quota_system=etcd",
         "--etcd_servers=trillian-etcd-cluster-client:2379",
-        "--etcd_http_service=trillian-logserver-http",
+        "--etcd_service=trillian-logserver",
         "--rpc_endpoint=0.0.0.0:8090",
         "--http_endpoint=0.0.0.0:8091",
         "--tracing",

--- a/deployment/log-signer-deployment.yaml
+++ b/deployment/log-signer-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         "--storage_system=$(STORAGE_SYSTEM)",
         "--etcd_servers=trillian-etcd-cluster-client:2379",
         "--quota_system=etcd",
-        "--etcd_http_service=trillian-logsigner-http",
+        "--etcd_service=trillian-logsigner",
         "--http_endpoint=0.0.0.0:8091",
         "--sequencer_guard_window=1s",
         "$(SIGNER_INTERVAL)",

--- a/examples/deployment/kubernetes/trillian-log-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         "--storage_system=$(STORAGE_SYSTEM)",
         "--quota_system=etcd",
         "--etcd_servers=trillian-etcd-cluster-client:2379",
-        "--etcd_http_service=trillian-logserver-http",
+        "--etcd_service=trillian-logserver",
         "--rpc_endpoint=0.0.0.0:8090",
         "--http_endpoint=0.0.0.0:8091",
         "--tracing",

--- a/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
+++ b/examples/deployment/kubernetes/trillian-log-signer-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         "--storage_system=$(STORAGE_SYSTEM)",
         "--etcd_servers=trillian-etcd-cluster-client:2379",
         "--quota_system=etcd",
-        "--etcd_http_service=trillian-logsigner-http",
+        "--etcd_service=trillian-logsigner",
         "--http_endpoint=0.0.0.0:8091",
         "--sequencer_guard_window=1s",
         "$(SIGNER_INTERVAL)",

--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -144,8 +144,8 @@ log_prep_test() {
     ETCD_OPTS="--etcd_servers=${etcd_server}"
     ETCD_DB_DIR=default.etcd
     wait_for_server_startup ${etcd_port}
-    logserver_opts="${logserver_opts} --etcd_http_service=trillian-logserver-http --etcd_service=trillian-logserver --quota_system=etcd"
-    logsigner_opts="${logsigner_opts} --etcd_http_service=trillian-logsigner-http --quota_system=etcd"
+    logserver_opts="${logserver_opts} --etcd_service=trillian-logserver --quota_system=etcd"
+    logsigner_opts="${logsigner_opts} --etcd_service=trillian-logsigner --quota_system=etcd"
   else
     if  [[ ${log_signer_count} > 1 ]]; then
       echo "*** Warning: running multiple signers with no etcd instance ***"
@@ -208,12 +208,12 @@ log_prep_test() {
   done
 
   if [[ ! -z "${ETCD_OPTS}" ]]; then
-    RPC_SERVERS="trillian-logserver"
-    echo "Registered log servers @${RPC_SERVERS}/"
-    ETCDCTL_API=3 etcdctl get ${RPC_SERVERS}/ --prefix
+    RPC_SERVERS="trillian-logserver/rpc"
+    echo "Registered log servers @${RPC_SERVERS}"
+    ETCDCTL_API=3 etcdctl get ${RPC_SERVERS}
     echo "Registered HTTP endpoints"
-    ETCDCTL_API=3 etcdctl get trillian-logserver-http/ --prefix
-    ETCDCTL_API=3 etcdctl get trillian-logsigner-http/ --prefix
+    ETCDCTL_API=3 etcdctl get trillian-logserver/http
+    ETCDCTL_API=3 etcdctl get trillian-logsigner/http
   fi
 }
 


### PR DESCRIPTION
This affects the usage of `trillian_log_server` and `trillian_log_signer`.

Previously the log server had two services, each with a single endpoint (for http and rpc). etcd now supports (nay, forces) that service endpoints can't be announced raw and need to be in a service namespace. Thus we now announce endpoints at `trillian-logserver/http` and `trillian-logserver/rpc`. The `--etcd_http_service` flag has been removed and only `--etcd_service` is available to override the service name (`trillian-logserver` by default).

This supercedes the old behaviour of announcing at, e.g. `trillian-logserver-http/localhost:5055` and `trillian-logserver/localhost:5054`. Note that the endpoint address was included in the key. That seems risky as multiple keys could co-exist and a client querying with `--prefix` won't know which is canonical.

This change also affects the log signer, and changes its key from `trillian-logsigner-http` to `trillian-logsigner/http`, and the flag for changing the service name is renamed from `--etcd_http_service` to just `--etcd_service`.

Keys announced as of v1.3.13 release:

```
etcdctl get trillian --prefix
trillian-logserver-http/localhost:50055
{"Op":0,"Addr":"localhost:50055","Metadata":null}
trillian-logserver/localhost:50054
{"Op":0,"Addr":"localhost:50054","Metadata":null}
```

Keys announced after this change:

```
etcdctl get trillian --prefix
trillian-logserver/http
{"Op":0,"Addr":"localhost:50055","Metadata":null}
trillian-logserver/rpc
{"Op":0,"Addr":"localhost:50054","Metadata":null}
```

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
