### PR TITLE
[Dependabot] Use multi-directory config for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,72 +21,19 @@ updates:
         - "*"
 
 - package-ecosystem: docker
-  directory: /examples/deployment/docker/db_client
-  schedule:
-    interval: weekly
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /examples/deployment/docker/db_server
+  directories:
+    - /examples/deployment/docker/db_client
+    - /examples/deployment/docker/db_server
+    - /examples/deployment/docker/envsubst
+    - /examples/deployment/docker/log_server
+    - /examples/deployment/docker/log_signer
+    - /examples/deployment/kubernetes/mysql/image
+    - /integration/cloudbuild/testbase
   schedule:
     interval: weekly
   ignore:
     - dependency-name: "mysql"
       versions: [">= 9.0"]
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /examples/deployment/docker/envsubst
-  schedule:
-    interval: weekly
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /examples/deployment/docker/log_server
-  schedule:
-    interval: weekly
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /examples/deployment/docker/log_signer
-  schedule:
-    interval: weekly
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /examples/deployment/kubernetes/mysql/image
-  schedule:
-    interval: weekly
-  groups:
-    docker-deps:
-      applies-to: version-updates
-      patterns:
-        - "*"
-
-- package-ecosystem: docker
-  directory: /integration/cloudbuild/testbase
-  schedule:
-    interval: weekly
   groups:
     docker-deps:
       applies-to: version-updates


### PR DESCRIPTION
This removes a lot of duplication from the config. The problem I was trying to solve was making all of the docker deps be updated at the same time. This is what the 'groups' configuration block is supposed to do, but it doesn't seem to work in isolation. We'll see if this change in conjunction with that changes the update behaviour. If not, at least any further changes to the configs are done only in one place instead of in 7 almost identical blocks.
