### PR TITLE
Deprecate merkle packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Removals
  * #2711: Unused `storage/tools/hasher` removed.
+ * #2715: Packages under `merkle` are deprecated and to be removed.
 
 ### Misc improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## HEAD
 
-* Start using `github.com/transparency-dev/merkle` as a replacement to the
-  `merkle` libraries in this repository. This is not a breaking change, but
-  we recommend clients also migrate over to this library at the earliest
-  convenient time; the long term plan is to remove `merkle` from this repo.
 * `countFromInformationSchema` function to add support for MySQL 8.
 
 ### Removals
  * #2711: Unused `storage/tools/hasher` removed.
- * #2715: Packages under `merkle` are deprecated and to be removed.
+ * #2715: Packages under `merkle` are deprecated and to be removed. Use
+   https://github.com/transparency-dev/merkle instead.
 
 ### Misc improvements
 

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -15,8 +15,8 @@
 // Package compact provides compact Merkle tree data structures.
 //
 // Deprecated: This package is superseded by the corresponding functionality in
-// https://github.com/transparency-dev/merkle/compact. It will be removed in
-// future releases of Trillian.
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package compact
 
 import (

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 // Package compact provides compact Merkle tree data structures.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle/compact. It will be removed in
+// future releases of Trillian.
 package compact
 
 import (

--- a/merkle/compact/range_test.go
+++ b/merkle/compact/range_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/google/trillian/merkle/testonly"
+	"github.com/google/trillian/merkle/rfc6962"  // nolint:staticcheck
+	"github.com/google/trillian/merkle/testonly" // nolint:staticcheck
 
 	_ "github.com/golang/glog" // Required for flag handling
 )

--- a/merkle/doc.go
+++ b/merkle/doc.go
@@ -13,4 +13,8 @@
 // limitations under the License.
 
 // Package merkle provides Merkle tree manipulation functions.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package merkle

--- a/merkle/hashers/tree_hasher.go
+++ b/merkle/hashers/tree_hasher.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package hashers provides an interface for log hashers.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package hashers
 
 // LogHasher provides the hash functions needed to compute dense merkle trees.

--- a/merkle/log_proofs.go
+++ b/merkle/log_proofs.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"math/bits"
 
-	"github.com/google/trillian/merkle/compact"
+	"github.com/google/trillian/merkle/compact" // nolint:staticcheck
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -20,8 +20,8 @@ import (
 
 	_ "github.com/golang/glog" // Logging flags for overarching "go test" runs.
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/google/trillian/merkle/compact" // nolint:staticcheck
+	"github.com/google/trillian/merkle/rfc6962" // nolint:staticcheck
 )
 
 // TestCalcInclusionProofNodeAddresses contains inclusion proof tests. For

--- a/merkle/logverifier/hash_chainer.go
+++ b/merkle/logverifier/hash_chainer.go
@@ -14,7 +14,7 @@
 
 package logverifier
 
-import "github.com/google/trillian/merkle/hashers"
+import "github.com/google/trillian/merkle/hashers" // nolint:staticcheck
 
 // hashChainer provides convenience methods for hashing subranges of Merkle
 // Tree proofs to obtain (sub-)tree hashes. Depending on how the path to a tree

--- a/merkle/logverifier/log_verifier.go
+++ b/merkle/logverifier/log_verifier.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package logverifier implements proof verificaion helpers for Merkle trees.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package logverifier
 
 import (

--- a/merkle/logverifier/log_verifier.go
+++ b/merkle/logverifier/log_verifier.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"math/bits"
 
-	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/merkle/hashers" // nolint:staticcheck
 )
 
 // RootMismatchError occurs when an inclusion proof fails.

--- a/merkle/logverifier/log_verifier_test.go
+++ b/merkle/logverifier/log_verifier_test.go
@@ -23,7 +23,7 @@ import (
 
 	_ "github.com/golang/glog"
 	"github.com/google/trillian/internal/merkle/inmemory"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/google/trillian/merkle/rfc6962" // nolint:staticcheck
 )
 
 type inclusionProofTestVector struct {

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 // Package rfc6962 provides hashing functionality according to RFC6962.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle/rfc6962. It will be removed in
+// future releases of Trillian.
 package rfc6962
 
 import (

--- a/merkle/rfc6962/rfc6962.go
+++ b/merkle/rfc6962/rfc6962.go
@@ -15,8 +15,8 @@
 // Package rfc6962 provides hashing functionality according to RFC6962.
 //
 // Deprecated: This package is superseded by the corresponding functionality in
-// https://github.com/transparency-dev/merkle/rfc6962. It will be removed in
-// future releases of Trillian.
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package rfc6962
 
 import (

--- a/merkle/testonly/constants.go
+++ b/merkle/testonly/constants.go
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 // Package testonly contains code and data for testing Merkle trees.
+//
+// Deprecated: This package is superseded by the corresponding functionality in
+// https://github.com/transparency-dev/merkle/testonly. It will be removed in
+// future releases of Trillian.
 package testonly
 
 import "github.com/google/trillian/testonly"

--- a/merkle/testonly/constants.go
+++ b/merkle/testonly/constants.go
@@ -15,8 +15,8 @@
 // Package testonly contains code and data for testing Merkle trees.
 //
 // Deprecated: This package is superseded by the corresponding functionality in
-// https://github.com/transparency-dev/merkle/testonly. It will be removed in
-// future releases of Trillian.
+// https://github.com/transparency-dev/merkle. It will be removed in future
+// releases of Trillian.
 package testonly
 
 import "github.com/google/trillian/testonly"


### PR DESCRIPTION
Trillian is using https://github.com/transparency-dev/merkle. The `merkle` packages
in Trillian will be removed in next releases.

Part of #2338.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
