### PR TITLE
PostgreSQL is now in beta mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Storage
 
 * For PostgreSQL, explicitly create index on SequencedLeafData(TreeId, LeafIdentityHash) by @robstradling in https://github.com/google/trillian/pull/3695
+* PostgreSQL is now in beta mode by @robstradling in https://github.com/google/trillian/pull/3772
 
 ### Misc
 

--- a/docs/Feature_Implementation_Matrix.md
+++ b/docs/Feature_Implementation_Matrix.md
@@ -64,7 +64,7 @@ The Log storage implementations supporting the original Trillian log.
 | CloudSpanner    | Beta     |                     | Google maintains continuous-integration environment based on CloudSpanner.  |
 | MySQL            | GA      | ✓                   |                                                                             |
 | CockroachDB      | Alpha   |                     | Supported by [Equinix Metal](https://deploy.equinix.com/).                  |
-| PostgreSQL       | Alpha   |                     | Supported by [Rob Stradling](https://github.com/robstradling) at [Sectigo](https://github.com/sectigo). |
+| PostgreSQL       | Beta    |                     | Supported by [Rob Stradling](https://github.com/robstradling) at [Sectigo](https://github.com/sectigo). |
 
 ##### Spanner
 This is a Google-internal implementation, and is used by all of Google's current Trillian deployments.
@@ -92,9 +92,9 @@ It's currently in alpha mode and is not yet in production use.
 
 ##### PostgreSQL
 
-This implementation has been tested with PostgreSQL 17.0.
+This implementation has been tested with PostgreSQL 17.0 and 13.20.
 
-It's currently in alpha mode and is not yet in production use.
+It's currently in beta mode, and is used by some of Sectigo's current Trillian deployments.
 
 ### Monitoring
 
@@ -126,7 +126,7 @@ Supported frameworks for quota management.
 | MySQL           | Beta    | ?                   |                                                                             |
 | Redis           | Alpha   | ✓                   |                                                                             |
 | CockroachDB     | Alpha   |                     | Supported by [Equinix Metal](https://deploy.equinix.com/).                  |
-| PostgreSQL      | Alpha   |                     | Supported by [Rob Stradling](https://github.com/robstradling) at [Sectigo](https://github.com/sectigo). |
+| PostgreSQL      | Beta    |                     | Supported by [Rob Stradling](https://github.com/robstradling) at [Sectigo](https://github.com/sectigo). |
 
 ### Key management
 

--- a/storage/README.md
+++ b/storage/README.md
@@ -5,7 +5,7 @@
 The interface, various concrete implementations, and any associated components
 live here. Interfaces and types are defined at the top level package.
 
-Currently, there are two usable storage implementation for logs:
+Currently, there are three usable storage implementation for logs:
    * MySQL/MariaDB in the [mysql/](mysql) package.
    * Cloud Spanner in the [cloudspanner](cloudspanner) package.
    * PostgreSQL in the [postgresql/](postgresql) package (in beta mode).

--- a/storage/README.md
+++ b/storage/README.md
@@ -8,6 +8,7 @@ live here. Interfaces and types are defined at the top level package.
 Currently, there are two usable storage implementation for logs:
    * MySQL/MariaDB in the [mysql/](mysql) package.
    * Cloud Spanner in the [cloudspanner](cloudspanner) package.
+   * PostgreSQL in the [postgresql/](postgresql) package (in beta mode).
 
 The MySQL / MariaDB implementation includes support for Maps. This has not yet
 been implemented by Cloud Spanner. There may be other storage implementations
@@ -15,7 +16,6 @@ available from third parties.
 
 These implementations are in alpha mode and are not yet ready to be used by
 real applications:
-   * PostgreSQL in the [postgresql/](postgresql) package.
    * CockroachDB in the [crdb/](crdb) package.
 
 These implementations are for test purposes only and should not be used by real


### PR DESCRIPTION
The PostgreSQL storage and quota backends have now seen some real-world usage in Sectigo's new Elephant and Tiger CT logs.  Some teething troubles were encountered (see in particular PRs #3769 and #3770), but after resolving those issues the new logs seem to be operating well.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
