### PR TITLE
SubtreeCache: Remove the write callback from Flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
    compact ranges corresponding to the requests.
  * Removed the single-tile callback from `SubtreeCache`, it uses only
    `GetSubtreesFunc` now.
+ * Removed `SetSubtreesFunc` callback from `SubtreeCache`. The tiles should be
+   written by the caller now, i.e. the caller must invoke the callback.
  * TODO(pavelkalinnikov): More changes are coming, and will be added here.
 
 ## v1.3.13

--- a/storage/cache/gen.go
+++ b/storage/cache/gen.go
@@ -17,14 +17,9 @@ package cache
 
 //go:generate mockgen -self_package github.com/google/trillian/storage/cache -package cache -imports github.com/google/trillian/storage/storagepb -destination mock_node_storage.go github.com/google/trillian/storage/cache NodeStorage
 
-import (
-	"context"
-
-	"github.com/google/trillian/storage/storagepb"
-)
+import "github.com/google/trillian/storage/storagepb"
 
 // NodeStorage provides an interface for storing and retrieving subtrees.
 type NodeStorage interface {
 	GetSubtree(prefix []byte) (*storagepb.SubtreeProto, error)
-	SetSubtrees(ctx context.Context, s []*storagepb.SubtreeProto) error
 }

--- a/storage/cache/mock_node_storage.go
+++ b/storage/cache/mock_node_storage.go
@@ -5,7 +5,6 @@
 package cache
 
 import (
-	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -48,18 +47,4 @@ func (m *MockNodeStorage) GetSubtree(arg0 []byte) (*storagepb.SubtreeProto, erro
 func (mr *MockNodeStorageMockRecorder) GetSubtree(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubtree", reflect.TypeOf((*MockNodeStorage)(nil).GetSubtree), arg0)
-}
-
-// SetSubtrees mocks base method.
-func (m *MockNodeStorage) SetSubtrees(arg0 context.Context, arg1 []*storagepb.SubtreeProto) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetSubtrees", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetSubtrees indicates an expected call of SetSubtrees.
-func (mr *MockNodeStorageMockRecorder) SetSubtrees(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubtrees", reflect.TypeOf((*MockNodeStorage)(nil).SetSubtrees), arg0, arg1)
 }

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -231,8 +231,8 @@ func (s *SubtreeCache) SetNodes(nodes []tree.Node, getSubtrees GetSubtreesFunc) 
 	return nil
 }
 
-// Flush returns all dirty Subtrees that need to be written back to storage.
-func (s *SubtreeCache) Flush() ([]*storagepb.SubtreeProto, error) {
+// UpdatedTiles returns all updated tiles that need to be written to storage.
+func (s *SubtreeCache) UpdatedTiles() ([]*storagepb.SubtreeProto, error) {
 	var toWrite []*storagepb.SubtreeProto
 	for k, v := range s.subtrees {
 		if !s.dirtyPrefixes[k] {

--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -16,7 +16,6 @@ package cache
 
 import (
 	"bytes"
-	"context"
 	"flag"
 	"fmt"
 	"sync"
@@ -35,9 +34,6 @@ var populateConcurrency = flag.Int("populate_subtree_concurrency", 256, "Max num
 
 // GetSubtreesFunc describes a function which can return a number of Subtrees from storage.
 type GetSubtreesFunc func(ids [][]byte) ([]*storagepb.SubtreeProto, error)
-
-// SetSubtreesFunc describes a function which can store a collection of Subtrees into storage.
-type SetSubtreesFunc func(ctx context.Context, s []*storagepb.SubtreeProto) error
 
 // SubtreeCache provides a caching access to Subtree storage. Currently there are assumptions
 // in the code that all subtrees are multiple of 8 in depth and that log subtrees are always
@@ -235,25 +231,22 @@ func (s *SubtreeCache) SetNodes(nodes []tree.Node, getSubtrees GetSubtreesFunc) 
 	return nil
 }
 
-// Flush causes the cache to write all dirty Subtrees back to storage.
-func (s *SubtreeCache) Flush(ctx context.Context, setSubtrees SetSubtreesFunc) error {
-	treesToWrite := make([]*storagepb.SubtreeProto, 0)
+// Flush returns all dirty Subtrees that need to be written back to storage.
+func (s *SubtreeCache) Flush() ([]*storagepb.SubtreeProto, error) {
+	var toWrite []*storagepb.SubtreeProto
 	for k, v := range s.subtrees {
 		if !s.dirtyPrefixes[k] {
 			continue
 		}
 		if !bytes.Equal([]byte(k), v.Prefix) {
-			return fmt.Errorf("inconsistent cache: prefix key is %v, but cached object claims %v", k, v.Prefix)
+			return nil, fmt.Errorf("inconsistent cache: prefix key is %v, but cached object claims %v", k, v.Prefix)
 		}
 		if len(v.Leaves) > 0 {
 			if err := prepareLogTile(v); err != nil {
-				return err
+				return nil, err
 			}
-			treesToWrite = append(treesToWrite, v)
+			toWrite = append(toWrite, v)
 		}
 	}
-	if len(treesToWrite) == 0 {
-		return nil
-	}
-	return setSubtrees(ctx, treesToWrite)
+	return toWrite, nil
 }

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -122,7 +122,7 @@ func TestCacheGetNodesReadsSubtrees(t *testing.T) {
 	}
 }
 
-func TestCacheFlush(t *testing.T) {
+func TestCacheDirty(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -170,9 +170,9 @@ func TestCacheFlush(t *testing.T) {
 		t.Fatalf("SetNodes: %v", err)
 	}
 
-	tiles, err := c.Flush()
+	tiles, err := c.UpdatedTiles()
 	if err != nil {
-		t.Fatalf("failed to flush cache: %v", err)
+		t.Fatalf("failed to get updated tiles: %v", err)
 	}
 	store(tiles)
 
@@ -314,12 +314,12 @@ func TestIdempotentWrites(t *testing.T) {
 		if err := c.SetNodes(nodes, getSubtrees(m)); err != nil {
 			t.Fatalf("%d: failed to set node hash: %v", i, err)
 		}
-		tiles, err := c.Flush()
+		tiles, err := c.UpdatedTiles()
 		if err != nil {
-			t.Fatalf("%d: failed to flush cache: %v", i, err)
+			t.Fatalf("%d: failed to get updated tiles: %v", i, err)
 		}
 		if i > 0 && len(tiles) > 0 {
-			t.Fatalf("unexpected dirty tiles on write attempt %d", i)
+			t.Fatalf("unexpected updated tiles on write attempt %d", i)
 		}
 		store(tiles)
 	}

--- a/storage/cache/subtree_cache_test.go
+++ b/storage/cache/subtree_cache_test.go
@@ -172,8 +172,14 @@ func TestCacheFlush(t *testing.T) {
 		t.Fatalf("SetNodes: %v", err)
 	}
 
-	if err := c.Flush(ctx, m.SetSubtrees); err != nil {
+	tiles, err := c.Flush()
+	if err != nil {
 		t.Fatalf("failed to flush cache: %v", err)
+	}
+	if len(tiles) > 0 {
+		if err := m.SetSubtrees(ctx, tiles); err != nil {
+			t.Fatalf("SetSubtrees: %v", err)
+		}
 	}
 
 	for k, v := range expectedSetIDs {
@@ -316,8 +322,14 @@ func TestIdempotentWrites(t *testing.T) {
 		if err := c.SetNodes(nodes, getSubtrees(m)); err != nil {
 			t.Fatalf("%d: failed to set node hash: %v", i, err)
 		}
-		if err := c.Flush(ctx, m.SetSubtrees); err != nil {
+		tiles, err := c.Flush()
+		if err != nil {
 			t.Fatalf("%d: failed to flush cache: %v", i, err)
+		}
+		if len(tiles) > 0 {
+			if err := m.SetSubtrees(ctx, tiles); err != nil {
+				t.Fatalf("%d: SetSubtrees: %v", i, err)
+			}
 		}
 	}
 

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -247,7 +247,11 @@ func (t *treeTX) storeSubtrees(ctx context.Context, sts []*storagepb.SubtreeProt
 }
 
 func (t *treeTX) flushSubtrees(ctx context.Context) error {
-	return t.cache.Flush(ctx, t.storeSubtrees)
+	tiles, err := t.cache.UpdatedTiles()
+	if err != nil {
+		return err
+	}
+	return t.storeSubtrees(ctx, tiles)
 }
 
 // Commit attempts to apply all actions perfomed to the underlying Spanner

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -223,9 +223,12 @@ func (t *treeTX) Commit(ctx context.Context) error {
 	defer t.unlock()
 
 	if t.writeRevision > -1 {
-		if err := t.subtreeCache.Flush(ctx, func(ctx context.Context, st []*storagepb.SubtreeProto) error {
-			return t.storeSubtrees(ctx, st)
-		}); err != nil {
+		tiles, err := t.subtreeCache.UpdatedTiles()
+		if err != nil {
+			glog.Warningf("SubtreeCache updated tiles error: %v", err)
+			return err
+		}
+		if err := t.storeSubtrees(ctx, tiles); err != nil {
 			glog.Warningf("TX commit flush error: %v", err)
 			return err
 		}

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -343,9 +343,12 @@ func (t *treeTX) Commit(ctx context.Context) error {
 	defer t.mu.Unlock()
 
 	if t.writeRevision > -1 {
-		if err := t.subtreeCache.Flush(ctx, func(ctx context.Context, st []*storagepb.SubtreeProto) error {
-			return t.storeSubtrees(ctx, st)
-		}); err != nil {
+		tiles, err := t.subtreeCache.UpdatedTiles()
+		if err != nil {
+			glog.Warningf("SubtreeCache updated tiles error: %v", err)
+			return err
+		}
+		if err := t.storeSubtrees(ctx, tiles); err != nil {
 			glog.Warningf("TX commit flush error: %v", err)
 			return err
 		}


### PR DESCRIPTION
The control inversion in `SubtreeCache` unnecessarily complicates the code,
for example by needing to have a mock interface to test it.

This change removes the write method of the mock interface and inverts the
control so that the caller is responsible for doing the write themselves.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
