### PR TITLE
Ignore ErrTxDone when closing transactions

### DIFF
--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -132,7 +132,10 @@ func (t *adminTX) Close() error {
 		return nil
 	}
 	t.closed = true
-	return t.tx.Rollback()
+	if err := t.tx.Rollback(); err != nil && err != sql.ErrTxDone {
+		return err
+	}
+	return nil
 }
 
 func (t *adminTX) GetTree(ctx context.Context, treeID int64) (*trillian.Tree, error) {


### PR DESCRIPTION
Transactions can be closed in indirect ways, such as the context being cancelled. The old code would log an error when then occurred, but the new code checks for the transaction already being closed and treats this as a success. Fixes #3734 and fixes #2998. Note that this doesn't change the behaviour except for the log output spam.
