### PR TITLE
Always provide a pkcs11.FromConfig function.

### DIFF
--- a/crypto/keys/pkcs11/no_pkcs11.go
+++ b/crypto/keys/pkcs11/no_pkcs11.go
@@ -1,3 +1,5 @@
+// +build !pkcs11
+
 // Copyright 2017 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,27 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proto
+package pkcs11
 
 import (
-	"context"
 	"crypto"
-	"flag"
-	"fmt"
+	"errors"
 
-	"github.com/google/trillian/crypto/keys"
-	"github.com/google/trillian/crypto/keys/pkcs11"
 	"github.com/google/trillian/crypto/keyspb"
-	"google.golang.org/protobuf/proto"
 )
 
-var modulePath = flag.String("pkcs11_module_path", "", "Path to the PKCS#11 module to use for keys that use the PKCS#11 interface")
-
-func init() {
-	keys.RegisterHandler(&keyspb.PKCS11Config{}, func(ctx context.Context, pb proto.Message) (crypto.Signer, error) {
-		if cfg, ok := pb.(*keyspb.PKCS11Config); ok {
-			return pkcs11.FromConfig(*modulePath, cfg)
-		}
-		return nil, fmt.Errorf("pkcs11: got %T, want *keyspb.PKCS11Config", pb)
-	})
+// FromConfig returns an error indicating that PKCS11 is not supported.
+func FromConfig(_ string, _ *keyspb.PKCS11Config) (crypto.Signer, error) {
+	return nil, errors.New("pkcs11: Not supported in this binary")
 }

--- a/crypto/keys/pkcs11/proto/register_test.go
+++ b/crypto/keys/pkcs11/proto/register_test.go
@@ -1,5 +1,3 @@
-// +build pkcs11
-
 // Copyright 2017 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Instead of having it only exist when PKCS11 support is present, have this function always available, but return an error when PKCS11 support is not compiled in.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
