### PR TITLE
Bump kaniko to v1.20.0 to fix #3338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Notable Changes
 
 * Updated go version 1.20 -> 1.21
+* Bump kaniko (used to build Docker images in GCB) to 1.20.0
 
 ## v1.6.0 (Jan 2024)
 

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -9,7 +9,7 @@ options:
   machineType: E2_HIGHCPU_32
 steps:
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
@@ -17,7 +17,7 @@ steps:
   - --cache=true
   - --cache-dir= # Cache is in Google Container Registry
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
@@ -26,7 +26,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -14,7 +14,7 @@ options:
 steps:
 
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${COMMIT_SHA}
@@ -22,7 +22,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry.
 
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${COMMIT_SHA}
@@ -30,7 +30,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ['-']
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${COMMIT_SHA}

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -5,14 +5,14 @@ options:
   machineType: E2_HIGHCPU_32
 steps:
 - id: build_db_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/db_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/db_server:${TAG_NAME}
   - --cache=true
   - --cache-dir= # Cache is in Google Container Registry
 - id: build_log_server
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_server/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_server:${TAG_NAME}
@@ -20,7 +20,7 @@ steps:
   - --cache-dir= # Cache is in Google Container Registry
   waitFor: ["-"]
 - id: build_log_signer
-  name: gcr.io/kaniko-project/executor:v1.15.0
+  name: gcr.io/kaniko-project/executor:v1.20.0
   args:
   - --dockerfile=examples/deployment/docker/log_signer/Dockerfile
   - --destination=gcr.io/${PROJECT_ID}/log_signer:${TAG_NAME}


### PR DESCRIPTION
This PR bumps `kaniko` (as used in the CloudBuild process to produce Docker images) to `v1.20.0` in an attempt to fix #3338 .

Earlier versions of Kaniko apparently had a bug where they'd produce not-quite-OCI-compliant images, this seems to have been fixed in https://github.com/GoogleContainerTools/kaniko/pull/2700.

We'll need to re-trigger the build for v1.6.0 if possible, or consider tagging/releasing a v1.6.1 if not.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
