### PR TITLE
Build the trillian_log_server and trillian_log_signer binary without depending on glibc

### DIFF
--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build the server.
-RUN go install ./cmd/trillian_log_server
+RUN CGO_ENABLED=0 go install ./cmd/trillian_log_server
 # Run the licensing tool and save licenses, copyright notices, etc.
 RUN go run github.com/google/go-licenses save ./cmd/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build the signer.
-RUN go install ./cmd/trillian_log_signer
+RUN CGO_ENABLED=0 go install ./cmd/trillian_log_signer
 # Run the licensing tool and save licenses, copyright notices, etc.
 RUN go run github.com/google/go-licenses save ./cmd/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
This PR avoids similar issue like https://github.com/google/certificate-transparency-go/issues/1118.

Here is the distroless Dockerfile example for Go.
https://github.com/GoogleContainerTools/distroless/blob/main/examples/go/Dockerfile

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
