### PR TITLE
fix: swap ed25519 to standard lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Replace deprecated `golang.org/x/crypto/ed25519` with stdlib `crypto/ed25519` by @JasonPowr
+
 ## v1.7.3
 
 * Recommended go version for development: 1.25

--- a/crypto/keys/der/der.go
+++ b/crypto/keys/der/der.go
@@ -23,8 +23,9 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"crypto/ed25519"
+
 	"github.com/google/trillian/crypto/keyspb"
-	"golang.org/x/crypto/ed25519"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/crypto/keys/testonly/keys.go
+++ b/crypto/keys/testonly/keys.go
@@ -20,6 +20,7 @@ package testonly
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -29,8 +30,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // MustMarshalPublicPEMToDER reads a PEM-encoded public key and returns it in DER encoding.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	go.etcd.io/etcd/server/v3 v3.6.11
 	go.etcd.io/etcd/v3 v3.6.11
 	go.opencensus.io v0.24.0
-	golang.org/x/crypto v0.49.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/tools v0.43.0
@@ -196,6 +195,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect


### PR DESCRIPTION
Replace deprecated golang.org/x/crypto/ed25519 with stdlib crypto/ed25519

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
