### PR TITLE
Factor out Layout for sparse Merkle trees

### DIFF
--- a/merkle/smt/layout.go
+++ b/merkle/smt/layout.go
@@ -27,13 +27,13 @@ type Layout struct {
 }
 
 // NewLayout creates a tree layout based on the passed-in tier heights.
-func NewLayout(heights []int) Layout {
+func NewLayout(heights []uint) Layout {
 	depths := make([]int, len(heights)+1)
 	for i, h := range heights {
 		if h <= 0 {
 			panic("tile heights must be positive")
 		}
-		depths[i+1] = depths[i] + h
+		depths[i+1] = depths[i] + int(h)
 	}
 	return Layout{depths: depths}
 }

--- a/merkle/smt/layout.go
+++ b/merkle/smt/layout.go
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import "sort"
+
+// Layout defines the mapping between tree nodes and tiles.
+//
+// The tree is divided into horizontal tiers of the heights specified in the
+// constructor. The tiers are counted down from the tree root. Nodes located at
+// the tier borders are roots of the corresponding tiles. A tile includes all
+// the nodes strictly below the tile root, within a single tier.
+type Layout struct {
+	depths []int
+}
+
+// NewLayout creates a tree layout based on the passed-in tier heights.
+func NewLayout(heights []int) Layout {
+	depths := make([]int, len(heights)+1)
+	for i, h := range heights {
+		if h <= 0 {
+			panic("tile heights must be positive")
+		}
+		depths[i+1] = depths[i] + h
+	}
+	return Layout{depths: depths}
+}
+
+// Locate returns the tier info that nodes at the given depth belong to. The
+// first returned value is the depth of the root node, for any tile in this
+// tier. The second value is the height of the tiles.
+//
+// If depth is 0, or beyond the tree height, then the result is undefined.
+func (l Layout) Locate(depth uint) (uint, uint) {
+	if depth == 0 { // The root belongs to its own "pseudo" tile.
+		return 0, 0
+	}
+	i := sort.SearchInts(l.depths, int(depth)) // 1 <= i <= len(depths)
+	rootDepth := uint(l.depths[i-1])
+	if ln := len(l.depths); i >= ln { // Anything below the leaves does not exist.
+		return rootDepth, 0
+	}
+	return rootDepth, uint(l.depths[i]) - rootDepth
+}

--- a/merkle/smt/layout_test.go
+++ b/merkle/smt/layout_test.go
@@ -17,8 +17,8 @@ package smt
 import "testing"
 
 func TestLayoutLocate(t *testing.T) {
-	l1 := NewLayout([]int{1, 2, 4, 8})
-	l2 := NewLayout([]int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176})
+	l1 := NewLayout([]uint{1, 2, 4, 8})
+	l2 := NewLayout([]uint{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176})
 	for _, tc := range []struct {
 		desc  string
 		l     Layout

--- a/merkle/smt/layout_test.go
+++ b/merkle/smt/layout_test.go
@@ -14,9 +14,7 @@
 
 package smt
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestLayoutLocate(t *testing.T) {
 	l1 := NewLayout([]int{1, 2, 4, 8})

--- a/merkle/smt/layout_test.go
+++ b/merkle/smt/layout_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smt
+
+import (
+	"testing"
+)
+
+func TestLayoutLocate(t *testing.T) {
+	l1 := NewLayout([]int{1, 2, 4, 8})
+	l2 := NewLayout([]int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176})
+	for _, tc := range []struct {
+		desc  string
+		l     Layout
+		depth uint
+		wantD uint
+		wantH uint
+	}{
+		{desc: "l1-root", l: l1, depth: 0, wantD: 0, wantH: 0},
+		{desc: "l1-1", l: l1, depth: 1, wantD: 0, wantH: 1},
+		{desc: "l1-2", l: l1, depth: 2, wantD: 1, wantH: 2},
+		{desc: "l1-3", l: l1, depth: 3, wantD: 1, wantH: 2},
+		{desc: "l1-4", l: l1, depth: 4, wantD: 3, wantH: 4},
+		{desc: "l1-5", l: l1, depth: 5, wantD: 3, wantH: 4},
+		{desc: "l1-7", l: l1, depth: 7, wantD: 3, wantH: 4},
+		{desc: "l1-8", l: l1, depth: 8, wantD: 7, wantH: 8},
+		{desc: "l1-10", l: l1, depth: 10, wantD: 7, wantH: 8},
+		{desc: "l1-leaves", l: l1, depth: 15, wantD: 7, wantH: 8},
+
+		{desc: "l2-root", l: l2, depth: 0, wantD: 0, wantH: 0},
+		{desc: "l2-3", l: l2, depth: 3, wantD: 0, wantH: 8},
+		{desc: "l2-8", l: l2, depth: 8, wantD: 0, wantH: 8},
+		{desc: "l2-10", l: l2, depth: 10, wantD: 8, wantH: 8},
+		{desc: "l2-20", l: l2, depth: 20, wantD: 16, wantH: 8},
+		{desc: "l2-63", l: l2, depth: 63, wantD: 56, wantH: 8},
+		{desc: "l2-64", l: l2, depth: 64, wantD: 56, wantH: 8},
+		{desc: "l2-79", l: l2, depth: 79, wantD: 72, wantH: 8},
+		{desc: "l2-80", l: l2, depth: 80, wantD: 72, wantH: 8},
+		{desc: "l2-81", l: l2, depth: 81, wantD: 80, wantH: 176},
+		{desc: "l2-100", l: l2, depth: 100, wantD: 80, wantH: 176},
+		{desc: "l2-leaves", l: l2, depth: 256, wantD: 80, wantH: 176},
+		{desc: "l2-out-of-range", l: l2, depth: 257, wantD: 256, wantH: 0},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			d, h := tc.l.Locate(tc.depth)
+			if got, want := d, tc.wantD; got != want {
+				t.Errorf("tier depth is %d, want %d", got, want)
+			}
+			if got, want := h, tc.wantH; got != want {
+				t.Errorf("tier height is %d, want %d", got, want)
+			}
+		})
+	}
+}

--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -79,9 +79,9 @@ func merge(nodes, updates NodesRow) NodesRow {
 
 // scan visits all non-empty nodes of the tile except the root. The order of
 // node visits is arbitrary.
-func (t Tile) scan(l *tree.Layout, h mapHasher, visit func(Node)) error {
+func (t Tile) scan(l Layout, h mapHasher, visit func(Node)) error {
 	top := t.ID.BitLen()
-	height := uint(l.TileHeight(int(top)))
+	_, height := l.Locate(top + 1)
 	// TODO(pavelkalinnikov): Remove HStar3 side effects, to avoid copying here.
 	// Currently, the Update method modifies the nodes given to NewHStar3.
 	leaves := make([]Node, len(t.Leaves))

--- a/merkle/smt/tile_test.go
+++ b/merkle/smt/tile_test.go
@@ -109,7 +109,7 @@ func TestTileMerge(t *testing.T) {
 }
 
 func TestTileScan(t *testing.T) {
-	lo := NewLayout([]int{8, 24})
+	lo := NewLayout([]uint{8, 24})
 	h := bindHasher(coniks.Default, 1)
 
 	ids := []tree.NodeID2{

--- a/merkle/smt/tile_test.go
+++ b/merkle/smt/tile_test.go
@@ -109,7 +109,7 @@ func TestTileMerge(t *testing.T) {
 }
 
 func TestTileScan(t *testing.T) {
-	lo := tree.NewLayout([]int{8, 24})
+	lo := NewLayout([]int{8, 24})
 	h := bindHasher(coniks.Default, 1)
 
 	ids := []tree.NodeID2{

--- a/merkle/smt/tiles_test.go
+++ b/merkle/smt/tiles_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestTileSetAdd(t *testing.T) {
 	hasher := coniks.Default
-	l := tree.NewLayout([]int{8, 8})
+	l := NewLayout([]int{8, 8})
 
 	existing := Tile{
 		ID:     tree.NewNodeID2("\x00", 8),
@@ -64,7 +64,7 @@ func TestTileSetAdd(t *testing.T) {
 }
 
 func TestTileSetHashes(t *testing.T) {
-	l := tree.NewLayout([]int{8, 8})
+	l := NewLayout([]int{8, 8})
 	ts := NewTileSet(0, coniks.Default, l)
 
 	count := 0
@@ -100,7 +100,7 @@ func TestTileSetHashes(t *testing.T) {
 }
 
 func TestTileSetMutationBuild(t *testing.T) {
-	l := tree.NewLayout([]int{8, 8})
+	l := NewLayout([]int{8, 8})
 	ids := []tree.NodeID2{
 		tree.NewNodeID2("\x00\x00", 16),
 		tree.NewNodeID2("\x00\x70", 16),

--- a/merkle/smt/tiles_test.go
+++ b/merkle/smt/tiles_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestTileSetAdd(t *testing.T) {
 	hasher := coniks.Default
-	l := NewLayout([]int{8, 8})
+	l := NewLayout([]uint{8, 8})
 
 	existing := Tile{
 		ID:     tree.NewNodeID2("\x00", 8),
@@ -64,7 +64,7 @@ func TestTileSetAdd(t *testing.T) {
 }
 
 func TestTileSetHashes(t *testing.T) {
-	l := NewLayout([]int{8, 8})
+	l := NewLayout([]uint{8, 8})
 	ts := NewTileSet(0, coniks.Default, l)
 
 	count := 0
@@ -100,7 +100,7 @@ func TestTileSetHashes(t *testing.T) {
 }
 
 func TestTileSetMutationBuild(t *testing.T) {
-	l := NewLayout([]int{8, 8})
+	l := NewLayout([]uint{8, 8})
 	ids := []tree.NodeID2{
 		tree.NewNodeID2("\x00\x00", 16),
 		tree.NewNodeID2("\x00\x70", 16),

--- a/storage/tree/layout.go
+++ b/storage/tree/layout.go
@@ -116,16 +116,6 @@ func (l *Layout) TileHeight(rootDepth int) int {
 	return l.getStratumAt(rootDepth).height
 }
 
-// GetTileRootID returns the ID for the root of the tile that the node with the
-// given ID belongs to.
-func (l *Layout) GetTileRootID(id NodeID2) NodeID2 {
-	if depth := id.BitLen(); depth > 0 {
-		info := l.getStratumAt(int(depth) - 1)
-		return id.Prefix(uint(info.idBytes * 8))
-	}
-	return NodeID2{}
-}
-
 func (l *Layout) getStratumAt(depth int) stratumInfo {
 	return l.sIndex[depth/depthQuantum]
 }

--- a/storage/tree/layout_test.go
+++ b/storage/tree/layout_test.go
@@ -23,11 +23,7 @@ import (
 	"github.com/google/trillian/merkle/compact"
 )
 
-var (
-	// TODO(pavelkalinnikov): Use only log layout.
-	defaultMapStrata = []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176}
-	defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8}
-)
+var defaultLogStrata = []int{8, 8, 8, 8, 8, 8, 8, 8}
 
 func TestGetTileID(t *testing.T) {
 	layout := NewLayout(defaultLogStrata)
@@ -108,8 +104,8 @@ func TestStrataIndex(t *testing.T) {
 	}
 }
 
-func TestDefaultMapStrataIndex(t *testing.T) {
-	layout := NewLayout(defaultMapStrata)
+func TestDefaultLogStrataIndex(t *testing.T) {
+	layout := NewLayout(defaultLogStrata)
 	for _, tc := range []struct {
 		depth int
 		want  stratumInfo
@@ -119,10 +115,9 @@ func TestDefaultMapStrataIndex(t *testing.T) {
 		{7, stratumInfo{0, 8}},
 		{8, stratumInfo{1, 8}},
 		{15, stratumInfo{1, 8}},
-		{79, stratumInfo{9, 8}},
-		{80, stratumInfo{10, 176}},
-		{81, stratumInfo{10, 176}},
-		{156, stratumInfo{10, 176}},
+		{30, stratumInfo{3, 8}},
+		{60, stratumInfo{7, 8}},
+		{63, stratumInfo{7, 8}},
 	} {
 		t.Run(fmt.Sprintf("depth:%d", tc.depth), func(t *testing.T) {
 			got := layout.getStratumAt(tc.depth)
@@ -134,7 +129,7 @@ func TestDefaultMapStrataIndex(t *testing.T) {
 }
 
 func TestLayoutTileHeight(t *testing.T) {
-	layout := NewLayout(defaultMapStrata)
+	layout := NewLayout([]int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 176})
 	for _, tc := range []struct {
 		depth  int
 		height int


### PR DESCRIPTION
The old `Layout` type was made to cover both logs and maps. This change factors out the
`smt`-specific part of `Layout` into a separate type.

#2378