### PR TITLE
When a SQL error occurs, clean up all prepared statement.

### DIFF
--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -741,6 +741,7 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 	args = append(args, t.treeID)
 	rows, err := stx.QueryContext(ctx, args...)
 	if err != nil {
+		t.ls.cleanAllStmt()
 		klog.Warningf("Query() %s hash = %v", desc, err)
 		return nil, err
 	}


### PR DESCRIPTION
As described in # 420, when the prepared statement fails unexpectedly in the database, the program cannot be recovered.

This PR will clear all the prepared statements in the cache when the statement execution error occurs (this is because other prepared statements may also make errors).

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
