### PR TITLE
Remove use of `rand.Seed`

### DIFF
--- a/integration/log.go
+++ b/integration/log.go
@@ -211,8 +211,7 @@ func genEntries(params TestParameters) []*trillian.LogLeaf {
 	// Shuffle the leaves to see if that breaks things, but record the rand seed
 	// so we can reproduce failures.
 	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-	perm := rand.Perm(int(params.LeafCount))
+	perm := rand.New(rand.NewSource(seed)).Perm(int(params.LeafCount))
 	klog.Infof("Generating %d leaves, %d unique, using permutation seed %d", params.LeafCount, params.UniqueLeaves, seed)
 
 	leaves := make([]*trillian.LogLeaf, 0, params.LeafCount)


### PR DESCRIPTION
`rand.Seed` is deprecated as of `go1.20`, but I also suspect that setting this seed didn't do what it was intended to; it's likely this was intended to control the pseudo random data producing the certs to be logged in the integration test, but that uses `crypto/rand` internally which is unaffected by the seed in `math/rand`.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
