### PR TITLE
Bump go from 1.19 to 1.20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,9 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.20
+        go-version: '1.20'
+        check-latest: true
+        cache: true
 
     - uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.19
+        go-version: 1.20
 
     - uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
       with:
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.19'
+        go-version: '1.20'
         check-latest: true
         cache: true
 
@@ -49,7 +49,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.19'
+        go-version: '1.20'
         check-latest: true
         cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## HEAD
 
+* Recommended go version for development: 1.20
+  * This is the version used by the cloudbuild presubmits. Using a
+    different version can lead to presubmits failing due to unexpected
+    diffs.
+
+
 ## v.1.5.2
 
 * Recommended go version for development: 1.19

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The current state of feature implementation is recorded in the
 
 To build and test Trillian you need:
 
- - Go 1.19 or later (go 1.19 matches cloudbuild, and is preferred for developers
+ - Go 1.20 or later (go 1.20 matches cloudbuild, and is preferred for developers
    that will be submitting PRs to this project).
 
 To run many of the tests (and production deployment) you need:

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster
+FROM golang:1.20-buster
 
 RUN apt-get update && \
     apt-get install -y mariadb-client

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster as build
+FROM golang:1.20-buster as build
 
 WORKDIR /trillian
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster as build
+FROM golang:1.20-buster as build
 
 WORKDIR /trillian
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/trillian
 
-go 1.19
+go 1.20
 
 require (
 	bitbucket.org/creachadair/shell v0.0.7

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for Trillan integration tests.
-FROM golang:1.19-buster
+FROM golang:1.20-buster
 
 WORKDIR /testbase
 


### PR DESCRIPTION
The current stable version on https://go.dev/dl/ is 1.21 and we support the last two minor versions. This unblocks #3079.
