### PR TITLE
Updated linter to latest version and fixed errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,16 +18,16 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - deadcode
+    - depguard
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - govet
+    - ineffassign
     - megacheck
     - misspell
-    - govet
-    - depguard
-    - deadcode
-    - ineffassign
+    - revive
     - varcheck
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * #2568: Allow disabling the writes of ephemeral nodes to storage via the
   `--tree_ids_with_no_ephemeral_nodes` flag to the sequencer.
+* #2748: `--cloudspanner_max_burst_sessions` deprecated (it hasn't had any
+  effect for a while, now it's more explicit)
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   `--tree_ids_with_no_ephemeral_nodes` flag to the sequencer.
 
 ### Dependency updates
+
+* Updated golangci-lint to v1.46.1 (developers should update to this version)
 * Removed dependency on certificate-transparency-go
 
 ## v1.4.1

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ and tests over the codebase.
 
 #### Install [golangci-lint](https://github.com/golangci/golangci-lint#local-installation).
 ```bash
-go install github.com/golangci/golangci-lint/cmd/golangci-lint
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.1
 ```
 
 #### Run code generation, build, test and linters

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
   xxd
 
 # Install golangci-lint. See docs at: https://golangci-lint.run/usage/install/.
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
 
 RUN mkdir protoc && \
     (cd protoc && \

--- a/storage/cloudspanner/storage_provider.go
+++ b/storage/cloudspanner/storage_provider.go
@@ -37,13 +37,13 @@ var (
 	csSessionMaxOpened                   = flag.Uint64("cloudspanner_max_open_sessions", 0, "Max open sessions.")
 	csSessionMinOpened                   = flag.Uint64("cloudspanner_min_open_sessions", 0, "Min open sessions.")
 	csSessionMaxIdle                     = flag.Uint64("cloudspanner_max_idle_sessions", 0, "Max idle sessions.")
-	csSessionMaxBurst                    = flag.Uint64("cloudspanner_max_burst_sessions", 0, "Max concurrent create session requests.")
 	csSessionWriteSessions               = flag.Float64("cloudspanner_write_sessions", 0, "Fraction of write capable sessions to maintain.")
 	csSessionHCWorkers                   = flag.Int("cloudspanner_num_healthcheckers", 0, "Number of health check workers for Spanner session pool.")
 	csSessionHCInterval                  = flag.Duration("cloudspanner_healthcheck_interval", 0, "Interval betweek pinging sessions.")
 	csSessionTrackHandles                = flag.Bool("cloudspanner_track_session_handles", false, "determines whether the session pool will keep track of the stacktrace of the goroutines that take sessions from the pool.")
 	csDequeueAcrossMerkleBucketsFraction = flag.Float64("cloudspanner_dequeue_bucket_fraction", 0.75, "Fraction of merkle keyspace to dequeue from, set to zero to disable.")
 	csReadOnlyStaleness                  = flag.Duration("cloudspanner_readonly_staleness", time.Minute, "How far in the past to perform readonly operations. Within limits, raising this should help to increase performance/reduce latency.")
+	_                                    = flag.Uint64("cloudspanner_max_burst_sessions", 0, "No longer used")
 
 	csMu              sync.RWMutex
 	csStorageInstance *cloudSpannerProvider
@@ -81,7 +81,6 @@ func configFromFlags() spanner.ClientConfig {
 	setUint64IfNotDefault(&r.SessionPoolConfig.MaxOpened, *csSessionMaxOpened)
 	setUint64IfNotDefault(&r.SessionPoolConfig.MinOpened, *csSessionMinOpened)
 	setUint64IfNotDefault(&r.SessionPoolConfig.MaxIdle, *csSessionMaxIdle)
-	setUint64IfNotDefault(&r.SessionPoolConfig.MaxBurst, *csSessionMaxBurst)
 	setFloat64IfNotDefault(&r.SessionPoolConfig.WriteSessions, *csSessionWriteSessions)
 	setIntIfNotDefault(&r.SessionPoolConfig.HealthCheckWorkers, *csSessionHCWorkers)
 	r.SessionPoolConfig.TrackSessionHandles = *csSessionTrackHandles


### PR DESCRIPTION
The spanner storage had the following error:
```
storage/cloudspanner/storage_provider.go:84:25: SA1019: r.SessionPoolConfig.MaxBurst is deprecated: MaxBurst exists for historical compatibility and should not be used. MaxBurst was used to limit the number of sessions that the session pool could create within a time frame. This was an early safety valve to prevent a client from overwhelming the backend if a large number of sessions was suddenly needed. The session pool would then pause the creation of sessions for a while. Such a pause is no longer needed and the implementation has been removed from the pool. (staticcheck)
	setUint64IfNotDefault(&r.SessionPoolConfig.MaxBurst, *csSessionMaxBurst)
```
