### PR TITLE
Update README for a world with no GOPATH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ the original files; if you do, you'll need to install the prerequisites:
   - protocol buffer definitions for standard Google APIs:
 
     ```bash
-    git clone https://github.com/googleapis/googleapis.git $GOPATH/src/github.com/googleapis/googleapis
+    git clone https://github.com/googleapis/googleapis.git $(go env GOPATH)/src/github.com/googleapis/googleapis
     ```
 
 and run the following:


### PR DESCRIPTION
Fix instructions for installing proto deps - these days we can't rely on `GOPATH` being explicitly set.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [X] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
