### PR TITLE
Replace deprecated `prune-whitelist` flag with `prune-allowlist` for `kubectl` command

### DIFF
--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -92,7 +92,7 @@ steps:
   - -f=envsubst-spanner/trillian-log-signer-service.yaml
   - --prune
   - --all
-  - --prune-whitelist=core/v1/ConfigMap
+  - --prune-allowlist=core/v1/ConfigMap
   env:
   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
@@ -141,7 +141,7 @@ steps:
   - -f=envsubst-mysql/trillian-log-signer-service.yaml
   - --prune
   - --all
-  - --prune-whitelist=core/v1/ConfigMap
+  - --prune-allowlist=core/v1/ConfigMap
   env:
   - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

Warning message from the Google Cloud Build:

```
Step #10 - "apply_k8s_cfgs_for_mysql_dryrun": Running: kubectl apply --dry-run=server --namespace=mysql -f=envsubst-mysql/etcd-cluster.yaml -f=envsubst-mysql/trillian-ci-mysql.yaml -f=envsubst-mysql/trillian-mysql.yaml -f=envsubst-mysql/trillian-log-deployment.yaml -f=envsubst-mysql/trillian-log-service.yaml -f=envsubst-mysql/trillian-log-signer-deployment.yaml -f=envsubst-mysql/trillian-log-signer-service.yaml --prune --all --prune-whitelist=core/v1/ConfigMap
Step #10 - "apply_k8s_cfgs_for_mysql_dryrun": Flag --prune-whitelist has been deprecated, Use --prune-allowlist instead.
```

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
