### PR TITLE
Upgraded beam to v2.31.0-RC1

### DIFF
--- a/experimental/batchmap/batchmap.shims.go
+++ b/experimental/batchmap/batchmap.shims.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/schema"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
@@ -35,12 +36,19 @@ func init() {
 	runtime.RegisterFunction(partitionByPrefixLenFn)
 	runtime.RegisterFunction(tileToNodeHashFn)
 	runtime.RegisterType(reflect.TypeOf((*Entry)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*Entry)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*Tile)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*Tile)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*context.Context)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*context.Context)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*leafShardFn)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*leafShardFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*nodeHash)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*nodeHash)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*tileHashFn)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*tileHashFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*tileUpdateFn)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*tileUpdateFn)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*leafShardFn)(nil)).Elem(), wrapMakerLeafShardFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*tileHashFn)(nil)).Elem(), wrapMakerTileHashFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*tileUpdateFn)(nil)).Elem(), wrapMakerTileUpdateFn)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	bitbucket.org/creachadair/shell v0.0.6
 	cloud.google.com/go/spanner v1.21.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.8
-	github.com/apache/beam v2.29.0+incompatible
+	github.com/apache/beam v2.31.0-RC1+incompatible
 	github.com/fullstorydev/grpcurl v1.8.1
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g
 github.com/apache/beam v2.28.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/beam v2.29.0+incompatible h1:L9vCd0iu9eUdmonWGyi/zbmiQhG5BYktWsodq+OJnFI=
 github.com/apache/beam v2.29.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
+github.com/apache/beam v2.31.0-RC1+incompatible h1:McUgIEGjNv0vZrHV63dgzDJ/nxsDmHWZ1mg3ntLnc6w=
+github.com/apache/beam v2.31.0-RC1+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=


### PR DESCRIPTION
v2.29.0 is pretty old, and v2.30.0 flat out didn't work on Dataflow. May as well upgrade to a release candidate rather than something which no client can run.