### PR TITLE
Fix log server not exiting properly on SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+### Misc
+* Fix log server not exiting properly on SIGINT
+
 ## v.1.5.0
 
 ### Storage

--- a/server/admin/tree_gc.go
+++ b/server/admin/tree_gc.go
@@ -98,7 +98,6 @@ func (gc *DeletedTreeGC) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timeAfter(d):
-		default:
 		}
 
 	}

--- a/server/admin/tree_gc.go
+++ b/server/admin/tree_gc.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	timeNow   = time.Now
-	timeSleep = time.Sleep
+	timeAfter = time.After
 
 	hardDeleteCounter monitoring.Counter
 	metricsOnce       sync.Once
@@ -85,12 +85,6 @@ func NewDeletedTreeGC(admin storage.AdminStorage, threshold, minRunInterval time
 // Run starts the tree garbage collection process. It runs until ctx is cancelled.
 func (gc *DeletedTreeGC) Run(ctx context.Context) {
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
 		count, err := gc.RunOnce(ctx)
 		if err != nil {
 			klog.Errorf("DeletedTreeGC.Run: %v", err)
@@ -100,7 +94,13 @@ func (gc *DeletedTreeGC) Run(ctx context.Context) {
 		}
 
 		d := gc.minRunInterval + time.Duration(rand.Int63n(gc.minRunInterval.Nanoseconds()))
-		timeSleep(d)
+		select {
+		case <-ctx.Done():
+			return
+		case <-timeAfter(d):
+		default:
+		}
+
 	}
 }
 


### PR DESCRIPTION
Make the tree garbage collection coroutine exit immediately when the context is cancelled.

This fixes an issue that appeared in 1.4.1: after receiving SIGINT `trillian_log_server` starts shutting down but seems to get stuck and needs to be killed.


<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
