### PR TITLE
Move dependabot to monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     go-deps:
       applies-to: version-updates
@@ -13,7 +13,7 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     github-actions-deps:
       applies-to: version-updates
@@ -30,7 +30,7 @@ updates:
     - /examples/deployment/kubernetes/mysql/image
     - /integration/cloudbuild/testbase
   schedule:
-    interval: weekly
+    interval: monthly
   ignore:
     - dependency-name: "mysql"
       versions: [">= 9.0"]
@@ -43,4 +43,4 @@ updates:
 - package-ecosystem: npm
   directory: /scripts/gcb2slack
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
Weekly is requiring a lot of human time to review and support non-standard upgrades (e.g. protobuf changes that require regen files). Moving to monthly to give us some more breathing space.
