### PR TITLE
Make Append methods variadic

### DIFF
--- a/internal/merkle/inmemory/tree.go
+++ b/internal/merkle/inmemory/tree.go
@@ -33,13 +33,21 @@ func New(hasher merkle.LogHasher) *Tree {
 	return &Tree{hasher: hasher}
 }
 
-// AppendData adds the leaf hash of the given entry to the end of the tree.
-func (t *Tree) AppendData(data []byte) {
-	t.Append(t.hasher.HashLeaf(data))
+// AppendData adds the leaf hashes of the given entries to the end of the tree.
+func (t *Tree) AppendData(entries ...[]byte) {
+	for _, data := range entries {
+		t.appendImpl(t.hasher.HashLeaf(data))
+	}
 }
 
-// Append adds the given leaf hash to the end of the tree.
-func (t *Tree) Append(hash []byte) {
+// Append adds the given leaf hashes to the end of the tree.
+func (t *Tree) Append(hashes ...[]byte) {
+	for _, hash := range hashes {
+		t.appendImpl(hash)
+	}
+}
+
+func (t *Tree) appendImpl(hash []byte) {
 	level := 0
 	for ; (t.size>>level)&1 == 1; level++ {
 		row := append(t.hashes[level], hash)

--- a/merkle/logverifier/log_verifier_test.go
+++ b/merkle/logverifier/log_verifier_test.go
@@ -540,8 +540,7 @@ func createTree(size int64) (*inmemory.Tree, LogVerifier) {
 
 func growTree(tree *inmemory.Tree, upTo int64) {
 	for i := int64(tree.Size()); i < upTo; i++ {
-		data := []byte(fmt.Sprintf("data:%d", i))
-		tree.AppendData(data)
+		tree.AppendData([]byte(fmt.Sprintf("data:%d", i)))
 	}
 }
 


### PR DESCRIPTION
This change makes `Append*` methods of `inmemory.Tree` variadic, so that they
are more convenient for use in tests.