### PR TITLE
Rewrite in-memory Merkle tree tests

### DIFF
--- a/internal/merkle/inmemory/reference_test.go
+++ b/internal/merkle/inmemory/reference_test.go
@@ -1,0 +1,135 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmemory
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/bits"
+	"testing"
+
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
+	to "github.com/transparency-dev/merkle/testonly"
+)
+
+// refRootHash returns the root hash of a Merkle tree with the given entries.
+// This is a reference implementation for cross-checking.
+func refRootHash(entries [][]byte, hasher merkle.LogHasher) []byte {
+	if len(entries) == 0 {
+		return hasher.EmptyRoot()
+	}
+	if len(entries) == 1 {
+		return hasher.HashLeaf(entries[0])
+	}
+	split := downToPowerOfTwo(uint64(len(entries)))
+	return hasher.HashChildren(
+		refRootHash(entries[:split], hasher),
+		refRootHash(entries[split:], hasher))
+}
+
+// refInclusionProof returns the inclusion proof for the given leaf index in a
+// Merkle tree with the given entries. This is a reference implementation for
+// cross-checking.
+func refInclusionProof(entries [][]byte, index uint64, hasher merkle.LogHasher) [][]byte {
+	size := uint64(len(entries))
+	if size == 1 || index >= size {
+		return nil
+	}
+	split := downToPowerOfTwo(size)
+	if index < split {
+		return append(
+			refInclusionProof(entries[:split], index, hasher),
+			refRootHash(entries[split:], hasher))
+	}
+	return append(
+		refInclusionProof(entries[split:], index-split, hasher),
+		refRootHash(entries[:split], hasher))
+}
+
+// refConsistencyProof returns the consistency proof for the two tree sizes, in
+// a Merkle tree with the given entries. This is a reference implementation for
+// cross-checking.
+func refConsistencyProof(entries [][]byte, size2, size1 uint64, hasher merkle.LogHasher, haveRoot1 bool) [][]byte {
+	if size1 == 0 || size1 > size2 {
+		return nil
+	}
+	// Consistency proof for two equal sizes is empty.
+	if size1 == size2 {
+		// Record the hash of this subtree if it's not the root for which the proof
+		// was originally requested (which happens when size1 is a power of 2).
+		if !haveRoot1 {
+			return [][]byte{refRootHash(entries[:size1], hasher)}
+		}
+		return nil
+	}
+
+	// At this point: 0 < size1 < size2.
+	split := downToPowerOfTwo(size2)
+	if size1 <= split {
+		// Root of size1 is in the left subtree of size2. Prove that the left
+		// subtrees are consistent, and record the hash of the right subtree (only
+		// present in size2).
+		return append(
+			refConsistencyProof(entries[:split], split, size1, hasher, haveRoot1),
+			refRootHash(entries[split:], hasher))
+	}
+
+	// Root of size1 is at the same level as size2 root. Prove that the right
+	// subtrees are consistent. The right subtree doesn't contain the root of
+	// size1, so set haveRoot1 = false. Record the hash of the left subtree
+	// (equal in both trees).
+	return append(
+		refConsistencyProof(entries[split:], size2-split, size1-split, hasher, false),
+		refRootHash(entries[:split], hasher))
+}
+
+// downToPowerOfTwo returns the largest power of two smaller than x.
+func downToPowerOfTwo(x uint64) uint64 {
+	if x < 2 {
+		panic("downToPowerOfTwo requires value >= 2")
+	}
+	return uint64(1) << (bits.Len64(x-1) - 1)
+}
+
+func TestDownToPowerOfTwo(t *testing.T) {
+	for _, inOut := range [][2]uint64{
+		{2, 1}, {7, 4}, {8, 4}, {63, 32}, {28937, 16384},
+	} {
+		if got, want := downToPowerOfTwo(inOut[0]), inOut[1]; got != want {
+			t.Errorf("downToPowerOfTwo(%d): got %d, want %d", inOut[0], got, want)
+		}
+	}
+}
+
+func TestRefInclusionProof(t *testing.T) {
+	data := to.LeafInputs()
+
+	for _, path := range testPaths {
+		referencePath := refInclusionProof(data[:path.snapshot], path.leaf, rfc6962.DefaultHasher)
+
+		if len(referencePath) != len(path.testVector) {
+			t.Errorf("Mismatched path length: %d, %d: %v %v",
+				len(referencePath), len(path.testVector), path, referencePath)
+		}
+
+		for i := 0; i < len(path.testVector); i++ {
+			if !bytes.Equal(referencePath[i], hx(path.testVector[i])) {
+				t.Errorf("Path mismatch: %s, %s", hex.EncodeToString(referencePath[i]),
+					path.testVector[i])
+			}
+		}
+	}
+}

--- a/internal/merkle/inmemory/reference_test.go
+++ b/internal/merkle/inmemory/reference_test.go
@@ -26,6 +26,13 @@ import (
 	to "github.com/transparency-dev/merkle/testonly"
 )
 
+// The reference Merkle tree hashing and proof algorithms in this file directly
+// implement the definitions from RFC 6962 [1]. We use this implementation only
+// for testing correctness of other more flexible and performant algorithms,
+// such as the in-memory Tree type and compact ranges.
+//
+// [1] https://datatracker.ietf.org/doc/html/rfc6962#section-2
+
 // refRootHash returns the root hash of a Merkle tree with the given entries.
 // This is a reference implementation for cross-checking.
 func refRootHash(entries [][]byte, hasher merkle.LogHasher) []byte {

--- a/internal/merkle/inmemory/reference_test.go
+++ b/internal/merkle/inmemory/reference_test.go
@@ -15,6 +15,7 @@
 package inmemory
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/bits"
 	"testing"
@@ -186,4 +187,13 @@ func TestRefConsistencyProof(t *testing.T) {
 			}
 		})
 	}
+}
+
+// hx decodes a hex string or panics.
+func hx(hs string) []byte {
+	data, err := hex.DecodeString(hs)
+	if err != nil {
+		panic(fmt.Errorf("failed to decode test data: %s", hs))
+	}
+	return data
 }

--- a/internal/merkle/inmemory/reference_test.go
+++ b/internal/merkle/inmemory/reference_test.go
@@ -155,3 +155,35 @@ func TestRefInclusionProof(t *testing.T) {
 		})
 	}
 }
+
+func TestRefConsistencyProof(t *testing.T) {
+	for _, tc := range []struct {
+		size1 uint64
+		size2 uint64
+		want  [][]byte
+	}{
+		{size1: 1, size2: 1, want: nil},
+		{size1: 1, size2: 8, want: [][]byte{
+			hx("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"),
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"),
+		}},
+		{size1: 2, size2: 5, want: [][]byte{
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"),
+		}},
+		{size1: 6, size2: 8, want: [][]byte{
+			hx("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"),
+			hx("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"),
+			hx("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
+		}},
+	} {
+		t.Run(fmt.Sprintf("%d:%d", tc.size1, tc.size2), func(t *testing.T) {
+			entries := to.LeafInputs()
+			got := refConsistencyProof(entries[:tc.size2], tc.size2, tc.size1, rfc6962.DefaultHasher, true)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("refConsistencyProof: diff (-got +want)\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/merkle/inmemory/reference_test.go
+++ b/internal/merkle/inmemory/reference_test.go
@@ -25,6 +25,45 @@ import (
 	to "github.com/transparency-dev/merkle/testonly"
 )
 
+// Generated from C++ ReferenceMerklePath, not the Go one so we can verify
+// that they are both producing the same paths in a sanity test.
+var testPaths = []pathTestVector{
+	{0, 1, []string{}},
+	{1, 2, []string{"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"}},
+	{
+		0,
+		8,
+		[]string{
+			"96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7",
+			"5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+			"6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4",
+		},
+	},
+	{
+		5,
+		8,
+		[]string{
+			"bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b",
+			"ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0",
+			"d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7",
+		},
+	},
+	{
+		2,
+		3,
+		[]string{"fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"},
+	},
+	{
+		1,
+		5,
+		[]string{
+			"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+			"5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+			"bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b",
+		},
+	},
+}
+
 // refRootHash returns the root hash of a Merkle tree with the given entries.
 // This is a reference implementation for cross-checking.
 func refRootHash(entries [][]byte, hasher merkle.LogHasher) []byte {

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -18,12 +18,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"math/bits"
 	"math/rand"
 	"testing"
 
 	_ "github.com/golang/glog"
-	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/merkle/rfc6962"
 	to "github.com/transparency-dev/merkle/testonly"
 )
@@ -127,87 +125,6 @@ func makeFuzzTestData() [][]byte {
 	return data
 }
 
-// REFERENCE IMPLEMENTATIONS
-
-// downToPowerOfTwo returns the largest power of two smaller than x.
-func downToPowerOfTwo(x uint64) uint64 {
-	if x < 2 {
-		panic("downToPowerOfTwo requires value >= 2")
-	}
-	return uint64(1) << (bits.Len64(x-1) - 1)
-}
-
-// refRootHash returns the root hash of a Merkle tree with the given entries.
-// This is a reference implementation for cross-checking.
-func refRootHash(entries [][]byte, hasher merkle.LogHasher) []byte {
-	if len(entries) == 0 {
-		return hasher.EmptyRoot()
-	}
-	if len(entries) == 1 {
-		return hasher.HashLeaf(entries[0])
-	}
-	split := downToPowerOfTwo(uint64(len(entries)))
-	return hasher.HashChildren(
-		refRootHash(entries[:split], hasher),
-		refRootHash(entries[split:], hasher))
-}
-
-// refInclusionProof returns the inclusion proof for the given leaf index in a
-// Merkle tree with the given entries. This is a reference implementation for
-// cross-checking.
-func refInclusionProof(entries [][]byte, index uint64, hasher merkle.LogHasher) [][]byte {
-	size := uint64(len(entries))
-	if size == 1 || index >= size {
-		return nil
-	}
-	split := downToPowerOfTwo(size)
-	if index < split {
-		return append(
-			refInclusionProof(entries[:split], index, hasher),
-			refRootHash(entries[split:], hasher))
-	}
-	return append(
-		refInclusionProof(entries[split:], index-split, hasher),
-		refRootHash(entries[:split], hasher))
-}
-
-// refConsistencyProof returns the consistency proof for the two tree sizes, in
-// a Merkle tree with the given entries. This is a reference implementation for
-// cross-checking.
-func refConsistencyProof(entries [][]byte, size2, size1 uint64, hasher merkle.LogHasher, haveRoot1 bool) [][]byte {
-	if size1 == 0 || size1 > size2 {
-		return nil
-	}
-	// Consistency proof for two equal sizes is empty.
-	if size1 == size2 {
-		// Record the hash of this subtree if it's not the root for which the proof
-		// was originally requested (which happens when size1 is a power of 2).
-		if !haveRoot1 {
-			return [][]byte{refRootHash(entries[:size1], hasher)}
-		}
-		return nil
-	}
-
-	// At this point: 0 < size1 < size2.
-	split := downToPowerOfTwo(size2)
-	if size1 <= split {
-		// Root of size1 is in the left subtree of size2. Prove that the left
-		// subtrees are consistent, and record the hash of the right subtree (only
-		// present in size2).
-		return append(
-			refConsistencyProof(entries[:split], split, size1, hasher, haveRoot1),
-			refRootHash(entries[split:], hasher))
-	}
-
-	// Root of size1 is at the same level as size2 root. Prove that the right
-	// subtrees are consistent. The right subtree doesn't contain the root of
-	// size1, so set haveRoot1 = false. Record the hash of the left subtree
-	// (equal in both trees).
-	return append(
-		refConsistencyProof(entries[split:], size2-split, size1-split, hasher, false),
-		refRootHash(entries[:split], hasher))
-}
-
 func validateTree(t *testing.T, mt *Tree, size uint64) {
 	t.Helper()
 	if got, want := mt.Size(), size; got != want {
@@ -246,37 +163,6 @@ func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	mt := makeEmptyTree()
 	mt.AppendData(to.LeafInputs()...)
 	validateTree(t, mt, 8)
-}
-
-func TestDownToPowerOfTwoSanity(t *testing.T) {
-	for _, inOut := range [][2]uint64{
-		{2, 1}, {7, 4}, {8, 4}, {63, 32}, {28937, 16384},
-	} {
-		if got, want := downToPowerOfTwo(inOut[0]), inOut[1]; got != want {
-			t.Errorf("downToPowerOfTwo(%d): got %d, want %d", inOut[0], got, want)
-		}
-	}
-}
-
-func TestReferenceMerklePathSanity(t *testing.T) {
-	mt := makeEmptyTree()
-	data := to.LeafInputs()
-
-	for _, path := range testPaths {
-		referencePath := refInclusionProof(data[:path.snapshot], path.leaf, mt.hasher)
-
-		if len(referencePath) != len(path.testVector) {
-			t.Errorf("Mismatched path length: %d, %d: %v %v",
-				len(referencePath), len(path.testVector), path, referencePath)
-		}
-
-		for i := 0; i < len(path.testVector); i++ {
-			if !bytes.Equal(referencePath[i], hx(path.testVector[i])) {
-				t.Errorf("Path mismatch: %s, %s", hex.EncodeToString(referencePath[i]),
-					path.testVector[i])
-			}
-		}
-	}
 }
 
 func TestMerkleTreeRootFuzz(t *testing.T) {

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -204,6 +204,21 @@ func TestTreeConsistencyProof(t *testing.T) {
 	}
 }
 
+func TestTreeAppend(t *testing.T) {
+	entries := genEntries(256)
+	mt1 := makeEmptyTree()
+	mt1.AppendData(entries...)
+
+	mt2 := makeEmptyTree()
+	for _, entry := range entries {
+		mt2.Append(rfc6962.DefaultHasher.HashLeaf(entry))
+	}
+
+	if diff := cmp.Diff(mt1, mt2, cmp.AllowUnexported(Tree{})); diff != "" {
+		t.Errorf("Trees built with AppendData and Append mismatch: diff (-mt1 +mt2)\n%s", diff)
+	}
+}
+
 func TestTreeAppendAssociativity(t *testing.T) {
 	entries := genEntries(256)
 	mt1 := makeEmptyTree()

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC. All Rights Reserved.
+// Copyright 2022 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	to "github.com/transparency-dev/merkle/testonly"
 )
-
-// TODO(pavelkalinnikov): Rewrite this file entirely.
 
 func validateTree(t *testing.T, mt *Tree, size uint64) {
 	t.Helper()

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -32,13 +32,6 @@ import (
 
 var fuzzTestSize = int64(256)
 
-// Some paths for the reference tree.
-type pathTestVector struct {
-	leaf       uint64
-	snapshot   uint64
-	testVector []string
-}
-
 type proofTestVector struct {
 	snapshot1 uint64
 	snapshot2 uint64

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -31,15 +31,6 @@ import (
 
 // TODO(pavelkalinnikov): Rewrite this file entirely.
 
-// hx decodes a hex string or panics.
-func hx(hs string) []byte {
-	data, err := hex.DecodeString(hs)
-	if err != nil {
-		panic(fmt.Errorf("failed to decode test data: %s", hs))
-	}
-	return data
-}
-
 func makeEmptyTree() *Tree {
 	return New(rfc6962.DefaultHasher)
 }

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -300,17 +300,13 @@ func referenceSnapshotConsistency(inputs [][]byte, snapshot2 uint64,
 	return proof, nil
 }
 
-func TestEmptyTreeIsEmpty(t *testing.T) {
+func TestEmptyTree(t *testing.T) {
 	mt := makeEmptyTree()
-
 	if size := mt.Size(); size != 0 {
-		t.Errorf("Empty tree had leaves: %d", size)
+		t.Errorf("Size: %d, want 0", size)
 	}
-}
-
-func TestEmptyTreeHash(t *testing.T) {
-	if got, want := makeEmptyTree().Hash(), to.EmptyRootHash(); !bytes.Equal(got, want) {
-		t.Errorf("empty tree hash mismatch: %x, want %x", got, want)
+	if got, want := mt.Hash(), to.EmptyRootHash(); !bytes.Equal(got, want) {
+		t.Errorf("Hash: %x, want %x", got, want)
 	}
 }
 

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -25,14 +25,12 @@ import (
 	_ "github.com/golang/glog"
 	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/merkle/rfc6962"
+	to "github.com/transparency-dev/merkle/testonly"
 )
 
 // TODO(pavelkalinnikov): Rewrite this file entirely.
 
 var fuzzTestSize = int64(256)
-
-// This is the hash of an empty string
-var emptyTreeHashValue = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 // Inputs to the reference tree, which has eight leaves.
 var leafInputs = [][]byte{
@@ -320,11 +318,8 @@ func TestEmptyTreeIsEmpty(t *testing.T) {
 }
 
 func TestEmptyTreeHash(t *testing.T) {
-	actual := makeEmptyTree().Hash()
-	actualStr := hex.EncodeToString(actual)
-
-	if actualStr != emptyTreeHashValue {
-		t.Errorf("Unexpected empty tree hash: %s", actualStr)
+	if got, want := makeEmptyTree().Hash(), to.EmptyRootHash(); !bytes.Equal(got, want) {
+		t.Errorf("empty tree hash mismatch: %x, want %x", got, want)
 	}
 }
 
@@ -337,7 +332,7 @@ func validateTree(mt *Tree, l uint64, t *testing.T) {
 		t.Errorf("Incorrect root %d, got %s", l, got)
 	}
 
-	if got, want := getRootAsString(mt, 0), emptyTreeHashValue; got != want {
+	if got, want := getRootAsString(mt, 0), hex.EncodeToString(to.EmptyRootHash()); got != want {
 		t.Errorf("Incorrect root(0) %d, got %s", l, got)
 	}
 

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -304,22 +304,17 @@ func TestEmptyTree(t *testing.T) {
 	}
 }
 
-func validateTree(t *testing.T, mt *Tree, l uint64) {
-	if got, want := mt.Size(), l+1; got != want {
-		t.Errorf("Incorrect leaf count %d, expecting %d", got, want)
-	}
-
-	if got, want := hex.EncodeToString(mt.HashAt(l+1)), rootsAtSize[l]; got != want {
-		t.Errorf("Incorrect root %d, got %s", l, got)
+func validateTree(t *testing.T, mt *Tree, size uint64) {
+	if got, want := mt.Size(), size; got != want {
+		t.Errorf("Size: %d, want %d", got, want)
 	}
 
 	if got, want := mt.HashAt(0), to.EmptyRootHash(); !bytes.Equal(got, want) {
-		t.Errorf("Incorrect root(0) %d, got %x", l, got)
+		t.Errorf("HashAt(0/%d): %s, want %s", size, got, want)
 	}
-
-	for j := uint64(0); j <= l; j++ {
-		if got, want := hex.EncodeToString(mt.HashAt(j+1)), rootsAtSize[j]; got != want {
-			t.Errorf("Incorrect root %d, %d, got %s", l, j, got)
+	for s := uint64(1); s <= size; s++ {
+		if got, want := hex.EncodeToString(mt.HashAt(s)), rootsAtSize[s-1]; got != want {
+			t.Errorf("HashAt(%d/%d): %s, want %s", s, size, got, want)
 		}
 	}
 }
@@ -328,7 +323,7 @@ func TestBuildTreeBuildOneAtATime(t *testing.T) {
 	mt := makeEmptyTree()
 	for i, entry := range to.LeafInputs() {
 		mt.AppendData(entry)
-		validateTree(t, mt, uint64(i))
+		validateTree(t, mt, uint64(i+1))
 	}
 }
 
@@ -336,15 +331,15 @@ func TestBuildTreeBuildTwoChunks(t *testing.T) {
 	entries := to.LeafInputs()
 	mt := makeEmptyTree()
 	mt.AppendData(entries[:3]...)
-	validateTree(t, mt, 2)
+	validateTree(t, mt, 3)
 	mt.AppendData(entries[3:8]...)
-	validateTree(t, mt, 7)
+	validateTree(t, mt, 8)
 }
 
 func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	mt := makeEmptyTree()
 	mt.AppendData(to.LeafInputs()...)
-	validateTree(t, mt, 7)
+	validateTree(t, mt, 8)
 }
 
 func TestDownToPowerOfTwoSanity(t *testing.T) {

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -281,16 +281,6 @@ func referenceSnapshotConsistency(inputs [][]byte, snapshot2 uint64,
 	return proof, nil
 }
 
-func TestEmptyTree(t *testing.T) {
-	mt := makeEmptyTree()
-	if size := mt.Size(); size != 0 {
-		t.Errorf("Size: %d, want 0", size)
-	}
-	if got, want := mt.Hash(), to.EmptyRootHash(); !bytes.Equal(got, want) {
-		t.Errorf("Hash: %x, want %x", got, want)
-	}
-}
-
 func validateTree(t *testing.T, mt *Tree, size uint64) {
 	t.Helper()
 	if got, want := mt.Size(), size; got != want {
@@ -309,6 +299,7 @@ func validateTree(t *testing.T, mt *Tree, size uint64) {
 
 func TestBuildTreeBuildOneAtATime(t *testing.T) {
 	mt := makeEmptyTree()
+	validateTree(t, mt, 0)
 	for i, entry := range to.LeafInputs() {
 		mt.AppendData(entry)
 		validateTree(t, mt, uint64(i+1))

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -304,7 +304,7 @@ func TestEmptyTree(t *testing.T) {
 	}
 }
 
-func validateTree(mt *Tree, l uint64, t *testing.T) {
+func validateTree(t *testing.T, mt *Tree, l uint64) {
 	if got, want := mt.Size(), l+1; got != want {
 		t.Errorf("Incorrect leaf count %d, expecting %d", got, want)
 	}
@@ -328,7 +328,7 @@ func TestBuildTreeBuildOneAtATime(t *testing.T) {
 	mt := makeEmptyTree()
 	for i, entry := range to.LeafInputs() {
 		mt.AppendData(entry)
-		validateTree(mt, uint64(i), t)
+		validateTree(t, mt, uint64(i))
 	}
 }
 
@@ -336,15 +336,15 @@ func TestBuildTreeBuildTwoChunks(t *testing.T) {
 	entries := to.LeafInputs()
 	mt := makeEmptyTree()
 	mt.AppendData(entries[:3]...)
-	validateTree(mt, 2, t)
+	validateTree(t, mt, 2)
 	mt.AppendData(entries[3:8]...)
-	validateTree(mt, 7, t)
+	validateTree(t, mt, 7)
 }
 
 func TestBuildTreeBuildAllAtOnce(t *testing.T) {
 	mt := makeEmptyTree()
 	mt.AppendData(to.LeafInputs()...)
-	validateTree(mt, 7, t)
+	validateTree(t, mt, 7)
 }
 
 func TestDownToPowerOfTwoSanity(t *testing.T) {

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -32,31 +32,6 @@ import (
 
 var fuzzTestSize = int64(256)
 
-type proofTestVector struct {
-	snapshot1 uint64
-	snapshot2 uint64
-	proof     []string
-}
-
-// Generated from ReferenceSnapshotConsistency in C++ version.
-var testProofs = []proofTestVector{
-	{1, 1, []string{}},
-	{1, 8, []string{
-		"96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7",
-		"5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
-		"6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4",
-	}},
-	{6, 8, []string{
-		"0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a",
-		"ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0",
-		"d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7",
-	}},
-	{2, 5, []string{
-		"5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
-		"bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b",
-	}},
-}
-
 // hx decodes a hex string or panics.
 func hx(hs string) []byte {
 	data, err := hex.DecodeString(hs)

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -292,6 +292,7 @@ func TestEmptyTree(t *testing.T) {
 }
 
 func validateTree(t *testing.T, mt *Tree, size uint64) {
+	t.Helper()
 	if got, want := mt.Size(), size; got != want {
 		t.Errorf("Size: %d, want %d", got, want)
 	}

--- a/internal/merkle/inmemory/tree_test.go
+++ b/internal/merkle/inmemory/tree_test.go
@@ -146,15 +146,6 @@ func makeFuzzTestData() [][]byte {
 	return data
 }
 
-func getRootAsString(mt *Tree, size uint64) string {
-	if size > mt.Size() {
-		// Doesn't matter what this is as long as it could never be a valid
-		// hex encoding of a hash
-		return "<nil>"
-	}
-	return hex.EncodeToString(mt.HashAt(size))
-}
-
 // REFERENCE IMPLEMENTATIONS
 
 // Get the largest power of two smaller than i.
@@ -328,23 +319,17 @@ func validateTree(mt *Tree, l uint64, t *testing.T) {
 		t.Errorf("Incorrect leaf count %d, expecting %d", got, want)
 	}
 
-	if got, want := getRootAsString(mt, l+1), rootsAtSize[l]; got != want {
+	if got, want := hex.EncodeToString(mt.HashAt(l+1)), rootsAtSize[l]; got != want {
 		t.Errorf("Incorrect root %d, got %s", l, got)
 	}
 
-	if got, want := getRootAsString(mt, 0), hex.EncodeToString(to.EmptyRootHash()); got != want {
-		t.Errorf("Incorrect root(0) %d, got %s", l, got)
+	if got, want := mt.HashAt(0), to.EmptyRootHash(); !bytes.Equal(got, want) {
+		t.Errorf("Incorrect root(0) %d, got %x", l, got)
 	}
 
 	for j := uint64(0); j <= l; j++ {
-		if got, want := getRootAsString(mt, j+1), rootsAtSize[j]; got != want {
+		if got, want := hex.EncodeToString(mt.HashAt(j+1)), rootsAtSize[j]; got != want {
 			t.Errorf("Incorrect root %d, %d, got %s", l, j, got)
-		}
-	}
-
-	for k := l + 1; k <= 8; k++ {
-		if got, want := getRootAsString(mt, k+1), "<nil>"; got != want {
-			t.Errorf("Got root for missing leaf %d, %d, %s", l, k, got)
 		}
 	}
 }


### PR DESCRIPTION
This change completes the TODO of rewriting the unit tests for the in-memory `Tree` type.
The new tests are mostly a rework of the previous tests.

The methodology of testing remains the same:
1) There is a reference implementation of root hash and proofs computation, translated from
definitions in RFC 6962. It is tested using "golden" tests and sanity checks.
2) The `Tree` type is tested exhaustively, to make sure it produces the same result as the
reference implementation.

The goal is to move the `Tree` type and tests to https://github.com/transparency-dev/merkle
`testonly` package, as it can be widely reused for tests.