### PR TITLE
Correct hostname and 'root' user in PostgreSQL deployment example

### DIFF
--- a/examples/deployment/postgresql/docker-compose.yml
+++ b/examples/deployment/postgresql/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: [
       "--quota_system=postgresql",
       "--storage_system=postgresql",
-      "--postgresql_uri=postgresql:///defaultdb?host=localhost&user=test&password=zaphod",
+      "--postgresql_uri=postgresql:///defaultdb?host=postgresql&user=postgres",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--alsologtostderr",
@@ -39,7 +39,7 @@ services:
     command: [
       "--quota_system=postgresql",
       "--storage_system=postgresql",
-      "--postgresql_uri=postgresql:///defaultdb?host=localhost&user=test&password=zaphod",
+      "--postgresql_uri=postgresql:///defaultdb?host=postgresql&user=postgres",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--force_master",

--- a/examples/deployment/postgresql/docker-compose.yml
+++ b/examples/deployment/postgresql/docker-compose.yml
@@ -6,9 +6,6 @@ services:
       dockerfile: examples/deployment/docker/db_server/postgresql/Dockerfile
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
-      - POSTGRESQL_DATABASE=defaultdb
-      - POSTGRESQL_USER=test
-      - POSTGRESQL_PASSWORD=zaphod
     restart: always # keep the PostgreSQL server running
   trillian-log-server:
     build:

--- a/examples/deployment/postgresql/docker-compose.yml
+++ b/examples/deployment/postgresql/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: [
       "--quota_system=postgresql",
       "--storage_system=postgresql",
-      "--postgresql_uri=postgresql:///defaultdb?host=postgresql&user=postgres",
+      "--postgresql_uri=postgresql:///?host=postgresql&user=postgres",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--alsologtostderr",
@@ -39,7 +39,7 @@ services:
     command: [
       "--quota_system=postgresql",
       "--storage_system=postgresql",
-      "--postgresql_uri=postgresql:///defaultdb?host=postgresql&user=postgres",
+      "--postgresql_uri=postgresql:///?host=postgresql&user=postgres",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--force_master",


### PR DESCRIPTION
Updates the deployment example added in https://github.com/google/trillian/pull/3675 to help make the Cloud Build tests in https://github.com/google/certificate-transparency-go/pull/1618 succeed.

With this PR, everything starts up OK when I run `docker-compose -f examples/deployment/postgresql/docker-compose.yml up -d postgresql trillian-log-server trillian-log-signer` locally.  (Whereas previously the log-server container could not connect to postgres).

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
