### PR TITLE
Add metric tracking queued/skipped leaves

### DIFF
--- a/server/log_rpc_server.go
+++ b/server/log_rpc_server.go
@@ -118,6 +118,15 @@ func (t *TrillianLogRPCServer) QueueLeaf(ctx context.Context, req *trillian.Queu
 	if len(ret) != 1 {
 		return nil, status.Errorf(codes.Internal, "unexpected count of leaves %d", len(ret))
 	}
+
+	// Mirror the use of this counter in AddSequencedLeaves below.
+	label := strconv.FormatInt(req.LogId, 10)
+	if s := ret[0].Status; s == nil || s.Code == int32(codes.OK) {
+		t.leafCounter.Inc(label, "inserted")
+	} else {
+		t.leafCounter.Inc(label, "skipped")
+	}
+
 	return &trillian.QueueLeafResponse{QueuedLeaf: ret[0]}, nil
 }
 


### PR DESCRIPTION
This PR replicates the use of the `leafCounter` metric seen in `AddSequencedLeaves` into `QueueLeaves`.

This should enable operators insight into how many duplicate submission requests they're seeing.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
