### PR TITLE
chore: relax go directive to permit 1.22.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/google/trillian
 
-go 1.22.7
+go 1.22.0
+
+toolchain go1.22.10
 
 require (
 	bitbucket.org/creachadair/shell v0.0.8


### PR DESCRIPTION
Setting this to 1.22.7 requires all consumers to be building with the 1.22.7 or newer release of Go 1.22 and to update their own go.mod accordingly — this seems unnecessarily restrictive for a library module, particularly as the code itself doesn't currently use any modern language constructs and builds fine even with older Go versions.

Instead set the go directive to 1.22.0 and use the toolchain directive to recommend the latest 1.22.x when building locally.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
