### PR TITLE
Don't update to MySQL 9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,8 @@ updates:
   schedule:
     interval: weekly
   ignore:
-    versions:
-      - ">= 9.0"
+    - dependency-name: "mysql"
+      versions: [">= 9.0"]
   groups:
     docker-deps:
       applies-to: version-updates


### PR DESCRIPTION
Be more explicit about which dependency to apply the filter to. Somehow
in #3560 I thought that the dependency to ignore was implicit because
there is only one base image. However, #3581 shows that it didn't work.
Trying again.
