### PR TITLE
Wordsmithing/refactoring to make docs more accessible

### DIFF
--- a/docs/claimantmodel/CoreModel.md
+++ b/docs/claimantmodel/CoreModel.md
@@ -28,7 +28,7 @@ The only party which can verify that a certificate was issued under authorizatio
 <dt>Verifier<sup>CERT</sup></dt>
 <dd>Domain Owner</dd>
 <dt>Arbiter<sup>CERT</sup></dt>
-<dd>Brower Vendor</dd>
+<dd>Browser Vendor</dd>
 </dl>
 
 The Browser has sufficient trust in the CA to employ a strategy of [Trust But Verify](#trust-but-verify), however this model alone does not provide a mechanism to ensure that any Statement<sup>CERT</sup> relied on by Believer<sup>CERT</sup> can be discovered by Verifier<sup>CERT</sup>. This is why Certificate Transparency was created; to allow verifiers to discover all of the certificates that have been believed.

--- a/docs/claimantmodel/CoreModel.md
+++ b/docs/claimantmodel/CoreModel.md
@@ -9,6 +9,13 @@ This paper introduces an intuitive, standalone model for a common scenario where
 There is a **Claimant** that makes a **Claim** that is relied upon by a **Believer** as a precondition to take an action they would not have taken if the claim was false. Claims are represented by signed **Statements**. The veracity of a Claim can be verified by a **Claim Verifier**, who will notify a **Claim Arbiter** of any false Claims.
 
 ## Example: Certification Claims
+
+As a concrete example of the Claimant Model in action, we'll model one of the core claims made by [Certificate Authorities](https://en.wikipedia.org/wiki/Certificate_authority) (CAs).
+A CA should create and sign a Certificate, *only at the request of the Domain Owner*.
+A user's web browser receives this cert when attempting to establish a secure connection to a domain, and proceeds with the connection only if it was signed by a CA that the Browser Vendor has blessed.
+In the event of a CA issuing bad certificates, the Browser Vendor can protect their users by removing the CA from the blessed set.
+The only party which can verify that a certificate was issued under authorization is the Domain Owner.
+
 <dl>
 <dt>Claim<sup>CERT</sup></dt>
 <dd><i>"I, ${CA}, am authorized to certify $pubKey for $domain"</i></dd>
@@ -17,16 +24,15 @@ There is a **Claimant** that makes a **Claim** that is relied upon by a **Believ
 <dt>Claimant<sup>CERT</sup></dt>
 <dd>Certificate Authority</dd>
 <dt>Believer<sup>CERT</sup></dt>
-<dd>User Agent (Browser)</dd>
+<dd>Web Browser</dd>
 <dt>Verifier<sup>CERT</sup></dt>
 <dd>Domain Owner</dd>
 <dt>Arbiter<sup>CERT</sup></dt>
-<dd>User Agent Vendor</dd>
+<dd>Brower Vendor</dd>
 </dl>
 
-The CA creates and signs a Certificate. The UA receives this cert when attempting to establish a secure connection to a domain, and proceeds with the connection only if it was signed by a CA that the Browser Vendor has blessed. In the event of a CA issuing bad certificates, the Browser Vendor can protect their users by removing the CA from the blessed set. The only party which can verify that a certificate was issued under authorization is the Domain Owner.
-
-The Browser has sufficient trust in the CA to employ a strategy of [Trust But Verify](#trust-but-verify), however this model alone does not provide a mechanism to ensure that any Statement<sup>CERT</sup> relied on by Believer<sup>CERT</sup> can be discovered by Verifier<sup>CERT</sup>. This is why Certificate Transparency was created. Using Logs to provide this discoverability is described in [Claimant Model: Logs](Logs.md).
+The Browser has sufficient trust in the CA to employ a strategy of [Trust But Verify](#trust-but-verify), however this model alone does not provide a mechanism to ensure that any Statement<sup>CERT</sup> relied on by Believer<sup>CERT</sup> can be discovered by Verifier<sup>CERT</sup>. This is why Certificate Transparency was created; to allow verifiers to discover all of the certificates that have been believed.
+Using Logs to provide this discoverability is described in [Claimant Model: Logs](Logs.md).
 
 <!-- TODO(mhutchinson): Discuss Closed Loop Systems below and link to this. -->
 

--- a/docs/claimantmodel/Logs.md
+++ b/docs/claimantmodel/Logs.md
@@ -9,12 +9,20 @@ Log Transparency as described here should be applied to situations where the Cla
 
 A Claim is discoverable if it can be found by the Verifier without information being passed to them by the Believer. This property is essential when Believers are employing Trust But Verify and the identity of all Verifiers does not form part of the Believer’s [TCB](https://en.wikipedia.org/wiki/Trusted_computing_base).
 
+More formally: *Any claim believed by any honest Believer must be eventually verified by an honest Verifier*.
+
 Another way to conceptualize this is that Logs provide a verifiable transport mechanism to ensure that any Claim that a Believer relies on will be eventually discovered by the Verifier.
 
 # Model
 Log Transparency is another application of the Claimant Model to solve a transport problem in what we will refer to as System<sup>DOMAIN</sup>; it provides a mechanism for all Statement<sup>DOMAIN</sup> relied upon by Believer<sup>DOMAIN</sup> to be discovered by Verifier<sup>DOMAIN</sup>.
 
 ## System<sup>LOG</sup>
+
+A log operator maintains an append-only list of Statement<sup>DOMAIN</sup>, and presents all clients with the same list.
+The log produces and signs checkpoints to commit to the state of the list as it grows, and committments to data to by a checkpoint should be cryptographically verifiable.
+A Statement<sup>DOMAIN</sup> should only be believed once its inclusion in the log has been verified.
+Clients of the log should verify that any new checkpoints they receive are consistent with any previous checkpoint that they have relied on, and checkpoints can be shared amongst clients to detect any inconsistencies in the list of data being presented.
+
 <dl>
 <dt>Claim<sup>LOG</sup></dt>
 <dd><i>"I make available a globally consistent, append-only list of Statement<sup>DOMAIN</sup>"</i></dd>
@@ -30,18 +38,19 @@ Log Transparency is another application of the Claimant Model to solve a transpo
 <dd>Log Arbiter</dd>
 </dl>
 
-## New Artifacts
+### Artifacts
 <dl>
 <dt>Log Checkpoint (aka STH)</dt>
-<dd>a <i>signed statement</i> by the <i>Claim Log</i> which declares the number of <i>Claims</i> in the log, and represents a verifiable commitment to the contents of the log. The signature on a Checkpoint states nothing about the veracity of any claims, but asserts that:
+<dd>a <i>signed statement</i> by the <i>Claim Log</i> which declares the number of <i>Claims</i> in the log, and represents a verifiable commitment to the contents of the log.
+    The signature on a Checkpoint states nothing about the veracity of any Claim<sup>DOMAIN</sup>, but asserts that:
 <ul>
 <li>This Checkpoint is consistent with all earlier Checkpoints; and</li>
-<li>All Claims committed to by this Checkpoint are immutable and discoverable</li>
+<li>All Statement<sup>DOMAIN</sup> committed to by this Checkpoint are immutable and discoverable</li>
 </ul>
 </dd>
 </dl>
 
-## New Roles
+### Roles
 <dl>
 <dt>Claim Log (Claimant<sup>Log</sup>)</dt>
 <dd>maintains the log, appends well-formed Statements, and periodically produces Checkpoints. All Statements must be made available to Verifier<sup>DOMAIN</sup>, and commitments made available to all roles.</dd>
@@ -63,7 +72,7 @@ This mechanism doesn’t always require proof, e.g. you can’t prove that a log
 <dd>writes Claims to the Log. This role doesn’t map to a role in the Claimant Model, but someone has to do it. In many systems this will be the Claimant, but it could also be the Believer, or another third party.</dd>
 </dl>
 
-## Relationship Graph
+### Relationship Graph
 This shows which roles must know about the actors playing the other roles before any of the machinery starts moving. For example, the Believer must know about the Claimant ahead of time because they need to have some basis on which to trust a Claim and verify its authenticity.
 
 Believer, Claimant, Claim Verifier, and Claimant Arbiter are all for System<sup>DOMAIN</sup>.


### PR DESCRIPTION
Improved the flow a little. Before introducing a Claimant Model using the template, I've included free text before it which explains in relatively plain English how the system functions. In the core model, this was mostly a case of moving the paragraph from after the template up to before it.