### PR TITLE
Inline LogMetadata interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
    interfaces.
  * Removed the `ReadOnlyLogTX` interface, and put its only used
    `GetActiveLogIDs` method to `LogStorage`.
+ * Inlined the `LogMetadata` interface to `ReadOnlyLogStorage`.
  * TODO(pavelkalinnikov): More changes are coming, and will be added here.
 
 ## v1.3.13

--- a/storage/log_storage.go
+++ b/storage/log_storage.go
@@ -87,7 +87,10 @@ type LogTreeTX interface {
 // ReadOnlyLogStorage represents a narrowed read-only view into a LogStorage.
 type ReadOnlyLogStorage interface {
 	DatabaseChecker
-	LogMetadata
+
+	// GetActiveLogIDs returns a list of the IDs of all the logs that are
+	// configured in storage and are eligible to have entries sequenced.
+	GetActiveLogIDs(ctx context.Context) ([]int64, error)
 
 	// SnapshotForTree starts a read-only transaction for the specified treeID.
 	// Commit must be called when the caller is finished with the returned object,
@@ -145,11 +148,4 @@ type LogStorage interface {
 	// TODO(pavelkalinnikov): Not checking values of the occupied indices might
 	// be a good optimization. Could also be optional.
 	AddSequencedLeaves(ctx context.Context, tree *trillian.Tree, leaves []*trillian.LogLeaf, timestamp time.Time) ([]*trillian.QueuedLogLeaf, error)
-}
-
-// LogMetadata provides access to information about the logs in storage
-type LogMetadata interface {
-	// GetActiveLogIDs returns a list of the IDs of all the logs that are
-	// configured in storage and are eligible to have entries sequenced.
-	GetActiveLogIDs(ctx context.Context) ([]int64, error)
 }


### PR DESCRIPTION
Proper way of factoring it out would be putting it in the //log package
containing the operation code, which is the only user of this interface.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
