### PR TITLE
Make countFromInformationSchema function compatible with MySQL 8

### DIFF
--- a/quota/mysqlqm/mysql_quota.go
+++ b/quota/mysqlqm/mysql_quota.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strconv"
 
 	"github.com/google/trillian/quota"
 )
@@ -97,6 +99,10 @@ func (m *QuotaManager) countUnsequenced(ctx context.Context) (int, error) {
 }
 
 func countFromInformationSchema(ctx context.Context, db *sql.DB) (int, error) {
+	// turn off statistics caching for MySQL 8
+	if err := turnOffInformationSchemaCache(ctx, db); err != nil {
+		return 0, err
+	}
 	// information_schema.tables doesn't have an explicit PK, so let's play it safe and ensure
 	// the cursor returns a single row.
 	rows, err := db.QueryContext(ctx, countFromInformationSchemaQuery, "Unsequenced", "BASE TABLE")
@@ -123,4 +129,30 @@ func countFromTable(ctx context.Context, db *sql.DB) (int, error) {
 		return 0, err
 	}
 	return count, nil
+}
+
+// turnOffInformationSchemaCache turn off statistics caching for MySQL 8
+// To always retrieve the latest statistics directly from the storage engine and bypass cached values, set information_schema_stats_expiry to 0.
+// See https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_information_schema_stats_expiry
+func turnOffInformationSchemaCache(ctx context.Context, db *sql.DB) error {
+	opt := "information_schema_stats_expiry"
+	res := db.QueryRowContext(ctx, "SHOW VARIABLES LIKE '%"+opt+"%'")
+	var none, expiry string
+	err := res.Scan(&none, &expiry)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+
+		return fmt.Errorf("Failed to get variable %q: %v", opt, err)
+	}
+
+	exp, err := strconv.Atoi(expiry)
+	if err != nil || exp != 0 {
+		if _, err := db.ExecContext(ctx, "SET SESSION "+opt+"=0"); err != nil {
+			return fmt.Errorf("Failed to set variable %q: %v", opt, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Turn off statistics caching for MySQL 8.
To always retrieve the latest statistics directly from the storage engine and bypass cached values, set information_schema_stats_expiry to 0.
See https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_information_schema_stats_expiry

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
