### PR TITLE
Gracefully exit the program when the lease expired 

### DIFF
--- a/cmd/internal/serverutil/main.go
+++ b/cmd/internal/serverutil/main.go
@@ -211,8 +211,9 @@ func (m *Main) newGRPCServer() (*grpc.Server, error) {
 	return s, nil
 }
 
-// AnnounceSelf announces this binary's presence to etcd.  Returns a function that
-// should be called on process exit, and a Context to notify the lease expired.
+// AnnounceSelf announces this binary's presence to etcd. This calls the cancel
+// function if the keepalive lease with etcd expires.  Returns a function that
+// should be called on process exit.
 // AnnounceSelf does nothing if client is nil.
 func AnnounceSelf(ctx context.Context, client *clientv3.Client, etcdService, endpoint string, cancel func()) func() {
 	if client == nil {

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/google/trillian/quota/etcd/quotapb"
 	"github.com/google/trillian/server"
 	"github.com/google/trillian/storage"
-	"github.com/google/trillian/util"
 	"github.com/google/trillian/util/clock"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
@@ -126,19 +125,12 @@ func main() {
 	}
 
 	// Announce our endpoints to etcd if so configured.
-	unannounce, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint)
+	unannounce := serverutil.AnnounceSelf(ctx, client, *etcdService, *rpcEndpoint, cancel)
 	defer unannounce()
 
-	// cancel main context when lease expired
-	cancelAwait := util.AwaitContext(expiredCTX, cancel)
-	defer cancelAwait()
-
 	if *httpEndpoint != "" {
-		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint, cancel)
 		defer unannounceHTTP()
-
-		cancelAwait := util.AwaitContext(expiredCTX, cancel)
-		defer cancelAwait()
 	}
 
 	qm, err := quota.NewManager(*quotaSystem)

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -150,8 +150,12 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
 		defer unannounceHTTP()
+
+		// cancel main context when lease expired
+		cancelAwait := util.AwaitContext(expiredCTX, cancel)
+		defer cancelAwait()
 	}
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -150,12 +150,8 @@ func main() {
 	// Start HTTP server (optional)
 	if *httpEndpoint != "" {
 		// Announce our endpoint to etcd if so configured.
-		unannounceHTTP, expiredCTX := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint)
+		unannounceHTTP := serverutil.AnnounceSelf(ctx, client, *etcdHTTPService, *httpEndpoint, cancel)
 		defer unannounceHTTP()
-
-		// cancel main context when lease expired
-		cancelAwait := util.AwaitContext(expiredCTX, cancel)
-		defer cancelAwait()
 	}
 
 	// Start the sequencing loop, which will run until we terminate the process. This controls

--- a/util/process.go
+++ b/util/process.go
@@ -42,21 +42,3 @@ func AwaitSignal(ctx context.Context, doneFn func()) {
 		glog.Infof("AwaitSignal canceled: %v", ctx.Err())
 	}
 }
-
-// AwaitContext waits for context done, then runs the given function.
-func AwaitContext(ctx context.Context, doneFn func()) func() {
-	if ctx == nil {
-		return func() {}
-	}
-	stopAwait, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			doneFn()
-		case <-stopAwait.Done():
-		}
-	}()
-
-	return cancel
-}

--- a/util/process.go
+++ b/util/process.go
@@ -42,3 +42,21 @@ func AwaitSignal(ctx context.Context, doneFn func()) {
 		glog.Infof("AwaitSignal canceled: %v", ctx.Err())
 	}
 }
+
+// AwaitContext waits for context done, then runs the given function.
+func AwaitContext(ctx context.Context, doneFn func()) func() {
+	if ctx == nil {
+		return func() {}
+	}
+	stopAwait, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			doneFn()
+		case <-stopAwait.Done():
+		}
+	}()
+
+	return cancel
+}


### PR DESCRIPTION
This PR can let trillian proactively Listen "LeaseKeepAliveResponse" channel returned by KeepAlive in ETCD client. When automatic renewal interruption is detected, Exit the program by canceling the context.

Fixes #2654,#2249

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
