### PR TITLE
Enable TLS support for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Bump golangci-lint to v2.1.6
 * Fix leader resignation during a graceful shutdown by @osmman in https://github.com/google/trillian/pull/3790
 * Add optional gRPC message size limit via `--max_msg_size_bytes` flag by @fghanmi in https://github.com/google/trillian/pull/3801
+* Add TLS support for PostgreSQL: https://github.com/google/trillian/pull/3831
+  * `--postgresql_tls_ca`: users can provide a CA certificate, that is used to establish a secure communication with PostgreSQL server. 
+  * `--postgresql_verify_full`: users can enable full TLS verification for PostgreSQL (sslmode=verify-full). If false, only sslmode=verify-ca is used.
 
 ## v1.7.2
 

--- a/storage/postgresql/provider_test.go
+++ b/storage/postgresql/provider_test.go
@@ -16,6 +16,10 @@ package postgresql
 
 import (
 	"flag"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/trillian/storage"
@@ -42,5 +46,107 @@ func TestPostgreSQLStorageProviderErrorPersistence(t *testing.T) {
 
 	if err2 != err1 {
 		t.Fatalf("Expected second call to 'storage.NewProvider' to fail with %q, instead got: %q", err1, err2)
+	}
+}
+
+func TestBuildPostgresTLSURINoTLS(t *testing.T) {
+	defer flagsaver.Save().MustRestore()
+	originalURI := "postgresql:///defaultdb?host=localhost&user=test"
+	if err := flag.Set("postgresql_tls_ca", ""); err != nil {
+		t.Fatalf("Failed to set flag: %v", err)
+	}
+
+	modified, err := BuildPostgresTLSURI(originalURI)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if modified != originalURI {
+		t.Errorf("Expected unmodified URI %q, got %q", originalURI, modified)
+	}
+}
+
+func TestBuildPostgresTLSURIMissingCAFile(t *testing.T) {
+	defer flagsaver.Save().MustRestore()
+
+	if err := flag.Set("postgresql_tls_ca", "/path/does/not/exist.crt"); err != nil {
+		t.Fatalf("Failed to set flag: %v", err)
+	}
+
+	_, err := BuildPostgresTLSURI("postgresql:///defaultdb")
+	if err == nil {
+		t.Fatalf("Expected error due to missing CA file, got nil")
+	}
+	if !strings.Contains(err.Error(), "CA file error") {
+		t.Fatalf("Expected CA file error, got: %v", err)
+	}
+}
+
+func TestBuildPostgresTLSURIVerifyCA(t *testing.T) {
+	defer flagsaver.Save().MustRestore()
+
+	tmp := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(tmp, []byte("test_ca_cert_content"), 0400); err != nil {
+		t.Fatalf("Failed to write CA file: %v", err)
+	}
+
+	if err := flag.Set("postgresql_tls_ca", tmp); err != nil {
+		t.Fatalf("Failed to set CA flag: %v", err)
+	}
+	if err := flag.Set("postgresql_verify_full", "false"); err != nil {
+		t.Fatalf("Failed to set verify flag: %v", err)
+	}
+
+	original := "postgresql:///defaultdb?host=localhost&user=test"
+	modified, err := BuildPostgresTLSURI(original)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(modified)
+	if err != nil {
+		t.Fatalf("Failed to parse modified URI: %v", err)
+	}
+	q := u.Query()
+
+	if q.Get("sslrootcert") != tmp {
+		t.Errorf("Expected sslrootcert=%q, got %q", tmp, q.Get("sslrootcert"))
+	}
+	if q.Get("sslmode") != "verify-ca" {
+		t.Errorf("Expected sslmode=verify-ca, got %q", q.Get("sslmode"))
+	}
+}
+
+func TestBuildPostgresTLSURIVerifyFull(t *testing.T) {
+	defer flagsaver.Save().MustRestore()
+
+	tmp := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(tmp, []byte("test_ca_cert_content"), 0400); err != nil {
+		t.Fatalf("Failed to write CA file: %v", err)
+	}
+
+	if err := flag.Set("postgresql_tls_ca", tmp); err != nil {
+		t.Fatalf("Failed to set CA flag: %v", err)
+	}
+	if err := flag.Set("postgresql_verify_full", "true"); err != nil {
+		t.Fatalf("Failed to set verify_full flag: %v", err)
+	}
+
+	original := "postgresql:///defaultdb?host=localhost&user=test"
+	modified, err := BuildPostgresTLSURI(original)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(modified)
+	if err != nil {
+		t.Fatalf("Failed to parse modified URI: %v", err)
+	}
+	q := u.Query()
+
+	if q.Get("sslrootcert") != tmp {
+		t.Errorf("Expected sslrootcert=%q, got %q", tmp, q.Get("sslrootcert"))
+	}
+	if q.Get("sslmode") != "verify-full" {
+		t.Errorf("Expected sslmode=verify-full, got %q", q.Get("sslmode"))
 	}
 }


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
This PR adds TLS support for PostgreSQL connections in the Trillian server/signer. The key changes include:
Added new flags:

- `postgresql_tls_ca`: Path to the CA certificate file for PostgreSQL TLS connection.
- `postgresql_verify_full`: Enable full TLS verification for PostgreSQL (sslmode=verify-full). If false, only sslmode=verify-ca is used.

_If no TLS configuration is provided, the connection defaults to non-TLS, ensuring backward compatibility._



Tracking issue: https://github.com/google/trillian/issues/3830
### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
