### PR TITLE
Re-introduce etcd `NewFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # TRILLIAN Changelog
 
+### Election system
+* Reintroduce an exported ectd `NewFactory` function.
+
 ## HEAD
 
 ## v1.7.2

--- a/util/election2/etcd/election.go
+++ b/util/election2/etcd/election.go
@@ -132,6 +132,16 @@ type Factory struct {
 	lockDir    string
 }
 
+// NewFactory builds an election factory that uses the given parameters. The
+// passed in etcd client should remain valid for the lifetime of the object.
+func NewFactory(instanceID string, client *clientv3.Client, lockDir string) *Factory {
+	return &Factory{
+		client:     client,
+		instanceID: instanceID,
+		lockDir:    lockDir,
+	}
+}
+
 // NewElection creates a specific Election instance.
 func (f *Factory) NewElection(ctx context.Context, resourceID string) (election2.Election, error) {
 	// TODO(pavelkalinnikov): Re-create the session if it expires.


### PR DESCRIPTION
Re-introduce a `NewFactory` method which was deleted in #3721. Migrillian uses this, and since it's gone Trillian can't be updated anymore: https://github.com/google/certificate-transparency-go/pull/1693.

### Checklist
- [X] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
