### PR TITLE
Bump golangci-lint from 1.51.1 to 1.55.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
       with:
-        version: 'v1.51.1'
+        version: 'v1.55.1'
         args: ./storage/crdb
 
   unit-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Bump golangci-lint from 1.51.1 to 1.55.1 (developers should update to this version)
+
 ## v1.5.3
 
 * Recommended go version for development: 1.20

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ go generate -x ./...  # hunts for //go:generate comments and runs them
 
 The Trillian codebase uses go.mod to declare fixed versions of its dependencies. 
 With Go modules, updating a dependency simply involves running `go get`:
-```
+
+```bash
 go get package/path       # Fetch the latest published version
 go get package/path@X.Y.Z # Fetch a specific published version
 go get package/path@HEAD  # Fetch the latest commit 
@@ -203,7 +204,8 @@ Be warned however, that this may undo any selected versions that resolve issues 
 
 While running `go build` and `go test`, go will add any ambiguous transitive dependencies to `go.mod`
 To clean these up run:
-```
+
+```bash
 go mod tidy
 ```
 
@@ -213,20 +215,22 @@ The [`scripts/presubmit.sh`](scripts/presubmit.sh) script runs various tools
 and tests over the codebase.
 
 #### Install [golangci-lint](https://github.com/golangci/golangci-lint#local-installation).
+
 ```bash
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
 ```
 
 #### Run code generation, build, test and linters
+
 ```bash
 ./scripts/presubmit.sh
 ```
 
 #### Or just run the linters alone
+
 ```bash
 golangci-lint run
 ```
-
 
 ## Design
 

--- a/integration/cloudbuild/testbase/Dockerfile
+++ b/integration/cloudbuild/testbase/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
   xxd
 
 # Install golangci-lint. See docs at: https://golangci-lint.run/usage/install/.
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.1
 
 # Install CockroachDB, see https://www.cockroachlabs.com/docs/v22.1/install-cockroachdb-linux
 RUN curl https://binaries.cockroachdb.com/cockroach-v22.1.11.linux-amd64.tgz | tar -xz && cp -i cockroach-v22.1.11.linux-amd64/cockroach /usr/local/bin/


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
This PR unblocks https://github.com/google/trillian/pull/3175.


### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
