### PR TITLE
Add logID to fetched leaves metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## HEAD
 
+* Export logserver read counter metric together with logIDs
 * Recommended go version for development: 1.20
   * This is the version used by the cloudbuild presubmits. Using a
     different version can lead to presubmits failing due to unexpected
     diffs.
-
 
 ## v.1.5.2
 

--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -77,6 +77,7 @@ func NewTrillianLogRPCServer(registry extension.Registry, timeSource clock.TimeS
 		fetchedLeaves: mf.NewCounter(
 			"fetched_leaves",
 			"Count of individual leaves fetched through GetLeaves* calls",
+			"logid",
 		),
 	}
 }
@@ -446,7 +447,8 @@ func (t *TrillianLogRPCServer) GetLeavesByRange(ctx context.Context, req *trilli
 		if err != nil {
 			return nil, err
 		}
-		t.fetchedLeaves.Add(float64(len(leaves)))
+		label := strconv.FormatInt(req.LogId, 10)
+		t.fetchedLeaves.Add(float64(len(leaves)), label)
 		r.Leaves = leaves
 	}
 

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -260,7 +261,8 @@ func TestGetLeavesByRange(t *testing.T) {
 			t.Errorf("GetLeavesByRange(%d, %+d)=%+v; want %+v", req.StartIndex, req.Count, got, test.want)
 		}
 
-		if gotCount, wantCount := server.fetchedLeaves.Value(), float64(len(test.want)); gotCount != wantCount {
+		label := strconv.FormatInt(req.LogId, 10)
+		if gotCount, wantCount := server.fetchedLeaves.Value(label), float64(len(test.want)); gotCount != wantCount {
 			t.Errorf("GetLeavesByRange() incremented fetched count by %f,  want %f", gotCount, wantCount)
 		}
 	}


### PR DESCRIPTION
This allows to break down the number of leaves fetched by log id.