### PR TITLE
Add unique index on sequenced leaf identity hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   we recommend clients also migrate over to this library at the earliest
   convenient time; the long term plan is to remove `merkle` from this repo.
 * `countFromInformationSchema` function to add support for MySQL 8.
+* The mysql and cloudspanner storage schemas now require that the
+  LeafIdentityHash column is unique. This prevents multiple SequencedLeafData
+  rows from referencing the same LeafData row via foreign key.
 
 ## v1.4.0
 

--- a/storage/cloudspanner/spanner.sdl
+++ b/storage/cloudspanner/spanner.sdl
@@ -58,6 +58,9 @@ CREATE INDEX SequenceByMerkleHash
   ON SequencedLeafData(TreeID, MerkleLeafHash)
   STORING(LeafIdentityHash);
 
+CREATE UNIQUE INDEX SequenceByIdentityHash
+  ON SequencedLeafData(TreeID, LeafIdentityHash);
+
 CREATE TABLE Unsequenced(
   TreeID                 INT64 NOT NULL,
   Bucket                 INT64 NOT NULL,

--- a/storage/mysql/schema/storage.sql
+++ b/storage/mysql/schema/storage.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS SequencedLeafData(
   MerkleLeafHash       VARBINARY(255) NOT NULL,
   IntegrateTimestampNanos BIGINT NOT NULL,
   PRIMARY KEY(TreeId, SequenceNumber),
+  UNIQUE KEY(TreeId, LeafIdentityHash),
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE,
   FOREIGN KEY(TreeId, LeafIdentityHash) REFERENCES LeafData(TreeId, LeafIdentityHash) ON DELETE CASCADE
 );


### PR DESCRIPTION
Both the mysql and cloudspanner storage backends currently enforce that
all rows in the LeafData table have unique LeafIdentityHash values, by
virtue of that column being part of the table's primary key. This
restriction is used by Trillian to detect duplicate submissions and
return already-sequenced data rather than integrating the submitted leaf
entry a second time.

However, the same uniqueness constraint is not enforced on the
SequencedLeafData table. This means that, in exceptional circumstances
such as those documented in the Oak 2022 CT Log[1], multiple
SequencedLeafData rows can have the same foreign key, and end up
referencing the same underlying LeafData row. This results in corruption
of the log, and violation of its cryptographic guarantees.

Add a UNIQUE KEY constraint on the (TreeId, LeafIdentityHash) tuple in
the SequencedLeafData table to ensure that this situation cannot arise
again.

[1] https://groups.google.com/a/chromium.org/g/ct-policy/c/sdPvvZSp7Rw/m/6UqU1MN8AQAJ

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).