### PR TITLE
Sensible default quota and storage systems when MySQL support unavailable

### DIFF
--- a/cmd/internal/provider/default_systems.go
+++ b/cmd/internal/provider/default_systems.go
@@ -1,0 +1,30 @@
+package provider
+
+import (
+	"slices"
+
+	"github.com/google/trillian/quota"
+	"github.com/google/trillian/storage"
+)
+
+var (
+	DefaultQuotaSystem   string
+	DefaultStorageSystem string
+)
+
+func init() {
+	defaultProvider := "mysql"
+	providers := storage.Providers()
+	if len(providers) > 0 && !slices.Contains(providers, defaultProvider) {
+		slices.Sort(providers)
+		defaultProvider = providers[0]
+	}
+	DefaultStorageSystem = defaultProvider
+
+	providers = quota.Providers()
+	if len(providers) > 0 && !slices.Contains(providers, defaultProvider) {
+		slices.Sort(providers)
+		defaultProvider = providers[0]
+	}
+	DefaultQuotaSystem = defaultProvider
+}

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/klog/v2"
 
 	// Register supported storage and quota providers.
-	_ "github.com/google/trillian/cmd/internal/provider"
+	"github.com/google/trillian/cmd/internal/provider"
 )
 
 var (
@@ -58,10 +58,10 @@ var (
 	etcdService     = flag.String("etcd_service", "trillian-logserver", "Service name to announce ourselves under")
 	etcdHTTPService = flag.String("etcd_http_service", "trillian-logserver-http", "Service name to announce our HTTP endpoint under")
 
-	quotaSystem = flag.String("quota_system", "mysql", fmt.Sprintf("Quota system to use. One of: %v", quota.Providers()))
+	quotaSystem = flag.String("quota_system", provider.DefaultQuotaSystem, fmt.Sprintf("Quota system to use. One of: %v", quota.Providers()))
 	quotaDryRun = flag.Bool("quota_dry_run", false, "If true no requests are blocked due to lack of tokens")
 
-	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", storage.Providers()))
+	storageSystem = flag.String("storage_system", provider.DefaultStorageSystem, fmt.Sprintf("Storage system to use. One of: %v", storage.Providers()))
 
 	treeGCEnabled            = flag.Bool("tree_gc", true, "If true, tree garbage collection (hard-deletion) is periodically performed")
 	treeDeleteThreshold      = flag.Duration("tree_delete_threshold", serverutil.DefaultTreeDeleteThreshold, "Minimum period a tree has to remain deleted before being hard-deleted")

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -52,7 +52,7 @@ import (
 	"k8s.io/klog/v2"
 
 	// Register supported storage and quota providers.
-	_ "github.com/google/trillian/cmd/internal/provider"
+	"github.com/google/trillian/cmd/internal/provider"
 )
 
 var (
@@ -69,12 +69,12 @@ var (
 	lockDir                  = flag.String("lock_file_path", "/test/multimaster", "etcd lock file directory path")
 	healthzTimeout           = flag.Duration("healthz_timeout", time.Second*5, "Timeout used during healthz checks")
 
-	quotaSystem         = flag.String("quota_system", "mysql", fmt.Sprintf("Quota system to use. One of: %v", quota.Providers()))
+	quotaSystem         = flag.String("quota_system", provider.DefaultQuotaSystem, fmt.Sprintf("Quota system to use. One of: %v", quota.Providers()))
 	quotaIncreaseFactor = flag.Float64("quota_increase_factor", log.QuotaIncreaseFactor,
 		"Increase factor for tokens replenished by sequencing-based quotas (1 means a 1:1 relationship between sequenced leaves and replenished tokens)."+
 			"Only effective for --quota_system=etcd.")
 
-	storageSystem = flag.String("storage_system", "mysql", fmt.Sprintf("Storage system to use. One of: %v", storage.Providers()))
+	storageSystem = flag.String("storage_system", provider.DefaultStorageSystem, fmt.Sprintf("Storage system to use. One of: %v", storage.Providers()))
 
 	preElectionPause   = flag.Duration("pre_election_pause", 1*time.Second, "Maximum time to wait before starting elections")
 	masterHoldInterval = flag.Duration("master_hold_interval", 60*time.Second, "Minimum interval to hold mastership for")


### PR DESCRIPTION
It no longer makes sense to hardcode "mysql" as the default value for `-quota_system` and `-storage_system`, because after https://github.com/google/trillian/pull/3664 it's now possible to omit MySQL support when building the log_server and log_signer.

For backwards compatibility "mysql" should remain the default when MySQL support is available, but otherwise an available storage system and an available (and if possible matching) quota system should be the default.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
