### PR TITLE
Emit a better error message on verify fail

### DIFF
--- a/merkle/logverifier/log_verifier.go
+++ b/merkle/logverifier/log_verifier.go
@@ -16,6 +16,7 @@ package logverifier
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/bits"
@@ -30,7 +31,9 @@ type RootMismatchError struct {
 }
 
 func (e RootMismatchError) Error() string {
-	return fmt.Sprintf("calculated root:\n%v\n does not match expected root:\n%v", e.CalculatedRoot, e.ExpectedRoot)
+	return fmt.Sprintf("calculated root %s does not match expected root %s",
+		base64.StdEncoding.EncodeToString(e.CalculatedRoot),
+		base64.StdEncoding.EncodeToString(e.ExpectedRoot))
 }
 
 // LogVerifier verifies inclusion and consistency proofs for append only logs.


### PR DESCRIPTION
Old message renders like:

calculated root:
[255 199 ...  70 147 149 140 31 227 198 230 121 101 84]
does not match expected root:
[220 94 ...  71 196 132 63 30 31 192 68 94 193 54 205]

This renders the hashes using base64 and puts them on a single line.