### PR TITLE
Update merkle, fixup treetex tool

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -395,8 +395,8 @@ func main() {
 		if begin+1 < end {
 			modifyNodeInfo(nodes.IDs[end-1].Parent(), func(n *nodeInfo) { n.proof = true })
 		}
-		for h, i := uint(0), leafID.Index; h < height; h, i = h+1, i>>1 {
-			id := compact.NewNodeID(h, i)
+
+		for id := leafID; id.Level < height; id = id.Parent() {
 			modifyNodeInfo(id, func(n *nodeInfo) { n.incPath = true })
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/pseudomuto/protoc-gen-doc v1.5.0
-	github.com/transparency-dev/merkle v0.0.0-20220331122146-fd7bbd80f70a
+	github.com/transparency-dev/merkle v0.0.0-20220401133819-3a5b1d72b2dd
 	go.etcd.io/etcd/client/v3 v3.5.2
 	go.etcd.io/etcd/etcdctl/v3 v3.5.2
 	go.etcd.io/etcd/server/v3 v3.5.2

--- a/go.sum
+++ b/go.sum
@@ -793,8 +793,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
-github.com/transparency-dev/merkle v0.0.0-20220331122146-fd7bbd80f70a h1:LGI/LDlV3b2RYQGvaLlPFPjMJuos4dG1yWCSb95/RL8=
-github.com/transparency-dev/merkle v0.0.0-20220331122146-fd7bbd80f70a/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
+github.com/transparency-dev/merkle v0.0.0-20220401133819-3a5b1d72b2dd h1:MuZTyMIN+K1WeqLYOuWN3aeVAN83WdjQP9VdIQlkOx0=
+github.com/transparency-dev/merkle v0.0.0-20220401133819-3a5b1d72b2dd/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=


### PR DESCRIPTION
This change:

- Updates `merkle` dependency.
- Fixes `treetex` tool to draw ephemeral node of proofs correctly.
- Does drive-by simplification.