### PR TITLE
Split out the function to create a crypto.Signer from a PrivateKey proto.

### DIFF
--- a/crypto/keys/der/der.go
+++ b/crypto/keys/der/der.go
@@ -15,6 +15,7 @@
 package der
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
@@ -23,11 +24,15 @@ import (
 
 	"github.com/google/trillian/crypto/keyspb"
 	"golang.org/x/crypto/ed25519"
+	"google.golang.org/protobuf/proto"
 )
 
-// FromProto takes a PrivateKey protobuf message and returns the private key contained within.
-func FromProto(pb *keyspb.PrivateKey) (crypto.Signer, error) {
-	return UnmarshalPrivateKey(pb.GetDer())
+// FromProto builds a crypto.Signer from a proto.Message, which must be of type PrivateKey.
+func FromProto(_ context.Context, pb proto.Message) (crypto.Signer, error) {
+	if pb, ok := pb.(*keyspb.PrivateKey); ok {
+		return UnmarshalPrivateKey(pb.GetDer())
+	}
+	return nil, fmt.Errorf("der: got %T, want *keyspb.PrivateKey", pb)
 }
 
 // UnmarshalPrivateKey reads a DER-encoded private key.

--- a/crypto/keys/der/proto/register.go
+++ b/crypto/keys/der/proto/register.go
@@ -17,21 +17,11 @@
 package proto
 
 import (
-	"context"
-	"crypto"
-	"fmt"
-
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
-	"google.golang.org/protobuf/proto"
 )
 
 func init() {
-	keys.RegisterHandler(&keyspb.PrivateKey{}, func(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
-		if pb, ok := pb.(*keyspb.PrivateKey); ok {
-			return der.FromProto(pb)
-		}
-		return nil, fmt.Errorf("der: got %T, want *keyspb.PrivateKey", pb)
-	})
+	keys.RegisterHandler(&keyspb.PrivateKey{}, der.FromProto)
 }

--- a/crypto/keys/der/proto/register_test.go
+++ b/crypto/keys/der/proto/register_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/testonly"
 	"github.com/google/trillian/crypto/keyspb"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestProtoHandler(t *testing.T) {
@@ -34,41 +33,15 @@ func TestProtoHandler(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, test := range []struct {
-		desc     string
-		keyProto proto.Message
-		wantErr  bool
-	}{
-		{
-			desc: "PrivateKey",
-			keyProto: &keyspb.PrivateKey{
-				Der: keyDER,
-			},
-		},
-		{
-			desc: "PrivateKey with invalid DER",
-			keyProto: &keyspb.PrivateKey{
-				Der: []byte("foobar"),
-			},
-			wantErr: true,
-		},
-		{
-			desc:     "PrivateKey with missing DER",
-			keyProto: &keyspb.PrivateKey{},
-			wantErr:  true,
-		},
-	} {
-		signer, err := keys.NewSigner(ctx, test.keyProto)
-		if gotErr := err != nil; gotErr != test.wantErr {
-			t.Errorf("%v: NewSigner(_, %#v) = (_, %q), want (_, nil)", test.desc, test.keyProto, err)
-			continue
-		} else if gotErr {
-			continue
-		}
+	keyProto := &keyspb.PrivateKey{Der: keyDER}
 
-		// Check that the returned signer can produce signatures successfully.
-		if err := testonly.SignAndVerify(signer, signer.Public()); err != nil {
-			t.Errorf("%v: SignAndVerify() = %q, want nil", test.desc, err)
-		}
+	signer, err := keys.NewSigner(ctx, keyProto)
+	if err != nil {
+		t.Errorf("keys.NewSigner(_, %#v) = (_, %q), want (_, nil)", keyProto, err)
+	}
+
+	// Check that the returned signer can produce signatures successfully.
+	if err := testonly.SignAndVerify(signer, signer.Public()); err != nil {
+		t.Errorf("SignAndVerify() = %q, want nil", err)
 	}
 }


### PR DESCRIPTION
This allows it to be reused, and also tests it more directly.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
