### PR TITLE
storage: Remove revision from GetMerkleNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
  * Removed the deprecated crypto.NewSHA256Signer function.
  * Finish removing the `LogMetadata.GetUnsequencedCounts()` method.
 
+### Storage refactoring
+ * `NodeReader.GetMerkleNodes` does not accept revisions anymore. The
+   implementations must use the transaction's `ReadRevision` instead.
+ * TODO(pavelkalinnikov): More changes are coming, and will be added here.
+
 ## v1.3.13
 [Published 2021-02-16](https://github.com/google/trillian/releases/tag/v1.3.13)
 

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -151,7 +151,7 @@ func (s Sequencer) initCompactRangeFromStorage(ctx context.Context, root *types.
 		storIDs[i] = nodeID
 	}
 
-	nodes, err := tx.GetMerkleNodes(ctx, int64(root.Revision), storIDs)
+	nodes, err := tx.GetMerkleNodes(ctx, storIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Merkle nodes: %v", err)
 	}

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -318,7 +318,7 @@ func createTestContext(ctrl *gomock.Controller, params testParameters) (testCont
 		for _, node := range *params.merkleNodesGet {
 			ids = append(ids, node.NodeID)
 		}
-		mockTx.EXPECT().GetMerkleNodes(gomock.Any(), params.writeRevision-1, ids).Return(*params.merkleNodesGet, params.merkleNodesGetError)
+		mockTx.EXPECT().GetMerkleNodes(gomock.Any(), ids).Return(*params.merkleNodesGet, params.merkleNodesGetError)
 	}
 
 	if params.updatedLeaves != nil {
@@ -774,7 +774,7 @@ func TestIntegrateBatch_PutTokens(t *testing.T) {
 			logTX.EXPECT().DequeueLeaves(any, any, any).Return(test.leaves, nil)
 			logTX.EXPECT().LatestSignedLogRoot(any).Return(testSignedRoot16, nil)
 			if len(test.leaves) != 0 {
-				logTX.EXPECT().GetMerkleNodes(any, any, any).Return(compactTree16, nil)
+				logTX.EXPECT().GetMerkleNodes(any, any).Return(compactTree16, nil)
 			}
 			logTX.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(int64(testRoot16.Revision+1), nil)
 			logTX.EXPECT().UpdateSequencedLeaves(any, any).AnyTimes().Return(nil)

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -456,14 +456,7 @@ func tryGetConsistencyProof(ctx context.Context, firstTreeSize, secondTreeSize, 
 	if err != nil {
 		return nil, err
 	}
-
-	// Do all the node fetches at the second tree revision, which is what the node ids were calculated
-	// against.
-	rev, err := tx.ReadRevision(ctx)
-	if err != nil {
-		return nil, err
-	}
-	proof, err := fetchNodesAndBuildProof(ctx, tx, hasher, rev, 0, nodeFetches)
+	proof, err := fetchNodesAndBuildProof(ctx, tx, hasher, 0, nodeFetches)
 	if err != nil {
 		return nil, err
 	}
@@ -728,12 +721,7 @@ func getInclusionProofForLeafIndex(ctx context.Context, tx storage.ReadOnlyLogTr
 	if err != nil {
 		return nil, err
 	}
-
-	rev, err := tx.ReadRevision(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return fetchNodesAndBuildProof(ctx, tx, hasher, rev, leafIndex, proofNodeIDs)
+	return fetchNodesAndBuildProof(ctx, tx, hasher, leafIndex, proofNodeIDs)
 }
 
 func (t *TrillianLogRPCServer) getTreeAndHasher(ctx context.Context, treeID int64, opts trees.GetOpts) (*trillian.Tree, hashers.LogHasher, error) {

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -96,8 +96,7 @@ var (
 
 	tree1              = addTreeID(stestonly.LogTree, logID1)
 	getLogRootRequest1 = trillian.GetLatestSignedLogRootRequest{LogId: logID1}
-	revision1          = int64(5)
-	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7, Revision: uint64(revision1)}
+	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7, Revision: uint64(5)}
 	signedRoot1, _     = fixedSigner.SignLogRoot(root1)
 
 	getByHashRequest1 = trillian.GetLeavesByHashRequest{LogId: logID1, LeafHash: [][]byte{leafHash1, leafHash3}}
@@ -897,9 +896,8 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -911,10 +909,9 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// The server expects three nodes from storage but we return only two
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -926,10 +923,9 @@ func TestGetProofByHashErrors(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
 				tx.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return([]*trillian.LogLeaf{{LeafIndex: 2}}, nil)
 				// We set this up so one of the returned nodes has the wrong ID
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByHashRequest7,
@@ -1031,8 +1027,7 @@ func TestGetProofByHash(t *testing.T) {
 
 			mockTX.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
 			mockTX.EXPECT().GetLeavesByHash(gomock.Any(), [][]byte{leafHash1}, false).Return(tc.leavesByHashVal, nil)
-			mockTX.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil).AnyTimes()
-			mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+			mockTX.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 				{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 				{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 				{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1132,8 +1127,7 @@ func TestGetProofByIndex(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{}, errors.New("STORAGE"))
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1146,8 +1140,7 @@ func TestGetProofByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				// The server expects three nodes from storage but we return only two
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeRevision: 3}, {NodeRevision: 2}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1160,8 +1153,7 @@ func TestGetProofByIndex(t *testing.T) {
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				// We set this up so one of the returned nodes has the wrong ID
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: stestonly.MustCreateNodeIDForTreeCoords(4, 5, 64), NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Close().Return(nil)
 			},
 			req:    &getInclusionProofByIndexRequest7,
@@ -1173,8 +1165,7 @@ func TestGetProofByIndex(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3}, {NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2}, {NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3}}, nil)
 				tx.EXPECT().Commit(gomock.Any()).Return(errors.New("COMMIT"))
 				tx.EXPECT().Close().Return(nil)
 			},
@@ -1211,8 +1202,7 @@ func TestGetProofByIndex(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1322,8 +1312,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1340,8 +1329,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1383,8 +1371,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1402,8 +1389,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1446,8 +1432,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				tx := storage.NewMockLogTreeTX(c)
 				s.EXPECT().SnapshotForTree(gomock.Any(), cmpMatcher{tree1}).Return(tx, nil)
 				tx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(signedRoot1, nil)
-				tx.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-				tx.EXPECT().GetMerkleNodes(gomock.Any(), revision1, nodeIdsInclusionSize7Index2).Return([]tree.Node{
+				tx.EXPECT().GetMerkleNodes(gomock.Any(), nodeIdsInclusionSize7Index2).Return([]tree.Node{
 					{NodeID: nodeIdsInclusionSize7Index2[0], NodeRevision: 3, Hash: []byte("nodehash0")},
 					{NodeID: nodeIdsInclusionSize7Index2[1], NodeRevision: 2, Hash: []byte("nodehash1")},
 					{NodeID: nodeIdsInclusionSize7Index2[2], NodeRevision: 3, Hash: []byte("nodehash2")},
@@ -1581,7 +1566,6 @@ type consistProofTest struct {
 	root        *trillian.SignedLogRoot
 	noRoot      bool
 	rootErr     error
-	noRev       bool
 	nodeIDs     []tree.NodeID
 	nodes       []tree.Node
 	getNodesErr error
@@ -1598,7 +1582,6 @@ func TestGetConsistencyProof(t *testing.T) {
 			errStr:   "SnapshotFor",
 			snapErr:  errors.New("SnapshotForTree() failed"),
 			noRoot:   true,
-			noRev:    true,
 			noCommit: true,
 		},
 		{
@@ -1606,7 +1589,6 @@ func TestGetConsistencyProof(t *testing.T) {
 			req:      &getConsistencyProofRequest7,
 			errStr:   "LatestSigned",
 			rootErr:  errors.New("LatestSignedLogRoot() failed"),
-			noRev:    true,
 			noCommit: true,
 		},
 		{
@@ -1614,7 +1596,6 @@ func TestGetConsistencyProof(t *testing.T) {
 			req:      &getConsistencyProofRequest7,
 			errStr:   "not read current log root",
 			root:     corruptLogRoot,
-			noRev:    true,
 			noCommit: true,
 		},
 		{
@@ -1659,7 +1640,6 @@ func TestGetConsistencyProof(t *testing.T) {
 			req:        &getConsistencyProofRequest48,
 			wantHashes: nil,
 			nodeIDs:    nil,
-			noRev:      true,
 			noCommit:   true,
 		},
 		{
@@ -1695,11 +1675,8 @@ func TestGetConsistencyProof(t *testing.T) {
 				}
 				mockTX.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(root, test.rootErr)
 			}
-			if !test.noRev {
-				mockTX.EXPECT().ReadRevision(gomock.Any()).Return(int64(root1.Revision), nil)
-			}
 			if test.nodeIDs != nil {
-				mockTX.EXPECT().GetMerkleNodes(gomock.Any(), revision1, test.nodeIDs).Return(test.nodes, test.getNodesErr)
+				mockTX.EXPECT().GetMerkleNodes(gomock.Any(), test.nodeIDs).Return(test.nodes, test.getNodesErr)
 			}
 			if !test.noCommit {
 				mockTX.EXPECT().Commit(gomock.Any()).Return(test.commitErr)

--- a/server/proof_fetcher.go
+++ b/server/proof_fetcher.go
@@ -33,10 +33,10 @@ const proofMaxBitLen = 64
 // This includes rehashing where necessary to serve proofs for tree sizes between stored tree
 // revisions. This code only relies on the NodeReader interface so can be tested without
 // a complete storage implementation.
-func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hashers.LogHasher, treeRevision, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (*trillian.Proof, error) {
+func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hashers.LogHasher, leafIndex int64, proofNodeFetches []merkle.NodeFetch) (*trillian.Proof, error) {
 	ctx, spanEnd := spanFor(ctx, "fetchNodesAndBuildProof")
 	defer spanEnd()
-	proofNodes, err := fetchNodes(ctx, tx, treeRevision, proofNodeFetches)
+	proofNodes, err := fetchNodes(ctx, tx, proofNodeFetches)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func fetchNodesAndBuildProof(ctx context.Context, tx storage.NodeReader, th hash
 
 // fetchNodes extracts the NodeIDs from a list of NodeFetch structs and passes them
 // to storage, returning the result after some additional validation checks.
-func fetchNodes(ctx context.Context, tx storage.NodeReader, treeRevision int64, fetches []merkle.NodeFetch) ([]tree.Node, error) {
+func fetchNodes(ctx context.Context, tx storage.NodeReader, fetches []merkle.NodeFetch) ([]tree.Node, error) {
 	ctx, spanEnd := spanFor(ctx, "fetchNodes")
 	defer spanEnd()
 	proofNodeIDs := make([]tree.NodeID, 0, len(fetches))
@@ -71,7 +71,7 @@ func fetchNodes(ctx context.Context, tx storage.NodeReader, treeRevision int64, 
 		proofNodeIDs = append(proofNodeIDs, id)
 	}
 
-	proofNodes, err := tx.GetMerkleNodes(ctx, treeRevision, proofNodeIDs)
+	proofNodes, err := tx.GetMerkleNodes(ctx, proofNodeIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/proof_fetcher_test.go
+++ b/server/proof_fetcher_test.go
@@ -45,7 +45,7 @@ func TestTree813FetchAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		proof, err := fetchNodesAndBuildProof(ctx, r, hasher, testTreeRevision, int64(l), fetches)
+		proof, err := fetchNodesAndBuildProof(ctx, r, hasher, int64(l), fetches)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func TestTree32InclusionProofFetchAll(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				proof, err := fetchNodesAndBuildProof(ctx, r, hasher, testTreeRevision, int64(l), fetches)
+				proof, err := fetchNodesAndBuildProof(ctx, r, hasher, int64(l), fetches)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -133,7 +133,7 @@ func TestTree32InclusionProofFetchMultiBatch(t *testing.T) {
 			}
 
 			// Use the highest tree revision that should be available from the node reader
-			proof, err := fetchNodesAndBuildProof(ctx, r, hasher, testTreeRevision+3, l, fetches)
+			proof, err := fetchNodesAndBuildProof(ctx, r, hasher, l, fetches)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -170,7 +170,7 @@ func TestTree32ConsistencyProofFetchAll(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				proof, err := fetchNodesAndBuildProof(ctx, r, hasher, testTreeRevision, int64(s1), fetches)
+				proof, err := fetchNodesAndBuildProof(ctx, r, hasher, int64(s1), fetches)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -410,12 +410,16 @@ func (t *treeTX) getSubtree(ctx context.Context, rev int64, id tree.NodeID) (p *
 }
 
 // GetMerkleNodes returns the requested set of nodes at, or before, the
-// specified tree revision.
-func (t *treeTX) GetMerkleNodes(ctx context.Context, rev int64, ids []tree.NodeID) ([]tree.Node, error) {
+// transaction read revision.
+func (t *treeTX) GetMerkleNodes(ctx context.Context, ids []tree.NodeID) ([]tree.Node, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.stx == nil {
 		return nil, ErrTransactionClosed
+	}
+	rev, err := t.ReadRevision(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get read revision: %v", err)
 	}
 
 	return t.cache.GetNodes(ids,

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	stree "github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -259,6 +260,12 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 		return t.treeTX.writeRevision, errors.New("logTreeTX write revision not populated")
 	}
 	return t.treeTX.writeRevision, nil
+}
+
+// GetMerkleNodes returns the requested nodes at (or below) the read revision.
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []stree.NodeID) ([]stree.Node, error) {
+	rev := int64(t.root.Revision)
+	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -234,11 +234,6 @@ func (t *treeTX) getSubtreesAtRev(ctx context.Context, rev int64) cache.GetSubtr
 	}
 }
 
-// GetMerkleNodes returns the requests nodes at (or below) the passed in treeRevision.
-func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []stree.NodeID) ([]stree.Node, error) {
-	return t.subtreeCache.GetNodes(nodeIDs, t.getSubtreesAtRev(ctx, treeRevision))
-}
-
 func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []stree.Node) error {
 	for _, n := range nodes {
 		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -501,18 +501,18 @@ func (mr *MockLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 interface
 }
 
 // GetMerkleNodes mocks base method.
-func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
+func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMerkleNodes indicates an expected call of GetMerkleNodes.
-func (mr *MockLogTreeTXMockRecorder) GetMerkleNodes(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockLogTreeTXMockRecorder) GetMerkleNodes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleNodes", reflect.TypeOf((*MockLogTreeTX)(nil).GetMerkleNodes), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleNodes", reflect.TypeOf((*MockLogTreeTX)(nil).GetMerkleNodes), arg0, arg1)
 }
 
 // GetSequencedLeafCount mocks base method.
@@ -946,18 +946,18 @@ func (mr *MockReadOnlyLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 i
 }
 
 // GetMerkleNodes mocks base method.
-func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 int64, arg2 []tree.NodeID) ([]tree.Node, error) {
+func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []tree.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].([]tree.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMerkleNodes indicates an expected call of GetMerkleNodes.
-func (mr *MockReadOnlyLogTreeTXMockRecorder) GetMerkleNodes(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockReadOnlyLogTreeTXMockRecorder) GetMerkleNodes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleNodes", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).GetMerkleNodes), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleNodes", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).GetMerkleNodes), arg0, arg1)
 }
 
 // GetSequencedLeafCount mocks base method.

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -370,6 +371,14 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 		return t.treeTX.writeRevision, errors.New("logTreeTX write revision not populated")
 	}
 	return t.treeTX.writeRevision, nil
+}
+
+// GetMerkleNodes returns the requested nodes at the read revision.
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []tree.NodeID) ([]tree.Node, error) {
+	t.treeTX.mu.Lock()
+	defer t.treeTX.mu.Unlock()
+	rev := int64(t.root.Revision)
+	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -75,7 +75,7 @@ func TestNodeRoundTrip(t *testing.T) {
 			runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
 				forceWriteRevision(writeRev, tx)
 				// Need to read nodes before attempting to write.
-				if _, err := tx.GetMerkleNodes(ctx, writeRev-1, preread); err != nil {
+				if _, err := tx.GetMerkleNodes(ctx, preread); err != nil {
 					t.Fatalf("Failed to read nodes: %s", err)
 				}
 				if err := tx.SetMerkleNodes(ctx, tc.store); err != nil {
@@ -85,7 +85,7 @@ func TestNodeRoundTrip(t *testing.T) {
 			})
 
 			runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
-				readNodes, err := tx.GetMerkleNodes(ctx, writeRev, tc.read)
+				readNodes, err := tx.GetMerkleNodes(ctx, tc.read)
 				if err != nil {
 					t.Fatalf("Failed to retrieve nodes: %s", err)
 				}
@@ -122,7 +122,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 			forceWriteRevision(writeRevision, tx)
 
 			// Need to read nodes before attempting to write
-			if _, err := tx.GetMerkleNodes(ctx, writeRevision-1, nodeIDsToRead); err != nil {
+			if _, err := tx.GetMerkleNodes(ctx, nodeIDsToRead); err != nil {
 				t.Fatalf("Failed to read nodes: %s", err)
 			}
 			if err := tx.SetMerkleNodes(ctx, nodesToStore); err != nil {
@@ -134,7 +134,7 @@ func TestLogNodeRoundTripMultiSubtree(t *testing.T) {
 
 	{
 		runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
-			readNodes, err := tx.GetMerkleNodes(ctx, 100, nodeIDsToRead)
+			readNodes, err := tx.GetMerkleNodes(ctx, nodeIDsToRead)
 			if err != nil {
 				t.Fatalf("Failed to retrieve nodes: %s", err)
 			}

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -351,14 +351,6 @@ func (t *treeTX) getSubtreesAtRev(ctx context.Context, rev int64) cache.GetSubtr
 	}
 }
 
-// GetMerkleNodes returns the requests nodes at (or below) the passed in treeRevision.
-func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []tree.NodeID) ([]tree.Node, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	return t.subtreeCache.GetNodes(nodeIDs, t.getSubtreesAtRev(ctx, treeRevision))
-}
-
 func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/storage/tree"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -367,6 +368,11 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 		return t.treeTX.writeRevision, errors.New("logTreeTX write revision not populated")
 	}
 	return t.treeTX.writeRevision, nil
+}
+
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []tree.NodeID) ([]tree.Node, error) {
+	rev := int64(t.root.Revision)
+	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/postgres/storage_test.go
+++ b/storage/postgres/storage_test.go
@@ -54,7 +54,7 @@ func TestNodeRoundTrip(t *testing.T) {
 			forceWriteRevision(writeRevision, tx)
 
 			// Need to read nodes before attempting to write
-			if _, err := tx.GetMerkleNodes(ctx, 99, nodeIDsToRead); err != nil {
+			if _, err := tx.GetMerkleNodes(ctx, nodeIDsToRead); err != nil {
 				t.Fatalf("Failed to read nodes: %s", err)
 			}
 			if err := tx.SetMerkleNodes(ctx, nodesToStore); err != nil {
@@ -66,7 +66,7 @@ func TestNodeRoundTrip(t *testing.T) {
 
 	{
 		runLogTX(s, tree, t, func(ctx context.Context, tx storage.LogTreeTX) error {
-			readNodes, err := tx.GetMerkleNodes(ctx, 100, nodeIDsToRead)
+			readNodes, err := tx.GetMerkleNodes(ctx, nodeIDsToRead)
 			if err != nil {
 				t.Fatalf("Failed to retrieve nodes: %s", err)
 			}

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -400,10 +400,6 @@ func (t *treeTX) Close() error {
 	return nil
 }
 
-func (t *treeTX) GetMerkleNodes(ctx context.Context, treeRevision int64, nodeIDs []tree.NodeID) ([]tree.Node, error) {
-	return t.subtreeCache.GetNodes(nodeIDs, t.getSubtreesAtRev(ctx, treeRevision))
-}
-
 func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 	for _, n := range nodes {
 		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,

--- a/storage/tools/dump_tree/dumplib.go
+++ b/storage/tools/dump_tree/dumplib.go
@@ -279,7 +279,7 @@ func Main(args Options) string {
 	glog.Info("Producing output")
 
 	if args.Traverse {
-		return traverseTreeStorage(ctx, ls, tree, args.TreeSize, int64(root.Revision))
+		return traverseTreeStorage(ctx, ls, tree, args.TreeSize)
 	}
 
 	if args.DumpLeaves {
@@ -407,7 +407,7 @@ func sequenceLeaves(ls storage.LogStorage, seq *log.Sequencer, tree *trillian.Tr
 	glog.Info("Finished sequencing")
 }
 
-func traverseTreeStorage(ctx context.Context, ls storage.LogStorage, tt *trillian.Tree, ts int, rev int64) string {
+func traverseTreeStorage(ctx context.Context, ls storage.LogStorage, tt *trillian.Tree, ts int) string {
 	out := new(bytes.Buffer)
 	nodesAtLevel := int64(ts)
 
@@ -444,7 +444,7 @@ func traverseTreeStorage(ctx context.Context, ls storage.LogStorage, tt *trillia
 				glog.Fatalf("NewNodeIDForTreeCoords: (%d, %d): got: %v, want: no err", level, node, err)
 			}
 
-			nodes, err := tx.GetMerkleNodes(context.TODO(), rev, []tree.NodeID{nodeID})
+			nodes, err := tx.GetMerkleNodes(context.TODO(), []tree.NodeID{nodeID})
 			if err != nil {
 				glog.Fatalf("GetMerkleNodes: %s: %v", nodeID.CoordString(), err)
 			}

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -62,7 +62,7 @@ type TreeTX interface {
 
 // TreeWriter represents additional transaction methods that modify the tree.
 type TreeWriter interface {
-	// SetMerkleNodes stores the provided nodes, at the transaction's writeRevision.
+	// SetMerkleNodes writes the nodes, at the write revision.
 	SetMerkleNodes(ctx context.Context, nodes []tree.Node) error
 
 	// WriteRevision returns the tree revision that any writes through this TreeTX will be stored at.
@@ -78,7 +78,6 @@ type DatabaseChecker interface {
 // NodeReader provides read-only access to the stored tree nodes, as an interface to allow easier
 // testing of node manipulation.
 type NodeReader interface {
-	// GetMerkleNodes looks up the set of nodes identified by ids, at
-	// treeRevision, and returns them in the same order.
-	GetMerkleNodes(ctx context.Context, treeRevision int64, ids []tree.NodeID) ([]tree.Node, error)
+	// GetMerkleNodes returns tree nodes by their IDs, in the requested order.
+	GetMerkleNodes(ctx context.Context, ids []tree.NodeID) ([]tree.Node, error)
 }


### PR DESCRIPTION
Log trees always read from the revision corresponding to the root which
is read in the beginning of the transaction. There is no need for it to
make a roundtrip to the application layer.

Part of a larger refactoring [#2378]. More follow-up changes are WIP.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
