### PR TITLE
Cloudbuild: Lock the golang tooling to a minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+* Recommended go version for development: 1.16x
+  * This is the version used by the cloudbuild presubmits. Using a
+    different version can lead to presubmits failing due to unexpected
+    diffs.
 * GCP terraform script updated. GKE 1.19 and updated CPU type to E2
 
 ### Dependency updates

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The current state of feature implementation is recorded in the
 
 To build and test Trillian you need:
 
- - Go 1.14 or later.
+ - Go 1.14 or later (go 1.16 matches cloudbuild, and is preferred for developers
+   that will be submitting PRs to this project).
 
 To run many of the tests (and production deployment) you need:
 

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster
+FROM golang:1.16-buster
 
 RUN apt-get update && \
     apt-get install -y mariadb-client

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster as build
+FROM golang:1.16-buster as build
 
 WORKDIR /trillian
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster as build
+FROM golang:1.16-buster as build
 
 WORKDIR /trillian
 

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for Trillan integration tests.
-FROM golang:buster
+FROM golang:1.16-buster
 
 WORKDIR /testbase
 


### PR DESCRIPTION
Larger deltas in go tooling and expectations occur on minor version changes, which can cause problems for presubmits. Specifically, 1.16 to 1.17 has a change to how go:build lines are preferred, which is introducing diffs into PRs that are orthogonal. Locking this down means we now have an explicit decision about when we jump and address these changes.
