### PR TITLE
Use a PostgreSQL service container in the GitHub workflow

### DIFF
--- a/.github/workflows/test_pgdb.yaml
+++ b/.github/workflows/test_pgdb.yaml
@@ -32,6 +32,21 @@ jobs:
 
   integration-and-unit-tests:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --name pgsql
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -44,20 +59,6 @@ jobs:
     - name: Build before tests
       run: go mod download && go build ./...
     
-    - name: Run PostgreSQL
-      run: docker run --rm -d --name=pgsql -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:latest
-
-    - name: Wait for PostgreSQL
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
-      with:
-        timeout_seconds: 15
-        max_attempts: 3
-        retry_on: error
-        command: docker exec pgsql psql -U postgres -c "SELECT 1"
-
-    - name: Get PostgreSQL logs
-      run: docker logs pgsql 2>&1
-
     - name: Run integration tests
       run: ./integration/integration_test.sh
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add PostgreSQL quota manager and storage backend by @robstradling in https://github.com/google/trillian/pull/3644
 * PostgreSQL deployment example by @robstradling in https://github.com/google/trillian/pull/3675
 * PostgreSQL documentation / consistency fixes by @robstradling in https://github.com/google/trillian/pull/3676
+* Use a PostgreSQL service container in the GitHub workflow by @robstradling in https://github.com/google/trillian/pull/3680
 
 ### Misc
 


### PR DESCRIPTION
This seems like a cleaner approach to running PostgreSQL in a GitHub workflow.  (h/t @roger2hk).

As documented here: https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
