### PR TITLE
merkle: Proof generation cleanup

### DIFF
--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -64,14 +64,14 @@ func CalcConsistencyProofNodeAddresses(size1, size2 int64) ([]NodeFetch, error) 
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: size1 %d > size2 %d", size1, size2)
 	}
 
-	return consistencyNodes(size1, size2)
+	return consistencyNodes(size1, size2), nil
 }
 
 // consistencyNodes returns node addresses for the consistency proof between
 // the given tree sizes.
-func consistencyNodes(size1, size2 int64) ([]NodeFetch, error) {
+func consistencyNodes(size1, size2 int64) []NodeFetch {
 	if size1 == size2 {
-		return []NodeFetch{}, nil
+		return []NodeFetch{}
 	}
 
 	// TODO(pavelkalinnikov): Make the capacity estimate accurate.
@@ -88,7 +88,7 @@ func consistencyNodes(size1, size2 int64) ([]NodeFetch, error) {
 
 	// Now append the path from this node to the root of size2.
 	p := proofNodes(index, level, uint64(size2), true)
-	return append(proof, p...), nil
+	return append(proof, p...)
 }
 
 // proofNodes returns the node IDs necessary to prove that the (level, index)

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -64,22 +64,22 @@ func CalcConsistencyProofNodeAddresses(size1, size2 int64) ([]NodeFetch, error) 
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameter for consistency proof: size1 %d > size2 %d", size1, size2)
 	}
 
-	return consistencyNodes(size1, size2), nil
+	return consistencyNodes(uint64(size1), uint64(size2)), nil
 }
 
 // consistencyNodes returns node addresses for the consistency proof between
 // the given tree sizes.
-func consistencyNodes(size1, size2 int64) []NodeFetch {
+func consistencyNodes(size1, size2 uint64) []NodeFetch {
 	if size1 == size2 {
 		return []NodeFetch{}
 	}
 
 	// TODO(pavelkalinnikov): Make the capacity estimate accurate.
-	proof := make([]NodeFetch, 0, bits.Len64(uint64(size2))+1)
+	proof := make([]NodeFetch, 0, bits.Len64(size2)+1)
 
 	// Find the biggest perfect subtree that ends at size1.
-	level := uint(bits.TrailingZeros64(uint64(size1)))
-	index := uint64((size1 - 1)) >> level
+	level := uint(bits.TrailingZeros64(size1))
+	index := (size1 - 1) >> level
 	// If it does not cover the whole size1 tree, add this node to the proof.
 	if index != 0 {
 		n := compact.NewNodeID(level, index)
@@ -87,7 +87,7 @@ func consistencyNodes(size1, size2 int64) []NodeFetch {
 	}
 
 	// Now append the path from this node to the root of size2.
-	p := proofNodes(index, level, uint64(size2), true)
+	p := proofNodes(index, level, size2, true)
 	return append(proof, p...)
 }
 


### PR DESCRIPTION
This change switches internal proof generation code to use `uint64`, and removes
an unused error return value.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
