### PR TITLE
Switch from using unmaintained Google Cloud mysql db image to dockerhub official image

### DIFF
--- a/examples/deployment/docker/db_server/Dockerfile
+++ b/examples/deployment/docker/db_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/trillian-opensource-ci/mysql8:8.0@sha256:89d1c5d48cee111cdc6348704044a60578f5c0af9dfc55b6e58e32a01906bd21
+FROM mysql:8.0
 
 # TODO(roger2hk): Uncomment the below OS-level packages patch command as this is a temporary workaround to bypass the mysql8 gpg key rotation issue.
 # # Patch the OS-level packages and remove unneeded dependencies.


### PR DESCRIPTION
Alternative to https://github.com/google/trillian/pull/3270 
https://github.com/GoogleCloudPlatform/mysql-docker claims it is unmaintained and
hasn't seen an update in 5 months.  Without a specific reason for using this fork
we should try using the official image on dockerhub which is less likely to see breakages
or fall out of date.

Instead of pinning to a hash I'm following the 8.0 tag to automatically receive patch versions.
The reasoning being that the container is used during testing and is not
an included dependency in our final artifact.  Happy to consider pinning
if anybody thinks there is a call for it.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
