### PR TITLE
Replace LOCK TABLE statements with data-modifying CTEs in the stored procedures used by the PostgreSQL storage backend

### DIFF
--- a/storage/postgresql/log_storage.go
+++ b/storage/postgresql/log_storage.go
@@ -49,8 +49,7 @@ const (
 		" ExtraData BYTEA," +
 		" MerkleLeafHash BYTEA," +
 		" QueueTimestampNanos BIGINT," +
-		" QueueID BYTEA," +
-		" IsDuplicate BOOLEAN DEFAULT FALSE" +
+		" QueueID BYTEA" +
 		") ON COMMIT DROP"
 	queueLeavesSQL = "SELECT * FROM queue_leaves()"
 
@@ -61,9 +60,7 @@ const (
 		" ExtraData BYTEA," +
 		" MerkleLeafHash BYTEA," +
 		" QueueTimestampNanos BIGINT," +
-		" SequenceNumber BIGINT," +
-		" IsDuplicateLeafData BOOLEAN DEFAULT FALSE," +
-		" IsDuplicateSequencedLeafData BOOLEAN DEFAULT FALSE" +
+		" SequenceNumber BIGINT" +
 		") ON COMMIT DROP"
 	addSequencedLeavesSQL = "SELECT * FROM add_sequenced_leaves()"
 


### PR DESCRIPTION
The `LOCK TABLE` statement pairs in the two PostgreSQL functions at https://github.com/google/trillian/blob/master/storage/postgresql/schema/storage.sql#L163 are intended to ensure that each function call is an atomic operation, which is necessary for the duplicates detection in both functions to be guaranteed to work correctly.  However, with our new logs that use the Trillian PostgreSQL storage backend, we've encountered a number of situations where database sessions seem to be deadlocking due to these `LOCK TABLE` statements.  This is presumably because two consecutive `LOCK TABLE` statements are not an atomic operation.

In search of a better solution, TIL about [data-modifying CTEs](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING).  The PR rewrites each of the two functions as a single SQL statement with data-modifying CTEs.  Since [each SQL statement is an atomic operation](https://dba.stackexchange.com/a/207477), this approach achieves the desired result without the same timing-related risk of locking other sessions.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
