### PR TITLE
Bumped version of go from 1.16 to 1.17 for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-* Recommended go version for development: 1.16x
+* Recommended go version for development: 1.17x
   * This is the version used by the cloudbuild presubmits. Using a
     different version can lead to presubmits failing due to unexpected
     diffs.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The current state of feature implementation is recorded in the
 
 To build and test Trillian you need:
 
- - Go 1.14 or later (go 1.16 matches cloudbuild, and is preferred for developers
+ - Go 1.14 or later (go 1.17 matches cloudbuild, and is preferred for developers
    that will be submitting PRs to this project).
 
 To run many of the tests (and production deployment) you need:

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster
+FROM golang:1.17-buster
 
 RUN apt-get update && \
     apt-get install -y mariadb-client

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster as build
+FROM golang:1.17-buster as build
 
 WORKDIR /trillian
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster as build
+FROM golang:1.17-buster as build
 
 WORKDIR /trillian
 

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for Trillan integration tests.
-FROM golang:1.16-buster
+FROM golang:1.17-buster
 
 WORKDIR /testbase
 


### PR DESCRIPTION
This is what will be used by the presubmit scripts, and thus using different versions may not clear presubmit checks due to differences in go formatting, mod files, etc.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
