### PR TITLE
Split out the function to create a crypto.Signer from a PEMKeyFile proto.

### DIFF
--- a/crypto/keys/pem/pem.go
+++ b/crypto/keys/pem/pem.go
@@ -15,6 +15,7 @@
 package pem
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
@@ -23,6 +24,8 @@ import (
 	"io/ioutil"
 
 	"github.com/google/trillian/crypto/keys/der"
+	"github.com/google/trillian/crypto/keyspb"
+	"google.golang.org/protobuf/proto"
 )
 
 // ReadPrivateKeyFile reads a PEM-encoded private key from a file.
@@ -79,4 +82,12 @@ func UnmarshalPublicKey(keyPEM string) (crypto.PublicKey, error) {
 	}
 
 	return der.UnmarshalPublicKey(block.Bytes)
+}
+
+// FromProto builds a crypto.Signer from a proto.Message, which must be of type PEMKeyFile.
+func FromProto(_ context.Context, pb proto.Message) (crypto.Signer, error) {
+	if pb, ok := pb.(*keyspb.PEMKeyFile); ok {
+		return ReadPrivateKeyFile(pb.GetPath(), pb.GetPassword())
+	}
+	return nil, fmt.Errorf("pemfile: got %T, want *keyspb.PEMKeyFile", pb)
 }

--- a/crypto/keys/pem/pem_test.go
+++ b/crypto/keys/pem/pem_test.go
@@ -15,12 +15,15 @@
 package pem_test
 
 import (
+	"context"
 	"crypto"
 	"testing"
 
 	. "github.com/google/trillian/crypto/keys/pem"
 	ktestonly "github.com/google/trillian/crypto/keys/testonly"
+	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/testonly"
+	"google.golang.org/protobuf/proto"
 
 	_ "github.com/golang/glog"
 )
@@ -139,6 +142,64 @@ func TestLoadPrivateKeyAndSign(t *testing.T) {
 
 		// Check the key by creating a signature and verifying it.
 		if err := ktestonly.SignAndVerify(k, k.Public()); err != nil {
+			t.Errorf("%v: SignAndVerify() = %q, want nil", test.desc, err)
+		}
+	}
+}
+
+func TestFromProto(t *testing.T) {
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		desc     string
+		keyProto proto.Message
+		wantErr  bool
+	}{
+		{
+			desc: "PEMKeyFile",
+			keyProto: &keyspb.PEMKeyFile{
+				Path:     "../../../testdata/log-rpc-server.privkey.pem",
+				Password: "towel",
+			},
+		},
+		{
+			desc:     "wrong proto",
+			keyProto: &keyspb.PrivateKey{},
+			wantErr:  true,
+		},
+		{
+			desc: "PemKeyFile with non-existent file",
+			keyProto: &keyspb.PEMKeyFile{
+				Path: "non-existent.pem",
+			},
+			wantErr: true,
+		},
+		{
+			desc: "PemKeyFile with wrong password",
+			keyProto: &keyspb.PEMKeyFile{
+				Path:     "../../../testdata/log-rpc-server.privkey.pem",
+				Password: "wrong-password",
+			},
+			wantErr: true,
+		},
+		{
+			desc: "PemKeyFile with missing password",
+			keyProto: &keyspb.PEMKeyFile{
+				Path: "../../../testdata/log-rpc-server.privkey.pem",
+			},
+			wantErr: true,
+		},
+	} {
+		signer, err := FromProto(ctx, test.keyProto)
+		if gotErr := err != nil; gotErr != test.wantErr {
+			t.Errorf("%v: NewSigner(_, %#v) = (_, %q), want (_, nil)", test.desc, test.keyProto, err)
+			continue
+		} else if gotErr {
+			continue
+		}
+
+		// Check that the returned signer can produce signatures successfully.
+		if err := ktestonly.SignAndVerify(signer, signer.Public()); err != nil {
 			t.Errorf("%v: SignAndVerify() = %q, want nil", test.desc, err)
 		}
 	}

--- a/crypto/keys/pem/proto/register.go
+++ b/crypto/keys/pem/proto/register.go
@@ -17,21 +17,11 @@
 package proto
 
 import (
-	"context"
-	"crypto"
-	"fmt"
-
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
-	"google.golang.org/protobuf/proto"
 )
 
 func init() {
-	keys.RegisterHandler(&keyspb.PEMKeyFile{}, func(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
-		if pb, ok := pb.(*keyspb.PEMKeyFile); ok {
-			return pem.ReadPrivateKeyFile(pb.GetPath(), pb.GetPassword())
-		}
-		return nil, fmt.Errorf("pemfile: got %T, want *keyspb.PEMKeyFile", pb)
-	})
+	keys.RegisterHandler(&keyspb.PEMKeyFile{}, pem.FromProto)
 }

--- a/crypto/keys/pem/proto/register_test.go
+++ b/crypto/keys/pem/proto/register_test.go
@@ -21,58 +21,20 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/testonly"
 	"github.com/google/trillian/crypto/keyspb"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestProtoHandler(t *testing.T) {
 	ctx := context.Background()
 
-	for _, test := range []struct {
-		desc     string
-		keyProto proto.Message
-		wantErr  bool
-	}{
-		{
-			desc: "PEMKeyFile",
-			keyProto: &keyspb.PEMKeyFile{
-				Path:     "../../../../testdata/log-rpc-server.privkey.pem",
-				Password: "towel",
-			},
-		},
-		{
-			desc: "PemKeyFile with non-existent file",
-			keyProto: &keyspb.PEMKeyFile{
-				Path: "non-existent.pem",
-			},
-			wantErr: true,
-		},
-		{
-			desc: "PemKeyFile with wrong password",
-			keyProto: &keyspb.PEMKeyFile{
-				Path:     "../../../../testdata/log-rpc-server.privkey.pem",
-				Password: "wrong-password",
-			},
-			wantErr: true,
-		},
-		{
-			desc: "PemKeyFile with missing password",
-			keyProto: &keyspb.PEMKeyFile{
-				Path: "../../../../testdata/log-rpc-server.privkey.pem",
-			},
-			wantErr: true,
-		},
-	} {
-		signer, err := keys.NewSigner(ctx, test.keyProto)
-		if gotErr := err != nil; gotErr != test.wantErr {
-			t.Errorf("%v: NewSigner(_, %#v) = (_, %q), want (_, nil)", test.desc, test.keyProto, err)
-			continue
-		} else if gotErr {
-			continue
-		}
+	keyProto := &keyspb.PEMKeyFile{Path: "../../../../testdata/log-rpc-server.privkey.pem", Password: "towel"}
 
-		// Check that the returned signer can produce signatures successfully.
-		if err := testonly.SignAndVerify(signer, signer.Public()); err != nil {
-			t.Errorf("%v: SignAndVerify() = %q, want nil", test.desc, err)
-		}
+	signer, err := keys.NewSigner(ctx, keyProto)
+	if err != nil {
+		t.Errorf("keys.NewSigner(_, %#v) = (_, %q), want (_, nil)", keyProto, err)
+	}
+
+	// Check that the returned signer can produce signatures successfully.
+	if err := testonly.SignAndVerify(signer, signer.Public()); err != nil {
+		t.Errorf("SignAndVerify() = %q, want nil", err)
 	}
 }


### PR DESCRIPTION
This allows it to be reused, and also tests it more directly.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
