### PR TITLE
Disable race condition checking for beam code

### DIFF
--- a/experimental/batchmap/tmap_test.go
+++ b/experimental/batchmap/tmap_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 // Copyright 2020 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Unclear why these tests sometimes fail race checks, but it's far more likely to be the test harness than the code under test. It's also in experimental, and we don't want it blocking other changes to non-experimental code.
