### PR TITLE
Added comments to show how snippets were generated

### DIFF
--- a/docs/claimantmodel/experimental/cmd/render/internal/models/armorydrive/logsequence.md
+++ b/docs/claimantmodel/experimental/cmd/render/internal/models/armorydrive/logsequence.md
@@ -1,3 +1,6 @@
+<!--- This content generated with:
+go run github.com/google/trillian/docs/claimantmodel/experimental/cmd/render@master --full_model_file ./cmd/render/internal/models/armorydrive/full.yaml
+-->
 ```mermaid
 sequenceDiagram
     actor WithSecure

--- a/docs/claimantmodel/experimental/cmd/render/internal/tmpl_sequence.md
+++ b/docs/claimantmodel/experimental/cmd/render/internal/tmpl_sequence.md
@@ -1,4 +1,4 @@
-{{ $logClaimant := .Log.Claimant }}
+{{ $logClaimant := .Log.Claimant -}}
 ```mermaid
 sequenceDiagram
 {{- range .Actors}}

--- a/docs/claimantmodel/experimental/cmd/render/main.go
+++ b/docs/claimantmodel/experimental/cmd/render/main.go
@@ -80,7 +80,19 @@ func handleSingleModel(domain claimant.Model) {
 }
 
 func handleMultiModels(models claimant.Models) {
+	generateCommand := getGenerateDocs()
 	fmt.Printf("All actors:\n%s\n\n", strings.Join(models.Actors(), "\n"))
-	fmt.Printf("Models as markdown:\n%s\n\n", models.Markdown())
-	fmt.Printf("Sequence diagrams:\n%s\n\n", models.SequenceDiagram())
+	fmt.Printf("Models as markdown:\n%s\n%s\n\n", generateCommand, models.Markdown())
+	fmt.Printf("Sequence diagrams:\n%s\n%s\n\n", generateCommand, models.SequenceDiagram())
+}
+
+func getGenerateDocs() string {
+	builder := strings.Builder{}
+	builder.WriteString("<!--- This content generated with:\n")
+	builder.WriteString("go run github.com/google/trillian/docs/claimantmodel/experimental/cmd/render@master")
+	for _, a := range os.Args[1:] {
+		builder.WriteString(fmt.Sprintf(" %s", a))
+	}
+	builder.WriteString("\n-->")
+	return builder.String()
 }


### PR DESCRIPTION
As an example of how this appears:
```
<!--- This content generated with:
go run github.com/google/trillian/docs/claimantmodel/experimental/cmd/render@master --full_model_file ./cmd/render/internal/models/armorydrive/full.yaml
-->
```
