### PR TITLE
Bump MariaDB image from 10.3 to 11.1 in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -181,6 +181,6 @@ steps:
   entrypoint: ./integration/cloudbuild/run_integration.sh
   env:
     - GO_TEST_TIMEOUT=20m
-    - MYSQLD_IMAGE=mariadb:10.3
+    - MYSQLD_IMAGE=mariadb:11.1
   waitFor:
     - presubmits_done


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The mariadb:10.3 image became EOL on 11 May 2023 in https://github.com/MariaDB/mariadb-docker/commit/683c010c3ff2a77d0b9734a6468859080a4356e2.

https://hub.docker.com/_/mariadb

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
