### PR TITLE
Fix unbounded Count in GetLeavesByRange for PREORDERED_LOG trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Fix unbounded `Count` in `GetLeavesByRange` for `PREORDERED_LOG` trees by @DebasishTripathy13
+  * `storage/{mysql,postgresql,crdb,memory}` now cap `count` to a safe upper bound (`1<<16`) regardless of tree type, resolving the long-standing `TODO` on this line. Previously, an attacker-supplied `Count` on a `PREORDERED_LOG` tree (not bounded by `TreeSize` like `LOG` trees are) reached `make([]*trillian.LogLeaf, 0, count)` unclamped, panicking with `makeslice: cap out of range` and crashing the server process — with no request-level authorization on the log server, this was remotely triggerable by any client that could discover a tree ID via the also-unauthenticated `ListTrees`.
 * Allow unencrypted PEM private key files by @JasonPowr
   * `ReadPrivateKeyFile` and `FromProto` (via `PEMKeyFile`) now accept an empty password, treating the key as unencrypted. Previously, an empty password was rejected with an error.
 * Replace deprecated `golang.org/x/crypto/ed25519` with stdlib `crypto/ed25519` by @JasonPowr

--- a/security/poc/dos_chain_test.go
+++ b/security/poc/dos_chain_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package poc demonstrates, end to end, an unauthenticated denial-of-service
+// chain against a Trillian log server:
+//
+//  1. TrillianAdmin.ListTrees carries no request-level authorization
+//     (server/admin/admin_server.go, server/interceptor/interceptor.go), so
+//     any client that can open a connection can enumerate every tree's ID,
+//     type and state for free -- including PREORDERED_LOG trees.
+//
+//  2. TrillianLog.GetLeavesByRange does not bound `Count` for
+//     PREORDERED_LOG trees (storage/{mysql,postgresql,crdb}/log_storage.go).
+//     A huge attacker-supplied Count reaches
+//     `make([]*trillian.LogLeaf, 0, count)` unclamped, which panics
+//     ("makeslice: cap out of range") before a single row is read. No
+//     interceptor in the stack recovers panics, so the panic crashes the
+//     whole process -- every tree/tenant hosted by that server goes down,
+//     not just the targeted one.
+//
+// Chained together: an attacker with zero credentials and zero prior
+// knowledge of any tree ID can discover a target and crash the server with
+// two RPCs. Tree IDs are otherwise infeasible to guess (crypto/rand over the
+// full int64 range, see storage/tree_id.go), so step 1 is what turns step 2
+// from "needs insider knowledge" into "fully unauthenticated, any time".
+//
+// This test drives the real production server code (server/admin.Server,
+// server/TrillianLogRPCServer) through the real production interceptor
+// (server/interceptor.TrillianInterceptor) with a bare, unauthenticated
+// context -- no mocks stand in for the vulnerable logic. It uses the
+// in-memory storage backend purely so the PoC is self-contained and needs no
+// external database. storage/mysql, storage/postgresql and storage/crdb
+// contained the identical unbounded-count bug in getLeavesByRangeInternal
+// (same code shape, same fix applied there); see
+// storage/memory/log_storage_dos_test.go for a storage-only repro that
+// needs no server wiring at all.
+package poc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/trillian"
+	"github.com/google/trillian/extension"
+	"github.com/google/trillian/quota"
+	"github.com/google/trillian/server"
+	"github.com/google/trillian/server/admin"
+	"github.com/google/trillian/server/interceptor"
+	"github.com/google/trillian/storage"
+	_ "github.com/google/trillian/storage/memory" // registers the "memory" storage provider
+	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/types"
+	"github.com/google/trillian/util/clock"
+	"google.golang.org/grpc"
+)
+
+// seedActiveLog simulates a real, already-operating log deployment: an
+// operator has created a PREORDERED_LOG tree and it has already published
+// entries (TreeSize > 0). None of this setup is available to the attacker --
+// it stands in for "any PREORDERED_LOG tree that already exists in
+// production", which is the only precondition the real attack needs.
+func seedActiveLog(t *testing.T, reg extension.Registry, treeSize uint64) *trillian.Tree {
+	t.Helper()
+	ctx := context.Background()
+
+	tree, err := storage.CreateTree(ctx, reg.AdminStorage, testonly.PreorderedLogTree)
+	if err != nil {
+		t.Fatalf("CreateTree: %v", err)
+	}
+
+	root, err := (&types.LogRootV1{
+		TreeSize:       treeSize,
+		RootHash:       make([]byte, 32),
+		TimestampNanos: uint64(time.Now().UnixNano()),
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	err = reg.LogStorage.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
+		return tx.StoreSignedLogRoot(ctx, &trillian.SignedLogRoot{LogRoot: root})
+	})
+	if err != nil {
+		t.Fatalf("seed StoreSignedLogRoot: %v", err)
+	}
+	return tree
+}
+
+// TestUnauthenticatedEnumerationThenCrash reproduces the full chain against
+// real production server + interceptor code with a bare, credential-free
+// context.Background() throughout -- exactly what an unauthenticated
+// network attacker would send.
+func TestUnauthenticatedEnumerationThenCrash(t *testing.T) {
+	sp, err := storage.NewProvider("memory", nil)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	reg := extension.Registry{
+		AdminStorage: sp.AdminStorage(),
+		LogStorage:   sp.LogStorage(),
+	}
+
+	// --- Operator setup (not part of the attack) ---
+	victimTree := seedActiveLog(t, reg, 10)
+
+	// --- Production server + interceptor wiring, exactly as cmd/trillian_log_server does ---
+	adminSrv := admin.New(reg, nil)
+	logSrv := server.NewTrillianLogRPCServer(reg, clock.System)
+	// quota.Noop() is the documented, commonly-deployed --quota_system=noop
+	// configuration; it imposes no capacity limit (quota/noop.go), so it
+	// does not stand between the attacker and the crash.
+	intc := interceptor.New(reg.AdminStorage, quota.Noop(), false /* quotaDryRun */, nil)
+
+	attacker := context.Background() // zero credentials, zero metadata
+
+	// --- Attack step 1: unauthenticated enumeration ---
+	listInfo := &grpc.UnaryServerInfo{FullMethod: "/trillian.TrillianAdmin/ListTrees"}
+	listHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return adminSrv.ListTrees(ctx, req.(*trillian.ListTreesRequest))
+	}
+	respIface, err := intc.UnaryInterceptor(attacker, &trillian.ListTreesRequest{}, listInfo, listHandler)
+	if err != nil {
+		t.Fatalf("unauthenticated ListTrees was rejected (expected it to succeed, proving the bug is patched/mitigated elsewhere): %v", err)
+	}
+	resp := respIface.(*trillian.ListTreesResponse)
+
+	var discoveredID int64
+	for _, tr := range resp.Tree {
+		if tr.TreeId == victimTree.TreeId {
+			discoveredID = tr.TreeId
+		}
+	}
+	if discoveredID == 0 {
+		t.Fatalf("attacker did not discover the victim tree via unauthenticated ListTrees; got %d trees", len(resp.Tree))
+	}
+	t.Logf("[attacker] discovered PREORDERED_LOG tree %d via unauthenticated ListTrees (zero credentials)", discoveredID)
+
+	// --- Attack step 2: crash attempt using the discovered ID ---
+	getInfo := &grpc.UnaryServerInfo{FullMethod: "/trillian.TrillianLog/GetLeavesByRange"}
+	getHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return logSrv.GetLeavesByRange(ctx, req.(*trillian.GetLeavesByRangeRequest))
+	}
+	req := &trillian.GetLeavesByRangeRequest{
+		LogId:      discoveredID,
+		StartIndex: 0,
+		Count:      9223372036854775807, // math.MaxInt64 -- unauthenticated, unvalidated
+	}
+
+	// Pre-fix, this call panics inside make([]*trillian.LogLeaf, 0, count)
+	// with "runtime error: makeslice: cap out of range" and, because no
+	// interceptor in the stack recovers panics, brings down the whole
+	// process along with every other tree it was serving. Post-fix, the
+	// count is clamped and the call returns normally.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("VULNERABLE: unauthenticated GetLeavesByRange(Count=MaxInt64) on tree %d panicked: %v\n"+
+					"In a real deployment (no recover() in the gRPC handler chain) this panic crashes the "+
+					"entire trillian_log_server process -- a total, repeatable denial of service for every "+
+					"tree/tenant it hosts, triggered by a single unauthenticated RPC.", discoveredID, r)
+			}
+		}()
+		if _, err := intc.UnaryInterceptor(attacker, req, getInfo, getHandler); err != nil {
+			t.Fatalf("GetLeavesByRange returned an error instead of the expected clamped success: %v", err)
+		}
+	}()
+
+	t.Logf("[fixed] unauthenticated GetLeavesByRange(Count=MaxInt64) on tree %d returned safely -- count was clamped instead of reaching an unbounded make()", discoveredID)
+}

--- a/storage/crdb/log_storage.go
+++ b/storage/crdb/log_storage.go
@@ -633,6 +633,13 @@ func (t *logTreeTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.L
 	return res, nil
 }
 
+// maxGetLeavesByRangeCount caps the number of leaves a single GetLeavesByRange call will
+// attempt to fetch. Without this, an attacker-supplied count (e.g. on a PREORDERED_LOG tree,
+// which isn't bounded by TreeSize below) flows straight into a make([]*trillian.LogLeaf, 0,
+// count) allocation and crashes the process (runtime error: makeslice: cap out of range, or an
+// OOM kill for smaller-but-still-huge values) before a single row is read.
+const maxGetLeavesByRangeCount = 1 << 16
+
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -659,7 +666,9 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 			count = maxCount
 		}
 	}
-	// TODO(pavelkalinnikov): Further clip `count` to a safe upper bound like 64k.
+	if count > maxGetLeavesByRangeCount {
+		count = maxGetLeavesByRangeCount
+	}
 
 	args := []interface{}{start, start + count, t.treeID}
 	rows, err := t.tx.QueryContext(ctx, selectLeavesByRangeSQL, args...)

--- a/storage/memory/log_storage.go
+++ b/storage/memory/log_storage.go
@@ -282,7 +282,21 @@ func (t *logTreeTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.L
 	return nil, status.Errorf(codes.Unimplemented, "AddSequencedLeaves is not implemented")
 }
 
+// maxGetLeavesByRangeCount mirrors the cap applied by the SQL storage backends (mysql/
+// postgresql/crdb): an attacker-supplied count must never reach make([]*trillian.LogLeaf, 0,
+// count) unbounded, or the process crashes (runtime error: makeslice: cap out of range).
+const maxGetLeavesByRangeCount = 1 << 16
+
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
+	if count <= 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid count %d, want > 0", count)
+	}
+	if start < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid start %d, want >= 0", start)
+	}
+	if count > maxGetLeavesByRangeCount {
+		count = maxGetLeavesByRangeCount
+	}
 	ret := make([]*trillian.LogLeaf, 0, count)
 	for i := int64(0); i < count; i++ {
 		leaf := t.tx.Get(seqLeafKey(t.treeID, start+i))

--- a/storage/memory/log_storage_dos_test.go
+++ b/storage/memory/log_storage_dos_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/trillian"
+	"github.com/google/trillian/storage"
+	"github.com/google/trillian/storage/testonly"
+	"github.com/google/trillian/types"
+)
+
+// TestGetLeavesByRangeDoS reproduces, directly against the storage layer,
+// the bug that used to let an attacker-controlled Count reach an unclamped
+// make([]*trillian.LogLeaf, 0, count) allocation and crash the process
+// (runtime error: makeslice: cap out of range). storage/mysql,
+// storage/postgresql and storage/crdb had the identical shape: the
+// TreeSize-based clamp only applied to TreeType_LOG, leaving
+// TreeType_PREORDERED_LOG completely unbounded. The fix adds an
+// unconditional maxGetLeavesByRangeCount cap that applies regardless of
+// tree type.
+func TestGetLeavesByRangeDoS(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTreeStorage()
+	as := NewAdminStorage(ts)
+
+	tree, err := storage.CreateTree(ctx, as, testonly.PreorderedLogTree)
+	if err != nil {
+		t.Fatalf("CreateTree: %v", err)
+	}
+
+	ls := NewLogStorage(ts, nil)
+
+	// A real deployment only ever hits this code path once the log has
+	// published entries; simulate that by seeding a root directly.
+	root, err := (&types.LogRootV1{
+		RootHash:       make([]byte, 32),
+		TimestampNanos: uint64(time.Now().UnixNano()),
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	err = ls.ReadWriteTransaction(ctx, tree, func(ctx context.Context, tx storage.LogTreeTX) error {
+		return tx.StoreSignedLogRoot(ctx, &trillian.SignedLogRoot{LogRoot: root})
+	})
+	if err != nil {
+		t.Fatalf("seed StoreSignedLogRoot: %v", err)
+	}
+
+	tx, err := ls.SnapshotForTree(ctx, tree)
+	if err != nil {
+		t.Fatalf("SnapshotForTree: %v", err)
+	}
+	defer tx.Close()
+
+	// Before the fix, this call panicked with "runtime error: makeslice: cap
+	// out of range" instead of returning an error -- and nothing in the
+	// gRPC handler chain recovers panics, so it would have crashed the
+	// whole server process. If that regresses, fail loudly instead of
+	// letting the test binary itself crash uninformatively.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("VULNERABLE: GetLeavesByRange(count=MaxInt64) panicked instead of returning an error: %v", r)
+			}
+		}()
+		leaves, err := tx.GetLeavesByRange(ctx, 0, 9223372036854775807) // math.MaxInt64
+		if err != nil {
+			t.Fatalf("GetLeavesByRange returned an error instead of a clamped, safe result: %v", err)
+		}
+		if len(leaves) != 0 {
+			// Empty tree, so no actual leaves are stored; the point of this
+			// assertion is that we got here at all without allocating a
+			// multi-exabyte slice first.
+			t.Fatalf("got %d leaves, want 0 (empty tree)", len(leaves))
+		}
+	}()
+}

--- a/storage/mysql/log_storage.go
+++ b/storage/mysql/log_storage.go
@@ -602,6 +602,13 @@ func (t *logTreeTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.L
 	return res, nil
 }
 
+// maxGetLeavesByRangeCount caps the number of leaves a single GetLeavesByRange call will
+// attempt to fetch. Without this, an attacker-supplied count (e.g. on a PREORDERED_LOG tree,
+// which isn't bounded by TreeSize below) flows straight into a make([]*trillian.LogLeaf, 0,
+// count) allocation and crashes the process (runtime error: makeslice: cap out of range, or an
+// OOM kill for smaller-but-still-huge values) before a single row is read.
+const maxGetLeavesByRangeCount = 1 << 16
+
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -628,7 +635,9 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 			count = maxCount
 		}
 	}
-	// TODO(pavelkalinnikov): Further clip `count` to a safe upper bound like 64k.
+	if count > maxGetLeavesByRangeCount {
+		count = maxGetLeavesByRangeCount
+	}
 
 	args := []interface{}{start, start + count, t.treeID}
 	rows, err := t.tx.QueryContext(ctx, selectLeavesByRangeSQL, args...)

--- a/storage/postgresql/log_storage.go
+++ b/storage/postgresql/log_storage.go
@@ -637,6 +637,13 @@ func (t *logTreeTX) AddSequencedLeaves(ctx context.Context, leaves []*trillian.L
 	return res, nil
 }
 
+// maxGetLeavesByRangeCount caps the number of leaves a single GetLeavesByRange call will
+// attempt to fetch. Without this, an attacker-supplied count (e.g. on a PREORDERED_LOG tree,
+// which isn't bounded by TreeSize below) flows straight into a make([]*trillian.LogLeaf, 0,
+// count) allocation and crashes the process (runtime error: makeslice: cap out of range, or an
+// OOM kill for smaller-but-still-huge values) before a single row is read.
+const maxGetLeavesByRangeCount = 1 << 16
+
 func (t *logTreeTX) GetLeavesByRange(ctx context.Context, start, count int64) ([]*trillian.LogLeaf, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -663,7 +670,9 @@ func (t *logTreeTX) getLeavesByRangeInternal(ctx context.Context, start, count i
 			count = maxCount
 		}
 	}
-	// TODO(robstradling): Further clip `count` to a safe upper bound like 64k.
+	if count > maxGetLeavesByRangeCount {
+		count = maxGetLeavesByRangeCount
+	}
 
 	rows, err := t.tx.Query(ctx, selectLeavesByRangeSQL, start, start+count, t.treeID)
 	if err != nil {


### PR DESCRIPTION
Fixes #3914

### What

`getLeavesByRangeInternal` in `storage/mysql`, `storage/postgresql`, and
`storage/crdb` only clamps `count` to the tree's `TreeSize` when
`treeType == TreeType_LOG`. For `PREORDERED_LOG` trees that clamp is
skipped, and nothing else bounds `count` — it flows straight from the
client-supplied `GetLeavesByRangeRequest.Count` into
`make([]*trillian.LogLeaf, 0, count)`.

A large `Count` (e.g. `math.MaxInt64`) panics with `runtime error: makeslice:
cap out of range` before a single row is read. No interceptor in the gRPC
stack recovers panics, so this crashes the whole process — every
tree/tenant it hosts, not just the targeted one. See #3914 for the full
writeup, including why this is reachable with zero credentials
(`ListTrees` carries no request-level authorization either).

### The fix

Adds an unconditional `maxGetLeavesByRangeCount` (`1<<16`) cap, applied
*after* the existing `TreeType_LOG` clamp, in all three SQL backends. This
resolves the `// TODO: Further clip count to a safe upper bound like 64k`
comment that was already sitting directly above the vulnerable line in each
file. Applied the same cap to the in-memory backend (`storage/memory`),
which had no bound at all for either tree type — useful mainly for the
regression test below, since it isn't wired into any `cmd/` binary.

### Tests

- `storage/memory/log_storage_dos_test.go` — storage-layer repro, no
  external DB required. Calls `GetLeavesByRange(ctx, 0, math.MaxInt64)`
  directly against the real `logTreeTX`.
- `security/poc/dos_chain_test.go` — full chain through the real
  `admin.Server` + `TrillianLogRPCServer` + `TrillianInterceptor`, with a
  bare `context.Background()` throughout (no auth metadata), proving both
  halves of the chain: unauthenticated `ListTrees` enumeration, then the
  crash attempt via the discovered tree ID.

Both tests were run against the code before this fix (panic/`FAIL`,
`runtime error: makeslice: cap out of range`) and after (`PASS`) to confirm
they're a real regression guard and not tautological.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly — n/a, this is an
      internal bound fix with no user-facing API/behavior change beyond
      capping an already-unbounded, undocumented parameter.

### Note

I do not yet have a signed Google CLA on file for this account. Will sign
via the individual CLA link as soon as the CLA bot flags it on this PR.