### PR TITLE
Added the go:build lines that go1.17 prefers

### DIFF
--- a/crypto/keys/pkcs11/no_pkcs11.go
+++ b/crypto/keys/pkcs11/no_pkcs11.go
@@ -1,3 +1,4 @@
+//go:build !pkcs11
 // +build !pkcs11
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/crypto/keys/pkcs11/pkcs11.go
+++ b/crypto/keys/pkcs11/pkcs11.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/crypto/keys/pkcs11/pkcs11_test.go
+++ b/crypto/keys/pkcs11/pkcs11_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/quota/redis/redistb/embed_redis.go
+++ b/quota/redis/redistb/embed_redis.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/quota/redis/redistb/redistb_test.go
+++ b/quota/redis/redistb/redistb_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -1,3 +1,4 @@
+//go:build !batched_queue
 // +build !batched_queue
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -1,3 +1,4 @@
+//go:build batched_queue
 // +build batched_queue
 
 // Copyright 2017 Google LLC. All Rights Reserved.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build tools
 // +build tools
 
 // Package tools tracks dependencies on binaries not otherwise referenced in the trillian codebase.


### PR DESCRIPTION
This is related to #2608. After this change we should be able to bump the tooling to prefer go1.17 without diffs being generated in cloudbuild.