### PR TITLE
storage: Remove Rollback method from interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
  * Removed the tree storage `ReadRevision` and `WriteRevision` methods.
    Revisions are now an implementation detail of the current storages. The
    change allows log implementations which don't need revisions.
+ * Removed `Rollback` methods from storage interfaces, as `Close` is enough to
+   cover the use-case.
  * TODO(pavelkalinnikov): More changes are coming, and will be added here.
 
 ## v1.3.13

--- a/storage/admin_storage.go
+++ b/storage/admin_storage.go
@@ -31,13 +31,8 @@ type ReadOnlyAdminTX interface {
 	// considered consistent.
 	Commit() error
 
-	// Rollback aborts any performed operations, or returns an error.
-	// See Close() for a way to automatically manage transactions.
-	Rollback() error
-
 	// IsClosed returns true if the transaction is closed.
-	// A transaction is closed when either Commit() or Rollback() are
-	// called.
+	// A transaction is closed when either Commit() or Close() are called.
 	IsClosed() bool
 
 	// Close rolls back the transaction if it's not yet closed.

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -177,7 +177,7 @@ func (ls *logStorage) begin(ctx context.Context, tree *trillian.Tree, readonly b
 	if err := ltx.getLatestRoot(ctx); err == storage.ErrTreeNeedsInit {
 		return ltx, err
 	} else if err != nil {
-		tx.Rollback()
+		tx.Close()
 		return nil, err
 	}
 	return ltx, nil

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -30,10 +30,7 @@ type ReadOnlyLogTX interface {
 	// data read should be regarded as valid.
 	Commit(context.Context) error
 
-	// Rollback discards the read-only TX.
-	Rollback() error
-
-	// Close attempts to Rollback the TX if it's open, it's a noop otherwise.
+	// Close attempts to rollback the TX if it's open, it's a noop otherwise.
 	Close() error
 }
 
@@ -61,7 +58,7 @@ type ReadOnlyLogTreeTX interface {
 
 // LogTreeTX is the transactional interface for reading/updating a Log.
 // It extends the basic TreeTX interface with Log specific methods.
-// After a call to Commit or Rollback implementations must be in a clean state and have
+// After a call to Commit or Close implementations must be in a clean state and have
 // released any resources owned by the LogTX.
 // A LogTreeTX can only modify the tree specified in its creation.
 type LogTreeTX interface {

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -136,10 +136,6 @@ func (t *readOnlyLogTX) Commit(context.Context) error {
 	return nil
 }
 
-func (t *readOnlyLogTX) Rollback() error {
-	return nil
-}
-
 func (t *readOnlyLogTX) Close() error {
 	return nil
 }
@@ -172,12 +168,12 @@ func (m *memoryLogStorage) beginInternal(ctx context.Context, tree *trillian.Tre
 	if err == storage.ErrTreeNeedsInit {
 		return ltx, err
 	} else if err != nil {
-		ttx.Rollback()
+		ttx.Close()
 		return nil, err
 	}
 
 	if err := ltx.root.UnmarshalBinary(ltx.slr.LogRoot); err != nil {
-		ttx.Rollback()
+		ttx.Close()
 		return nil, err
 	}
 

--- a/storage/mock_storage.go
+++ b/storage/mock_storage.go
@@ -205,20 +205,6 @@ func (mr *MockAdminTXMockRecorder) ListTrees(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrees", reflect.TypeOf((*MockAdminTX)(nil).ListTrees), arg0, arg1)
 }
 
-// Rollback mocks base method.
-func (m *MockAdminTX) Rollback() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Rollback indicates an expected call of Rollback.
-func (mr *MockAdminTXMockRecorder) Rollback() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockAdminTX)(nil).Rollback))
-}
-
 // SoftDeleteTree mocks base method.
 func (m *MockAdminTX) SoftDeleteTree(arg0 context.Context, arg1 int64) (*trillian.Tree, error) {
 	m.ctrl.T.Helper()
@@ -515,20 +501,6 @@ func (mr *MockLogTreeTXMockRecorder) LatestSignedLogRoot(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestSignedLogRoot", reflect.TypeOf((*MockLogTreeTX)(nil).LatestSignedLogRoot), arg0)
 }
 
-// Rollback mocks base method.
-func (m *MockLogTreeTX) Rollback() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Rollback indicates an expected call of Rollback.
-func (mr *MockLogTreeTXMockRecorder) Rollback() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockLogTreeTX)(nil).Rollback))
-}
-
 // SetMerkleNodes mocks base method.
 func (m *MockLogTreeTX) SetMerkleNodes(arg0 context.Context, arg1 []tree.Node) error {
 	m.ctrl.T.Helper()
@@ -666,20 +638,6 @@ func (mr *MockReadOnlyAdminTXMockRecorder) ListTrees(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrees", reflect.TypeOf((*MockReadOnlyAdminTX)(nil).ListTrees), arg0, arg1)
 }
 
-// Rollback mocks base method.
-func (m *MockReadOnlyAdminTX) Rollback() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Rollback indicates an expected call of Rollback.
-func (mr *MockReadOnlyAdminTXMockRecorder) Rollback() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockReadOnlyAdminTX)(nil).Rollback))
-}
-
 // MockReadOnlyLogTX is a mock of ReadOnlyLogTX interface.
 type MockReadOnlyLogTX struct {
 	ctrl     *gomock.Controller
@@ -744,20 +702,6 @@ func (m *MockReadOnlyLogTX) GetActiveLogIDs(arg0 context.Context) ([]int64, erro
 func (mr *MockReadOnlyLogTXMockRecorder) GetActiveLogIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveLogIDs", reflect.TypeOf((*MockReadOnlyLogTX)(nil).GetActiveLogIDs), arg0)
-}
-
-// Rollback mocks base method.
-func (m *MockReadOnlyLogTX) Rollback() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Rollback indicates an expected call of Rollback.
-func (mr *MockReadOnlyLogTXMockRecorder) Rollback() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockReadOnlyLogTX)(nil).Rollback))
 }
 
 // MockReadOnlyLogTreeTX is a mock of ReadOnlyLogTreeTX interface.
@@ -883,18 +827,4 @@ func (m *MockReadOnlyLogTreeTX) LatestSignedLogRoot(arg0 context.Context) (*tril
 func (mr *MockReadOnlyLogTreeTXMockRecorder) LatestSignedLogRoot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestSignedLogRoot", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).LatestSignedLogRoot), arg0)
-}
-
-// Rollback mocks base method.
-func (m *MockReadOnlyLogTreeTX) Rollback() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Rollback indicates an expected call of Rollback.
-func (mr *MockReadOnlyLogTreeTXMockRecorder) Rollback() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockReadOnlyLogTreeTX)(nil).Rollback))
 }

--- a/storage/mysql/log_storage_test.go
+++ b/storage/mysql/log_storage_test.go
@@ -774,24 +774,6 @@ func TestGetActiveLogIDsEmpty(t *testing.T) {
 	}
 }
 
-func TestReadOnlyLogTX_Rollback(t *testing.T) {
-	ctx := context.Background()
-	cleanTestDB(DB)
-	s := NewLogStorage(DB, nil)
-	tx, err := s.Snapshot(ctx)
-	if err != nil {
-		t.Fatalf("Snapshot() = (_, %v), want = (_, nil)", err)
-	}
-	defer tx.Close()
-	if _, err := tx.GetActiveLogIDs(ctx); err != nil {
-		t.Fatalf("GetActiveLogIDs() = (_, %v), want = (_, nil)", err)
-	}
-	// It's a bit hard to have a more meaningful test. This should suffice.
-	if err := tx.Rollback(); err != nil {
-		t.Errorf("Rollback() = (_, %v), want = (_, nil)", err)
-	}
-}
-
 func ensureAllLeavesDistinct(leaves []*trillian.LogLeaf, t *testing.T) {
 	t.Helper()
 	// All the leaf value hashes should be distinct because the leaves were created with distinct

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -387,13 +387,6 @@ func (t *treeTX) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (t *treeTX) Rollback() error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	return t.rollbackInternal()
-}
-
 func (t *treeTX) rollbackInternal() error {
 	t.closed = true
 	if err := t.tx.Rollback(); err != nil {

--- a/storage/tree_storage.go
+++ b/storage/tree_storage.go
@@ -34,22 +34,19 @@ type ReadOnlyTreeTX interface {
 	// Commit attempts to commit any reads performed under this transaction.
 	Commit(context.Context) error
 
-	// Rollback aborts this transaction.
-	Rollback() error
-
-	// Close attempts to Rollback the TX if it's open, it's a noop otherwise.
+	// Close attempts to rollback the TX if it's open, it's a noop otherwise.
 	Close() error
 
 	// IsOpen indicates if this transaction is open. An open transaction is one for which
-	// Commit() or Rollback() has never been called. Implementations must do all clean up
-	// in these methods so transactions are assumed closed regardless of the reported success.
+	// Commit() has never been called. Implementations must do all clean up in these methods
+	// so transactions are assumed closed regardless of the reported success.
 	IsOpen() bool
 }
 
 // TreeTX represents an in-process tree-modifying transaction.
-// The transaction must end with a call to Commit or Rollback.
-// After a call to Commit or Rollback, all operations on the transaction will fail.
-// After a call to Commit or Rollback implementations must be in a clean state and have
+// The transaction must end with a call to Commit or Close.
+// After a call to Commit or Close, all operations on the transaction will fail.
+// After a call to Commit or Close implementations must be in a clean state and have
 // released any resources owned by the TreeTX.
 // A TreeTX can only modify the tree specified in its creation.
 type TreeTX interface {


### PR DESCRIPTION
The `Rollback` method is unused. For read-write transactions there is a
`ReadWriteTransaction` wrapper. For read transactions, `Close` is enough.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
