### PR TITLE
Improve PostgreSQL functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Storage
 
 * For PostgreSQL, explicitly create index on SequencedLeafData(TreeId, LeafIdentityHash) by @robstradling in https://github.com/google/trillian/pull/3695
+* Improve PostgreSQL functions by @robstradling in https://github.com/google/trillian/pull/3770
 
 ### Misc
 

--- a/storage/postgresql/schema/storage.sql
+++ b/storage/postgresql/schema/storage.sql
@@ -170,8 +170,7 @@ CREATE OR REPLACE FUNCTION queue_leaves(
 ) RETURNS SETOF bytea
 LANGUAGE plpgsql AS $$
 BEGIN
-  LOCK TABLE LeafData IN SHARE ROW EXCLUSIVE MODE;
-  LOCK TABLE Unsequenced IN SHARE ROW EXCLUSIVE MODE;
+  LOCK TABLE LeafData, Unsequenced IN SHARE ROW EXCLUSIVE MODE;
   UPDATE TempQueueLeaves t
     SET IsDuplicate = TRUE
     FROM LeafData l
@@ -196,8 +195,7 @@ CREATE OR REPLACE FUNCTION add_sequenced_leaves(
 ) RETURNS TABLE(leaf_identity_hash bytea, is_duplicate_leaf_data boolean, is_duplicate_sequenced_leaf_data boolean)
 LANGUAGE plpgsql AS $$
 BEGIN
-  LOCK TABLE LeafData IN SHARE ROW EXCLUSIVE MODE;
-  LOCK TABLE SequencedLeafData IN SHARE ROW EXCLUSIVE MODE;
+  LOCK TABLE LeafData, SequencedLeafData IN SHARE ROW EXCLUSIVE MODE;
   UPDATE TempAddSequencedLeaves t
     SET IsDuplicateLeafData = TRUE
     FROM LeafData l

--- a/storage/postgresql/schema/storage.sql
+++ b/storage/postgresql/schema/storage.sql
@@ -187,7 +187,6 @@ BEGIN
   RETURN QUERY SELECT DISTINCT LeafIdentityHash
     FROM TempQueueLeaves
     WHERE IsDuplicate;
-  RETURN;
 END;
 $$;
 
@@ -218,6 +217,5 @@ BEGIN
         AND NOT IsDuplicateSequencedLeafData;
   RETURN QUERY SELECT LeafIdentityHash, IsDuplicateLeafData, IsDuplicateSequencedLeafData
     FROM TempAddSequencedLeaves;
-  RETURN;
 END;
 $$;


### PR DESCRIPTION
In our CT logs that use the PostgreSQL quota manager, we've found that in practice `ANALYZE (SKIP_LOCKED TRUE)` in the count_estimate() function gets skipped a lot of the time.  Removing `(SKIP_LOCKED TRUE)` hurts performance, because it first has to wait for a lock and then it holds that lock until the `ANALYZE` operation completes.  For tables with a relatively small number of rows, it's actually a lot quicker to do a simple `SELECT count(1)` query (whereas for large tables, `SELECT count(1)` is very slow).  This PR implements a hybrid approach that avoids running `ANALYZE` when there are <1000 rows and avoids running `SELECT count(1)` for >1000 rows.  We've deployed this to our Elephant and Tiger CT logs, and it's definitely improved performance.

This PR also implements a couple of minor editorial changes to the queue_leaves() and add_sequenced_leaves() functions.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
