### PR TITLE
Disable the OS package patches to bypass the mysql8 gpg key rotation issue

### DIFF
--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,12 +1,13 @@
 FROM gcr.io/trillian-opensource-ci/mysql8:8.0@sha256:89d1c5d48cee111cdc6348704044a60578f5c0af9dfc55b6e58e32a01906bd21
 
-# Patch the OS-level packages and remove unneeded dependencies.
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y procps \
-    && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade \
-    && apt-get -y autoremove \
-    && rm -rf /var/lib/apt/lists/*
+# TODO(roger2hk): Uncomment the below OS-level packages patch command as this is a temporary workaround to bypass the mysql8 gpg key rotation issue.
+# # Patch the OS-level packages and remove unneeded dependencies.
+# ENV DEBIAN_FRONTEND=noninteractive
+# RUN apt-get update \
+#     && apt-get install -y procps \
+#     && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade \
+#     && apt-get -y autoremove \
+#     && rm -rf /var/lib/apt/lists/*
 
 # expects the build context to be: $GOPATH/src/github.com/google/trillian
 COPY examples/deployment/docker/db_server/mysql.cnf /etc/mysql/conf.d/trillian.cnf


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

This is a temporary workaround to bypass the mysql8 gpg key rotation issue. See https://github.com/GoogleCloudPlatform/mysql-docker/issues/98.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
