### PR TITLE
Use an older version of kaniko to attempt build fix

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -29,7 +29,7 @@ steps:
   waitFor:
   - tag_mysql
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
@@ -39,7 +39,7 @@ steps:
   waitFor:
   - push_mysql
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
@@ -48,7 +48,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -35,7 +35,7 @@ steps:
   - tag_mysql
 
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
@@ -45,7 +45,7 @@ steps:
   - push_mysql
 
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
@@ -53,7 +53,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ['-']
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -25,7 +25,7 @@ steps:
   waitFor:
   - tag_mysql
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
@@ -34,7 +34,7 @@ steps:
   waitFor:
   - push_mysql
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
@@ -42,7 +42,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor
+  name: gcr.io/kaniko-project/executor:v1.6.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}


### PR DESCRIPTION
Looks like this was updated yesterday and the 'latest' tag is pointing at something new, and we're seeing auth problems. This is a stab in the dark to see if using the old version fixes the problem. If this works, it should be temporary.
