### PR TITLE
storage: Use compact.NodeID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Storage refactoring
  * `NodeReader.GetMerkleNodes` does not accept revisions anymore. The
    implementations must use the transaction's `ReadRevision` instead.
+ * `TreeStorage` migrated to using `compact.NodeID` type suitable for logs.
  * TODO(pavelkalinnikov): More changes are coming, and will be added here.
 
 ## v1.3.13

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -30,6 +30,7 @@ import (
 	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/extension"
+	"github.com/google/trillian/merkle/compact"
 	_ "github.com/google/trillian/merkle/rfc6962" // Register the hasher.
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/quota"
@@ -73,7 +74,7 @@ var (
 	}
 	testSignedRoot0, _ = fixedLog1Signer.SignLogRoot(testRoot0)
 
-	updatedNodes0 = []tree.Node{{NodeID: tree.NodeID{Path: []uint8{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, PrefixLenBits: 64}, Hash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="), NodeRevision: 1}}
+	updatedNodes0 = []tree.Node{{ID: compact.NewNodeID(0, 0), Hash: testonly.MustDecodeBase64("bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=")}}
 	updatedRoot   = &types.LogRootV1{
 		TimestampNanos: uint64(fakeTime.UnixNano()),
 		RootHash:       []byte{110, 52, 11, 156, 255, 179, 122, 152, 156, 165, 68, 230, 187, 120, 10, 44, 120, 144, 29, 63, 179, 55, 56, 118, 133, 17, 163, 6, 23, 175, 160, 29},

--- a/storage/aliases.go
+++ b/storage/aliases.go
@@ -25,9 +25,6 @@ import (
 // NodeID is an alias to github.com/google/trillian/storage/tree.NodeID.
 type NodeID = tree.NodeID
 
-// Node is an alias to github.com/google/trillian/storage/tree.Node.
-type Node = tree.Node
-
 // Suffix is an alias to github.com/google/trillian/storage/tree.Suffix.
 type Suffix = tree.Suffix
 

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/cache"
 	"github.com/google/trillian/storage/cloudspanner/spannerpb"
@@ -411,7 +412,7 @@ func (t *treeTX) getSubtree(ctx context.Context, rev int64, id tree.NodeID) (p *
 
 // GetMerkleNodes returns the requested set of nodes at, or before, the
 // transaction read revision.
-func (t *treeTX) GetMerkleNodes(ctx context.Context, ids []tree.NodeID) ([]tree.Node, error) {
+func (t *treeTX) GetMerkleNodes(ctx context.Context, ids []compact.NodeID) ([]tree.Node, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.stx == nil {
@@ -474,7 +475,7 @@ func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 
 	for _, n := range nodes {
 		err := t.cache.SetNodeHash(
-			n.NodeID,
+			n.ID,
 			n.Hash,
 			func(nID tree.NodeID) (*storagepb.SubtreeProto, error) {
 				return t.getSubtree(ctx, writeRev-1, nID)

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/btree"
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
@@ -263,9 +264,9 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 }
 
 // GetMerkleNodes returns the requested nodes at (or below) the read revision.
-func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []stree.NodeID) ([]stree.Node, error) {
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, ids []compact.NodeID) ([]stree.Node, error) {
 	rev := int64(t.root.Revision)
-	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
+	return t.treeTX.subtreeCache.GetNodes(ids, t.treeTX.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -236,7 +236,7 @@ func (t *treeTX) getSubtreesAtRev(ctx context.Context, rev int64) cache.GetSubtr
 
 func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []stree.Node) error {
 	for _, n := range nodes {
-		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,
+		err := t.subtreeCache.SetNodeHash(n.ID, n.Hash,
 			func(nID stree.NodeID) (*storagepb.SubtreeProto, error) {
 				return t.getSubtree(ctx, t.writeRevision, nID)
 			})

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	trillian "github.com/google/trillian"
+	compact "github.com/google/trillian/merkle/compact"
 	tree "github.com/google/trillian/storage/tree"
 )
 
@@ -501,7 +502,7 @@ func (mr *MockLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 interface
 }
 
 // GetMerkleNodes mocks base method.
-func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []tree.NodeID) ([]tree.Node, error) {
+func (m *MockLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []compact.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].([]tree.Node)
@@ -946,7 +947,7 @@ func (mr *MockReadOnlyLogTreeTXMockRecorder) GetLeavesByRange(arg0, arg1, arg2 i
 }
 
 // GetMerkleNodes mocks base method.
-func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []tree.NodeID) ([]tree.Node, error) {
+func (m *MockReadOnlyLogTreeTX) GetMerkleNodes(arg0 context.Context, arg1 []compact.NodeID) ([]tree.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMerkleNodes", arg0, arg1)
 	ret0, _ := ret[0].([]tree.Node)

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
@@ -374,11 +375,11 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 }
 
 // GetMerkleNodes returns the requested nodes at the read revision.
-func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []tree.NodeID) ([]tree.Node, error) {
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, ids []compact.NodeID) ([]tree.Node, error) {
 	t.treeTX.mu.Lock()
 	defer t.treeTX.mu.Unlock()
 	rev := int64(t.root.Revision)
-	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
+	return t.subtreeCache.GetNodes(ids, t.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -356,7 +356,7 @@ func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 	defer t.mu.Unlock()
 
 	for _, n := range nodes {
-		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,
+		err := t.subtreeCache.SetNodeHash(n.ID, n.Hash,
 			func(nID tree.NodeID) (*storagepb.SubtreeProto, error) {
 				return t.getSubtree(ctx, t.writeRevision, nID)
 			})

--- a/storage/postgres/log_storage.go
+++ b/storage/postgres/log_storage.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
+	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/hashers/registry"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage"
@@ -370,9 +371,9 @@ func (t *logTreeTX) WriteRevision(ctx context.Context) (int64, error) {
 	return t.treeTX.writeRevision, nil
 }
 
-func (t *logTreeTX) GetMerkleNodes(ctx context.Context, nodeIDs []tree.NodeID) ([]tree.Node, error) {
+func (t *logTreeTX) GetMerkleNodes(ctx context.Context, ids []compact.NodeID) ([]tree.Node, error) {
 	rev := int64(t.root.Revision)
-	return t.treeTX.subtreeCache.GetNodes(nodeIDs, t.treeTX.getSubtreesAtRev(ctx, rev))
+	return t.treeTX.subtreeCache.GetNodes(ids, t.treeTX.getSubtreesAtRev(ctx, rev))
 }
 
 func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/postgres/tree_storage.go
+++ b/storage/postgres/tree_storage.go
@@ -402,7 +402,7 @@ func (t *treeTX) Close() error {
 
 func (t *treeTX) SetMerkleNodes(ctx context.Context, nodes []tree.Node) error {
 	for _, n := range nodes {
-		err := t.subtreeCache.SetNodeHash(n.NodeID, n.Hash,
+		err := t.subtreeCache.SetNodeHash(n.ID, n.Hash,
 			func(nID tree.NodeID) (*storagepb.SubtreeProto, error) {
 				return t.getSubtree(ctx, t.writeRevision, nID)
 			})

--- a/storage/tree/node.go
+++ b/storage/tree/node.go
@@ -23,15 +23,16 @@ import (
 	"math/bits"
 	"strconv"
 	"strings"
+
+	"github.com/google/trillian/merkle/compact"
 )
 
 const hexChars = "0123456789abcdef"
 
 // Node represents a single node in a Merkle tree.
 type Node struct {
-	NodeID       NodeID
-	Hash         []byte
-	NodeRevision int64
+	ID   compact.NodeID
+	Hash []byte
 }
 
 // NodeID is an identifier of a Merkle tree Node. A default constructed NodeID

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/storage/tree"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -63,6 +64,8 @@ type TreeTX interface {
 // TreeWriter represents additional transaction methods that modify the tree.
 type TreeWriter interface {
 	// SetMerkleNodes writes the nodes, at the write revision.
+	//
+	// TODO(pavelkalinnikov): Use tiles instead, here and in GetMerkleNodes.
 	SetMerkleNodes(ctx context.Context, nodes []tree.Node) error
 
 	// WriteRevision returns the tree revision that any writes through this TreeTX will be stored at.
@@ -75,9 +78,9 @@ type DatabaseChecker interface {
 	CheckDatabaseAccessible(context.Context) error
 }
 
-// NodeReader provides read-only access to the stored tree nodes, as an interface to allow easier
-// testing of node manipulation.
+// NodeReader provides read-only access to the stored tree nodes, as an
+// interface to allow easier testing of node manipulation.
 type NodeReader interface {
 	// GetMerkleNodes returns tree nodes by their IDs, in the requested order.
-	GetMerkleNodes(ctx context.Context, ids []tree.NodeID) ([]tree.Node, error)
+	GetMerkleNodes(ctx context.Context, ids []compact.NodeID) ([]tree.Node, error)
 }


### PR DESCRIPTION
The old `NodeID` type is very complex. This change replaces it with
the simple `compact.NodeID` from the application layer all the way down
to `SubtreeCache`, but the latter still uses the old type. In follow-up
changes it will be removed completely.

Part of #2378.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
