### PR TITLE
Add an optimized QueueLeaves implementation for single-leaf batches in the PostgreSQL storage backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Storage
 
 * For PostgreSQL, explicitly create index on SequencedLeafData(TreeId, LeafIdentityHash) by @robstradling in https://github.com/google/trillian/pull/3695
+* Add an optimized QueueLeaves implementation for single-leaf batches in the PostgreSQL storage backend by @robstradling in https://github.com/google/trillian/pull/3769
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Storage
 
 * For PostgreSQL, explicitly create index on SequencedLeafData(TreeId, LeafIdentityHash) by @robstradling in https://github.com/google/trillian/pull/3695
+* Fix error checking for QueueLeaves and AddSequencedLeaves in the PostgreSQL storage backend by @robstradling in https://github.com/google/trillian/pull/3752
 * Add an optimized QueueLeaves implementation for single-leaf batches in the PostgreSQL storage backend by @robstradling in https://github.com/google/trillian/pull/3769
 
 ### Misc

--- a/storage/postgresql/log_storage.go
+++ b/storage/postgresql/log_storage.go
@@ -42,6 +42,15 @@ import (
 )
 
 const (
+	queueLeafSQL = "WITH insert_leaf AS (" +
+		"INSERT INTO LeafData (TreeId,LeafIdentityHash,LeafValue,ExtraData,QueueTimestampNanos) " +
+		"VALUES ($1,$2,$3,$4,$5) " +
+		"ON CONFLICT DO NOTHING " +
+		"RETURNING *" +
+		") " +
+		"INSERT INTO Unsequenced (TreeId,Bucket,LeafIdentityHash,MerkleLeafHash,QueueTimestampNanos,QueueID) " +
+		"SELECT TreeId,0,LeafIdentityHash,$6,QueueTimestampNanos,$7 " +
+		"FROM insert_leaf"
 	createTempQueueLeavesTable = "CREATE TEMP TABLE TempQueueLeaves (" +
 		" TreeId BIGINT," +
 		" LeafIdentityHash BYTEA," +
@@ -295,7 +304,14 @@ func (m *postgreSQLLogStorage) QueueLeaves(ctx context.Context, tree *trillian.T
 	if err != nil {
 		return nil, err
 	}
-	existing, err := tx.QueueLeaves(ctx, leaves, queueTimestamp)
+
+	// Queue leave(s), using a more efficient implementation when the batch size is 1.
+	var existing []*trillian.LogLeaf
+	if len(leaves) == 1 {
+		existing, err = tx.QueueLeaf(ctx, leaves[0], queueTimestamp)
+	} else {
+		existing, err = tx.QueueLeaves(ctx, leaves, queueTimestamp)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -387,6 +403,55 @@ func (t *logTreeTX) DequeueLeaves(ctx context.Context, limit int, cutoffTime tim
 	dequeuedCounter.Add(float64(len(leaves)), label)
 
 	return leaves, nil
+}
+
+func (t *logTreeTX) QueueLeaf(ctx context.Context, leaf *trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Prepare details to store, but don't accept leaf if invalid.
+	if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
+		return nil, fmt.Errorf("queued leaf must have a leaf ID hash of length %d", t.hashSizeBytes)
+	}
+	leaf.QueueTimestamp = timestamppb.New(queueTimestamp)
+	if err := leaf.QueueTimestamp.CheckValid(); err != nil {
+		return nil, fmt.Errorf("got invalid queue timestamp: %w", err)
+	}
+	qTimestamp := leaf.QueueTimestamp.AsTime()
+	args := queueArgs(t.treeID, leaf.LeafIdentityHash, qTimestamp)
+	label := labelForTX(t)
+
+	// Create the leaf data record and work queue entry, unless the leaf already exists.
+	existingLeaves := make([]*trillian.LogLeaf, 1)
+	result, err := t.tx.Exec(ctx, queueLeafSQL, t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, args[0], leaf.MerkleLeafHash, args[1])
+	if err != nil {
+		klog.Warningf("Failed to queue leaf: %s", err)
+		return nil, postgresqlToGRPC(err)
+	}
+	queuedCounter.Add(1, label)
+	if result.RowsAffected() > 0 {
+		// Leaf did not already exist.
+		return existingLeaves, nil
+	}
+
+	var toRetrieve [][]byte
+	toRetrieve = append(toRetrieve, leaf.LeafIdentityHash)
+	queuedDupCounter.Inc(label)
+	results, err := t.getLeafDataByIdentityHash(ctx, toRetrieve)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve existing leaf: %v", err)
+	}
+	if len(results) != len(toRetrieve) {
+		return nil, fmt.Errorf("failed to retrieve existing leaf: got %d, want %d", len(results), len(toRetrieve))
+	}
+	// Replace the requested leaf with the actual leaf.
+	if bytes.Equal(results[0].LeafIdentityHash, leaf.LeafIdentityHash) {
+		existingLeaves[0] = results[0]
+	} else {
+		return nil, fmt.Errorf("failed to find existing leaf for hash %x", leaf.LeafIdentityHash)
+	}
+
+	return existingLeaves, nil
 }
 
 func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf, queueTimestamp time.Time) ([]*trillian.LogLeaf, error) {

--- a/storage/postgresql/log_storage_test.go
+++ b/storage/postgresql/log_storage_test.go
@@ -137,6 +137,7 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 	leaves2 := createTestLeaves(int64(count), 12)
 	leaves3 := createTestLeaves(3, 100)
 	leaves4 := createTestLeaves(3, 105)
+	leaves5 := createTestLeaves(1, 110)
 
 	// Note that tests accumulate queued leaves on top of each other.
 	tests := []struct {
@@ -164,6 +165,18 @@ func TestQueueDuplicateLeaf(t *testing.T) {
 			desc:   "[100, 100, 106, 101, 107]",
 			leaves: []*trillian.LogLeaf{leaves3[0], leaves3[0], leaves4[1], leaves3[1], leaves4[2]},
 			want:   []*trillian.LogLeaf{leaves3[0], leaves3[0], leaves4[1], leaves3[1], leaves4[2]},
+		},
+		{
+			// single leaf (dup)
+			desc:   "[100]",
+			leaves: []*trillian.LogLeaf{leaves3[0]},
+			want:   []*trillian.LogLeaf{leaves3[0]},
+		},
+		{
+			// single leaf (new)
+			desc:   "[110]",
+			leaves: []*trillian.LogLeaf{leaves5[0]},
+			want:   []*trillian.LogLeaf{leaves5[0]},
 		},
 	}
 


### PR DESCRIPTION
The current QueueLeaves implementation for PostgreSQL is optimised for sequencing large batches, but the approach it takes (temporary tables, and table locks to prevent concurrent operations on the LeafData and Unsequenced tables) imposes overheads that make it perform fairly poorly when sequencing small batches.  We've found that this is a pain point for our PostgreSQL-based Tiger and Elephant CT log shards that are now seeing a significant rate of submissions.

AIUI, Trillian's CT persona only ever calls QueueLeaves for batches containing a single-leaf.  i.e., one QueueLeaves operation per add-chain or add-pre-chain request.

This PR incorporates an alternative "QueueLeaf" implementation for PostgreSQL that's used for and optimised for single-leaf batches.  We deployed this to our Tiger and Elephant log shards about a week ago, and the results have been very promising.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
