### PR TITLE
Update mysql Dockerfile base image from ubuntu:trusty to ubuntu:jammy

### DIFF
--- a/examples/deployment/kubernetes/mysql/image/Dockerfile
+++ b/examples/deployment/kubernetes/mysql/image/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:jammy
 
 # add our user and group first to make sure their IDs get assigned
 # consistently, regardless of whatever dependencies get added
@@ -29,8 +29,8 @@ RUN rm -rf /var/lib/apt/lists/*
 
 RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A 9334A25F8507EFA5
 
-RUN echo "deb http://repo.percona.com/apt trusty main" > /etc/apt/sources.list.d/percona.list
-RUN echo "deb-src http://repo.percona.com/apt trusty main" >> /etc/apt/sources.list.d/percona.list
+RUN echo "deb http://repo.percona.com/apt jammy main" > /etc/apt/sources.list.d/percona.list
+RUN echo "deb-src http://repo.percona.com/apt jammy main" >> /etc/apt/sources.list.d/percona.list
 
 RUN { \
                 echo percona-server-server-${MYSQL_VERSION} percona-server-server/root_password password ''; \


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
Fix CVE vulnerabilities in the deprecated base image in mysql Dockerfile.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
