### PR TITLE
Comment LogRootV1 fields properly

### DIFF
--- a/types/logroot.go
+++ b/types/logroot.go
@@ -38,8 +38,9 @@ type LogRootV1 struct {
 	TreeSize       uint64
 	RootHash       []byte `tls:"minlen:0,maxlen:128"`
 	TimestampNanos uint64
-	Revision       uint64 // Deprecated.
-	Metadata       []byte `tls:"minlen:0,maxlen:65535"`
+	// Deprecated.
+	Revision uint64
+	Metadata []byte `tls:"minlen:0,maxlen:65535"`
 }
 
 // LogRoot holds the TLS-deserialization of the following structure

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -35,11 +35,20 @@ import (
 //   opaque metadata<0..65535>;
 // } LogRootV1;
 type LogRootV1 struct {
-	TreeSize       uint64
-	RootHash       []byte `tls:"minlen:0,maxlen:128"`
+	// TreeSize is the number of leaves in the log Merkle tree.
+	TreeSize uint64
+	// RootHash is the hash of the root node of the tree.
+	RootHash []byte `tls:"minlen:0,maxlen:128"`
+	// TimestampNanos is the time in nanoseconds for when this root was created,
+	// counting from the UNIX epoch.
 	TimestampNanos uint64
-	// Deprecated.
+
+	// Revision is the Merkle tree revision associated with this root.
+	//
+	// Deprecated: Revision is a concept internal to the storage layer.
 	Revision uint64
+
+	// Metadata holds additional data attached to this root.
 	Metadata []byte `tls:"minlen:0,maxlen:65535"`
 }
 

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -48,7 +48,7 @@ type LogRootV1 struct {
 	// Deprecated: Revision is a concept internal to the storage layer.
 	Revision uint64
 
-	// Metadata holds additional data attached to this root.
+	// Metadata holds additional data associated with this root.
 	Metadata []byte `tls:"minlen:0,maxlen:65535"`
 }
 


### PR DESCRIPTION
Deprecation syntax: https://github.com/golang/go/wiki/Deprecated