### PR TITLE
[k8s] Use new dry-run flag format

### DIFF
--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -73,7 +73,7 @@ steps:
   name: gcr.io/cloud-builders/kubectl
   args:
   - apply
-  - --server-dry-run
+  - --dry-run=server
   - -f=examples/deployment/kubernetes/etcd-deployment.yaml
   env:
   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
@@ -106,7 +106,7 @@ steps:
   name: gcr.io/cloud-builders/kubectl
   args:
   - apply
-  - --server-dry-run
+  - --dry-run=server
   - -f=envsubst-spanner/etcd-cluster.yaml
   - -f=envsubst-spanner/trillian-ci-spanner.yaml
   - -f=envsubst-spanner/trillian-log-deployment.yaml
@@ -153,7 +153,7 @@ steps:
   name: gcr.io/cloud-builders/kubectl
   args:
   - apply
-  - --server-dry-run
+  - --dry-run=server
   - --namespace=mysql
   - -f=envsubst-mysql/etcd-cluster.yaml
   - -f=envsubst-mysql/trillian-ci-mysql.yaml


### PR DESCRIPTION
Migrate away from deprecated `kubectl` dry-run flag format.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
