### PR TITLE
Remove WriteRevision from interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
  * `NodeReader.GetMerkleNodes` does not accept revisions anymore. The
    implementations must use the transaction's `ReadRevision` instead.
  * `TreeStorage` migrated to using `compact.NodeID` type suitable for logs.
- * Removed the tree storage `ReadRevision` method.
+ * Removed the tree storage `ReadRevision` and `WriteRevision` methods.
+   Revisions are now an implementation detail of the current storages. The
+   change allows log implementations which don't need revisions.
  * TODO(pavelkalinnikov): More changes are coming, and will be added here.
 
 ## v1.3.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
    - `TrillianLog.GetLeavesByIndex`
    - `TrillianLog.QueueLeaves`
  * Removed the incomplete Postgres storage backend (#1298).
+ * Deprecated `LogRootV1.Revision` field.
 
 ### Storage refactoring
  * `NodeReader.GetMerkleNodes` does not accept revisions anymore. The

--- a/integration/storagetest/logtests.go
+++ b/integration/storagetest/logtests.go
@@ -148,13 +148,11 @@ func (*logTests) TestReadWriteTransaction(ctx context.Context, t *testing.T, s s
 		wantNeedsInit bool
 		wantErr       bool
 		wantLogRoot   []byte
-		wantTXRev     int64
 	}{
 		{
 			desc:          "uninitializedBegin",
 			tree:          logTree(-1),
 			wantNeedsInit: true,
-			wantTXRev:     0,
 		},
 		{
 			desc: "activeLogBegin",
@@ -166,7 +164,6 @@ func (*logTests) TestReadWriteTransaction(ctx context.Context, t *testing.T, s s
 				}
 				return b
 			}(),
-			wantTXRev: 1,
 		},
 	}
 
@@ -176,10 +173,6 @@ func (*logTests) TestReadWriteTransaction(ctx context.Context, t *testing.T, s s
 				root, err := tx.LatestSignedLogRoot(ctx)
 				if err != nil && !(err == storage.ErrTreeNeedsInit && test.wantNeedsInit) {
 					t.Fatalf("%v: LatestSignedLogRoot() returned err = %v", test.desc, err)
-				}
-				gotRev, _ := tx.WriteRevision(ctx)
-				if gotRev != test.wantTXRev {
-					t.Errorf("%v: WriteRevision() = %v, want = %v", test.desc, gotRev, test.wantTXRev)
 				}
 				if got, want := root.GetLogRoot(), test.wantLogRoot; !bytes.Equal(got, want) {
 					var logRoot types.LogRootV1
@@ -546,7 +539,6 @@ func (*logTests) TestDequeueLeavesTwoBatches(ctx context.Context, t *testing.T, 
 	}
 
 	mustSignAndStoreLogRoot(ctx, t, s, tree, &types.LogRootV1{
-		Revision:       1,
 		TreeSize:       uint64(leavesToDequeue1),
 		TimestampNanos: 1,
 	})
@@ -623,7 +615,6 @@ func (*logTests) TestAddSequencedLeavesAndDequeueLeaves(ctx context.Context, t *
 		TimestampNanos: uint64(time.Now().UnixNano()),
 		TreeSize:       1,
 		RootHash:       []byte("roothash"),
-		Revision:       1,
 	})
 
 	// Check that the 2nd and 3rd sequenced entries are returned.

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -61,7 +61,6 @@ var testLeaf0Updated = &trillian.LogLeaf{
 var (
 	testRoot0 = &types.LogRootV1{
 		TreeSize: 0,
-		Revision: 0,
 		RootHash: []byte{},
 	}
 	testRoot0Bytes, _ = testRoot0.MarshalBinary()
@@ -72,7 +71,6 @@ var (
 		TimestampNanos: uint64(fakeTime.UnixNano()),
 		RootHash:       []byte{110, 52, 11, 156, 255, 179, 122, 152, 156, 165, 68, 230, 187, 120, 10, 44, 120, 144, 29, 63, 179, 55, 56, 118, 133, 17, 163, 6, 23, 175, 160, 29},
 		TreeSize:       1,
-		Revision:       1,
 	}
 	updatedRootBytes, _ = updatedRoot.MarshalBinary()
 	updatedSignedRoot   = &trillian.SignedLogRoot{LogRoot: updatedRootBytes}
@@ -95,7 +93,6 @@ func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 
 	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
-	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testSignedRoot0, nil)
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil)
 
@@ -144,7 +141,6 @@ func TestSequencerManagerCachesSigners(t *testing.T) {
 		gomock.InOrder(
 			mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testSignedRoot0, nil),
 			mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{}, nil),
-			mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil),
 			mockTx.EXPECT().Commit(gomock.Any()).Return(nil),
 			mockTx.EXPECT().Close().Return(nil),
 		)
@@ -170,7 +166,6 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 	// through sequencer as other tests cover this
 	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
-	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(int64(testRoot0.Revision+1), nil)
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime).Return([]*trillian.LogLeaf{testLeaf0}, nil)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testSignedRoot0, nil)
 	mockTx.EXPECT().UpdateSequencedLeaves(gomock.Any(), cmpMatcher{[]*trillian.LogLeaf{testLeaf0Updated}}).Return(nil)
@@ -216,7 +211,6 @@ func TestSequencerManagerGuardWindow(t *testing.T) {
 
 	mockTx.EXPECT().Commit(gomock.Any()).Return(nil)
 	mockTx.EXPECT().Close().Return(nil)
-	mockTx.EXPECT().WriteRevision(gomock.Any()).AnyTimes().Return(writeRev, nil)
 	mockTx.EXPECT().LatestSignedLogRoot(gomock.Any()).Return(testSignedRoot0, nil)
 	// Expect a 5 second guard window to be passed from manager -> sequencer -> storage
 	mockTx.EXPECT().DequeueLeaves(gomock.Any(), 50, fakeTime.Add(-time.Second*5)).Return([]*trillian.LogLeaf{}, nil)

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -78,8 +78,6 @@ var (
 
 var zeroDuration = 0 * time.Second
 
-const writeRev = int64(24)
-
 func TestSequencerManagerSingleLogNoLeaves(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -85,7 +85,7 @@ var (
 
 	tree1              = addTreeID(stestonly.LogTree, logID1)
 	getLogRootRequest1 = trillian.GetLatestSignedLogRootRequest{LogId: logID1}
-	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7, Revision: uint64(5)}
+	root1              = &types.LogRootV1{TimestampNanos: 987654321, RootHash: []byte("A NICE HASH"), TreeSize: 7}
 	root1Bytes, _      = root1.MarshalBinary()
 	signedRoot1        = &trillian.SignedLogRoot{LogRoot: root1Bytes}
 

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -457,7 +457,6 @@ func (tx *logTX) LatestSignedLogRoot(ctx context.Context) (*trillian.SignedLogRo
 		TimestampNanos: uint64(currentSTH.TsNanos),
 		RootHash:       currentSTH.RootHash,
 		TreeSize:       uint64(currentSTH.TreeSize),
-		Revision:       uint64(currentSTH.TreeRevision),
 		Metadata:       currentSTH.Metadata,
 	}).MarshalBinary()
 	if err != nil {
@@ -484,10 +483,6 @@ func (tx *logTX) StoreSignedLogRoot(ctx context.Context, root *trillian.SignedLo
 	if err := logRoot.UnmarshalBinary(root.LogRoot); err != nil {
 		glog.Warningf("Failed to parse log root: %x %v", root.LogRoot, err)
 		return err
-	}
-
-	if got, want := int64(logRoot.Revision), writeRev; got != want {
-		return status.Errorf(codes.Internal, "root.Revision: %v, want %v", got, want)
 	}
 
 	m := spanner.Insert(

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -327,16 +327,6 @@ func (t *treeTX) readRevision(ctx context.Context) (int64, error) {
 	return sth.TreeRevision, nil
 }
 
-// WriteRevision returns the tree revision at which any tree-modifying
-// operations will write.
-func (t *treeTX) WriteRevision(ctx context.Context) (int64, error) {
-	rev, err := t.writeRev(ctx)
-	if err != nil {
-		return -1, err
-	}
-	return rev, nil
-}
-
 // getSubtree retrieves the most recent subtree specified by id at (or below)
 // the requested revision.
 // If no such subtree exists it returns nil.

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -571,21 +571,6 @@ func (mr *MockLogTreeTXMockRecorder) UpdateSequencedLeaves(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSequencedLeaves", reflect.TypeOf((*MockLogTreeTX)(nil).UpdateSequencedLeaves), arg0, arg1)
 }
 
-// WriteRevision mocks base method.
-func (m *MockLogTreeTX) WriteRevision(arg0 context.Context) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteRevision", arg0)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WriteRevision indicates an expected call of WriteRevision.
-func (mr *MockLogTreeTXMockRecorder) WriteRevision(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRevision", reflect.TypeOf((*MockLogTreeTX)(nil).WriteRevision), arg0)
-}
-
 // MockReadOnlyAdminTX is a mock of ReadOnlyAdminTX interface.
 type MockReadOnlyAdminTX struct {
 	ctrl     *gomock.Controller

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -583,7 +583,6 @@ func TestLatestSignedLogRoot(t *testing.T) {
 	root, err := SignLogRoot(&types.LogRootV1{
 		TimestampNanos: 98765,
 		TreeSize:       16,
-		Revision:       0,
 		RootHash:       []byte(dummyHash),
 	})
 	if err != nil {
@@ -621,7 +620,6 @@ func TestDuplicateSignedLogRoot(t *testing.T) {
 	root, err := SignLogRoot(&types.LogRootV1{
 		TimestampNanos: 98765,
 		TreeSize:       16,
-		Revision:       0,
 		RootHash:       []byte(dummyHash),
 	})
 	if err != nil {
@@ -651,7 +649,6 @@ func TestLogRootUpdate(t *testing.T) {
 	root, err := SignLogRoot(&types.LogRootV1{
 		TimestampNanos: 98765,
 		TreeSize:       16,
-		Revision:       0,
 		RootHash:       []byte(dummyHash),
 	})
 	if err != nil {
@@ -660,7 +657,6 @@ func TestLogRootUpdate(t *testing.T) {
 	root2, err := SignLogRoot(&types.LogRootV1{
 		TimestampNanos: 98766,
 		TreeSize:       16,
-		Revision:       1,
 		RootHash:       []byte(dummyHash),
 	})
 	if err != nil {

--- a/storage/mysql/storage_test.go
+++ b/storage/mysql/storage_test.go
@@ -273,7 +273,7 @@ func mustSignAndStoreLogRoot(ctx context.Context, t *testing.T, l storage.LogSto
 }
 
 func storeLogRoot(ctx context.Context, tx storage.LogTreeTX, size, rev uint64, hash []byte) error {
-	logRoot, err := (&types.LogRootV1{TreeSize: size, Revision: rev, RootHash: hash}).MarshalBinary()
+	logRoot, err := (&types.LogRootV1{TreeSize: size, RootHash: hash}).MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("error marshaling new LogRoot: %v", err)
 	}

--- a/storage/tools/dump_tree/dumplib.go
+++ b/storage/tools/dump_tree/dumplib.go
@@ -185,10 +185,9 @@ func Main(args Options) string {
 			return fmt.Errorf("could not parse current log root: %v", err)
 		}
 
-		glog.Infof("STH at size %d has hash %s@%d",
+		glog.Infof("STH at size %d has hash %s",
 			root.TreeSize,
-			hex.EncodeToString(root.RootHash),
-			root.Revision)
+			hex.EncodeToString(root.RootHash))
 		return nil
 	})
 	if err != nil {

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -63,9 +63,6 @@ type TreeWriter interface {
 	//
 	// TODO(pavelkalinnikov): Use tiles instead, here and in GetMerkleNodes.
 	SetMerkleNodes(ctx context.Context, nodes []tree.Node) error
-
-	// WriteRevision returns the tree revision that any writes through this TreeTX will be stored at.
-	WriteRevision(ctx context.Context) (int64, error)
 }
 
 // DatabaseChecker performs connectivity checks on the database.

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -38,8 +38,8 @@ type LogRootV1 struct {
 	TreeSize       uint64
 	RootHash       []byte `tls:"minlen:0,maxlen:128"`
 	TimestampNanos uint64
-	Revision       uint64
-	Metadata       []byte `tls:"minlen:0,maxlen:65535"`
+	// Revision       uint64 // Deprecated.
+	Metadata []byte `tls:"minlen:0,maxlen:65535"`
 }
 
 // LogRoot holds the TLS-deserialization of the following structure

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -38,8 +38,8 @@ type LogRootV1 struct {
 	TreeSize       uint64
 	RootHash       []byte `tls:"minlen:0,maxlen:128"`
 	TimestampNanos uint64
-	// Revision       uint64 // Deprecated.
-	Metadata []byte `tls:"minlen:0,maxlen:65535"`
+	Revision       uint64 // Deprecated.
+	Metadata       []byte `tls:"minlen:0,maxlen:65535"`
 }
 
 // LogRoot holds the TLS-deserialization of the following structure


### PR DESCRIPTION
Existing storage implementations handle revisions internally. Revisions are removed from
the interfaces so that it becomes an implementation detail of each storage. This allows
more efficient implementations that don't require revisions.

This also deprecates the `Revision` field in the `LogRootV1` structure. This field questionably
shouldn't have existed in the first place (layering violation), because revision was a storage
layer concept, and wasn't visible through the external API, whereas `LogRootV1` is part of the
public API.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
