### PR TITLE
Increase some timeouts in integration tests

### DIFF
--- a/integration/functions.sh
+++ b/integration/functions.sh
@@ -37,10 +37,10 @@ wait_for_server_startup() {
   # as the test will fail if the server is really not up.
   local port=$1
   set +e
-  wget -q --spider --retry-connrefused --waitretry=1 -t 10 localhost:${port}
+  wget -q --spider --retry-connrefused --waitretry=2 -t 20 localhost:${port}
   # Wait a bit more to give it a chance to become actually available, e.g. if CI
   # environment is slow.
-  sleep 2
+  sleep 5
   wget -q --spider -t 1 localhost:${port}
   local rc=$?
   set -e


### PR DESCRIPTION
They are timing out regularly in GCB waiting for the log server to start. We can see from the output that the server starts shortly after, but these setup hooks have already failed by then and the whole harness is being torn down. Bumping these to take potentially 45s instead of 12s should give us plenty of time.
