### PR TITLE
Migrate spanner types off deprecated package

### DIFF
--- a/storage/cloudspanner/getdb_test.go
+++ b/storage/cloudspanner/getdb_test.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	databasepb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 )
 
 // To run cloudspanner tests,


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-go/blob/main/migration.md

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
