### PR TITLE
mysql: check for error when getting subtrees

### DIFF
--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -252,6 +252,10 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, ids [][]by
 		}
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
 	// The InternalNodes cache is possibly nil here, but the SubtreeCache (which called
 	// this method) will re-populate it.
 	return ret, nil


### PR DESCRIPTION
treeTX.getSubtrees iterates over a set of rows from `database/sql`, but it was failing to check the error status after exiting the for loop that iterates over them.

On our log deployment (Let's Encrypt Oak), this is causing mistaken error messages of `preload did not get all tiles` when the real error should be propagated from mysql (in our case, max_statement_time exceeded).

We're in the middle of trying to remediate a significant availability from for get-sth-consistency, and getting this landed and deployed would help eliminate a source of noise in our investigation.