### PR TITLE
CockroachDB: Optimize quota manager by using follower reads

### DIFF
--- a/quota/crdbqm/crdb_quota.go
+++ b/quota/crdbqm/crdb_quota.go
@@ -30,7 +30,9 @@ const (
 
 	// TODO(jaosorior): Come up with a more optimal solution for CRDB, as this is
 	// linear and too costly.
-	countFromUnsequencedTable = "SELECT COUNT(*) FROM Unsequenced"
+	// Using a follower read here to reduce latency on the query. While this will
+	// slightly less accurate than a read from the leader, it should be good enough.
+	countFromUnsequencedTable = "SELECT COUNT(*) FROM Unsequenced AS OF SYSTEM TIME follower_read_timestamp()"
 )
 
 // ErrTooManyUnsequencedRows is returned when tokens are requested but Unsequenced has grown


### PR DESCRIPTION
This takes into use CockroachDB's follower reads feature [1] which
allows for the expensive `SELECT` query to be executed on a local node
instead of the leader. This reduces latency for multi-region
deployments; though it slows down the tests as we now allow for some
time for the database writes to converge.

[1] https://www.cockroachlabs.com/docs/stable/follower-reads.html#when-to-use-exact-staleness-reads

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
