### PR TITLE
Patch 1

### DIFF
--- a/docs/Personalities.md
+++ b/docs/Personalities.md
@@ -68,8 +68,7 @@ an *identity hash* associated with a data item: items with the same identity
 hash are assumed equal, even if the full Merkle leaf structure differs
 (e.g. because it has a different timestamp attached).
 
-This means that a personality that wants to 
-duplicate entries can
+This means that a personality that wants to duplicate entries can
 do so by setting the `LeafIdentityHash` value on new Merkle tree leaves
 appropriately. The personality code also needs to cope with duplicates: the
 Merkle tree leaf in a successful `QueueLeaves` response may not be the same


### PR DESCRIPTION
Changed incorrect word usage from prevents to presents in gossip hub explanation docs.
I neglected to update the changelog since this did not seem important enough for that.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
