### PR TITLE
Fix db_server Docker image vulnerabilities

### DIFF
--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,5 +1,13 @@
 FROM gcr.io/trillian-opensource-ci/mysql5:5.7
 
+# Patch the OS-level packages and remove unneeded dependencies.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y procps \
+    && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY examples/deployment/docker/db_server/mysql.cnf /etc/mysql/conf.d/trillian.cnf
 COPY storage/mysql/schema/storage.sql /docker-entrypoint-initdb.d/storage.sql


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The image in marketplace.gcr.io/google/mysql5 is not yet updated as the following PRs are not merged.
https://github.com/GoogleCloudPlatform/mysql-docker/pull/87
https://github.com/GoogleCloudPlatform/mysql-docker/pull/90

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
