### PR TITLE
Upgrade golangci-lint version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - gocyclo
     - gofmt
@@ -28,7 +27,7 @@ linters:
     - megacheck
     - misspell
     - revive
-    - varcheck
+    - unused
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
 

--- a/client/rpcflags/rpcflags.go
+++ b/client/rpcflags/rpcflags.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package rpcflags defines flags for configuring RPC clients.
 package rpcflags
 
 import (

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cmd contains common code for the various binaries in this repository.
 package cmd
 
 import (

--- a/crypto/keys/der/der.go
+++ b/crypto/keys/der/der.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package der contains functions for marshaling and unmarshaling keys in DER format.
 package der
 
 import (

--- a/crypto/keys/pem/pem.go
+++ b/crypto/keys/pem/pem.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package pem contains functions for marshaling and unmarshaling keys in PEM format.
 package pem
 
 import (

--- a/crypto/keys/pkcs11/no_pkcs11.go
+++ b/crypto/keys/pkcs11/no_pkcs11.go
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package pkcs11 provides access to private keys using a PKCS#11 interface.
 package pkcs11
 
 import (

--- a/gen.go
+++ b/gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package trillian contains the generated protobuf code for the Trillian API.
 package trillian
 
 //go:generate protoc -I=. -I=third_party/googleapis --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. --go-grpc_opt=require_unimplemented_servers=false trillian_log_api.proto trillian_admin_api.proto trillian.proto --doc_out=markdown,api.md:./docs/

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
   xxd
 
 # Install golangci-lint. See docs at: https://golangci-lint.run/usage/install/.
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.3
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
 
 RUN mkdir protoc && \
     (cd protoc && \

--- a/integration/storagetest/doc.go
+++ b/integration/storagetest/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package storagetest contains tests and helpers for storage implementations.
+package storagetest

--- a/monitoring/opencensus/trace.go
+++ b/monitoring/opencensus/trace.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package opencensus enables tracing and metrics collection using OpenCensus.
 package opencensus
 
 import (

--- a/monitoring/testonly/doc.go
+++ b/monitoring/testonly/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package testonly contains test-only code.
+package testonly

--- a/quota/etcd/quota_provider.go
+++ b/quota/etcd/quota_provider.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package etcd provides the configuration and initialization of the etcd
+// quota manager.
 package etcd
 
 import (

--- a/quota/etcd/storagepb/gen.go
+++ b/quota/etcd/storagepb/gen.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package storagepb contains the protobuf definitions for using etcd as a
+// Trillian quota backend.
 package storagepb
 
 //go:generate protoc -I=. --go_out=paths=source_relative:. storagepb.proto

--- a/quota/redis/redistb/redistb.go
+++ b/quota/redis/redistb/redistb.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package redistb implements a token bucket using Redis.
 package redistb
 
 import (

--- a/server/doc.go
+++ b/server/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package server contains the Trillian log server implementation.
+package server

--- a/storage/cloudspanner/doc.go
+++ b/storage/cloudspanner/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package cloudspanner contains the Cloud Spanner storage implementation.
+package cloudspanner

--- a/storage/testonly/doc.go
+++ b/storage/testonly/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package testonly contains utilities and helpers to use in the storage tests.
+package testonly

--- a/testonly/integration/etcd/etcd.go
+++ b/testonly/integration/etcd/etcd.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package etcd contains a helper to start an embedded etcd server.
 package etcd
 
 import (

--- a/testonly/setup/doc.go
+++ b/testonly/setup/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package setup contains test-only code that's useful for setting up tests.
+package setup

--- a/util/election/doc.go
+++ b/util/election/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2022 Trillian Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package spannerpb contains the generated protobuf code for the Spanner
-// storage implementation.
-package spannerpb
-
-//go:generate protoc -I=. -I=../../../third_party/googleapis --go_out=paths=source_relative:. spanner.proto
+// Package election provides a generic interface for election of a leader.
+package election


### PR DESCRIPTION
This PR upgrades the golangci-lint version from v1.47.3 to v1.50.1

It also replaces some deprecated `golangci-lint` checks.

Finally, it addresses warnings from `golangci-lint` which were mostly just package documentation related.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
