### PR TITLE
Add MySQL TLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+* Add TLS support for MySQL: https://github.com/google/trillian/pull/3593
+  * `--mysql_tls_ca`: users can provide a CA certificate, that is used to establish a secure communication with MySQL server. 
+  * `--mysql_server_name`: users can provide the name of the MySQL server to be used as the Server Name in the TLS configuration.
+
 ## Notable Changes
 
 * Updated go version 1.20 -> 1.21

--- a/storage/mysql/provider.go
+++ b/storage/mysql/provider.go
@@ -15,8 +15,12 @@
 package mysql
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
+	"errors"
 	"flag"
+	"os"
 	"sync"
 
 	"github.com/google/trillian/monitoring"
@@ -24,13 +28,15 @@ import (
 	"k8s.io/klog/v2"
 
 	// Load MySQL driver
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 )
 
 var (
-	mySQLURI = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
-	maxConns = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
-	maxIdle  = flag.Int("mysql_max_idle_conns", -1, "Maximum idle database connections in the connection pool")
+	mySQLURI        = flag.String("mysql_uri", "test:zaphod@tcp(127.0.0.1:3306)/test", "Connection URI for MySQL database")
+	maxConns        = flag.Int("mysql_max_conns", 0, "Maximum connections to the database")
+	maxIdle         = flag.Int("mysql_max_idle_conns", -1, "Maximum idle database connections in the connection pool")
+	mySQLTLSCA      = flag.String("mysql_tls_ca", "", "Path to the CA certificate file for MySQL TLS connection ")
+	mySQLServerName = flag.String("mysql_server_name", "", "Name of the MySQL server to be used as the Server Name in the TLS configuration")
 
 	mysqlMu              sync.Mutex
 	mysqlErr             error
@@ -81,7 +87,14 @@ func getMySQLDatabaseLocked() (*sql.DB, error) {
 	if mysqlDB != nil || mysqlErr != nil {
 		return mysqlDB, mysqlErr
 	}
-	db, err := OpenDB(*mySQLURI)
+	if err := registerTLSConfig(); err != nil {
+		return nil, err
+	}
+	dsn := *mySQLURI
+	if *mySQLTLSCA != "" {
+		dsn += "?tls=custom"
+	}
+	db, err := OpenDB(dsn)
 	if err != nil {
 		mysqlErr = err
 		return nil, err
@@ -106,4 +119,33 @@ func (s *mysqlProvider) AdminStorage() storage.AdminStorage {
 
 func (s *mysqlProvider) Close() error {
 	return s.db.Close()
+}
+
+func registerTLSConfig() error {
+	if *mySQLTLSCA == "" {
+		return nil
+	}
+
+	rootCertPool := x509.NewCertPool()
+	pem, err := os.ReadFile(*mySQLTLSCA)
+	if err != nil {
+		return err
+	}
+	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+		return errors.New("failed to append PEM")
+	}
+	serverName := ""
+	if *mySQLServerName != "" {
+		serverName = *mySQLServerName
+	} else {
+		serverName = os.Getenv("MYSQL_HOSTNAME")
+	}
+	err = mysql.RegisterTLSConfig("custom", &tls.Config{
+		RootCAs:    rootCertPool,
+		ServerName: serverName,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

This PR adds TLS support for MySQL connections in the Trillian server/signer. The key changes include:
- Added new flags:
  - `mysql_tls_ca`: Path to the CA certificate file for the MySQL TLS connection.
  - `mysql_server_name`: Name of the MySQL server to be used as the Server Name in the TLS configuration.

- TLS Configuration Registration:
  - Added a new function `registerTLSConfig()` to handle the registration of the custom TLS configuration.

_If no TLS configuration is provided, the connection defaults to non-TLS, ensuring backward compatibility._

Issue: https://github.com/google/trillian/issues/3592
### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
