### PR TITLE
Remove the unused ListTreeIDs method from the AdminReader interface.

### DIFF
--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -79,11 +79,6 @@ type AdminReader interface {
 	// GetTree returns the tree corresponding to treeID or an error.
 	GetTree(ctx context.Context, treeID int64) (*trillian.Tree, error)
 
-	// ListTreeIDs returns the IDs of all trees in storage.
-	// Note that there's no authorization restriction on the IDs returned,
-	// so it should be used with caution in production code.
-	ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64, error)
-
 	// ListTrees returns all trees in storage.
 	// Note that there's no authorization restriction on the trees returned,
 	// so it should be used with caution in production code.

--- a/storage/cloudspanner/admin.go
+++ b/storage/cloudspanner/admin.go
@@ -243,20 +243,6 @@ func (t *adminTX) getTreeInfo(ctx context.Context, treeID int64) (*spannerpb.Tre
 	return info, nil
 }
 
-// ListTreeIDs implements AdminReader.ListTreeIDs.
-func (t *adminTX) ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64, error) {
-	ids := []int64{}
-	err := t.readTrees(ctx, includeDeleted, true /* idOnly */, func(r *spanner.Row) error {
-		var id int64
-		if err := r.Columns(&id); err != nil {
-			return err
-		}
-		ids = append(ids, id)
-		return nil
-	})
-	return ids, err
-}
-
 // ListTrees implements AdminReader.ListTrees.
 func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trillian.Tree, error) {
 	trees := []*trillian.Tree{}

--- a/storage/memory/admin_storage.go
+++ b/storage/memory/admin_storage.go
@@ -115,17 +115,6 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 	return tree.meta, nil
 }
 
-func (t *adminTX) ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64, error) {
-	t.ms.mu.RLock()
-	defer t.ms.mu.RUnlock()
-
-	var ret []int64
-	for _, v := range t.ms.trees {
-		ret = append(ret, v.meta.TreeId)
-	}
-	return ret, nil
-}
-
 func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trillian.Tree, error) {
 	t.ms.mu.RLock()
 	defer t.ms.mu.RUnlock()

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -190,21 +190,6 @@ func (mr *MockAdminTXMockRecorder) IsClosed() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClosed", reflect.TypeOf((*MockAdminTX)(nil).IsClosed))
 }
 
-// ListTreeIDs mocks base method.
-func (m *MockAdminTX) ListTreeIDs(arg0 context.Context, arg1 bool) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTreeIDs", arg0, arg1)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTreeIDs indicates an expected call of ListTreeIDs.
-func (mr *MockAdminTXMockRecorder) ListTreeIDs(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTreeIDs", reflect.TypeOf((*MockAdminTX)(nil).ListTreeIDs), arg0, arg1)
-}
-
 // ListTrees mocks base method.
 func (m *MockAdminTX) ListTrees(arg0 context.Context, arg1 bool) ([]*trillian.Tree, error) {
 	m.ctrl.T.Helper()
@@ -694,21 +679,6 @@ func (m *MockReadOnlyAdminTX) IsClosed() bool {
 func (mr *MockReadOnlyAdminTXMockRecorder) IsClosed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClosed", reflect.TypeOf((*MockReadOnlyAdminTX)(nil).IsClosed))
-}
-
-// ListTreeIDs mocks base method.
-func (m *MockReadOnlyAdminTX) ListTreeIDs(arg0 context.Context, arg1 bool) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTreeIDs", arg0, arg1)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTreeIDs indicates an expected call of ListTreeIDs.
-func (mr *MockReadOnlyAdminTXMockRecorder) ListTreeIDs(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTreeIDs", reflect.TypeOf((*MockReadOnlyAdminTX)(nil).ListTreeIDs), arg0, arg1)
 }
 
 // ListTrees mocks base method.

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -35,9 +35,6 @@ const (
 
 	nonDeletedWhere = " WHERE (Deleted IS NULL OR Deleted = 'false')"
 
-	selectTreeIDs           = "SELECT TreeId FROM Trees"
-	selectNonDeletedTreeIDs = selectTreeIDs + nonDeletedWhere
-
 	selectTrees = `
 		SELECT
 			TreeId,
@@ -167,37 +164,6 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 		return nil, fmt.Errorf("error reading tree %v: %v", treeID, err)
 	}
 	return tree, nil
-}
-
-func (t *adminTX) ListTreeIDs(ctx context.Context, includeDeleted bool) ([]int64, error) {
-	var query string
-	if includeDeleted {
-		query = selectTreeIDs
-	} else {
-		query = selectNonDeletedTreeIDs
-	}
-
-	stmt, err := t.tx.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	treeIDs := []int64{}
-	var treeID int64
-	for rows.Next() {
-		if err := rows.Scan(&treeID); err != nil {
-			return nil, err
-		}
-		treeIDs = append(treeIDs, treeID)
-	}
-	return treeIDs, nil
 }
 
 func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trillian.Tree, error) {

--- a/storage/mysql/admin_storage_test.go
+++ b/storage/mysql/admin_storage_test.go
@@ -106,23 +106,6 @@ func TestAdminTX_TreeWithNulls(t *testing.T) {
 			},
 		},
 		{
-			// ListTreeIDs *shouldn't* care about other columns, but let's test it just
-			// in case.
-			desc: "ListTreeIDs",
-			fn: func(ctx context.Context, tx storage.AdminTX) error {
-				ids, err := tx.ListTreeIDs(ctx, false /* includeDeleted */)
-				if err != nil {
-					return err
-				}
-				for _, id := range ids {
-					if id == treeID {
-						return nil
-					}
-				}
-				return fmt.Errorf("ID not found: %v", treeID)
-			},
-		},
-		{
 			desc: "ListTrees",
 			fn: func(ctx context.Context, tx storage.AdminTX) error {
 				trees, err := tx.ListTrees(ctx, false /* includeDeleted */)


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
