### PR TITLE
Use a separate unit to manage the cache of prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     different version can lead to presubmits failing due to unexpected
     diffs.
 
+* The prepared statement is managed by a separate unit (StmtCache), which wraps the sql.Struct structure to handle and monitor the execution errors of the prepared statement. When an error occurs during statement execution, it closes the statement and clears the cache, as well as increments the error monitoring indicator.
+
 ### Misc
 
 * Bump Go version from 1.17 to 1.19.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     different version can lead to presubmits failing due to unexpected
     diffs.
 
-* The prepared statement is managed by a separate unit (StmtCache), which wraps the sql.Struct structure to handle and monitor the execution errors of the prepared statement. When an error occurs during statement execution, it closes the statement and clears the cache, as well as increments the error monitoring indicator.
+* Use a separate unit (StmtCache) to manage the cache of prepared statements, which wraps the sql.Stmt struct to handle and monitor the execution errors of the prepared statement. When an error occurs during statement execution, it closes the statement and clears the cache, as well as increments the error monitoring indicator.
 
 ### Misc
 

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -21,11 +21,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"runtime/debug"
-	"strings"
 	"sync"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/storage/cache"
+	"github.com/google/trillian/storage/sqlutil"
 	"github.com/google/trillian/storage/storagepb"
 	"github.com/google/trillian/storage/tree"
 	"google.golang.org/protobuf/proto"
@@ -52,7 +53,7 @@ const (
  AND Subtree.SubtreeRevision = x.MaxRevision 
  AND Subtree.TreeId = x.TreeId
  AND Subtree.TreeId = ?`
-	placeholderSQL = "<placeholder>"
+	placeholderSQL = sqlutil.PlaceholderSQL
 )
 
 // mySQLTreeStorage is shared between the mySQLLog- and (forthcoming) mySQLMap-
@@ -60,12 +61,7 @@ const (
 type mySQLTreeStorage struct {
 	db *sql.DB
 
-	// Must hold the mutex before manipulating the statement map. Sharing a lock because
-	// it only needs to be held while the statements are built, not while they execute and
-	// this will be a short time. These maps are from the number of placeholder '?'
-	// in the query to the statement that should be used.
-	statementMutex sync.Mutex
-	statements     map[string]map[int]*sql.Stmt
+	stmtCache *sqlutil.StmtCache
 }
 
 // OpenDB opens a database connection for all MySQL-based storage implementations.
@@ -85,60 +81,19 @@ func OpenDB(dbURL string) (*sql.DB, error) {
 	return db, nil
 }
 
-func newTreeStorage(db *sql.DB) *mySQLTreeStorage {
+func newTreeStorage(db *sql.DB, mf monitoring.MetricFactory) *mySQLTreeStorage {
 	return &mySQLTreeStorage{
-		db:         db,
-		statements: make(map[string]map[int]*sql.Stmt),
+		db:        db,
+		stmtCache: sqlutil.NewStmtCache(db, mf),
 	}
 }
 
-// expandPlaceholderSQL expands an sql statement by adding a specified number of '?'
-// placeholder slots. At most one placeholder will be expanded.
-func expandPlaceholderSQL(sql string, num int, first, rest string) string {
-	if num <= 0 {
-		panic(fmt.Errorf("trying to expand SQL placeholder with <= 0 parameters: %s", sql))
-	}
-
-	parameters := first + strings.Repeat(","+rest, num-1)
-
-	return strings.Replace(sql, placeholderSQL, parameters, 1)
+func (m *mySQLTreeStorage) getSubtreeStmt(ctx context.Context, num int) (*sqlutil.Stmt, error) {
+	return m.stmtCache.GetStmt(ctx, selectSubtreeSQL, num, "?", "?")
 }
 
-// getStmt creates and caches sql.Stmt structs based on the passed in statement
-// and number of bound arguments.
-// TODO(al,martin): consider pulling this all out as a separate unit for reuse
-// elsewhere.
-func (m *mySQLTreeStorage) getStmt(ctx context.Context, statement string, num int, first, rest string) (*sql.Stmt, error) {
-	m.statementMutex.Lock()
-	defer m.statementMutex.Unlock()
-
-	if m.statements[statement] != nil {
-		if m.statements[statement][num] != nil {
-			// TODO(al,martin): we'll possibly need to expire Stmts from the cache,
-			// e.g. when DB connections break etc.
-			return m.statements[statement][num], nil
-		}
-	} else {
-		m.statements[statement] = make(map[int]*sql.Stmt)
-	}
-
-	s, err := m.db.PrepareContext(ctx, expandPlaceholderSQL(statement, num, first, rest))
-	if err != nil {
-		klog.Warningf("Failed to prepare statement %d: %s", num, err)
-		return nil, err
-	}
-
-	m.statements[statement][num] = s
-
-	return s, nil
-}
-
-func (m *mySQLTreeStorage) getSubtreeStmt(ctx context.Context, num int) (*sql.Stmt, error) {
-	return m.getStmt(ctx, selectSubtreeSQL, num, "?", "?")
-}
-
-func (m *mySQLTreeStorage) setSubtreeStmt(ctx context.Context, num int) (*sql.Stmt, error) {
-	return m.getStmt(ctx, insertSubtreeMultiSQL, num, "VALUES(?, ?, ?, ?)", "(?, ?, ?, ?)")
+func (m *mySQLTreeStorage) setSubtreeStmt(ctx context.Context, num int) (*sqlutil.Stmt, error) {
+	return m.stmtCache.GetStmt(ctx, insertSubtreeMultiSQL, num, "VALUES(?, ?, ?, ?)", "(?, ?, ?, ?)")
 }
 
 func (m *mySQLTreeStorage) beginTreeTx(ctx context.Context, tree *trillian.Tree, hashSizeBytes int, subtreeCache *cache.SubtreeCache) (treeTX, error) {
@@ -183,7 +138,7 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, ids [][]by
 	if err != nil {
 		return nil, err
 	}
-	stx := t.tx.StmtContext(ctx, tmpl)
+	stx := tmpl.WithTx(ctx, t.tx)
 	defer stx.Close()
 
 	args := make([]interface{}, 0, len(ids)+3)
@@ -291,7 +246,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 	if err != nil {
 		return err
 	}
-	stx := t.tx.StmtContext(ctx, tmpl)
+	stx := tmpl.WithTx(ctx, t.tx)
 	defer stx.Close()
 
 	r, err := stx.ExecContext(ctx, args...)

--- a/storage/sqlutil/stmt_cache.go
+++ b/storage/sqlutil/stmt_cache.go
@@ -1,0 +1,246 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/trillian/monitoring"
+	"k8s.io/klog/v2"
+)
+
+var (
+	once           sync.Once
+	errStmtCounter monitoring.Counter
+)
+
+// PlaceholderSQL SQL statement placeholder
+const PlaceholderSQL = "<placeholder>"
+
+// Stmt is wraps the sql.Stmt struct for handling and monitoring SQL errors.
+// If Stmt execution errors occur, it is automatically closed and the prepared statements in the cache are cleared.
+type Stmt struct {
+	statement      string
+	placeholderNum int
+	stmtCache      *StmtCache
+	stmt           *sql.Stmt
+	parentStmt     *Stmt
+}
+
+// errHandler handling and monitoring SQL errors
+// The err parameter standby
+func (s *Stmt) errHandler(_ error) {
+	o := s
+	if s.parentStmt != nil {
+		o = s.parentStmt
+	}
+
+	if err := o.Close(); err != nil {
+		klog.Warningf("Failed to close stmt: %s", err)
+	}
+
+	if o.stmtCache != nil {
+		once.Do(func() {
+			errStmtCounter = o.stmtCache.mf.NewCounter("sql_stmt_errors", "Number of statement execution errors")
+		})
+
+		errStmtCounter.Inc()
+	}
+}
+
+// SQLStmt returns the referenced sql.Stmt struct.
+func (s *Stmt) SQLStmt() *sql.Stmt {
+	return s.stmt
+}
+
+// Close closes the Stmt.
+// Clear if Stmt belongs to cache
+func (s *Stmt) Close() error {
+	if cache := s.stmtCache; cache != nil {
+		cache.clearOne(s)
+	}
+
+	return s.stmt.Close()
+}
+
+// WithTx returns a transaction-specific prepared statement from
+// an existing statement.
+func (s *Stmt) WithTx(ctx context.Context, tx *sql.Tx) *Stmt {
+	parent := s
+	if s.parentStmt != nil {
+		parent = s.parentStmt
+	}
+	return &Stmt{
+		parentStmt: parent,
+		stmt:       tx.StmtContext(ctx, parent.stmt),
+	}
+}
+
+// Exec executes a prepared statement with the given arguments and
+// returns a Result summarizing the effect of the statement.
+//
+// Exec uses context.Background internally; to specify the context, use
+// ExecContext.
+func (s *Stmt) Exec(args ...interface{}) (sql.Result, error) {
+	res, err := s.stmt.Exec(args...)
+	if err != nil {
+		s.errHandler(err)
+	}
+	return res, err
+}
+
+// ExecContext executes a prepared statement with the given arguments and
+// returns a Result summarizing the effect of the statement.
+func (s *Stmt) ExecContext(ctx context.Context, args ...interface{}) (sql.Result, error) {
+	res, err := s.stmt.ExecContext(ctx, args...)
+	if err != nil {
+		s.errHandler(err)
+	}
+	return res, err
+}
+
+// Query executes a prepared query statement with the given arguments
+// and returns the query results as a *Rows.
+//
+// Query uses context.Background internally; to specify the context, use
+// QueryContext.
+func (s *Stmt) Query(args ...interface{}) (*sql.Rows, error) {
+	res, err := s.stmt.Query(args...)
+	if err != nil {
+		s.errHandler(err)
+	}
+	return res, err
+}
+
+// QueryContext executes a prepared query statement with the given arguments
+// and returns the query results as a *Rows.
+func (s *Stmt) QueryContext(ctx context.Context, args ...interface{}) (*sql.Rows, error) {
+	res, err := s.stmt.QueryContext(ctx, args...)
+	if err != nil {
+		s.errHandler(err)
+	}
+	return res, err
+}
+
+// QueryRow executes a prepared query statement with the given arguments.
+// If an error occurs during the execution of the statement, that error will
+// be returned by a call to Scan on the returned *Row, which is always non-nil.
+// If the query selects no rows, the *Row's Scan will return ErrNoRows.
+// Otherwise, the *Row's Scan scans the first selected row and discards
+// the rest.
+//
+// Example usage:
+//
+//	var name string
+//	err := nameByUseridStmt.QueryRow(id).Scan(&name)
+//
+// QueryRow uses context.Background internally; to specify the context, use
+// QueryRowContext.
+func (s *Stmt) QueryRow(args ...interface{}) *sql.Row {
+	res := s.stmt.QueryRow(args...)
+	if err := res.Err(); err != nil {
+		s.errHandler(err)
+	}
+	return res
+}
+
+// QueryRowContext executes a prepared query statement with the given arguments.
+// If an error occurs during the execution of the statement, that error will
+// be returned by a call to Scan on the returned *Row, which is always non-nil.
+// If the query selects no rows, the *Row's Scan will return ErrNoRows.
+// Otherwise, the *Row's Scan scans the first selected row and discards
+// the rest.
+func (s *Stmt) QueryRowContext(ctx context.Context, args ...any) *sql.Row {
+	res := s.stmt.QueryRowContext(ctx, args...)
+	if err := res.Err(); err != nil {
+		s.errHandler(err)
+	}
+	return res
+}
+
+// StmtCache is a cache of the sql.Stmt structs.
+type StmtCache struct {
+	db             *sql.DB
+	statementMutex sync.Mutex
+	statements     map[string]map[int]*sql.Stmt
+	mf             monitoring.MetricFactory
+}
+
+// NewStmtCache creates a StmtCache instance.
+func NewStmtCache(db *sql.DB, mf monitoring.MetricFactory) *StmtCache {
+	if mf == nil {
+		mf = monitoring.InertMetricFactory{}
+	}
+
+	return &StmtCache{
+		db:         db,
+		statements: make(map[string]map[int]*sql.Stmt),
+		mf:         mf,
+	}
+}
+
+// clearOne clear the cache of a sql.Stmt.
+func (sc *StmtCache) clearOne(s *Stmt) {
+	if s == nil || s.stmt == nil || s.stmtCache != sc {
+		return
+	}
+
+	sc.statementMutex.Lock()
+	defer sc.statementMutex.Unlock()
+
+	if sc.statements[s.statement] != nil && sc.statements[s.statement][s.placeholderNum] == s.stmt {
+		sc.statements[s.statement][s.placeholderNum] = nil
+	}
+}
+
+func (sc *StmtCache) getStmt(ctx context.Context, statement string, num int, first, rest string) (*sql.Stmt, error) {
+	sc.statementMutex.Lock()
+	defer sc.statementMutex.Unlock()
+
+	if sc.statements[statement] != nil {
+		if sc.statements[statement][num] != nil {
+			return sc.statements[statement][num], nil
+		}
+	} else {
+		sc.statements[statement] = make(map[int]*sql.Stmt)
+	}
+
+	s, err := sc.db.PrepareContext(ctx, expandPlaceholderSQL(statement, num, first, rest))
+	if err != nil {
+		klog.Warningf("Failed to prepare statement %d: %s", num, err)
+		return nil, err
+	}
+
+	sc.statements[statement][num] = s
+
+	return s, nil
+}
+
+// expandPlaceholderSQL expands an sql statement by adding a specified number of '?'
+// placeholder slots. At most one placeholder will be expanded.
+func expandPlaceholderSQL(sql string, num int, first, rest string) string {
+	if num <= 0 {
+		panic(fmt.Errorf("trying to expand SQL placeholder with <= 0 parameters: %s", sql))
+	}
+
+	parameters := first + strings.Repeat(","+rest, num-1)
+
+	return strings.Replace(sql, PlaceholderSQL, parameters, 1)
+}
+
+// GetStmt creates and caches sql.Stmt structs and returns their wrapper structs Stmt.
+func (sc *StmtCache) GetStmt(ctx context.Context, statement string, num int, first, rest string) (*Stmt, error) {
+	stmt, err := sc.getStmt(ctx, statement, num, first, rest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Stmt{
+		statement:      statement,
+		placeholderNum: num,
+		stmtCache:      sc,
+		stmt:           stmt,
+	}, nil
+}


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

This PR is an improved version of #2936, with the following changes:

1.Use a separate unit (StmtCache) to manage the cache of prepared statements.
2.Wrap sql.Stmt struct to handle monitoring prepared statement execution errors.
3.When a statement execution error occurs, only clear the corresponding prepared statement cache, preventing circular cache clearing problems.
4.Add prepared statement execution error metrics.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
