### PR TITLE
Fix MySQL world-writable config warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ### Removals
  * #2711: Unused `storage/tools/hasher` removed.
 
+### Misc improvements
+
+ * #2712: Fix MySQL world-writable config warning.
+
 ## v1.4.0
 
 * Recommended go version for development: 1.17

--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -3,5 +3,5 @@ FROM gcr.io/trillian-opensource-ci/mysql5:5.7
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY examples/deployment/docker/db_server/mysql.cnf /etc/mysql/conf.d/trillian.cnf
 COPY storage/mysql/schema/storage.sql /docker-entrypoint-initdb.d/storage.sql
-RUN chmod -R 775 /docker-entrypoint-initdb.d
-
+RUN chmod -R 775 /docker-entrypoint-initdb.d && \
+    chmod 644 /etc/mysql/conf.d/trillian.cnf


### PR DESCRIPTION
Fix MySQL world-writable config warning 

```sh
mysqld: [Warning] World-writable config file '/etc/mysql/conf.d/trillian.cnf' is ignored.
```

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Note: I used additional command in `RUN ...` instead of `COPY --chmod=644 ...` to being compatible with old Docker Engines.

Fixes #2712

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
