### PR TITLE
Inlined storage/sql.go into both implementations that use it

### DIFF
--- a/storage/crdb/sqladminstorage.go
+++ b/storage/crdb/sqladminstorage.go
@@ -144,7 +144,7 @@ func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, er
 	}()
 
 	// GetTree is an entry point for most RPCs, let's provide somewhat nicer error messages.
-	tree, err := storage.ReadTree(stmt.QueryRowContext(ctx, treeID))
+	tree, err := readTree(stmt.QueryRowContext(ctx, treeID))
 	switch {
 	case err == sql.ErrNoRows:
 		// ErrNoRows doesn't provide useful information, so we don't forward it.
@@ -183,7 +183,7 @@ func (t *adminTX) ListTrees(ctx context.Context, includeDeleted bool) ([]*trilli
 	}()
 	trees := []*trillian.Tree{}
 	for rows.Next() {
-		tree, err := storage.ReadTree(rows)
+		tree, err := readTree(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -206,8 +206,8 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 	}
 
 	// Use the time truncated-to-millis throughout, as that's what's stored.
-	nowMillis := storage.ToMillisSinceEpoch(time.Now())
-	now := storage.FromMillisSinceEpoch(nowMillis)
+	nowMillis := toMillisSinceEpoch(time.Now())
+	now := fromMillisSinceEpoch(nowMillis)
 
 	newTree := proto.Clone(tree).(*trillian.Tree)
 	newTree.TreeId = id
@@ -328,8 +328,8 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 	// ensure all entries in SequencedLeafData are integrated.
 
 	// Use the time truncated-to-millis throughout, as that's what's stored.
-	nowMillis := storage.ToMillisSinceEpoch(time.Now())
-	now := storage.FromMillisSinceEpoch(nowMillis)
+	nowMillis := toMillisSinceEpoch(time.Now())
+	now := fromMillisSinceEpoch(nowMillis)
 	tree.UpdateTime = timestamppb.New(now)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build update time: %v", err)
@@ -366,7 +366,7 @@ func (t *adminTX) UpdateTree(ctx context.Context, treeID int64, updateFunc func(
 }
 
 func (t *adminTX) SoftDeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {
-	return t.updateDeleted(ctx, treeID, true /* deleted */, storage.ToMillisSinceEpoch(time.Now()) /* deleteTimeMillis */)
+	return t.updateDeleted(ctx, treeID, true /* deleted */, toMillisSinceEpoch(time.Now()) /* deleteTimeMillis */)
 }
 
 func (t *adminTX) UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {

--- a/storage/mysql/sql.go
+++ b/storage/mysql/sql.go
@@ -1,0 +1,128 @@
+// Copyright 2018 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/trillian"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// toMillisSinceEpoch converts a timestamp into milliseconds since epoch
+func toMillisSinceEpoch(t time.Time) int64 {
+	return t.UnixNano() / 1000000
+}
+
+// fromMillisSinceEpoch converts
+func fromMillisSinceEpoch(ts int64) time.Time {
+	return time.Unix(0, ts*1000000)
+}
+
+// setNullStringIfValid assigns src to dest if src is Valid.
+func setNullStringIfValid(src sql.NullString, dest *string) {
+	if src.Valid {
+		*dest = src.String
+	}
+}
+
+// row defines a common interface between sql.Row and sql.Rows(!)
+type row interface {
+	Scan(dest ...interface{}) error
+}
+
+// readTree takes a sql row and returns a tree
+func readTree(r row) (*trillian.Tree, error) {
+	tree := &trillian.Tree{}
+
+	// Enums and Datetimes need an extra conversion step
+	var treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm string
+	var createMillis, updateMillis, maxRootDurationMillis int64
+	var displayName, description sql.NullString
+	var privateKey, publicKey []byte
+	var deleted sql.NullBool
+	var deleteMillis sql.NullInt64
+	err := r.Scan(
+		&tree.TreeId,
+		&treeState,
+		&treeType,
+		&hashStrategy,
+		&hashAlgorithm,
+		&signatureAlgorithm,
+		&displayName,
+		&description,
+		&createMillis,
+		&updateMillis,
+		&privateKey,
+		&publicKey,
+		&maxRootDurationMillis,
+		&deleted,
+		&deleteMillis,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setNullStringIfValid(displayName, &tree.DisplayName)
+	setNullStringIfValid(description, &tree.Description)
+
+	// Convert all things!
+	if ts, ok := trillian.TreeState_value[treeState]; ok {
+		tree.TreeState = trillian.TreeState(ts)
+	} else {
+		return nil, fmt.Errorf("unknown TreeState: %v", treeState)
+	}
+	if tt, ok := trillian.TreeType_value[treeType]; ok {
+		tree.TreeType = trillian.TreeType(tt)
+	} else {
+		return nil, fmt.Errorf("unknown TreeType: %v", treeType)
+	}
+	if hashStrategy != "RFC6962_SHA256" {
+		return nil, fmt.Errorf("unknown HashStrategy: %v", hashStrategy)
+	}
+
+	// Let's make sure we didn't mismatch any of the casts above
+	ok := tree.TreeState.String() == treeState &&
+		tree.TreeType.String() == treeType
+	if !ok {
+		return nil, fmt.Errorf(
+			"mismatched enum: tree = %v, enums = [%v, %v, %v, %v, %v]",
+			tree,
+			treeState, treeType, hashStrategy, hashAlgorithm, signatureAlgorithm)
+	}
+
+	tree.CreateTime = timestamppb.New(fromMillisSinceEpoch(createMillis))
+	if err := tree.CreateTime.CheckValid(); err != nil {
+		return nil, fmt.Errorf("failed to parse create time: %w", err)
+	}
+	tree.UpdateTime = timestamppb.New(fromMillisSinceEpoch(updateMillis))
+	if err := tree.UpdateTime.CheckValid(); err != nil {
+		return nil, fmt.Errorf("failed to parse update time: %w", err)
+	}
+	tree.MaxRootDuration = durationpb.New(time.Duration(maxRootDurationMillis * int64(time.Millisecond)))
+
+	tree.Deleted = deleted.Valid && deleted.Bool
+	if tree.Deleted && deleteMillis.Valid {
+		tree.DeleteTime = timestamppb.New(fromMillisSinceEpoch(deleteMillis.Int64))
+		if err := tree.DeleteTime.CheckValid(); err != nil {
+			return nil, fmt.Errorf("failed to parse delete time: %w", err)
+		}
+	}
+
+	return tree, nil
+}


### PR DESCRIPTION
This removes an obstacle to executing #3201 cleanly. Despite the duplication, it's also logically cleaner. The different backend implementations should be able to evolve independently. Tying them together with common code for reading rows forces the same schema layout across all implementations.
