### PR TITLE
Fix flag initialization

### DIFF
--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -66,12 +66,10 @@ var (
 	QuotaIncreaseFactor = 1.1
 )
 
+// stringSet is a set of strings that can be parsed by flag package.
 type stringSet map[string]bool
 
 func (s *stringSet) String() string {
-	if (*s)["*"] {
-		return "*"
-	}
 	keys := make([]string, 0, len(*s))
 	for k, v := range *s {
 		if v {

--- a/log/sequencer.go
+++ b/log/sequencer.go
@@ -66,20 +66,39 @@ var (
 	QuotaIncreaseFactor = 1.1
 )
 
+type stringSet map[string]bool
+
+func (s *stringSet) String() string {
+	if (*s)["*"] {
+		return "*"
+	}
+	keys := make([]string, 0, len(*s))
+	for k, v := range *s {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	return strings.Join(keys, ",")
+}
+
+func (s *stringSet) Set(value string) error {
+	*s = make(stringSet)
+	for _, id := range strings.Split(value, ",") {
+		(*s)[id] = true
+	}
+	return nil
+}
+
 // The tree IDs for which sequencer does not store ephemeral node hashes.
 // Trillian releases up to v1.4.1 store the ephemeral hashes, which corresponds
 // to this slice being empty. Release v1.4.2 allows disabling this behaviour
 // for individual, or all trees (denoted by the "*" wildcard). The release
 // after v1.4.2 will switch to "*" behaviour unconditionally.
-var idsWithNoEphemeralNodes = make(map[string]bool)
+var idsWithNoEphemeralNodes stringSet
 
 // TODO(pavelkalinnikov): Remove this flag in the next release.
 func init() {
-	var ids string
-	flag.StringVar(&ids, "tree_ids_with_no_ephemeral_nodes", "", "Comma-separated list of tree IDs for which storing the ephemeral nodes is disabled, or * to disable it for all trees")
-	for _, id := range strings.Split(ids, ",") {
-		idsWithNoEphemeralNodes[id] = true
-	}
+	flag.Var(&idsWithNoEphemeralNodes, "tree_ids_with_no_ephemeral_nodes", "Comma-separated list of tree IDs for which storing the ephemeral nodes is disabled, or * to disable it for all trees")
 }
 
 func quotaIncreaseFactor() float64 {

--- a/log/sequencer_test.go
+++ b/log/sequencer_test.go
@@ -156,7 +156,7 @@ var (
 
 func init() {
 	// The tree ID used by TestIntegrateBatch.
-	idsWithNoEphemeralNodes["154035"] = true
+	idsWithNoEphemeralNodes = map[string]bool{"154035": true}
 }
 
 func makeSLR(root *types.LogRootV1) *trillian.SignedLogRoot {


### PR DESCRIPTION
Flag parsing happens in main, after all init functions have been called.
This change moves the parsing code, incorrectly placed in init, to a
custom flag Set method.

#1188

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
