### PR TITLE
Bump Go version in Docker base images to 1.20.8-bookworm

### DIFF
--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -35,7 +35,7 @@ steps:
   - tag_mysql
 
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor:v1.6.0
+  name: gcr.io/kaniko-project/executor:v1.15.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
@@ -45,7 +45,7 @@ steps:
   - push_mysql
 
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor:v1.6.0
+  name: gcr.io/kaniko-project/executor:v1.15.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
@@ -53,7 +53,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ['-']
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor:v1.6.0
+  name: gcr.io/kaniko-project/executor:v1.15.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}

--- a/examples/deployment/docker/db_client/Dockerfile
+++ b/examples/deployment/docker/db_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f67881324746362baf9572
+FROM golang:1.20.8-bookworm@sha256:b099af7250d673d249597b79049e3e53487c435acf285e07a36d4b49f9f4750a
 
 RUN apt-get update && \
     apt-get install -y mariadb-client

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -18,7 +18,7 @@ RUN go install ./cmd/trillian_log_server
 RUN go run github.com/google/go-licenses save ./cmd/trillian_log_server --save_path /THIRD_PARTY_NOTICES
 
 # Make a minimal image.
-FROM gcr.io/distroless/base@sha256:46c5b9bd3e3efff512e28350766b54355fce6337a0b44ba3f822ab918eca4520
+FROM gcr.io/distroless/base-debian12@sha256:d64f5483d2fd0cec2260941c443cb2947102e46e1a9fe36a321d0a788c1a49e0
 
 COPY --from=build /go/bin/trillian_log_server /
 COPY --from=build /THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f67881324746362baf9572 as build
+FROM golang:1.20.8-bookworm@sha256:b099af7250d673d249597b79049e3e53487c435acf285e07a36d4b49f9f4750a as build
 
 WORKDIR /trillian
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -18,7 +18,7 @@ RUN go install ./cmd/trillian_log_signer
 RUN go run github.com/google/go-licenses save ./cmd/trillian_log_signer --save_path /THIRD_PARTY_NOTICES
 
 # Make a minimal image.
-FROM gcr.io/distroless/base@sha256:46c5b9bd3e3efff512e28350766b54355fce6337a0b44ba3f822ab918eca4520
+FROM gcr.io/distroless/base-debian12@sha256:d64f5483d2fd0cec2260941c443cb2947102e46e1a9fe36a321d0a788c1a49e0
 
 COPY --from=build /go/bin/trillian_log_signer /
 COPY --from=build /THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f67881324746362baf9572 as build
+FROM golang:1.20.8-bookworm@sha256:b099af7250d673d249597b79049e3e53487c435acf285e07a36d4b49f9f4750a as build
 
 WORKDIR /trillian
 

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for Trillan integration tests.
-FROM golang:1.20-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f67881324746362baf9572
+FROM golang:1.20.8-bookworm@sha256:b099af7250d673d249597b79049e3e53487c435acf285e07a36d4b49f9f4750a
 
 WORKDIR /testbase
 

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
   docker-compose \
   lsof \
   mariadb-client \
-  netcat \
+  netcat-openbsd \
   socat \
   softhsm \
   unzip \


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

The Go base images are updated to `bookworm` as `buster` images were dropped in https://github.com/docker-library/golang/pull/456.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
