### PR TITLE
Remove export GO111MODULE=auto in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ and install them automatically upon build/test.
 To fetch the code, dependencies, and build Trillian, run the following:
 
 ```bash
-export GO111MODULE=auto
-
 git clone https://github.com/google/trillian.git
 cd trillian
 


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

As the minimum Go version in Trillian becomes 1.17, the default value of `GO111MODULE` is `on` which is equivalent to `auto`. The `export GO111MODULE=auto` is unnecessary.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).