### PR TITLE
Move golangci-lint from Cloud Build to GitHub Action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.20"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: v1.55.1
+          args: --timeout=8m

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,14 +47,15 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./integration/cloudbuild/prepare.sh
 
-# Run lint and porcelain checks, make sure the diff is empty and no files need
-# to be updated. This includes gofmt, golangci-linter, go mod tidy, go mod
-# generate and a few more.
-- id: lint
+# Run porcelain checks, make sure the diff is empty and no files need
+# to be updated. This includes gofmt, go mod tidy, go mod generate
+# and a few more.
+- id: check
   name: 'gcr.io/${PROJECT_ID}/trillian_testbase'
   entrypoint: ./scripts/presubmit.sh
   args:
     - --no-build
+    - --no-linters
     - --fix
     - --no-mod-tidy
     - --empty-diff
@@ -72,7 +73,7 @@ steps:
     - GOFLAGS=-race
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - lint
+    - check
 
 # Codecov
 - id: codecov
@@ -87,7 +88,7 @@ steps:
     - GO_TEST_TIMEOUT=20m
     - CODECOV_TOKEN=${_CODECOV_TOKEN}
   waitFor:
-    - lint
+    - check
 
 # Presubmit (Batched queue)
 - id: presubmit_batched
@@ -100,7 +101,7 @@ steps:
     - GOFLAGS=-race --tags=batched_queue
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - lint
+    - check
 
 # Presubmit (PKCS11)
 - id: presubmit_pkcs11
@@ -113,7 +114,7 @@ steps:
     - GOFLAGS=-race --tags=pkcs11
     - GO_TEST_TIMEOUT=20m
   waitFor:
-    - lint
+    - check
 
 # Try to spread the load a bit, we'll wait for all the presubmit.* steps
 # to finish before starting the integration.* ones.


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The Cloud Build duration will be slightly shorten by moving the golangci-lint to GitHub Action workflow.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
