### PR TITLE
Format code according to go1.19rc2

### DIFF
--- a/docs/merkletree/treetex/main.go
+++ b/docs/merkletree/treetex/main.go
@@ -19,7 +19,6 @@
 // Usage: go run main.go | xelatex
 // This should generate a PDF file called treetek.pdf containing a drawing of
 // the tree.
-//
 package main
 
 import (

--- a/log/operation_manager_test.go
+++ b/log/operation_manager_test.go
@@ -88,8 +88,9 @@ func (l logOpInfoMatcher) String() string {
 
 // Set up some log IDs in mock storage.
 // The following IDs have special behaviour:
-//  logIDThatFailsGetTreeOp: fail the GetTree() operation
-//  logIDWithNoDisplayName: return a tree with no DisplayName
+//
+//	logIDThatFailsGetTreeOp: fail the GetTree() operation
+//	logIDWithNoDisplayName: return a tree with no DisplayName
 func setupLogIDs(ctrl *gomock.Controller, logNames map[int64]string) (*storage.MockLogStorage, *storage.MockAdminStorage) {
 	ids := make([]int64, 0, len(logNames))
 	for id := range logNames {

--- a/merkle/compact/nodes.go
+++ b/merkle/compact/nodes.go
@@ -22,11 +22,11 @@ import "math/bits"
 // index is its horizontal position in this level ordered from left to right.
 // Consider an example below where nodes are labeled as [<level> <index>].
 //
-//           [2 0]
-//          /     \
-//       [1 0]     \
-//       /   \      \
-//   [0 0]  [0 1]  [0 2]
+//	        [2 0]
+//	       /     \
+//	    [1 0]     \
+//	    /   \      \
+//	[0 0]  [0 1]  [0 2]
 type NodeID struct {
 	Level uint
 	Index uint64

--- a/merkle/compact/range.go
+++ b/merkle/compact/range.go
@@ -239,9 +239,9 @@ func getMergePath(begin, mid, end uint64) (uint, uint) {
 // some integers m, k >= 0.
 //
 // The sequence of sizes is returned encoded as bitmasks left and right, where:
-//  - a 1 bit in a bitmask denotes a sub-range of the corresponding size 2^k
-//  - left mask bits in LSB-to-MSB order encode the left part of the sequence
-//  - right mask bits in MSB-to-LSB order encode the right part
+//   - a 1 bit in a bitmask denotes a sub-range of the corresponding size 2^k
+//   - left mask bits in LSB-to-MSB order encode the left part of the sequence
+//   - right mask bits in MSB-to-LSB order encode the right part
 //
 // The corresponding values of m are not returned (they can be calculated from
 // begin and the sub-range sizes).

--- a/merkle/log_proofs_test.go
+++ b/merkle/log_proofs_test.go
@@ -27,21 +27,21 @@ import (
 // TestCalcInclusionProofNodeAddresses contains inclusion proof tests. For
 // reference, consider the following example of a tree from RFC 6962:
 //
-//                hash              <== Level 3
-//               /    \
-//              /      \
-//             /        \
-//            /          \
-//           /            \
-//          k              l        <== Level 2
-//         / \            / \
-//        /   \          /   \
-//       /     \        /     \
-//      g       h      i      [ ]   <== Level 1
-//     / \     / \    / \    /
-//     a b     c d    e f    j      <== Level 0
-//     | |     | |    | |    |
-//     d0 d1   d2 d3  d4 d5  d6
+//	           hash              <== Level 3
+//	          /    \
+//	         /      \
+//	        /        \
+//	       /          \
+//	      /            \
+//	     k              l        <== Level 2
+//	    / \            / \
+//	   /   \          /   \
+//	  /     \        /     \
+//	 g       h      i      [ ]   <== Level 1
+//	/ \     / \    / \    /
+//	a b     c d    e f    j      <== Level 0
+//	| |     | |    | |    |
+//	d0 d1   d2 d3  d4 d5  d6
 //
 // Our storage node layers are always populated from the bottom up, hence the
 // gap at level 1, index 3 in the above picture.
@@ -151,21 +151,21 @@ func TestCalcInclusionProofNodeAddresses(t *testing.T) {
 // TestCalcConsistencyProofNodeAddresses contains consistency proof tests. For
 // reference, consider the following example:
 //
-//                hash5                         hash7
-//               /    \                        /    \
-//              /      \                      /      \
-//             /        \                    /        \
-//            /          \                  /          \
-//           /            \                /            \
-//          k             [ ]    -->      k              l
-//         / \            /              / \            / \
-//        /   \          /              /   \          /   \
-//       /     \        /              /     \        /     \
-//      g       h     [ ]             g       h      i      [ ]
-//     / \     / \    /              / \     / \    / \    /
-//     a b     c d    e              a b     c d    e f    j
-//     | |     | |    |              | |     | |    | |    |
-//     d0 d1   d2 d3  d4             d0 d1   d2 d3  d4 d5  d6
+//	           hash5                         hash7
+//	          /    \                        /    \
+//	         /      \                      /      \
+//	        /        \                    /        \
+//	       /          \                  /          \
+//	      /            \                /            \
+//	     k             [ ]    -->      k              l
+//	    / \            /              / \            / \
+//	   /   \          /              /   \          /   \
+//	  /     \        /              /     \        /     \
+//	 g       h     [ ]             g       h      i      [ ]
+//	/ \     / \    /              / \     / \    / \    /
+//	a b     c d    e              a b     c d    e f    j
+//	| |     | |    |              | |     | |    | |    |
+//	d0 d1   d2 d3  d4             d0 d1   d2 d3  d4 d5  d6
 //
 // The consistency proof between tree size 5 and 7 consists of nodes e, f, j,
 // and k. The node j is taken instead of its missing parent.

--- a/merkle/smt/node/id.go
+++ b/merkle/smt/node/id.go
@@ -26,13 +26,13 @@ import "fmt"
 // Sibling.
 //
 // The internal structure of ID is driven by its use-cases:
-// - To make ID objects immutable and comparable, the Golang string type is
-//   used for storing the bit string bytes.
-// - To make Sibling and Prefix operations fast, the last byte is stored
-//   separately from the rest of the bytes, so that it can be "amended".
-// - To make ID objects comparable, there is only one (canonical) way to encode
-//   an ID. For example, if the last byte is used partially, its unused bits
-//   are always unset. See invariants next to field definitions below.
+//   - To make ID objects immutable and comparable, the Golang string type is
+//     used for storing the bit string bytes.
+//   - To make Sibling and Prefix operations fast, the last byte is stored
+//     separately from the rest of the bytes, so that it can be "amended".
+//   - To make ID objects comparable, there is only one (canonical) way to encode
+//     an ID. For example, if the last byte is used partially, its unused bits
+//     are always unset. See invariants next to field definitions below.
 //
 // Constructors and methods of ID make sure its invariants are always met.
 //

--- a/merkle/smt/tile.go
+++ b/merkle/smt/tile.go
@@ -28,10 +28,10 @@ import (
 // all the remaining inner nodes of the tile.
 //
 // Invariants of this structure that must be preserved at all times:
-//  - ID is a prefix of Leaves' IDs, i.e. the nodes are in the same subtree.
-//  - IDs of Leaves have the same length, i.e. the nodes are at the same level.
-//  - Leaves are ordered by ID from left to right.
-//  - IDs of Leaves are unique.
+//   - ID is a prefix of Leaves' IDs, i.e. the nodes are in the same subtree.
+//   - IDs of Leaves have the same length, i.e. the nodes are at the same level.
+//   - Leaves are ordered by ID from left to right.
+//   - IDs of Leaves are unique.
 //
 // Algorithms that create Tile structures must ensure that these invariants
 // hold. Use NewNodesRow function for ordering nodes correctly.

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -967,8 +967,9 @@ func (tx *logTX) getUsingIndex(ctx context.Context, idx string, keys [][]byte, b
 // Any unknown hashes will simply be ignored, and the caller should inspect the
 // returned leaves to determine whether this has occurred.
 // TODO(al): Currently, this method does not populate the IntegrateTimestamp
-//   member of the returned leaves. We should convert this method to use SQL
-//   rather than denormalising IntegrateTimestampNanos into the index too.
+//
+//	member of the returned leaves. We should convert this method to use SQL
+//	rather than denormalising IntegrateTimestampNanos into the index too.
 func (tx *logTX) GetLeavesByHash(ctx context.Context, hashes [][]byte, bySeq bool) ([]*trillian.LogLeaf, error) {
 	return tx.getUsingIndex(ctx, seqDataByMerkleHashIdx, hashes, bySeq)
 }

--- a/storage/storagepb/gen.go
+++ b/storage/storagepb/gen.go
@@ -16,12 +16,15 @@
 // implementations.
 //
 // TODO(pavelkalinnikov, v2): SubtreeProto is used as:
-//  a) database storage unit in multiple storage implementations;
-//  b) data exchange format between storage and application layers;
-//  c) nodes index data structure.
+//
+//	a) database storage unit in multiple storage implementations;
+//	b) data exchange format between storage and application layers;
+//	c) nodes index data structure.
+//
 // We should change it so that:
-//  a) individual storage implementations define their own formats;
-//  b) data structures are defined in the application layer.
+//
+//	a) individual storage implementations define their own formats;
+//	b) data structures are defined in the application layer.
 package storagepb
 
 //go:generate protoc -I=. --go_out=paths=source_relative:. storage.proto

--- a/testonly/flagsaver/flagsaver.go
+++ b/testonly/flagsaver/flagsaver.go
@@ -16,10 +16,11 @@
 // TODO(RJPercival): Move this to its own GitHub project.
 //
 // Example:
-//   func TestFoo(t *testing.T) {
-//     defer flagsaver.Save().Restore()
-//     // Test code that changes flags
-//   } // flags are reset to their original values here.
+//
+//	func TestFoo(t *testing.T) {
+//	  defer flagsaver.Save().Restore()
+//	  // Test code that changes flags
+//	} // flags are reset to their original values here.
 package flagsaver
 
 import (

--- a/types/internal/tls/tls.go
+++ b/types/internal/tls/tls.go
@@ -108,41 +108,41 @@ var (
 //
 // For example, a TLS structure:
 //
-//   enum { e1(1), e2(2) } EnumType;
-//   struct {
-//      EnumType sel;
-//      select(sel) {
-//         case e1: uint16
-//         case e2: uint32
-//      } data;
-//   } VariantItem;
+//	enum { e1(1), e2(2) } EnumType;
+//	struct {
+//	   EnumType sel;
+//	   select(sel) {
+//	      case e1: uint16
+//	      case e2: uint32
+//	   } data;
+//	} VariantItem;
 //
 // would have a corresponding Go type:
 //
-//   type VariantItem struct {
-//      Sel    tls.Enum  `tls:"maxval:2"`
-//      Data16 *uint16   `tls:"selector:Sel,val:1"`
-//      Data32 *uint32   `tls:"selector:Sel,val:2"`
-//    }
+//	type VariantItem struct {
+//	   Sel    tls.Enum  `tls:"maxval:2"`
+//	   Data16 *uint16   `tls:"selector:Sel,val:1"`
+//	   Data32 *uint32   `tls:"selector:Sel,val:2"`
+//	 }
 //
 // TLS fixed-length vectors of types other than opaque or uint8 are not supported.
 //
 // For TLS variable-length vectors that are themselves used in other vectors,
 // create a single-field structure to represent the inner type. For example, for:
 //
-//   opaque InnerType<1..65535>;
-//   struct {
-//     InnerType inners<1,65535>;
-//   } Something;
+//	opaque InnerType<1..65535>;
+//	struct {
+//	  InnerType inners<1,65535>;
+//	} Something;
 //
 // convert to:
 //
-//   type InnerType struct {
-//      Val    []byte       `tls:"minlen:1,maxlen:65535"`
-//   }
-//   type Something struct {
-//      Inners []InnerType  `tls:"minlen:1,maxlen:65535"`
-//   }
+//	type InnerType struct {
+//	   Val    []byte       `tls:"minlen:1,maxlen:65535"`
+//	}
+//	type Something struct {
+//	   Inners []InnerType  `tls:"minlen:1,maxlen:65535"`
+//	}
 //
 // If the encoded value does not fit in the Go type, Unmarshal returns a parse error.
 func Unmarshal(b []byte, val interface{}) ([]byte, error) {

--- a/types/logroot.go
+++ b/types/logroot.go
@@ -27,13 +27,14 @@ import (
 
 // LogRootV1 holds the TLS-deserialization of the following structure
 // (described in RFC5246 section 4 notation):
-// struct {
-//   uint64 tree_size;
-//   opaque root_hash<0..128>;
-//   uint64 timestamp_nanos;
-//   uint64 revision;
-//   opaque metadata<0..65535>;
-// } LogRootV1;
+//
+//	struct {
+//	  uint64 tree_size;
+//	  opaque root_hash<0..128>;
+//	  uint64 timestamp_nanos;
+//	  uint64 revision;
+//	  opaque metadata<0..65535>;
+//	} LogRootV1;
 type LogRootV1 struct {
 	// TreeSize is the number of leaves in the log Merkle tree.
 	TreeSize uint64
@@ -55,12 +56,13 @@ type LogRootV1 struct {
 // LogRoot holds the TLS-deserialization of the following structure
 // (described in RFC5246 section 4 notation):
 // enum { v1(1), (65535)} Version;
-// struct {
-//   Version version;
-//   select(version) {
-//     case v1: LogRootV1;
-//   }
-// } LogRoot;
+//
+//	struct {
+//	  Version version;
+//	  select(version) {
+//	    case v1: LogRootV1;
+//	  }
+//	} LogRoot;
 type LogRoot struct {
 	Version tls.Enum   `tls:"size:2"`
 	V1      *LogRootV1 `tls:"selector:Version,val:1"`

--- a/util/election2/election.go
+++ b/util/election2/election.go
@@ -16,12 +16,12 @@
 // plugging in a custom underlying mechanism.
 //
 // There are two important abstractions in this package: instance and resource.
-// - An instance is a single client of the library. An instance is represented
-//   by an Election object (possibly multiple).
-// - A resource is something guarded by master election (e.g. a piece of data,
-//   or operation). Each resource has at most one (most of the time; see note
-//   below) master instance which is said to own this resource. A single
-//   instance may own multiple resources (one resource per Election object).
+//   - An instance is a single client of the library. An instance is represented
+//     by an Election object (possibly multiple).
+//   - A resource is something guarded by master election (e.g. a piece of data,
+//     or operation). Each resource has at most one (most of the time; see note
+//     below) master instance which is said to own this resource. A single
+//     instance may own multiple resources (one resource per Election object).
 //
 // Note: Sometimes there can be more than 1 instance "believing" to own a
 // resource. The reason is that the client code operates outside of the


### PR DESCRIPTION
Go formatting of docs has changed a little in 1.19: https://tip.golang.org/doc/go1.19\#go-doc. This formats the code in this repo so the docs are consistent with that. Previous versions of gofmt won't change this, and this allows old and new tooling to render the docs in increasingly better ways.

Announcement for 1.19rc2: https://groups.google.com/g/golang-announce/c/czoG5UpT0EU
