### PR TITLE
offer batching for mysql quota provider

### DIFF
--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 
 	"github.com/google/trillian/quota"
+	"github.com/google/trillian/quota/cacheqm"
 	"github.com/google/trillian/storage/mysql"
 	"k8s.io/klog/v2"
 )
@@ -25,8 +26,14 @@ import (
 // QuotaManagerName identifies the MySQL quota implementation.
 const QuotaManagerName = "mysql"
 
-var maxUnsequencedRows = flag.Int("max_unsequenced_rows", DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
-	"Only effective for quota_system=mysql.")
+var (
+	maxUnsequencedRows = flag.Int("max_unsequenced_rows", DefaultMaxUnsequenced, "Max number of unsequenced rows before rate limiting kicks in. "+
+		"Only effective for quota_system=mysql.")
+	mysqlQuotaMinBatchSize = flag.Int("mysql_quota_min_batch_size", 0, "Minimum number of tokens to request from the MySQL quota system. "+
+		"Zero or lower disables batching. Only effective for quota_system=mysql.")
+	mysqlQuotaMaxCacheEntries = flag.Int("mysql_quota_max_cache_entries", cacheqm.DefaultMaxCacheEntries, "Maximum number of quota specs in the MySQL quota cache. "+
+		"Only effective when mysql_quota_min_batch_size is positive.")
+)
 
 func init() {
 	if err := quota.RegisterProvider(QuotaManagerName, newMySQLQuotaManager); err != nil {
@@ -42,6 +49,14 @@ func newMySQLQuotaManager() (quota.Manager, error) {
 	qm := &QuotaManager{
 		DB:                 db,
 		MaxUnsequencedRows: *maxUnsequencedRows,
+	}
+	if *mysqlQuotaMinBatchSize > 0 {
+		cachedqm, err := cacheqm.NewCachedManager(qm, *mysqlQuotaMinBatchSize, *mysqlQuotaMaxCacheEntries)
+		if err != nil {
+			return nil, err
+		}
+		klog.Infof("Using cached MySQL QuotaManager with minimum batch size %d", *mysqlQuotaMinBatchSize)
+		return cachedqm, nil
 	}
 	klog.Info("Using MySQL QuotaManager")
 	return qm, nil

--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -51,6 +51,9 @@ func newMySQLQuotaManager() (quota.Manager, error) {
 		MaxUnsequencedRows: *maxUnsequencedRows,
 	}
 	if *mysqlQuotaMinBatchSize > 0 {
+		if *mysqlQuotaMinBatchSize >= *maxUnsequencedRows {
+			return nil, fmt.Errorf("mysql_quota_min_batch_size (%d) must be less than max_unsequenced_rows (%d)", *mysqlQuotaMinBatchSize, *maxUnsequencedRows)
+		}
 		cachedqm, err := cacheqm.NewCachedManager(qm, *mysqlQuotaMinBatchSize, *mysqlQuotaMaxCacheEntries)
 		if err != nil {
 			return nil, err

--- a/quota/mysqlqm/quota_provider.go
+++ b/quota/mysqlqm/quota_provider.go
@@ -16,6 +16,7 @@ package mysqlqm
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/quota/cacheqm"


### PR DESCRIPTION
Currently, the MySQL quota provider does a lookup on the row count of unsequenced rows for every single insert. By using the caching provider that already exists, grabbing tokens in batches will cause the provider to only check the row count when that batch of tokens is depleted. This mimics the setup for the etcd provider.

The batch size is set to 0, which retains the current default behavior of fetching a row count on every QueueLeaf call. 