### PR TITLE
Gracefully exit the program when the lease expired

### DIFF
--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -17,6 +17,7 @@ package serverutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -31,6 +32,7 @@ import (
 	"github.com/google/trillian/util/clock"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.etcd.io/etcd/client/v3/naming/endpoints"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
@@ -125,25 +127,54 @@ func (m *Main) Run(ctx context.Context) error {
 	trillian.RegisterTrillianAdminServer(srv, admin.New(m.Registry, m.AllowedTreeTypes))
 	reflection.Register(srv)
 
+	g, ctx := errgroup.WithContext(ctx)
+
 	if endpoint := m.HTTPEndpoint; endpoint != "" {
 		http.Handle("/metrics", promhttp.Handler())
 		http.HandleFunc("/healthz", m.healthz)
 
-		go func() {
+		s := &http.Server{
+			Addr: endpoint,
+		}
+
+		run := func() error {
 			glog.Infof("HTTP server starting on %v", endpoint)
 
 			var err error
 			// Let http.ListenAndServeTLS handle the error case when only one of the flags is set.
 			if m.TLSCertFile != "" || m.TLSKeyFile != "" {
-				err = http.ListenAndServeTLS(endpoint, m.TLSCertFile, m.TLSKeyFile, nil)
+				err = s.ListenAndServeTLS(m.TLSCertFile, m.TLSKeyFile)
 			} else {
-				err = http.ListenAndServe(endpoint, nil)
+				err = s.ListenAndServe()
 			}
 
 			if err != nil {
-				glog.Errorf("HTTP server stopped: %v", err)
+				if errors.Is(err, http.ErrServerClosed) {
+					return nil
+				}
+
+				err = fmt.Errorf("HTTP server stopped: %v", err)
 			}
-		}()
+
+			return err
+		}
+
+		shutdown := func() {
+			glog.Infof("Stopping HTTP server...")
+			glog.Flush()
+
+			// 15 second exit time limit
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			if err := s.Shutdown(ctx); err != nil {
+				glog.Errorf("Failed to http server shutdown: %v", err)
+			}
+		}
+
+		g.Go(func() error {
+			return srvRun(ctx, run, shutdown)
+		})
 	}
 
 	glog.Infof("RPC server starting on %v", m.RPCEndpoint)
@@ -152,14 +183,8 @@ func (m *Main) Run(ctx context.Context) error {
 		return err
 	}
 
-	// stop the RPC server when the context has been cancelled
-	go func() {
-		<-ctx.Done()
-		srv.GracefulStop()
-	}()
-
 	if m.TreeGCEnabled {
-		go func() {
+		g.Go(func() error {
 			glog.Info("Deleted tree GC started")
 			gc := admin.NewDeletedTreeGC(
 				m.Registry.AdminStorage,
@@ -167,20 +192,36 @@ func (m *Main) Run(ctx context.Context) error {
 				m.TreeDeleteMinInterval,
 				m.Registry.MetricFactory)
 			gc.Run(ctx)
-		}()
+			return nil
+		})
 	}
 
-	if err := srv.Serve(lis); err != nil {
-		glog.Errorf("RPC server terminated: %v", err)
+	run := func() error {
+		if err := srv.Serve(lis); err != nil {
+			return fmt.Errorf("RPC server terminated: %v", err)
+		}
+
+		return nil
 	}
 
-	glog.Infof("Stopping server, about to exit")
-	glog.Flush()
+	shutdown := func() {
+		glog.Infof("Stopping RPC server...")
+		glog.Flush()
+
+		srv.GracefulStop()
+	}
+
+	g.Go(func() error {
+		return srvRun(ctx, run, shutdown)
+	})
+
+	// wait for all jobs to exit gracefully
+	err = g.Wait()
 
 	// Give things a few seconds to tidy up
 	time.Sleep(time.Second * 5)
 
-	return nil
+	return err
 }
 
 // newGRPCServer starts a new Trillian gRPC server.
@@ -265,4 +306,24 @@ func listenKeepAliveRsp(ctx context.Context, keepAliveRspCh <-chan *clientv3.Lea
 			}
 		}
 	}
+}
+
+// srvRun .
+func srvRun(ctx context.Context, run func() error, shutdown func()) error {
+	exit := make(chan struct{})
+	var err error
+	go func() {
+		defer close(exit)
+		err = run()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdown()
+		// wait for run to return
+		<-exit
+	case <-exit:
+	}
+
+	return err
 }

--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -211,8 +211,9 @@ func (m *Main) newGRPCServer() (*grpc.Server, error) {
 	return s, nil
 }
 
-// AnnounceSelf announces this binary's presence to etcd.  Returns a function that
-// should be called on process exit, and a Context to notify the lease expired.
+// AnnounceSelf announces this binary's presence to etcd. This calls the cancel
+// function if the keepalive lease with etcd expires.  Returns a function that
+// should be called on process exit.
 // AnnounceSelf does nothing if client is nil.
 func AnnounceSelf(ctx context.Context, client *clientv3.Client, etcdService, endpoint string, cancel func()) func() {
 	if client == nil {

--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -260,8 +260,8 @@ func listenKeepAliveRsp(ctx context.Context, keepAliveRspCh <-chan *clientv3.Lea
 				return
 			case _, ok := <-keepAliveRspCh:
 				if !ok {
-					cancel()
 					glog.Errorf("listenKeepAliveRsp canceled: unexpected lease expired")
+					cancel()
 					return
 				}
 			}

--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -308,7 +308,7 @@ func listenKeepAliveRsp(ctx context.Context, keepAliveRspCh <-chan *clientv3.Lea
 	}
 }
 
-// srvRun .
+// srvRun run the server and call `shutdown` when the context has been cancelled
 func srvRun(ctx context.Context, run func() error, shutdown func()) error {
 	exit := make(chan struct{})
 	var err error

--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -155,7 +155,7 @@ func (m *Main) Run(ctx context.Context) error {
 	// stop the RPC server when the context has been cancelled
 	go func() {
 		<-ctx.Done()
-		srv.Stop()
+		srv.GracefulStop()
 	}()
 
 	if m.TreeGCEnabled {

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/clock"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
@@ -126,19 +125,12 @@ func main() {
 	}
 
 	// Announce our endpoints to etcd if so configured.
-	unannounce, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint)
+	unannounce := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint, cancel)
 	defer unannounce()
 
-	// cancel main context when lease expired
-	cancelAwait := util.AwaitContext(expiredCTX, cancel)
-	defer cancelAwait()
-
 	if *httpEndpoint != "" {
-		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint, cancel)
 		defer unannounceHTTP()
-
-		cancelAwait := util.AwaitContext(expiredCTX, cancel)
-		defer cancelAwait()
 	}
 
 	qm, err := quota.NewManager(*quotaSystem)

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
+	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/clock"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
@@ -93,6 +94,7 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	go util.AwaitSignal(ctx, cancel)
 
 	var options []grpc.ServerOption
 	mf := prometheus.MetricFactory{}

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -150,8 +150,12 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
 		defer unannounceHTTP()
+
+		// cancel main context when lease expired
+		cancelAwait := util.AwaitContext(expiredCTX, cancel)
+		defer cancelAwait()
 	}
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -150,12 +150,8 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint, cancel)
 		defer unannounceHTTP()
-
-		// cancel main context when lease expired
-		cancelAwait := util.AwaitContext(expiredCTX, cancel)
-		defer cancelAwait()
 	}
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls

--- a/util/process.go
+++ b/util/process.go
@@ -42,21 +42,3 @@ func AwaitSignal(ctx context.Context, doneFn func()) {
 		glog.Infof("AwaitSignal canceled: %v", ctx.Err())
 	}
 }
-
-// AwaitContext waits for context done, then runs the given function.
-func AwaitContext(ctx context.Context, doneFn func()) func() {
-	if ctx == nil {
-		return func() {}
-	}
-	stopAwait, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			doneFn()
-		case <-stopAwait.Done():
-		}
-	}()
-
-	return cancel
-}

--- a/util/process.go
+++ b/util/process.go
@@ -42,3 +42,21 @@ func AwaitSignal(ctx context.Context, doneFn func()) {
 		glog.Infof("AwaitSignal canceled: %v", ctx.Err())
 	}
 }
+
+// AwaitContext waits for context done, then runs the given function.
+func AwaitContext(ctx context.Context, doneFn func()) func() {
+	if ctx == nil {
+		return func() {}
+	}
+	stopAwait, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			doneFn()
+		case <-stopAwait.Done():
+		}
+	}()
+
+	return cancel
+}


### PR DESCRIPTION
This PR can let `trillian` proactively Listen "LeaseKeepAliveResponse" channel returned by `KeepAlive` in ETCD client. When automatic renewal interruption is detected,  Exit the program by canceling the context.

Fixes #2654,#2249
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
