### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/client/backoff/backoff.go
+++ b/client/backoff/backoff.go
@@ -34,7 +34,7 @@ func (re RetriableError) Error() string {
 }
 
 // RetriableErrorf wraps a formatted string into a RetriableError.
-func RetriableErrorf(format string, a ...interface{}) error {
+func RetriableErrorf(format string, a ...any) error {
 	return RetriableError(fmt.Sprintf(format, a...))
 }
 

--- a/integration/storagetest/logtests.go
+++ b/integration/storagetest/logtests.go
@@ -51,7 +51,7 @@ func RunLogStorageTests(t *testing.T, storageFactory LogStorageFactory) {
 	}
 }
 
-func logTestFunctions(t *testing.T, x interface{}) map[string]LogStorageTest {
+func logTestFunctions(t *testing.T, x any) map[string]LogStorageTest {
 	tests := make(map[string]LogStorageTest)
 	xv := reflect.ValueOf(x)
 	for _, name := range testFunctions(x) {

--- a/integration/storagetest/testrunner.go
+++ b/integration/storagetest/testrunner.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-func testFunctions(x interface{}) []string {
+func testFunctions(x any) []string {
 	const prefix = "Test"
 	xt := reflect.TypeOf(x)
 	tests := []string{}

--- a/log/operation_manager_test.go
+++ b/log/operation_manager_test.go
@@ -74,7 +74,7 @@ type logOpInfoMatcher struct {
 	BatchSize int
 }
 
-func (l logOpInfoMatcher) Matches(x interface{}) bool {
+func (l logOpInfoMatcher) Matches(x any) bool {
 	o, ok := x.(*OperationInfo)
 	if !ok {
 		return false

--- a/log/sequencer_manager_test.go
+++ b/log/sequencer_manager_test.go
@@ -190,9 +190,9 @@ func TestSequencerManagerSingleLogOneLeaf(t *testing.T) {
 
 // cmpMatcher is a custom gomock.Matcher that uses cmp.Equal combined with a
 // cmp.Comparer that knows how to properly compare proto.Message types.
-type cmpMatcher struct{ want interface{} }
+type cmpMatcher struct{ want any }
 
-func (m cmpMatcher) Matches(got interface{}) bool {
+func (m cmpMatcher) Matches(got any) bool {
 	return cmp.Equal(got, m.want, cmp.Comparer(proto.Equal))
 }
 

--- a/monitoring/rpc_stats_interceptor.go
+++ b/monitoring/rpc_stats_interceptor.go
@@ -68,7 +68,7 @@ func (r *RPCStatsInterceptor) recordFailureLatency(labels []string, startTime ti
 // Interceptor returns a UnaryServerInterceptor that can be registered with an RPC server and
 // will record request counts / errors and latencies for that servers handlers
 func (r *RPCStatsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		labels := []string{info.FullMethod}
 
 		// This interceptor wraps the request handler so we should track the

--- a/monitoring/rpc_stats_interceptor_test.go
+++ b/monitoring/rpc_stats_interceptor_test.go
@@ -32,14 +32,14 @@ var fakeTime = time.Date(2016, 10, 3, 12, 38, 27, 36, time.UTC)
 type recordingUnaryHandler struct {
 	// ctx and req are recorded on invocation
 	ctx context.Context
-	req interface{}
+	req any
 	// rsp and err are returned on invocation
-	rsp interface{}
+	rsp any
 	err error
 }
 
 func (r recordingUnaryHandler) handler() grpc.UnaryHandler {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		r.ctx = ctx
 		r.req = req
 		return r.rsp, r.err

--- a/quota/etcd/quotaapi/quota_server_test.go
+++ b/quota/etcd/quotaapi/quota_server_test.go
@@ -155,7 +155,7 @@ func TestServer_CreateConfig(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	rpc := func(ctx context.Context, req interface{}) (*quotapb.Config, error) {
+	rpc := func(ctx context.Context, req any) (*quotapb.Config, error) {
 		return quotaClient.CreateConfig(ctx, req.(*quotapb.CreateConfigRequest))
 	}
 	for _, test := range tests {
@@ -306,7 +306,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	rpc := func(ctx context.Context, req interface{}) (*quotapb.Config, error) {
+	rpc := func(ctx context.Context, req any) (*quotapb.Config, error) {
 		return quotaClient.UpdateConfig(ctx, req.(*quotapb.UpdateConfigRequest))
 	}
 	for _, test := range tests {
@@ -462,7 +462,7 @@ type upsertRequest interface {
 	GetName() string
 }
 
-type upsertRPC func(ctx context.Context, req interface{}) (*quotapb.Config, error)
+type upsertRPC func(ctx context.Context, req any) (*quotapb.Config, error)
 
 // runUpsertTest runs either CreateConfig or UpdateConfig tests, depending on the supplied rpc.
 // Storage is reset() before the test is executed.

--- a/quota/redis/redistb/redistb.go
+++ b/quota/redis/redistb/redistb.go
@@ -29,8 +29,8 @@ import (
 // implementations (e.g. regular Redis, Redis Cluster, sharded, etc.)
 type RedisClient interface {
 	// Required to load and execute scripts
-	Eval(script string, keys []string, args ...interface{}) *redis.Cmd
-	EvalSha(sha1 string, keys []string, args ...interface{}) *redis.Cmd
+	Eval(script string, keys []string, args ...any) *redis.Cmd
+	EvalSha(sha1 string, keys []string, args ...any) *redis.Cmd
 	ScriptExists(hashes ...string) *redis.BoolSliceCmd
 	ScriptLoad(script string) *redis.StringCmd
 }
@@ -101,7 +101,7 @@ func (tb *TokenBucket) Call(
 		now, nowUs = timeToRedisPair(tb.timeSource.Now())
 	}
 
-	args := []interface{}{
+	args := []any{
 		replenishRate,
 		capacity,
 		numTokens,
@@ -124,9 +124,9 @@ func (tb *TokenBucket) Call(
 		return false, 0, err
 	}
 
-	returnVals, ok := result.([]interface{})
+	returnVals, ok := result.([]any)
 	if !ok {
-		return false, 0, fmt.Errorf("redistb: invalid return type %T (expected []interface{})", result)
+		return false, 0, fmt.Errorf("redistb: invalid return type %T (expected []any)", result)
 	}
 
 	// The script returns:

--- a/quota/redis/redistb/redistb_test.go
+++ b/quota/redis/redistb/redistb_test.go
@@ -827,9 +827,9 @@ func deserializeRedisResults(t *testing.T, resp *redis.Cmd) (bool, int64, int64,
 	}
 
 	// Deserialize results
-	returnVals, ok := results.([]interface{})
+	returnVals, ok := results.([]any)
 	if !ok {
-		t.Fatalf("invalid return type %T (expected []interface{})", results)
+		t.Fatalf("invalid return type %T (expected []any)", results)
 	}
 
 	var allowed bool

--- a/server/interceptor/interceptor.go
+++ b/server/interceptor/interceptor.go
@@ -69,12 +69,12 @@ type RequestProcessor interface {
 	// Before implements all interceptor logic that happens before the handler is called.
 	// It returns a (potentially) modified context that's passed forward to the handler (and After),
 	// plus an error, in case the request should be interrupted before the handler is invoked.
-	Before(ctx context.Context, req interface{}, method string) (context.Context, error)
+	Before(ctx context.Context, req any, method string) (context.Context, error)
 
 	// After implements all interceptor logic that happens after the handler is invoked.
 	// Before must be invoked prior to After and the same RequestProcessor instance must to be used
 	// to process a given request.
-	After(ctx context.Context, resp interface{}, method string, handlerErr error)
+	After(ctx context.Context, resp any, method string, handlerErr error)
 }
 
 // TrillianInterceptor checks that:
@@ -124,7 +124,7 @@ func incRequestDeniedCounter(reason string, treeID int64, quotaUser string) {
 }
 
 // UnaryInterceptor executes the TrillianInterceptor logic for unary RPCs.
-func (i *TrillianInterceptor) UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func (i *TrillianInterceptor) UnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	// Implement UnaryInterceptor using a RequestProcessor, so we
 	// 1. exercise it
 	// 2. make it easier to port this logic to non-gRPC implementations.
@@ -150,7 +150,7 @@ type trillianProcessor struct {
 	info   *rpcInfo
 }
 
-func (tp *trillianProcessor) Before(ctx context.Context, req interface{}, method string) (context.Context, error) {
+func (tp *trillianProcessor) Before(ctx context.Context, req any, method string) (context.Context, error) {
 	// Skip if the interceptor is not enabled for this service.
 	if !enabledServices[serviceName(method)] {
 		return ctx, nil
@@ -203,7 +203,7 @@ func (tp *trillianProcessor) Before(ctx context.Context, req interface{}, method
 	return ctx, nil
 }
 
-func (tp *trillianProcessor) After(ctx context.Context, resp interface{}, method string, handlerErr error) {
+func (tp *trillianProcessor) After(ctx context.Context, resp any, method string, handlerErr error) {
 	if !enabledServices[serviceName(method)] {
 		return
 	}
@@ -319,7 +319,7 @@ type chargable interface {
 }
 
 // chargedUsers returns user identifiers for any chargable user quotas.
-func chargedUsers(req interface{}) []string {
+func chargedUsers(req any) []string {
 	c, ok := req.(chargable)
 	if !ok {
 		return nil
@@ -332,7 +332,7 @@ func chargedUsers(req interface{}) []string {
 	return chargeTo.User
 }
 
-func newRPCInfoForRequest(req interface{}) (*rpcInfo, error) {
+func newRPCInfoForRequest(req any) (*rpcInfo, error) {
 	// Set "safe" defaults: enable all interception and assume requests are readonly.
 	info := &rpcInfo{
 		getTree:   true,
@@ -413,7 +413,7 @@ func newRPCInfoForRequest(req interface{}) (*rpcInfo, error) {
 	return info, nil
 }
 
-func newRPCInfo(req interface{}) (*rpcInfo, error) {
+func newRPCInfo(req any) (*rpcInfo, error) {
 	info, err := newRPCInfoForRequest(req)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ type treeRequest interface {
 }
 
 // ErrorWrapper is a grpc.UnaryServerInterceptor that wraps the errors emitted by the underlying handler.
-func ErrorWrapper(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func ErrorWrapper(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	ctx, spanEnd := spanFor(ctx, "ErrorWrapper")
 	defer spanEnd()
 	rsp, err := handler(ctx, req)

--- a/server/interceptor/interceptor_test.go
+++ b/server/interceptor/interceptor_test.go
@@ -71,7 +71,7 @@ func TestTrillianInterceptor_TreeInterception(t *testing.T) {
 	tests := []struct {
 		desc       string
 		method     string
-		req        interface{}
+		req        any
 		handlerErr error
 		wantErr    bool
 		wantTree   *trillian.Tree
@@ -196,7 +196,7 @@ func TestTrillianInterceptor_QuotaInterception(t *testing.T) {
 		desc         string
 		dryRun       bool
 		method       string
-		req          interface{}
+		req          any
 		specs        []quota.Spec
 		getTokensErr error
 		wantCode     codes.Code
@@ -371,7 +371,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 	tests := []struct {
 		desc                         string
 		method                       string
-		req, resp                    interface{}
+		req, resp                    any
 		specs                        []quota.Spec
 		handlerErr                   error
 		wantGetTokens, wantPutTokens int
@@ -485,7 +485,7 @@ func TestTrillianInterceptor_QuotaInterception_ReturnsTokens(t *testing.T) {
 func TestTrillianInterceptor_NotIntercepted(t *testing.T) {
 	tests := []struct {
 		method string
-		req    interface{}
+		req    any
 	}{
 		// Admin
 		{method: "/trillian.TrillianAdmin/CreateTree", req: &trillian.CreateTreeRequest{}},
@@ -524,7 +524,7 @@ func TestTrillianInterceptor_BeforeAfter(t *testing.T) {
 
 	tests := []struct {
 		desc          string
-		req, resp     interface{}
+		req, resp     any
 		handlerErr    error
 		wantBeforeErr bool
 	}{
@@ -690,7 +690,7 @@ func TestErrorWrapper(t *testing.T) {
 	badLlamaErr := status.Errorf(codes.InvalidArgument, "Bad Llama")
 	tests := []struct {
 		desc         string
-		resp         interface{}
+		resp         any
 		err, wantErr error
 	}{
 		{
@@ -724,14 +724,14 @@ func equalError(x, y error) bool {
 
 type fakeHandler struct {
 	called bool
-	resp   interface{}
+	resp   any
 	err    error
 	// Attributes recorded by run calls
 	ctx context.Context
-	req interface{}
+	req any
 }
 
-func (f *fakeHandler) run(ctx context.Context, req interface{}) (interface{}, error) {
+func (f *fakeHandler) run(ctx context.Context, req any) (any, error) {
 	if f.called {
 		panic("handler already called; either create a new handler or set called to false before reusing")
 	}
@@ -742,13 +742,13 @@ func (f *fakeHandler) run(ctx context.Context, req interface{}) (interface{}, er
 }
 
 type fakeInterceptor struct {
-	key    interface{}
-	val    interface{}
+	key    any
+	val    any
 	called bool
 	err    error
 }
 
-func (f *fakeInterceptor) run(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func (f *fakeInterceptor) run(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	if f.called {
 		panic("interceptor already called; either create a new interceptor or set called to false before reusing")
 	}

--- a/server/log_rpc_server_test.go
+++ b/server/log_rpc_server_test.go
@@ -45,9 +45,9 @@ import (
 
 // cmpMatcher is a custom gomock.Matcher that uses cmp.Equal combined with a
 // cmp.Comparer that knows how to properly compare proto.Message types.
-type cmpMatcher struct{ want interface{} }
+type cmpMatcher struct{ want any }
 
-func (m cmpMatcher) Matches(got interface{}) bool {
+func (m cmpMatcher) Matches(got any) bool {
 	return cmp.Equal(got, m.want, cmp.Comparer(proto.Equal))
 }
 

--- a/storage/cloudspanner/admin.go
+++ b/storage/cloudspanner/admin.go
@@ -292,7 +292,7 @@ func (t *adminTX) CreateTree(ctx context.Context, tree *trillian.Tree) (*trillia
 			"TreeInfo",
 			"Deleted",
 		},
-		[]interface{}{
+		[]any{
 			info.TreeId,
 			int64(info.TreeState),
 			int64(info.TreeType),
@@ -436,7 +436,7 @@ func (t *adminTX) updateTreeInfo(ctx context.Context, info *spannerpb.TreeInfo) 
 			"Deleted",
 			"DeleteTimeMillis",
 		},
-		[]interface{}{
+		[]any{
 			info.TreeId,
 			int64(info.TreeState),
 			int64(info.TreeType),

--- a/storage/cloudspanner/log_storage.go
+++ b/storage/cloudspanner/log_storage.go
@@ -513,7 +513,7 @@ func (tx *logTX) StoreSignedLogRoot(ctx context.Context, root *trillian.SignedLo
 			"TreeRevision",
 			"TreeMetadata",
 		},
-		[]interface{}{
+		[]any{
 			int64(tx.treeID),
 			int64(logRoot.TimestampNanos),
 			int64(logRoot.TreeSize),

--- a/storage/cloudspanner/tree_storage.go
+++ b/storage/cloudspanner/tree_storage.go
@@ -237,7 +237,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, sts []*storagepb.SubtreeProt
 		m := spanner.Insert(
 			subtreeTbl,
 			[]string{colTreeID, colSubtreeID, colRevision, colSubtree},
-			[]interface{}{t.treeID, st.Prefix, t._writeRev, stBytes},
+			[]any{t.treeID, st.Prefix, t._writeRev, stBytes},
 		)
 		if err := stx.BufferWrite([]*spanner.Mutation{m}); err != nil {
 			return err

--- a/storage/crdb/common_test.go
+++ b/storage/crdb/common_test.go
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 	status := m.Run()
 
 	// Clean up databases
-	testDBs.Range(func(key, value interface{}) bool {
+	testDBs.Range(func(key, value any) bool {
 		testName := key.(string)
 		klog.Infof("Cleaning up database for test %s", testName)
 

--- a/storage/crdb/log_storage.go
+++ b/storage/crdb/log_storage.go
@@ -478,7 +478,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		}
 
 		// Create the work queue entry
-		args := []interface{}{
+		args := []any{
 			t.treeID,
 			leaf.LeafIdentityHash,
 			leaf.MerkleLeafHash,
@@ -661,7 +661,7 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 	}
 	// TODO(pavelkalinnikov): Further clip `count` to a safe upper bound like 64k.
 
-	args := []interface{}{start, start + count, t.treeID}
+	args := []any{start, start + count, t.treeID}
 	rows, err := t.tx.QueryContext(ctx, selectLeavesByRangeSQL, args...)
 	if err != nil {
 		klog.Warningf("Failed to get leaves by range: %s", err)
@@ -808,7 +808,7 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		}
 	}()
 
-	var args []interface{}
+	var args []any
 	for _, hash := range leafHashes {
 		args = append(args, []byte(hash))
 	}

--- a/storage/crdb/queue.go
+++ b/storage/crdb/queue.go
@@ -74,8 +74,8 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 	return leaf, dequeueInfo(leafIDHash, queueTimestamp), nil
 }
 
-func queueArgs(_ int64, _ []byte, queueTimestamp time.Time) []interface{} {
-	return []interface{}{queueTimestamp.UnixNano()}
+func queueArgs(_ int64, _ []byte, queueTimestamp time.Time) []any {
+	return []any{queueTimestamp.UnixNano()}
 }
 
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {

--- a/storage/crdb/sql.go
+++ b/storage/crdb/sql.go
@@ -43,7 +43,7 @@ func setNullStringIfValid(src sql.NullString, dest *string) {
 
 // row defines a common interface between sql.Row and sql.Rows(!)
 type row interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }
 
 // ReadTree takes a sql row and returns a tree

--- a/storage/crdb/sqladminstorage.go
+++ b/storage/crdb/sqladminstorage.go
@@ -375,7 +375,7 @@ func (t *adminTX) UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tre
 
 // updateDeleted updates the Deleted and DeleteTimeMillis fields of the specified tree.
 // deleteTimeMillis must be either an int64 (in millis since epoch) or nil.
-func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis interface{}) (*trillian.Tree, error) {
+func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis any) (*trillian.Tree, error) {
 	if err := validateDeleted(ctx, t.tx, treeID, !deleted); err != nil {
 		return nil, err
 	}

--- a/storage/crdb/tree_storage.go
+++ b/storage/crdb/tree_storage.go
@@ -195,7 +195,7 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, ids [][]by
 		}
 	}()
 
-	args := make([]interface{}, 0, len(ids)+3)
+	args := make([]any, 0, len(ids)+3)
 
 	// populate args with ids.
 	for _, id := range ids {
@@ -283,7 +283,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 
 	// TODO(al): probably need to be able to batch this in the case where we have
 	// a really large number of subtrees to store.
-	args := make([]interface{}, 0, len(subtrees))
+	args := make([]any, 0, len(subtrees))
 
 	for _, s := range subtrees {
 		s := s

--- a/storage/memory/tree_storage.go
+++ b/storage/memory/tree_storage.go
@@ -101,7 +101,7 @@ func (m *TreeStorage) getTree(id int64) *tree {
 // kv is a simple key->value type which implements btree's Item interface.
 type kv struct {
 	k string
-	v interface{}
+	v any
 }
 
 // Less than by k's string key

--- a/storage/mysql/admin_storage.go
+++ b/storage/mysql/admin_storage.go
@@ -417,7 +417,7 @@ func (t *adminTX) UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tre
 
 // updateDeleted updates the Deleted and DeleteTimeMillis fields of the specified tree.
 // deleteTimeMillis must be either an int64 (in millis since epoch) or nil.
-func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis interface{}) (*trillian.Tree, error) {
+func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis any) (*trillian.Tree, error) {
 	if err := validateDeleted(ctx, t.tx, treeID, !deleted); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -450,7 +450,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		}
 
 		// Create the work queue entry
-		args := []interface{}{
+		args := []any{
 			t.treeID,
 			leaf.LeafIdentityHash,
 			leaf.MerkleLeafHash,
@@ -630,7 +630,7 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 	}
 	// TODO(pavelkalinnikov): Further clip `count` to a safe upper bound like 64k.
 
-	args := []interface{}{start, start + count, t.treeID}
+	args := []any{start, start + count, t.treeID}
 	rows, err := t.tx.QueryContext(ctx, selectLeavesByRangeSQL, args...)
 	if err != nil {
 		klog.Warningf("Failed to get leaves by range: %s", err)
@@ -777,7 +777,7 @@ func (t *logTreeTX) getLeavesByHashInternal(ctx context.Context, leafHashes [][]
 		}
 	}()
 
-	var args []interface{}
+	var args []any
 	for _, hash := range leafHashes {
 		args = append(args, []byte(hash))
 	}

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -76,8 +76,8 @@ func (t *logTreeTX) dequeueLeaf(rows *sql.Rows) (*trillian.LogLeaf, dequeuedLeaf
 	return leaf, dequeueInfo(leafIDHash, queueTimestamp), nil
 }
 
-func queueArgs(_ int64, _ []byte, queueTimestamp time.Time) []interface{} {
-	return []interface{}{queueTimestamp.UnixNano()}
+func queueArgs(_ int64, _ []byte, queueTimestamp time.Time) []any {
+	return []any{queueTimestamp.UnixNano()}
 }
 
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {

--- a/storage/mysql/queue_batching.go
+++ b/storage/mysql/queue_batching.go
@@ -87,14 +87,14 @@ func generateQueueID(treeID int64, leafIdentityHash []byte, timestamp int64) []b
 	return h.Sum(nil)
 }
 
-func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []interface{} {
+func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []any {
 	timestamp := queueTimestamp.UnixNano()
-	return []interface{}{timestamp, generateQueueID(treeID, identityHash, timestamp)}
+	return []any{timestamp, generateQueueID(treeID, identityHash, timestamp)}
 }
 
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
 	querySuffix := []string{}
-	args := []interface{}{}
+	args := []any{}
 	dequeuedLeaves := make([]dequeuedLeaf, 0, len(leaves))
 	for _, leaf := range leaves {
 		if err := leaf.IntegrateTimestamp.CheckValid(); err != nil {
@@ -136,7 +136,7 @@ func (t *logTreeTX) removeSequencedLeaves(ctx context.Context, queueIDs []dequeu
 		return err
 	}
 	stx := t.tx.StmtContext(ctx, tmpl)
-	args := make([]interface{}, len(queueIDs))
+	args := make([]any, len(queueIDs))
 	for i, q := range queueIDs {
 		args[i] = []byte(q)
 	}

--- a/storage/mysql/sql.go
+++ b/storage/mysql/sql.go
@@ -47,7 +47,7 @@ func setNullStringIfValid(src sql.NullString, dest *string) {
 
 // row defines a common interface between sql.Row and sql.Rows(!)
 type row interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }
 
 // readTree takes a sql row and returns a tree

--- a/storage/mysql/tree_storage.go
+++ b/storage/mysql/tree_storage.go
@@ -210,9 +210,9 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, ids [][]by
 		}
 	}()
 
-	var args []interface{}
+	var args []any
 	if t.subtreeRevs {
-		args = make([]interface{}, 0, len(ids)+3)
+		args = make([]any, 0, len(ids)+3)
 		// populate args with ids.
 		for _, id := range ids {
 			klog.V(4).Infof("  id: %x", id)
@@ -222,7 +222,7 @@ func (t *treeTX) getSubtrees(ctx context.Context, treeRevision int64, ids [][]by
 		args = append(args, treeRevision)
 		args = append(args, t.treeID)
 	} else {
-		args = make([]interface{}, 0, len(ids)+1)
+		args = make([]any, 0, len(ids)+1)
 		args = append(args, t.treeID)
 
 		// populate args with ids.
@@ -311,7 +311,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 
 	// TODO(al): probably need to be able to batch this in the case where we have
 	// a really large number of subtrees to store.
-	args := make([]interface{}, 0, len(subtrees))
+	args := make([]any, 0, len(subtrees))
 
 	// If not using subtree revisions then default value of 0 is fine. There is no
 	// significance to this value, other than it cannot be NULL in the DB.

--- a/storage/postgresql/admin_storage.go
+++ b/storage/postgresql/admin_storage.go
@@ -270,7 +270,7 @@ func (t *adminTX) UndeleteTree(ctx context.Context, treeID int64) (*trillian.Tre
 
 // updateDeleted updates the Deleted and DeleteTimeMillis fields of the specified tree.
 // deleteTimeMillis must be either an int64 (in millis since epoch) or nil.
-func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis interface{}) (*trillian.Tree, error) {
+func (t *adminTX) updateDeleted(ctx context.Context, treeID int64, deleted bool, deleteTimeMillis any) (*trillian.Tree, error) {
 	if err := validateDeleted(ctx, t.tx, treeID, !deleted); err != nil {
 		return nil, err
 	}

--- a/storage/postgresql/log_storage.go
+++ b/storage/postgresql/log_storage.go
@@ -460,7 +460,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 
 	// Prepare rows to copy, but don't accept batches if any of the leaves are invalid.
 	leafMap := make(map[string]int)
-	copyRows := make([][]interface{}, 0, len(leaves))
+	copyRows := make([][]any, 0, len(leaves))
 	for i, leaf := range leaves {
 		if len(leaf.LeafIdentityHash) != t.hashSizeBytes {
 			return nil, fmt.Errorf("queued leaf must have a leaf ID hash of length %d", t.hashSizeBytes)
@@ -471,7 +471,7 @@ func (t *logTreeTX) QueueLeaves(ctx context.Context, leaves []*trillian.LogLeaf,
 		}
 		qTimestamp := leaf.QueueTimestamp.AsTime()
 		args := queueArgs(t.treeID, leaf.LeafIdentityHash, qTimestamp)
-		copyRows = append(copyRows, []interface{}{t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, leaf.MerkleLeafHash, args[0], args[1]})
+		copyRows = append(copyRows, []any{t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, leaf.MerkleLeafHash, args[0], args[1]})
 		leafMap[hex.EncodeToString(leaf.LeafIdentityHash)] = i
 	}
 	label := labelForTX(t)
@@ -570,14 +570,14 @@ func (t *logTreeTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.L
 
 	// Prepare rows to copy.
 	leafMap := make(map[string]int)
-	copyRows := make([][]interface{}, 0, len(leaves))
+	copyRows := make([][]any, 0, len(leaves))
 	for i, leaf := range leaves {
 		// This should fail on insert, but catch it early.
 		if got, want := len(leaf.LeafIdentityHash), t.hashSizeBytes; got != want {
 			return nil, status.Errorf(codes.FailedPrecondition, "leaves[%d] has incorrect hash size %d, want %d", i, got, want)
 		}
 
-		copyRows = append(copyRows, []interface{}{t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, leaf.MerkleLeafHash, timestamp.UnixNano(), leaf.LeafIndex})
+		copyRows = append(copyRows, []any{t.treeID, leaf.LeafIdentityHash, leaf.LeafValue, leaf.ExtraData, leaf.MerkleLeafHash, timestamp.UnixNano(), leaf.LeafIndex})
 		leafMap[hex.EncodeToString(leaf.LeafIdentityHash)] = i
 		res[i] = &trillian.QueuedLogLeaf{Status: ok}
 	}

--- a/storage/postgresql/queue.go
+++ b/storage/postgresql/queue.go
@@ -86,13 +86,13 @@ func generateQueueID(treeID int64, leafIdentityHash []byte, timestamp int64) []b
 	return h.Sum(nil)
 }
 
-func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []interface{} {
+func queueArgs(treeID int64, identityHash []byte, queueTimestamp time.Time) []any {
 	timestamp := queueTimestamp.UnixNano()
-	return []interface{}{timestamp, generateQueueID(treeID, identityHash, timestamp)}
+	return []any{timestamp, generateQueueID(treeID, identityHash, timestamp)}
 }
 
 func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillian.LogLeaf) error {
-	rows := make([][]interface{}, 0, len(leaves))
+	rows := make([][]any, 0, len(leaves))
 	dequeuedLeaves := make([]dequeuedLeaf, 0, len(leaves))
 	for _, leaf := range leaves {
 		// This should fail on insert but catch it early
@@ -104,7 +104,7 @@ func (t *logTreeTX) UpdateSequencedLeaves(ctx context.Context, leaves []*trillia
 			return fmt.Errorf("got invalid integrate timestamp: %w", err)
 		}
 		iTimestamp := leaf.IntegrateTimestamp.AsTime()
-		rows = append(rows, []interface{}{t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano()})
+		rows = append(rows, []any{t.treeID, leaf.LeafIdentityHash, leaf.MerkleLeafHash, leaf.LeafIndex, iTimestamp.UnixNano()})
 		qe, ok := t.dequeued[string(leaf.LeafIdentityHash)]
 		if !ok {
 			return fmt.Errorf("attempting to update leaf that wasn't dequeued. IdentityHash: %x", leaf.LeafIdentityHash)

--- a/storage/postgresql/sql.go
+++ b/storage/postgresql/sql.go
@@ -43,7 +43,7 @@ func setNullStringIfValid(src sql.NullString, dest *string) {
 
 // row defines a common interface between sql.Row and sql.Rows(!)
 type row interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }
 
 // readTree takes a sql row and returns a tree

--- a/storage/postgresql/tree_storage.go
+++ b/storage/postgresql/tree_storage.go
@@ -201,7 +201,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 
 	// TODO(robstradling): probably need to be able to batch this in the case where we have
 	// a really large number of subtrees to store.
-	rows := make([][]interface{}, 0, len(subtrees))
+	rows := make([][]any, 0, len(subtrees))
 
 	for _, s := range subtrees {
 		s := s
@@ -212,7 +212,7 @@ func (t *treeTX) storeSubtrees(ctx context.Context, subtrees []*storagepb.Subtre
 		if err != nil {
 			return err
 		}
-		rows = append(rows, []interface{}{t.treeID, s.Prefix, subtreeBytes})
+		rows = append(rows, []any{t.treeID, s.Prefix, subtreeBytes})
 	}
 
 	// Create temporary subtree table.

--- a/storage/testonly/admin_storage_tester.go
+++ b/storage/testonly/admin_storage_tester.go
@@ -576,7 +576,7 @@ type spec struct {
 }
 
 // makeTreeOrFail delegates to makeTree. If makeTree returns a non-nil error, failFn is called.
-func makeTreeOrFail(ctx context.Context, s storage.AdminStorage, spec spec, failFn func(string, ...interface{})) *trillian.Tree {
+func makeTreeOrFail(ctx context.Context, s storage.AdminStorage, spec spec, failFn func(string, ...any)) *trillian.Tree {
 	tree, err := makeTree(ctx, s, spec)
 	if err != nil {
 		failFn("makeTree() returned err = %v", err)

--- a/storage/testonly/matchers.go
+++ b/storage/testonly/matchers.go
@@ -31,7 +31,7 @@ func NodeSet(nodes []tree.Node) gomock.Matcher {
 type nodeSet []tree.Node
 
 // Matches implements the gomock.Matcher API.
-func (n nodeSet) Matches(x interface{}) bool {
+func (n nodeSet) Matches(x any) bool {
 	nodes, ok := x.([]tree.Node)
 	if !ok {
 		return false

--- a/testonly/matchers/atleast.go
+++ b/testonly/matchers/atleast.go
@@ -32,7 +32,7 @@ type atLeastMatcher struct {
 
 // Matches tests whether a supplied value, which must be of an int type is
 // at least the value the AtLeast matcher expects. If so then it returns true.
-func (m atLeastMatcher) Matches(x interface{}) bool {
+func (m atLeastMatcher) Matches(x any) bool {
 	if x, ok := x.(int); ok {
 		return x >= m.num
 	}

--- a/testonly/matchers/proto.go
+++ b/testonly/matchers/proto.go
@@ -31,7 +31,7 @@ func ProtoEqual(m proto.Message) gomock.Matcher {
 }
 
 // Matches implements the gomock.Matcher API.
-func (pe protoEqual) Matches(msg interface{}) bool {
+func (pe protoEqual) Matches(msg any) bool {
 	m, ok := msg.(proto.Message)
 	if !ok {
 		return false

--- a/types/internal/tls/tls.go
+++ b/types/internal/tls/tls.go
@@ -145,13 +145,13 @@ var (
 //	}
 //
 // If the encoded value does not fit in the Go type, Unmarshal returns a parse error.
-func Unmarshal(b []byte, val interface{}) ([]byte, error) {
+func Unmarshal(b []byte, val any) ([]byte, error) {
 	return UnmarshalWithParams(b, val, "")
 }
 
 // UnmarshalWithParams allows field parameters to be specified for the
 // top-level element. The form of the params is the same as the field tags.
-func UnmarshalWithParams(b []byte, val interface{}, params string) ([]byte, error) {
+func UnmarshalWithParams(b []byte, val any, params string) ([]byte, error) {
 	info, err := fieldTagToFieldInfo(params, "")
 	if err != nil {
 		return nil, err
@@ -504,14 +504,14 @@ func parseField(v reflect.Value, data []byte, initOffset int, info *fieldInfo) (
 }
 
 // Marshal returns the TLS encoding of val.
-func Marshal(val interface{}) ([]byte, error) {
+func Marshal(val any) ([]byte, error) {
 	return MarshalWithParams(val, "")
 }
 
 // MarshalWithParams returns the TLS encoding of val, and allows field
 // parameters to be specified for the top-level element.  The form
 // of the params is the same as the field tags.
-func MarshalWithParams(val interface{}, params string) ([]byte, error) {
+func MarshalWithParams(val any, params string) ([]byte, error) {
 	info, err := fieldTagToFieldInfo(params, "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace all occurrences of `interface{}` with the equivalent `any` type alias introduced in Go 1.18.

This is a mechanical refactoring with no behavioral changes.

Fixes are limited to type literal usage only (not interface definitions).