### PR TITLE
Fix slice allocation size/capacity

### DIFF
--- a/storage/cache/subtree_cache.go
+++ b/storage/cache/subtree_cache.go
@@ -144,7 +144,7 @@ func (s *SubtreeCache) preload(ids []compact.NodeID, getSubtrees GetSubtreesFunc
 		}
 		delete(want, string(t.Prefix))
 	}
-	notFound := make([]string, len(want))
+	notFound := make([]string, 0, len(want))
 	for id := range want {
 		notFound = append(notFound, id)
 	}


### PR DESCRIPTION
The incorrectly allocated `notFound` slice nevertheless did not result in
an incorrect behaviour of `SubtreeCache`, because `Flush` would ignore
these tiles as not "dirty" and/or being empty. Hence this bug was not
caught by the tests. It doesn't need a regression test for the same reason.