### PR TITLE
Pin the version of cockroach for tests to a specific version

### DIFF
--- a/storage/crdb/common_test.go
+++ b/storage/crdb/common_test.go
@@ -43,7 +43,7 @@ func (db *testDBHandle) GetDB() *sql.DB {
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	ts, err := testserver.NewTestServer()
+	ts, err := testserver.NewTestServer(testserver.CustomVersionOpt("22.2.7"))
 	if err != nil {
 		klog.Exitf("Failed to start test server: %v", err)
 	}


### PR DESCRIPTION
./storage/crdb tests have started failing in GCP recently. Investigation shows that this is pulling the latest tagged version, which breaks hermetic builds. This PR is a test to see if using the previous version fixes the issue, and if so, I propose merging this to unblock things and then discussing with the community to look for better solutions.
