### PR TITLE
Trust dependabot prs

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -16,4 +16,4 @@ annotations:
   - type: comment
     text: "/gcbrun"
 trustedContributors:
-  - dependabot
+  - dependabot[bot]

--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+annotations:
+  - type: comment
+    text: "/gcbrun"
+trustedContributors:
+  - dependabot
+

--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -17,4 +17,3 @@ annotations:
     text: "/gcbrun"
 trustedContributors:
   - dependabot
-


### PR DESCRIPTION
cargo culting from https://github.com/GoogleCloudPlatform/anthos-samples/pull/573/files.  I haven't seen any examples that use dependabot as Google repos seem to prefer renovatebot. I found https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution which suggests the GitHub username should work.

