### PR TITLE
Bump github.com/transparency-dev/merkle from 0.0.1 to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Bump Go version from 1.17 to 1.19.
 * Updated golangci-lint to v1.51.1 (developers should update to this version)
+* Update transparency-dev/merkle to v0.0.2
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 * Bump Go version from 1.17 to 1.19.
 * Updated golangci-lint to v1.51.1 (developers should update to this version)
-* Update transparency-dev/merkle to v0.0.2
 
 ### Dependency updates
 
 * Bump contrib.go.opencensus.io/exporter/stackdriver from 0.13.12 to 0.13.14 by @samuelattwood in https://github.com/google/trillian/pull/2950
+* Update transparency-dev/merkle to v0.0.2
 
 ## v1.5.1
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/pseudomuto/protoc-gen-doc v1.5.1
-	github.com/transparency-dev/merkle v0.0.1
+	github.com/transparency-dev/merkle v0.0.2
 	go.etcd.io/etcd/client/v3 v3.5.8
 	go.etcd.io/etcd/etcdctl/v3 v3.5.8
 	go.etcd.io/etcd/server/v3 v3.5.8

--- a/go.sum
+++ b/go.sum
@@ -1273,6 +1273,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/transparency-dev/merkle v0.0.1 h1:T9/9gYB8uZl7VOJIhdwjALeRWlxUxSfDEysjfmx+L9E=
 github.com/transparency-dev/merkle v0.0.1/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
+github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
+github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
[upgrade transparency-dev/merkle from v0.0.1 to v0.0.2](https://github.com/google/trillian/commit/03fa7659ed4aa787f045ff99c06df34015d73d2e)

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
